### PR TITLE
feat(verification): config-resolved policy + onboarding integration — slice 2 (epic #1515, v2.11.0 preview 1)

### DIFF
--- a/docs/designs/2026-06-11-verification-ladder-slice2.md
+++ b/docs/designs/2026-06-11-verification-ladder-slice2.md
@@ -1,0 +1,280 @@
+# Verification ladder — slice 2: config-resolved policy + onboarding integration (R2 + R9)
+
+**Date:** 2026-06-11 · **Workflow:** `verification-ladder-slice2` · **Epic:** #1515 (milestone 15, v2.11.0)
+**Sub-issues:** #1517 (R2 — verification policy, config-resolved tier→gate sequences), #1524 (R9 — onboarding integration + doctor check)
+**Predecessor:** `docs/designs/2026-06-09-verification-ladder-slice1.md` (PR #1535, merged)
+
+## 1. Goal & scope
+
+Complete Phase 1 of epic #1515. Slice 1 shipped the verification ladder's spine — the frozen
+`(riskTier, boundaryTouching) → gate sequence` table in `workflow/verification-policy.ts`,
+deliberately config-free, with its header documenting the contract this slice now fulfills:
+*"the override layer composes ON TOP of this table, it does not replace it."* Slice 2 delivers
+that override layer (R2) and plugs verification into the onboard/doctor reconciler (R9), making
+this the last feature slice before the **v2.11.0-preview.1** cut.
+
+**In scope:**
+
+- A strict `verification:` block in `.exarchos.yml` (ProjectConfigSchema side) carrying per-cell
+  gate-sequence overrides, schema-constrained to the `GateName` enum.
+- `resolveVerificationPolicy` — a layered resolver (config cell > built-in cell) mirroring the
+  toolchain resolver idiom; consumed by `prepare_delegation`'s stamp and `resolvePolicySkip`.
+- Per-workflow severity: oneshot workflows resolve verification-gate failures to advisory.
+- R9: `ResolvedCommandsSchema` grows `mutation`/`lint`; `detectDesiredState` resolves them via
+  the existing `resolveVerificationRuntime`; `doctor --fix` seeds **commands only**.
+- New doctor check `verification-toolchain` (`verificationToolchainResolvable`).
+- T0 characterization pinning current onboard/doctor outputs before the fold.
+
+**Out of scope (explicitly):** R5 `check_mutation_adequacy` (#1520), R6 cheap-mix planning
+defaults (#1521), R10 governance (#1525), SIV-5/6/7, SIV-3 Layer B, custom (non-built-in) gate
+names in sequences, per-*tier* severity (rationale §4.4), and writing verification-policy
+defaults into consumer config (rationale §4.6 — the gen-time bake trap). No new MCP actions and
+no new CLI verbs are added anywhere in this slice.
+
+## 2. Constraints (invariant anchors)
+
+Anchored to `.exarchos/invariants.md`. Always-load set probed during design: **INV-6** (the
+watch-item — tier→gate *policy* stays a typed substrate module + config, never skill prose or
+workflow-typed branches; the one workflow-typed fact, oneshot-advisory, is expressed as data in
+the resolver, not branching prose), **INV-1** (resolution is pure over config input; gate runs
+keep emitting `gate.executed`; no side state), **INV-2** (onboard and doctor stay two callers
+over one reconciler core; no behavior in adapters), **INV-5a** (the `verification:` block is
+schema-constrained — gate names are a `z.enum` over `VERIFICATION_GATE_NAMES`, `.strict()`
+keys, duplicate-free refinement — not prose-validated), **INV-5b** (gates keep the fixed
+carrier; skip results carry the policy-source discriminant), **INV-8** (gate re-runs keep
+idempotency-collapsing via `operationId`; never CAS-pin follow-on events), **INV-12** (the
+resolved sequence keeps riding delegation records and `next_actions`), **INV-15** (everything
+local).
+
+Pulled on domain match: **INV-4** (R9 resolves toolchains at detect-time and seeds *commands*
+as explicit tier-2 config — the resolved *policy* is never baked into shipped artifacts or
+consumer config), **INV-5d** (deliberate property: this slice registers zero new actions — the
+composite-tool count and per-action schema surface are untouched).
+
+## 3. Architecture — the resolved policy
+
+```
+            .exarchos.yml  verification.policy.<cell>     (override layer, optional)
+                              │  cell-wise full replacement
+                              ▼
+   resolveVerificationPolicy(config)                      (NEW — workflow/verification-policy-resolver.ts)
+                              │
+                              │  fallback per cell
+                              ▼
+   resolveVerificationSequence(tier, boundary)            (slice 1 — frozen built-in table, UNCHANGED)
+
+   Consumers (all read the RESOLVED policy — one resolver, every call site):
+     • prepare_delegation  → stamps task.verificationSequence     (prepare-delegation.ts:405)
+     • resolvePolicySkip   → gate self-skip decision              (gate-utils.ts)
+     • playbooks           → gate-name references
+   Severity stays on the EXISTING surface: review.gates / review.dimensions
+   (resolveGateSeverity), extended only with workflow-type awareness (oneshot → warning).
+```
+
+The six policy cells are `(low|medium|high) × (base|boundary)`. Resolution is **cell-wise full
+replacement**: a configured cell wins verbatim; an absent cell falls back to the built-in cell
+(which for boundary cells is the slice-1 base+append result). No delta merging (`add:`/
+`remove:` forms) — replacement is explicit, deterministic, and trivially diffable, mirroring
+how `toolchains:` entries override built-ins wholesale rather than patching them.
+
+## Technical Design
+
+### 4.1 `verification:` config block
+
+New top-level key in `ProjectConfigSchema` (`config/yaml-schema.ts`) — **not**
+`ExarchosConfigSchema` (`exarchos-config-schema.ts`), because the consumers
+(`prepare_delegation`, gates) read `ResolvedProjectConfig` from `config/resolve.ts`:
+
+```yaml
+verification:
+  policy:                      # all keys optional; absent cell → built-in cell
+    low: [check_static_analysis]
+    medium: [check_static_analysis, check_test_adequacy]
+    high: [check_static_analysis, check_test_adequacy, check_integration_suite]
+    boundary:                  # boundaryTouching = true cells
+      low: [check_static_analysis, check_contract_drift]
+      medium: [...]
+      high: [...]
+```
+
+Zod shape: `.strict()` at every level; sequence values `z.array(z.enum(VERIFICATION_GATE_NAMES))`
+with a duplicate-free `.refine`; empty arrays permitted (an explicit "run nothing for this
+cell" is a legitimate consumer decision and is visibly logged by the skip reason, §4.3).
+`GateName`/`VERIFICATION_GATE_NAMES` are imported from `workflow/verification-policy.ts` — the
+single source of truth; the schema must never re-declare the name list. `resolve.ts` threads
+the parsed block onto `ResolvedProjectConfig.verification` with `DEFAULTS.verification =
+{ policy: {} }` (empty override layer). Unknown gate names fail at parse time with the standard
+Zod error envelope — config validation, not gate-time surprise.
+
+**Plan-time verify:** the repo's `.exarchos.yml` already carries keys (`review:`, `agents:`)
+unknown to the strict `ExarchosConfigSchema`, so the toolchain loader demonstrably tolerates
+foreign top-level keys; confirm the same holds for `verification:` on that path (a
+`RepoConfig`-style round-trip test).
+
+### 4.2 `resolveVerificationPolicy` — the layered resolver
+
+New sibling module `workflow/verification-policy-resolver.ts` (the slice-1 table module stays
+byte-for-byte config-free, honoring its own header contract). Exported surface:
+
+```ts
+resolveVerificationPolicy(
+  riskTier: RiskTier,
+  boundaryTouching: boolean,
+  config?: ResolvedProjectConfig,
+): { sequence: readonly GateName[]; source: 'builtin' | 'config' }
+```
+
+Synchronous and pure over its inputs — same discipline as `resolveTestRuntime` (layered,
+per-field, no I/O). `config` absent or cell unset → delegate to
+`resolveVerificationSequence(tier, boundary)` with `source: 'builtin'`; cell set → the
+configured array verbatim (frozen) with `source: 'config'`. The `source` discriminant is not
+decoration: it flows into the gate-skip reason (§4.3) and the doctor visibility surface (§4.7),
+so an operator can always answer "why did/didn't this gate run?" from the output alone
+(INV-5b honesty). The resolver is the **only** module that composes config with the table;
+every consumer call site imports it rather than `resolveVerificationSequence` directly —
+preventing the stamp-vs-skip desync hazard (§5).
+
+Unit tests: cell-wise override wins / absent-cell fallback / empty-array cell / frozen output /
+`source` correctness — plus a property-style sweep asserting that with no config the resolver
+is extensionally identical to the slice-1 table for all six cells (the "additive, no behavior
+change by default" acceptance line of #1517).
+
+### 4.3 Consumer rewiring
+
+Three call sites move from the frozen table to the resolver, none changing shape:
+
+1. **`prepare_delegation`** (`orchestrate/prepare-delegation.ts:405`): the
+   `verificationSequence` stamp becomes `resolveVerificationPolicy(riskTier, boundaryTouching,
+   config).sequence`. The `TaskClassification` field type is unchanged (`readonly GateName[]`),
+   so delegation records, dispatch prompts, and `next_actions` carry resolved sequences with
+   zero schema churn — and zero new action input fields (sidestepping the
+   `buildRegistrationSchema` collision trap entirely).
+2. **`resolvePolicySkip`** (`orchestrate/gate-utils.ts`): gains an optional `config` parameter
+   and resolves through the same resolver. The skip reason string is extended with the policy
+   source: `"…(sequence: …, policy: config)"` so a config-induced skip is never mistaken for a
+   built-in decision. Absent-stamp behavior is preserved exactly (both stamps required, else
+   run unconditionally).
+3. **Playbooks** (`workflow/playbooks.ts`): continue referencing gate names through the policy
+   surface, never literals — audit during implementation that no slice-1 reference bypasses the
+   resolver.
+
+R7's tier-conditional prompt assembly already reads the stamped sequence off the delegation
+record, so it inherits config-resolved policy with no change — verify with one characterization
+test rather than new plumbing.
+
+### 4.4 Per-workflow severity (oneshot → advisory)
+
+#1517's acceptance requires gate sequencing to respect per-workflow severity (oneshot
+advisory). Severity already has a home — `resolveGateSeverity` layering `review.gates[gate]` >
+`review.dimensions[dim]` > blocking — and slice 1 already seeds ladder-gate defaults into
+`DEFAULTS.review.gates`. We extend that resolution with one workflow-aware layer rather than
+growing a parallel severity surface under `verification:`: `resolveGateSeverity` (or a thin
+wrapper taking `workflowType`) resolves verification-ladder gates to `warning` when
+`workflowType === 'oneshot'` **unless** an explicit `review.gates[gate]` override says
+otherwise — explicit config always wins, mirroring the invariants catalog's
+`severity.by-workflow` precedent. The workflow-type → default-severity fact is expressed as a
+data table in the severity module (INV-6: data, not branching prose in skills).
+
+**Non-goal — per-tier severity** (e.g. `check_test_adequacy` blocking at high but warning at
+medium): the tier axis already controls *whether* a gate runs (the sequence); severity controls
+*how hard a failure lands*. Crossing the two axes multiplies the config surface without a
+driving use case in the epic or research docs. If a real consumer need appears, it composes
+onto `review.gates` later without breaking this shape.
+
+### 4.5 R9 — DesiredState + detect + seed (commands only)
+
+`ResolvedCommandsSchema` (`core/onboarding/types.ts`) grows `mutation: z.string().optional()`
+and `lint: z.string().optional()` — same optionality semantics as the existing fields (the
+layered resolver may leave any field unresolved). `detectDesiredState` switches its resolution
+call from `resolveTestRuntime` to the slice-1 `resolveVerificationRuntime` (same module, wider
+field set, same tier order), populating the new fields. The diff step then naturally emits a
+`config`-kind PlanStep when resolved commands are missing from `.exarchos.yml`, and `apply` /
+`doctor --fix` seeds them — **the same seed path test/typecheck use today**, no new step kinds,
+no new surfaces (INV-2: one reconciler core, two callers).
+
+Seeding commands is correct where seeding policy would not be: a seeded command is the
+operator's explicit tier-2 declaration the resolver honors above detection — onboarding's whole
+purpose — and it goes stale only if the repo's toolchain changes (which `doctor` re-detects).
+A seeded *policy default* would freeze today's built-in table into consumer config, silently
+diverging as the built-in evolves — the gen-time-placeholder trap (#1483) in config form.
+Accordingly, this design **reframes** #1524's "DesiredState carries verification-policy
+defaults" line: the resolved policy is surfaced read-only through doctor (§4.7) for
+visibility/drift purposes; `apply` never writes a `verification:` block. The reframe is recorded
+on the issue at synthesis time.
+
+### 4.6 Doctor check — `verification-toolchain`
+
+New `orchestrate/doctor/checks/verification-toolchain.ts`, registered in `ALL_CHECKS`
+(`doctor/index.ts`), following the established probe-based `CheckFn` contract
+(cf. `invariants-catalog.ts`). The probe calls `resolveVerificationRuntime` for the repo and
+reports per-field resolvability — today **no** doctor check covers this (confirmed gap; the
+ladder's gates degrade silently to skipped/advisory when commands don't resolve).
+
+Status mapping (final wording at plan time): **Pass** — `test`, `typecheck`, and `mutation` all
+resolve (the #1524 acceptance triple; `lint` named informationally); **Warning** — any of the
+triple unresolved, with `fix:` naming the two remedies (`doctor --fix` to seed what detection
+found; or declare the field in `.exarchos.yml` / `toolchains:` for toolchains detection can't
+see); **Skipped** — no toolchain detectable at all (empty repo), with the reason naming what
+detection looked for. The check's detail payload also carries the **resolved policy source**
+per cell (`builtin`/`config` from §4.2) — this is the read-only policy visibility that replaces
+config seeding (§4.5). Like every check it is read-only; the *fix* path is the reconciler's,
+keeping detect/diff/apply as the single mutation surface (INV-2).
+
+### 4.7 T0 characterization
+
+Before any reconciler/doctor extension lands: characterization tests pinning (a) the current
+12-check doctor roster output shape (names, categories, status vocabulary) and (b) the current
+`DesiredState`/`ReconcilePlan` shapes for a representative fixture repo — written against the
+real loader/reconciler (per the dev-catalog precedent: test file-writers by re-parsing through
+the real loader, not against hand-built literals). These tests are the safety net the epic's
+test plan requires ("Feathers characterization … before any demotion/fold") and double as the
+regression harness for the `ResolvedCommandsSchema` widening — the existing-field behavior must
+be byte-identical after the slice.
+
+## 5. Conformance summary & known hazards
+
+| Surface | Invariants | Note |
+|---|---|---|
+| `verification:` block | INV-5a, INV-6 | Strict Zod, enum-constrained names; policy as config data |
+| Policy resolver | INV-6, INV-1, INV-4 | Pure layering; table untouched; resolve-never-bake |
+| Consumer rewiring | INV-12, INV-5b | Same stamp shape; skip reasons carry policy source |
+| Per-workflow severity | INV-6 | Data table in severity module; explicit config wins |
+| DesiredState/seed | INV-2, INV-4 | One reconciler core; commands seeded, policy never |
+| Doctor check | INV-2, INV-5b | Read-only; fix path stays in reconciler |
+
+**Hazards (named traps from the repo's memory):**
+
+- **Stamp-vs-skip desync** — if any call site keeps importing `resolveVerificationSequence`
+  directly while others use the resolver, a configured override skips gates the stamp promised
+  (or vice versa). Mitigation: the resolver is the only composing module; an ESLint-able grep
+  in review (`resolveVerificationSequence(` outside the resolver + table tests) plus a
+  round-trip test stamping and skipping under the same config.
+- **Registration-schema field collision** — no orchestrate action gains new input fields in
+  this slice; if the plan introduces any (it should not), field name+type must match across
+  actions or `buildRegistrationSchema` throws at MCP startup.
+- **Composite dispatch handler gap** — N/A by construction: zero new actions. State explicitly
+  in the plan so no task invents one.
+- **Two-schema config split** — `verification:` goes in `yaml-schema.ts` only; adding it to the
+  strict `ExarchosConfigSchema` too would create a second parse authority (and the loaders'
+  unknown-key tolerance needs the §4.1 round-trip test).
+- **Doctor roster count** — #1524 says "12th check" but the roster already has 12 (it predates
+  `invariants-catalog`); the design adds the 13th. Cosmetic, but fix the issue text at
+  synthesis so the docs don't ship a wrong count.
+
+## 6. Acceptance & test plan
+
+- Default policy resolution extensionally identical to slice 1's table when no
+  `verification:` block is configured (property sweep over all six cells) — #1517's "additive"
+  line.
+- `.exarchos.yml` override unit tests: cell replacement, absent-cell fallback, empty cell,
+  unknown-gate parse rejection, duplicate rejection.
+- Oneshot workflows resolve ladder-gate failures to advisory unless explicitly overridden;
+  feature workflows unchanged.
+- Stamp/skip round-trip: a configured cell produces matching `verificationSequence` stamps and
+  `resolvePolicySkip` decisions, with `policy: config` in the skip reason.
+- R9: `detectDesiredState` resolves `mutation`/`lint`; `doctor --fix` seeds them; re-run is
+  idempotent (empty plan). T0 characterization green before and after.
+- `verification-toolchain` check: Pass/Warning/Skipped mapping unit-tested through
+  `handleDoctorWithChecks` (dispatch-through, per the handler-gap lesson).
+- Full: `npm run test:run` (root + `servers/exarchos-mcp`), `npm run typecheck`,
+  `npm run lint:invariants` green.

--- a/docs/guides/exarchos-yml-verification.md
+++ b/docs/guides/exarchos-yml-verification.md
@@ -1,0 +1,78 @@
+# `.exarchos.yml` — the `verification:` block
+
+Overrides the verification ladder's **gate sequences** per policy cell. Ships with
+v2.11.0 (epic #1515, R2/#1517). Without this block, the built-in ladder applies —
+declaring it is always optional and always additive.
+
+## The policy model
+
+Every delegated task carries two orthogonal classification signals (derived
+mechanically, or set explicitly in the plan):
+
+- `riskTier` — `low | medium | high` blast radius
+- `boundaryTouching` — whether the task crosses an I/O / schema boundary
+
+The pair selects one of **six policy cells**, each resolving to an ordered list of
+verification gate names. The built-in table (the substrate default,
+`workflow/verification-policy.ts`):
+
+| Cell | Sequence |
+|---|---|
+| low | `check_static_analysis` |
+| medium | `check_static_analysis → check_test_adequacy` |
+| high | `check_static_analysis → check_test_adequacy → check_integration_suite` |
+| low + boundary | low + `check_contract_drift` |
+| medium + boundary | medium + `check_contract_drift → check_mock_boundary` |
+| high + boundary | high + `check_contract_drift → check_mock_boundary` |
+
+## Overriding cells
+
+```yaml
+verification:
+  policy:
+    medium: [check_static_analysis, check_test_adequacy, check_contract_drift]
+    boundary:
+      low: [check_static_analysis, check_contract_drift]
+```
+
+Semantics:
+
+- **Cell-wise full replacement.** A configured cell wins verbatim; an absent cell
+  falls back to the built-in cell. There is no add/remove delta merging.
+- **Gate names are schema-constrained** to the registered gate set
+  (`check_static_analysis`, `check_test_adequacy`, `check_integration_suite`,
+  `check_contract_drift`, `check_mock_boundary`). An unknown name or a duplicate
+  within a cell fails at config parse, not at gate time.
+- **An explicit empty cell is valid** — `medium: []` means "run no ladder gates
+  for medium-tier non-boundary tasks." The skip is visible: gate results carry
+  the policy source in their skip reason (`policy: config`).
+- **Resolution is observable.** The `verification-toolchain` doctor check reports
+  each cell's source (`builtin` vs `config`), and every gate skipped by policy
+  names the resolved sequence and its source.
+
+## Per-workflow severity
+
+Verification-ladder gate failures resolve to **advisory (warning)** for `oneshot`
+workflows by default; `feature` / `debug` / `refactor` workflows keep blocking
+semantics. An explicit per-gate severity override (`review.gates.<gate>`) always
+wins over the workflow default. Severity stays on the existing `review:` surface —
+the `verification:` block governs *which gates run*, not *how hard they fail*.
+
+## What is deliberately NOT here
+
+- **No policy seeding.** `onboard` / `doctor --fix` seed resolved *commands*
+  (`test:`, `typecheck:`, `mutation:`, `lint:`) into `.exarchos.yml`, but never
+  write a `verification:` block. Seeding policy would freeze today's built-in
+  defaults into your repo and silently diverge as the substrate evolves — policy
+  resolves at runtime, every run.
+- **No custom gate names.** Sequences compose the registered gates only.
+- **No per-tier severity.** The tier axis controls whether a gate runs; severity
+  controls how hard a failure lands. They don't cross.
+
+## See also
+
+- [`toolchain-resolution.md`](toolchain-resolution.md) — how the ladder's
+  commands (`test`/`typecheck`/`mutation`/`lint`/`contract`) resolve.
+- `docs/designs/2026-06-11-verification-ladder-slice2.md` — the design this
+  block shipped with (R2 #1517 + R9 #1524).
+- `docs/designs/2026-06-09-verification-ladder-slice1.md` — the ladder itself.

--- a/docs/guides/exarchos-yml-verification.md
+++ b/docs/guides/exarchos-yml-verification.md
@@ -1,8 +1,11 @@
 # `.exarchos.yml` — the `verification:` block
 
 Overrides the verification ladder's **gate sequences** per policy cell. Ships with
-v2.11.0 (epic #1515, R2/#1517). Without this block, the built-in ladder applies —
-declaring it is always optional and always additive.
+v2.11.0 (epic #1515, R2/#1517). Without this block, the built-in ladder applies.
+Declaring it is optional, and resolution is per cell: each cell you specify **fully
+replaces** the built-in sequence for that cell (replacement, not a merge — the
+sequence you write is the sequence that runs), while every cell you omit keeps its
+built-in default.
 
 ## The policy model
 

--- a/docs/guides/toolchain-resolution.md
+++ b/docs/guides/toolchain-resolution.md
@@ -1,9 +1,18 @@
 # Toolchain & command resolution
 
-Exarchos resolves a repository's **test / typecheck / install** commands through a
-layered resolver. Universality comes from the *strategy*, not from a baked-in list
-of languages: a built-in convention table covers the common ecosystems, and two
-declaration tiers let any toolchain work with zero changes to Exarchos.
+Exarchos resolves a repository's **test / typecheck / install** commands — and,
+since the verification ladder (epic #1515), the wider **mutation / lint** field
+set via `resolveVerificationRuntime` — through a layered resolver. Universality
+comes from the *strategy*, not from a baked-in list of languages: a built-in
+convention table covers the common ecosystems, and two declaration tiers let any
+toolchain work with zero changes to Exarchos.
+
+Onboarding consumes the same resolver: `exarchos onboard` / `doctor --fix`
+resolve the full verification field set and seed resolved-but-undeclared
+`mutation:` / `lint:` commands into `.exarchos.yml` (commands only — the
+verification *policy* is never written into consumer config; it resolves at
+runtime, see [`exarchos-yml-verification.md`](exarchos-yml-verification.md)).
+The `verification-toolchain` doctor check reports per-field resolvability.
 
 ## Precedence (highest wins, per field)
 

--- a/docs/guides/toolchain-resolution.md
+++ b/docs/guides/toolchain-resolution.md
@@ -19,14 +19,18 @@ The `verification-toolchain` doctor check reports per-field resolvability.
 | # | Tier | Source | When it fires |
 |---|------|--------|---------------|
 | 1 | **override** | dispatch argument | a caller passes an explicit command |
-| 2 | **config** | `.exarchos.yml` `test:` / `typecheck:` / `install:` | you declare the command directly |
+| 2 | **config** | `.exarchos.yml` `test:` / `typecheck:` / `install:` / `mutation:` / `lint:` | you declare the command directly |
 | 3 | **toolchain-config** | `.exarchos.yml` `toolchains:` | a user-declared toolchain's marker matches the repo |
 | 4 | **task-runner** | `Taskfile.yml` · `justfile` · `mise.toml` · `Makefile` | a committed runner declares the conventional target |
 | 5 | **detection** | built-in toolchain registry | a built-in marker matches (node, .NET, Rust, Go, Python, Java, Ruby, PHP, Elixir, Swift, C/C++) |
 | — | unresolved | — | nothing matched → actionable remediation |
 
-Resolution is **per field**: `test` may come from a task runner while `install`
-falls through to the built-in registry.
+Resolution is **per field** across the whole verification surface — `test`,
+`typecheck`, `install`, `mutation`, and `lint` each resolve through the same five
+tiers independently: `test` may come from a task runner while `install` falls
+through to the built-in registry, and `mutation` / `lint` follow the identical
+precedence (a `.exarchos.yml` `mutation:` pin beats a task-runner target beats the
+built-in registry default).
 
 ## Built-in toolchains (tier 5)
 

--- a/docs/plans/2026-06-11-verification-ladder-slice2.md
+++ b/docs/plans/2026-06-11-verification-ladder-slice2.md
@@ -1,0 +1,289 @@
+# Implementation Plan: Verification Ladder — Slice 2 (R2 + R9)
+
+## Source Design
+Link: `docs/designs/2026-06-11-verification-ladder-slice2.md`
+
+## Scope
+**Target:** Full design — R2 config-resolved policy (#1517) + R9 onboarding integration (#1524)
+**Excluded:** R5 (#1520), R6 (#1521), R10 (#1525), SIV-3 Layer B, SIV-5/6/7, custom gate names, per-tier severity, policy seeding into consumer config — all explicitly out of scope per design §1.
+
+## Summary
+- Total tasks: 10
+- Parallel groups: Bundle A (R2) and Bundle B (R9) run concurrently; serialization points only inside each bundle
+- Estimated test count: ~38
+- Design coverage: §3, §4.1–§4.7, §5, §6 (see traceability table)
+
+## Conventions
+- All MCP-server code/tests under `servers/exarchos-mcp/src/` (prefix omitted below); test command `cd servers/exarchos-mcp && npm run test:run`.
+- **Zero new orchestrate actions and zero new action input fields** in this slice (design §5). Any task tempted to add one is out of spec — gates resolve `workflowType` from the state projection via `resolveWorkflowState`, never from new action args.
+- Doctor-check tests run **through `handleDoctorWithChecks`** (dispatch-through; DOA-trap lesson) in addition to any direct `CheckFn` unit tests.
+- High-blast tasks (001, 007 — type reshapes of `ResolvedProjectConfig` / `ResolvedCommandsSchema`): run the **full root + MCP suite** before merging their branches (per-task scope is too narrow for schema reshapes).
+- Workflow state reads in gate handlers use `resolveWorkflowState` (event-store-backed), never `.state.json` presence.
+
+## Spec Traceability
+
+| Design section | Requirement | Tasks |
+|---|---|---|
+| §4.1 `verification:` config block | strict Zod block in ProjectConfigSchema; enum-constrained gate names; resolve.ts threading; foreign-key tolerance round-trip | 001 |
+| §4.2 policy resolver | `resolveVerificationPolicy` layering config over frozen table; `source` discriminant; extensional-equivalence sweep | 002 |
+| §4.3 consumer rewiring | prepare_delegation stamp; resolvePolicySkip + source in skip reason; playbook audit; single-composer guard | 003, 004 |
+| §4.4 per-workflow severity | oneshot → warning data table; explicit gate override wins; workflowType from state projection | 005 |
+| §4.5 DesiredState + seed | ResolvedCommandsSchema +mutation/lint; detect via resolveVerificationRuntime; diff/apply seeding; idempotence | 007, 008 |
+| §4.6 doctor check | verification-toolchain CheckFn + probe + ALL_CHECKS; Pass/Warning/Skipped mapping; policy-source visibility | 009 |
+| §4.7 T0 characterization | doctor roster + DesiredState/ReconcilePlan shape pinning via real loader | 006 |
+| §5 hazards | stamp/skip desync guard; two-schema split; no new actions | 001, 004 (woven) |
+| §6 acceptance | end-to-end override round-trip; onboard seed acceptance | 004, 008 |
+
+## Task Breakdown
+
+### Task 001: `verification:` config block (ProjectConfigSchema + resolve.ts)
+
+**Phase:** RED → GREEN → REFACTOR
+**Test Layer:** unit
+**Risk Tier:** high
+**Boundary Touching:** false
+**Implements:** design §4.1
+
+**TDD Steps:**
+1. [RED] Write tests:
+   - `ProjectConfigSchema_VerificationPolicyValidCells_Parses` — all six cells accepted
+   - `ProjectConfigSchema_VerificationUnknownGateName_RejectsAtParse`
+   - `ProjectConfigSchema_VerificationDuplicateGateInCell_Rejects`
+   - `ProjectConfigSchema_VerificationUnknownKey_RejectsStrict`
+   - `ProjectConfigSchema_VerificationEmptyCellArray_Parses` (explicit "run nothing")
+   - `ResolveConfig_NoVerificationBlock_DefaultsToEmptyOverlay` (`resolved.verification.policy` = `{}`)
+   - `ExarchosConfigSchema_ForeignVerificationKey_ToleratedOnToolchainPath` (§4.1 round-trip: the toolchain loader keeps working on a `.exarchos.yml` carrying `verification:`)
+   - File: `config/yaml-schema.test.ts`, `config/resolve.test.ts`, `config/test-runtime-resolver.test.ts`
+   - Expected failure: `verification` is an unknown strict key / `resolved.verification` undefined
+2. [GREEN] Implement:
+   - `config/yaml-schema.ts` — `VerificationConfig` block (`.strict()`, `z.array(z.enum(VERIFICATION_GATE_NAMES))` + duplicate-free `.refine`, six optional cells: `low|medium|high` + `boundary.{low|medium|high}`); gate-name source imported from `workflow/verification-policy.ts` — never re-declared
+   - `config/resolve.ts` — thread onto `ResolvedProjectConfig.verification`; `DEFAULTS.verification = { policy: {} }`
+3. [REFACTOR] Single type for "policy overlay" shared by schema output and resolver input
+
+**Verification:**
+- [ ] Witnessed parse-rejection failures for the right reasons
+- [ ] Full root + MCP suite green (high-blast: `ResolvedProjectConfig` reshape)
+
+**Dependencies:** None
+**Parallelizable:** Yes (with 006)
+
+### Task 002: `resolveVerificationPolicy` layered resolver
+
+**Phase:** RED → GREEN → REFACTOR
+**Test Layer:** unit + property
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** design §4.2
+
+**TDD Steps:**
+1. [RED] Write tests in `workflow/verification-policy-resolver.test.ts`:
+   - `ResolveVerificationPolicy_NoConfig_DelegatesToBuiltinTable` (source `'builtin'`)
+   - `ResolveVerificationPolicy_ConfiguredCell_WinsVerbatim` (source `'config'`)
+   - `ResolveVerificationPolicy_AbsentCell_FallsBackPerCell` (mixed config: one cell set, others builtin)
+   - `ResolveVerificationPolicy_EmptyCell_ResolvesToEmptySequence`
+   - `ResolveVerificationPolicy_Output_IsFrozen`
+   - `ResolveVerificationPolicy_NoConfigSweep_ExtensionallyEqualsSlice1Table` (property sweep over all six cells — #1517's "additive, no default behavior change" line)
+   - Expected failure: module does not exist
+2. [GREEN] Implement `workflow/verification-policy-resolver.ts` — synchronous, pure; signature per design §4.2; the **only** module composing config with the table. `workflow/verification-policy.ts` stays byte-identical.
+3. [REFACTOR] None expected
+
+**Verification:**
+- [ ] Slice-1 table module untouched (`git diff --stat` shows no change to `verification-policy.ts`)
+
+**Dependencies:** 001
+**Parallelizable:** Yes (with 005, 007)
+
+### Task 003: Rewire `prepare_delegation` stamp to the resolver
+
+**Phase:** RED → GREEN
+**Test Layer:** integration
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** design §4.3.1
+
+**TDD Steps:**
+1. [RED] Write tests in `orchestrate/prepare-delegation.test.ts`:
+   - `ClassifyTask_ConfiguredPolicyCell_StampsConfigResolvedSequence`
+   - `ClassifyTask_NoVerificationConfig_StampsBuiltinSequence` (characterization: byte-identical to slice-1 behavior)
+   - Expected failure: stamp still comes from the frozen table, ignores config
+2. [GREEN] `orchestrate/prepare-delegation.ts:405` — swap `resolveVerificationSequence(riskTier, boundaryTouching)` for `resolveVerificationPolicy(riskTier, boundaryTouching, config).sequence`; thread `config` through `classifyTask`'s existing config access. `TaskClassification` field type unchanged.
+
+**Verification:**
+- [ ] R7 prompt assembly inherits resolved sequence (one characterization test reading the stamped delegation record)
+
+**Dependencies:** 002
+**Parallelizable:** Yes (with 004, 008)
+
+### Task 004: Rewire `resolvePolicySkip` + round-trip consistency + single-composer guard
+
+**Phase:** RED → GREEN
+**Test Layer:** integration (acceptance for the round-trip)
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** design §4.3.2, §4.3.3, §5 stamp-vs-skip hazard, §6 round-trip acceptance
+
+**TDD Steps:**
+1. [RED] Write tests in `orchestrate/gate-utils.test.ts` (+ a repo-conformance test file):
+   - `ResolvePolicySkip_ConfiguredCellExcludesGate_SkipsWithConfigSource` (reason contains `policy: config`)
+   - `ResolvePolicySkip_BuiltinDecision_ReasonNamesBuiltinSource`
+   - `ResolvePolicySkip_PartialStamp_StillRunsUnconditionally` (preserved behavior)
+   - `StampAndSkip_SameConfig_NeverDisagree` — acceptance round-trip: for every (tier, boundary, config-variant), the stamped sequence and the per-gate skip decisions are consistent
+   - `RepoConformance_ResolveVerificationSequence_OnlyImportedByResolverAndTableTests` — source-level guard (grep over `src/**`) preventing the stamp-vs-skip desync hazard
+   - Expected failure: skip ignores config; reason lacks source; guard finds the old direct imports
+2. [GREEN] `orchestrate/gate-utils.ts` — `resolvePolicySkip` gains optional `config`; resolves via `resolveVerificationPolicy`; reason string extended with policy source. Audit `workflow/playbooks.ts` references ride the policy surface (no literals).
+
+**Verification:**
+- [ ] Guard test fails if anyone re-imports the frozen table directly
+
+**Dependencies:** 002 (003 for the round-trip assertions)
+**Parallelizable:** Yes (with 003, 008)
+
+### Task 005: Per-workflow severity — oneshot → advisory
+
+**Phase:** RED → GREEN
+**Test Layer:** unit + integration
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** design §4.4
+
+**TDD Steps:**
+1. [RED] Write tests in `orchestrate/gate-severity.test.ts` + one ladder-gate dispatch test:
+   - `ResolveGateSeverity_OneshotLadderGate_DefaultsToWarning`
+   - `ResolveGateSeverity_OneshotWithExplicitGateOverride_OverrideWins` (`review.gates[gate]` beats the workflow default)
+   - `ResolveGateSeverity_FeatureWorkflow_UnchangedResolution` (characterization)
+   - `ResolveGateSeverity_NoWorkflowType_UnchangedResolution` (param optional; legacy callers unaffected)
+   - `HandleOrchestrate_OneshotTestAdequacyFailure_ResolvesAdvisory` — dispatch-through: gate handler resolves workflowType via `resolveWorkflowState(featureId)`, failure converts to warning
+   - Expected failure: severity resolution has no workflow layer
+2. [GREEN] `orchestrate/gate-severity.ts` — `WORKFLOW_DEFAULT_SEVERITY` data table (`{ oneshot: 'warning' }`, INV-6: data not prose); `resolveGateSeverity` gains optional `workflowType` param; resolution order: gate-level override > workflow default > dimension > blocking. Ladder-gate dispatch branches resolve workflowType from the state projection (fallback `'feature'`, mirroring `check_invariant_conformance`). **No new action input fields.**
+
+**Verification:**
+- [ ] Non-ladder gates and existing callers byte-identical (no `workflowType` → old behavior)
+
+**Dependencies:** 001
+**Parallelizable:** Yes (with 002, 007)
+
+### Task 006: T0 characterization — doctor roster + reconciler shapes
+
+**Phase:** RED-as-pin (characterization: written to PASS against current behavior before any change)
+**Test Layer:** integration
+**Risk Tier:** low
+**Boundary Touching:** false
+**Implements:** design §4.7
+
+**TDD Steps:**
+1. [PIN] Write characterization tests:
+   - `DoctorRoster_CurrentBuild_ExactlyTwelveChecksWithStableNames` — names + categories + status vocabulary pinned
+   - `DetectDesiredState_FixtureRepo_CurrentShape` — `DesiredState`/`ReconcilePlan` for a representative fixture, exercised **through the real loader/reconciler** (no hand-built literals)
+   - File: `orchestrate/doctor/doctor-roster.characterization.test.ts`, `core/onboarding/reconcile.characterization.test.ts`
+   - Run: MUST PASS against HEAD (this is the pin, not a failing-first test)
+2. [GREEN] N/A — no production change in this task
+
+**Verification:**
+- [ ] Tests green on unmodified HEAD; committed before 007/009 branch off
+
+**Dependencies:** None
+**Parallelizable:** Yes (with 001)
+
+### Task 007: `ResolvedCommandsSchema` + `detectDesiredState` widening
+
+**Phase:** RED → GREEN
+**Test Layer:** integration
+**Risk Tier:** high
+**Boundary Touching:** false
+**Implements:** design §4.5 (detect half)
+
+**TDD Steps:**
+1. [RED] Write tests in `core/onboarding/reconcile.detect.test.ts` + `types.test.ts`:
+   - `ResolvedCommandsSchema_MutationAndLint_Optional`
+   - `DetectDesiredState_NodeFixtureWithStryker_ResolvesMutationCommand`
+   - `DetectDesiredState_UnresolvableMutation_LeavesFieldAbsent`
+   - `DetectDesiredState_ExistingFields_ByteIdenticalToT0Pin` (against task 006's pin)
+   - Expected failure: schema lacks the fields; detect still calls `resolveTestRuntime`
+2. [GREEN] `core/onboarding/types.ts` — `ResolvedCommandsSchema` + `mutation`/`lint` (optional); `core/onboarding/reconcile.ts:26,105-107` — swap `resolveTestRuntime` → `resolveVerificationRuntime`, copy the two new fields (same `!== null` pattern).
+
+**Verification:**
+- [ ] T0 characterization (006) still green
+- [ ] Full root + MCP suite before merge (high-blast: shared schema widening)
+
+**Dependencies:** 006
+**Parallelizable:** Yes (with 002, 005)
+
+### Task 008: diff/apply seeding for `mutation`/`lint` + idempotence
+
+**Phase:** RED → GREEN
+**Test Layer:** integration (acceptance for the onboard round-trip)
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** design §4.5 (seed half), §6 acceptance
+
+**TDD Steps:**
+1. [RED] Write tests in `core/onboarding/reconcile.diff.test.ts` / `reconcile.apply.test.ts`:
+   - `Diff_ResolvedMutationMissingFromConfig_EmitsConfigStep`
+   - `Apply_MutationConfigStep_SeedsExarchosYml` — re-parse the written file **through the real loader** and assert the resolver now returns it at tier 2
+   - `Apply_ReRunAfterSeed_EmptyPlanIdempotent`
+   - `Apply_NeverWritesVerificationPolicyBlock` — the §4.5 negative guarantee (gen-time bake trap)
+   - Expected failure: diff/apply only know test/typecheck/install
+2. [GREEN] Extend the existing config-step generation/write path in `core/onboarding/reconcile.ts` to the widened field set — same `config`-kind PlanStep, no new step kinds.
+
+**Verification:**
+- [ ] `doctor --fix` path covered via the reconciler entry used by doctor (one reconciler core, two callers — INV-2)
+
+**Dependencies:** 007
+**Parallelizable:** Yes (with 003, 004)
+
+### Task 009: Doctor check `verification-toolchain`
+
+**Phase:** RED → GREEN
+**Test Layer:** integration
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** design §4.6
+
+**TDD Steps:**
+1. [RED] Write tests in `orchestrate/doctor/checks/verification-toolchain.test.ts` + roster test:
+   - `VerificationToolchain_AllTripleResolves_Pass` (test + typecheck + mutation)
+   - `VerificationToolchain_MutationUnresolved_WarningWithBothRemedies` (fix names `doctor --fix` and `.exarchos.yml`/`toolchains:`)
+   - `VerificationToolchain_NoToolchainDetected_SkippedWithReason`
+   - `VerificationToolchain_DetailPayload_CarriesPolicySourcePerCell` (read-only visibility, §4.6)
+   - `HandleDoctorWithChecks_RosterIncludesVerificationToolchain_ThirteenChecks` — dispatch-through; updates task 006's pinned count deliberately (12 → 13, the one intended roster change)
+   - Expected failure: check module absent; roster has 12
+2. [GREEN] New `orchestrate/doctor/checks/verification-toolchain.ts` (probe-based `CheckFn` per `invariants-catalog.ts` shape; probe wraps `resolveVerificationRuntime` + `resolveVerificationPolicy` source map); register in `doctor/index.ts` `ALL_CHECKS`.
+
+**Verification:**
+- [ ] Check is read-only; fix path remains the reconciler's (INV-2)
+
+**Dependencies:** 007 (+ 002 for the policy-source payload)
+**Parallelizable:** No (serializes after 007 within Bundle B)
+
+### Task 010: Docs ride-along
+
+**Phase:** N/A (docs-only)
+**Test Layer:** none
+**Risk Tier:** low
+**Boundary Touching:** false
+**Implements:** design §1, §4.5 reframe note, §5 roster-count note
+
+**Steps:**
+1. Document the `verification:` block (cells, replacement semantics, enum constraint, empty-cell meaning) in the configuration guide (`docs/guides/` — co-locate with the existing `exarchos-yml-invariants.md` pattern).
+2. Note in `docs/guides/toolchain-resolution.md` that onboarding now resolves the widened verification field set.
+3. Draft the #1524 issue comment recording the design reframe (policy surfaced read-only via doctor, never seeded) and the 12→13 roster-count correction — posted at synthesis.
+
+**Dependencies:** None (content finalized after 004/009 settle wording)
+**Parallelizable:** Yes
+
+## Parallelization Strategy
+
+```
+Group 1 (start immediately, parallel):   001 (R2 config)   006 (T0 pin)   010 (docs draft)
+Group 2 (after 001 / 006):               002, 005          007
+Group 3 (after 002 / 007):               003, 004          008, 009
+Merge order: high-blast tasks 001 and 007 merge with full-suite verification;
+             004's round-trip + guard land last in Bundle A; 009 last in Bundle B.
+```
+
+Bundle A (001→002→{003,004},005) and Bundle B (006→007→{008,009}) share no files; fully concurrent. Integration branch: `feature/verification-ladder-slice2`; task branches `task/NNN-<slug>` off the integration branch (never `main`).
+
+## Deferred Items
+
+- R5/R6/R10, SIV-3 Layer B, SIV-5/6/7 — later slices per epic phasing.
+- `devCatalog` boolean retirement, custom gate names, per-tier severity — recorded non-goals.

--- a/servers/exarchos-mcp/src/config/resolve.test.ts
+++ b/servers/exarchos-mcp/src/config/resolve.test.ts
@@ -306,4 +306,43 @@ describe('resolveConfig', () => {
       expect(() => { (resolved.agents as Record<string, unknown>).defaultModel = 'haiku'; }).toThrow();
     });
   });
+
+  describe('verification resolution', () => {
+    it('ResolveConfig_NoVerificationBlock_DefaultsToEmptyOverlay', () => {
+      // A config with no `verification:` block resolves to an empty override
+      // layer — `policy` is `{}` so the later resolver layers nothing over the
+      // frozen base policy table.
+      const resolved = resolveConfig({});
+      expect(resolved.verification).toBeDefined();
+      expect(resolved.verification.policy).toEqual({});
+    });
+
+    it('ResolveConfig_VerificationPolicyOverride_ThreadsOntoResolved', () => {
+      const resolved = resolveConfig({
+        verification: {
+          policy: {
+            low: ['check_static_analysis'],
+            boundary: { high: ['check_static_analysis', 'check_contract_drift', 'check_mock_boundary'] },
+          },
+        },
+      });
+      expect(resolved.verification.policy.low).toEqual(['check_static_analysis']);
+      expect(resolved.verification.policy.boundary?.high).toEqual([
+        'check_static_analysis',
+        'check_contract_drift',
+        'check_mock_boundary',
+      ]);
+    });
+
+    it('ResolveConfig_VerificationResolved_IsFrozen', () => {
+      const resolved = resolveConfig({ verification: { policy: { low: ['check_static_analysis'] } } });
+      expect(Object.isFrozen(resolved.verification)).toBe(true);
+      expect(Object.isFrozen(resolved.verification.policy)).toBe(true);
+    });
+
+    it('DEFAULTS_CarriesVerificationEmptyOverlay', () => {
+      expect(DEFAULTS.verification).toBeDefined();
+      expect(DEFAULTS.verification.policy).toEqual({});
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/config/resolve.test.ts
+++ b/servers/exarchos-mcp/src/config/resolve.test.ts
@@ -344,5 +344,21 @@ describe('resolveConfig', () => {
       expect(DEFAULTS.verification).toBeDefined();
       expect(DEFAULTS.verification.policy).toEqual({});
     });
+
+    it('ResolveConfig_DoesNotFreezeCallerVerificationOverlay', () => {
+      // The resolved overlay is deep-frozen; the caller's nested input must NOT
+      // be frozen by deepFreeze (mirrors resolveConfig_DoesNotFreezeCallerParams).
+      const cells: string[] = ['check_static_analysis'];
+      const project: ProjectConfig = {
+        verification: { policy: { low: cells as ('check_static_analysis')[], boundary: { high: ['check_contract_drift'] } } },
+      };
+
+      resolveConfig(project);
+
+      expect(Object.isFrozen(cells)).toBe(false);
+      expect(Object.isFrozen(project.verification!.policy!.boundary)).toBe(false);
+      cells.push('check_test_adequacy');
+      expect(cells).toHaveLength(2);
+    });
   });
 });

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -1,4 +1,4 @@
-import type { ProjectConfig } from './yaml-schema.js';
+import type { ProjectConfig, VerificationPolicyOverlay } from './yaml-schema.js';
 
 // ─── Resolved Types ─────────────────────────────────────────────────────────
 
@@ -64,6 +64,16 @@ export interface ResolvedProjectConfig {
     readonly operationThreshold: number;
     readonly enforceOnPhaseTransition: boolean;
     readonly enforceOnWaveDispatch: boolean;
+  };
+  /**
+   * The verification policy-overlay (R2 / task 001) — the per-cell gate-sequence
+   * overrides from `.exarchos.yml`. A config without a `verification:` block
+   * resolves to an empty overlay (`policy: {}`), meaning "override nothing" — the
+   * later resolver layers this over the frozen base policy table. Shares the
+   * `VerificationPolicyOverlay` shape with the YAML schema (single overlay type).
+   */
+  readonly verification: {
+    readonly policy: VerificationPolicyOverlay;
   };
 }
 
@@ -152,6 +162,11 @@ export const DEFAULTS: ResolvedProjectConfig = deepFreeze({
     operationThreshold: 20,
     enforceOnPhaseTransition: true,
     enforceOnWaveDispatch: true,
+  },
+  // Empty override layer: a config without a `verification:` block overrides no
+  // cell, so the resolver later falls through to the frozen base policy table.
+  verification: {
+    policy: {},
   },
 });
 
@@ -313,6 +328,16 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
   const enforceOnPhaseTransition = project.checkpoint?.['enforce-on-phase-transition'] ?? DEFAULTS.checkpoint.enforceOnPhaseTransition;
   const enforceOnWaveDispatch = project.checkpoint?.['enforce-on-wave-dispatch'] ?? DEFAULTS.checkpoint.enforceOnWaveDispatch;
 
+  // ── Verification ──
+  // Thread the parsed policy-overlay through as-is. A missing block (or missing
+  // `policy`) resolves to the empty overlay (`{}`) — "override nothing" — so
+  // the later resolver falls through to the base policy table. The overlay is
+  // a plain validated value; we shallow-clone so deepFreeze does not freeze the
+  // caller's input.
+  const verificationPolicy: VerificationPolicyOverlay = project.verification?.policy
+    ? { ...project.verification.policy }
+    : { ...DEFAULTS.verification.policy };
+
   const resolved: ResolvedProjectConfig = {
     agents: { defaultModel: agentDefaultModel, models: agentModels },
     review: {
@@ -327,6 +352,7 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
     plugins: { impeccable: { enabled: impeccableEnabled } },
     prune: { staleAfterDays, maxBatchSize, phaseExclusions, malformedHandling, requireDryRun },
     checkpoint: { operationThreshold, enforceOnPhaseTransition, enforceOnWaveDispatch },
+    verification: { policy: verificationPolicy },
   };
 
   return deepFreeze(resolved);

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -331,12 +331,14 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
   // ── Verification ──
   // Thread the parsed policy-overlay through as-is. A missing block (or missing
   // `policy`) resolves to the empty overlay (`{}`) — "override nothing" — so
-  // the later resolver falls through to the base policy table. The overlay is
-  // a plain validated value; we shallow-clone so deepFreeze does not freeze the
-  // caller's input.
+  // the later resolver falls through to the base policy table. The overlay
+  // nests (per-cell arrays + a `boundary` sub-policy), so we DEEP-clone before
+  // freezing — `deepFreeze` would otherwise reach through a shallow copy and
+  // freeze the caller's nested arrays/objects (matching the codebase's
+  // don't-freeze-caller-input discipline).
   const verificationPolicy: VerificationPolicyOverlay = project.verification?.policy
-    ? { ...project.verification.policy }
-    : { ...DEFAULTS.verification.policy };
+    ? structuredClone(project.verification.policy)
+    : structuredClone(DEFAULTS.verification.policy);
 
   const resolved: ResolvedProjectConfig = {
     agents: { defaultModel: agentDefaultModel, models: agentModels },

--- a/servers/exarchos-mcp/src/config/test-runtime-resolver.test.ts
+++ b/servers/exarchos-mcp/src/config/test-runtime-resolver.test.ts
@@ -10,6 +10,8 @@ import {
   resolveTestRuntime,
   resolveVerificationRuntime,
 } from './test-runtime-resolver.js';
+import { ExarchosConfigSchema } from './exarchos-config-schema.js';
+import { FullExarchosConfigSchema } from './yaml-schema.js';
 
 describe('resolveTestRuntime', () => {
   const tmpDirs: string[] = [];
@@ -1135,5 +1137,54 @@ describe('resolveVerificationRuntime', () => {
       ),
       { numRuns: 60 },
     );
+  });
+});
+
+// ─── task 001: verification: is a foreign key on the toolchain path ──────────
+//
+// The toolchain loader (`loadExarchosConfig` → readAndValidate) validates the
+// SAME `.exarchos.yml` via `FullExarchosConfigSchema = ExarchosConfigSchema
+// .merge(ProjectConfigSchema).strict()`. Project-concern keys (`review:` /
+// `agents:` / now `verification:`) live in `ProjectConfigSchema`, so they ride
+// through the merged schema on the toolchain path while the bare,
+// toolchain-only `ExarchosConfigSchema` (the resolver's own view) rejects them
+// all equally. These tests pin that `verification:` is tolerated on the
+// toolchain path by the SAME mechanism that already tolerates `review:`.
+
+describe('ExarchosConfigSchema verification-key tolerance', () => {
+  it('ExarchosConfigSchema_ForeignVerificationKey_ToleratedOnToolchainPath', () => {
+    // A config carrying toolchain keys AND a `verification:` block must parse on
+    // the toolchain-loader path (FullExarchosConfigSchema) exactly as a
+    // `review:` sibling does today — the project-concern key is tolerated, not
+    // rejected.
+    const withVerification = {
+      test: 'bun test',
+      verification: { policy: { low: ['check_static_analysis'] } },
+    };
+    const withReview = {
+      test: 'bun test',
+      review: { routing: { 'coderabbit-threshold': 0.4 } },
+    };
+
+    const verifResult = FullExarchosConfigSchema.safeParse(withVerification);
+    const reviewResult = FullExarchosConfigSchema.safeParse(withReview);
+
+    // Same verdict for both sibling project-concern keys: accepted.
+    expect(verifResult.success).toBe(true);
+    expect(reviewResult.success).toBe(true);
+    expect(verifResult.success).toBe(reviewResult.success);
+
+    // The toolchain key survives alongside the tolerated project-concern key.
+    if (verifResult.success) {
+      expect(verifResult.data.test).toBe('bun test');
+      expect(verifResult.data.verification?.policy?.low).toEqual(['check_static_analysis']);
+    }
+
+    // The bare toolchain-only schema (the resolver's own view) treats
+    // `verification:` and `review:` IDENTICALLY — both are foreign to it, so
+    // both are rejected by the SAME `.strict()` mechanism. (This is why the
+    // loader uses the merged schema, not the bare one.)
+    expect(ExarchosConfigSchema.safeParse(withVerification).success).toBe(false);
+    expect(ExarchosConfigSchema.safeParse(withReview).success).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/config/yaml-schema.test.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.test.ts
@@ -273,6 +273,76 @@ describe('ProjectConfigSchema', () => {
     });
   });
 
+  describe('verification section', () => {
+    it('ProjectConfigSchema_VerificationPolicyValidCells_Parses', () => {
+      // All six cells — base (low|medium|high) AND boundary (low|medium|high) —
+      // accept ordered gate-name lists drawn from VERIFICATION_GATE_NAMES.
+      const result = ProjectConfigSchema.safeParse({
+        verification: {
+          policy: {
+            low: ['check_static_analysis'],
+            medium: ['check_static_analysis', 'check_test_adequacy'],
+            high: ['check_static_analysis', 'check_test_adequacy', 'check_integration_suite'],
+            boundary: {
+              low: ['check_static_analysis', 'check_contract_drift'],
+              medium: ['check_static_analysis', 'check_test_adequacy', 'check_contract_drift', 'check_mock_boundary'],
+              high: ['check_static_analysis', 'check_test_adequacy', 'check_integration_suite', 'check_contract_drift', 'check_mock_boundary'],
+            },
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('ProjectConfigSchema_VerificationUnknownGateName_RejectsAtParse', () => {
+      const result = ProjectConfigSchema.safeParse({
+        verification: { policy: { low: ['check_does_not_exist'] } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('ProjectConfigSchema_VerificationDuplicateGateInCell_Rejects', () => {
+      const result = ProjectConfigSchema.safeParse({
+        verification: { policy: { low: ['check_static_analysis', 'check_static_analysis'] } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('ProjectConfigSchema_VerificationUnknownKey_RejectsStrict', () => {
+      // A typo'd key must fail at parse under `.strict()` — at every level.
+      const topLevelTypo = ProjectConfigSchema.safeParse({
+        verification: { policy: {}, extra: true },
+      });
+      expect(topLevelTypo.success).toBe(false);
+
+      const cellTypo = ProjectConfigSchema.safeParse({
+        verification: { policy: { lowww: ['check_static_analysis'] } },
+      });
+      expect(cellTypo.success).toBe(false);
+
+      const boundaryTypo = ProjectConfigSchema.safeParse({
+        verification: { policy: { boundary: { lowww: ['check_static_analysis'] } } },
+      });
+      expect(boundaryTypo.success).toBe(false);
+    });
+
+    it('ProjectConfigSchema_VerificationEmptyCellArray_Parses', () => {
+      // An explicit empty array means "run nothing for this cell" — valid.
+      const result = ProjectConfigSchema.safeParse({
+        verification: { policy: { low: [] } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('ProjectConfigSchema_VerificationOmitted_IsValid', () => {
+      const result = ProjectConfigSchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.verification).toBeUndefined();
+      }
+    });
+  });
+
   describe('agents section', () => {
     it('ProjectConfigSchema_AgentsSection_AcceptsValidConfig', () => {
       const result = ProjectConfigSchema.safeParse({

--- a/servers/exarchos-mcp/src/config/yaml-schema.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { InvariantsConfigSchema, ExarchosConfigSchema } from './exarchos-config-schema.js';
+import { VERIFICATION_GATE_NAMES } from '../workflow/verification-policy.js';
 
 // ─── Dimension Configuration ────────────────────────────────────────────────
 
@@ -151,6 +152,71 @@ const CheckpointConfig = z.object({
   'enforce-on-wave-dispatch': z.boolean().default(true),
 }).strict();
 
+// ─── Verification Configuration ────────────────────────────────────────────
+//
+// verification-ladder slice 1, R2 (#1517 / task 001) — the per-cell override
+// layer that composes ON TOP of the frozen base policy table in
+// `workflow/verification-policy.ts`. The base table maps each
+// `(riskTier, boundaryTouching)` cell to an ordered gate sequence; this block
+// lets a consumer REPLACE the sequence for any cell in `.exarchos.yml`. The
+// resolver (a later task) layers these overrides over the table — this block
+// only describes the override surface.
+//
+// `VERIFICATION_GATE_NAMES` is the single source of truth for the gate-name
+// vocabulary (imported, never re-declared). A cell value is an ordered,
+// DUPLICATE-FREE list of those names. An EMPTY array is valid — it is the
+// explicit "run nothing for this cell" override (distinct from an omitted cell,
+// which inherits the base table). `.strict()` at every level so a typo'd cell
+// key (`lowww:`) or stray field fails at parse rather than being silently
+// ignored.
+
+/** Ordered, duplicate-free list of gate names for a single policy cell. */
+const VerificationGateSequence = z
+  .array(z.enum(VERIFICATION_GATE_NAMES))
+  .refine(
+    (gates) => new Set(gates).size === gates.length,
+    { message: 'verification gate sequence must not contain duplicates' },
+  );
+
+/**
+ * The boundary-touching sub-policy: per-tier gate sequences applied when a task
+ * crosses an I/O / schema boundary. Mirrors the base-tier keys.
+ */
+const VerificationBoundaryPolicy = z
+  .object({
+    low: VerificationGateSequence.optional(),
+    medium: VerificationGateSequence.optional(),
+    high: VerificationGateSequence.optional(),
+  })
+  .strict();
+
+/**
+ * The policy-overlay: base-tier gate sequences plus an optional `boundary`
+ * sub-policy. Every key optional — a consumer overrides only the cells it
+ * cares about; omitted cells fall through to the base table.
+ */
+const VerificationPolicyConfig = z
+  .object({
+    low: VerificationGateSequence.optional(),
+    medium: VerificationGateSequence.optional(),
+    high: VerificationGateSequence.optional(),
+    boundary: VerificationBoundaryPolicy.optional(),
+  })
+  .strict();
+
+const VerificationConfig = z
+  .object({
+    policy: VerificationPolicyConfig.optional(),
+  })
+  .strict();
+
+/**
+ * Validated `.exarchos.yml` `verification:` block — the per-cell policy
+ * overlay. The resolver (R2 follow-on) and `ResolvedProjectConfig.verification`
+ * share this single overlay-shape type; it is NOT a copy of the base table.
+ */
+export type VerificationPolicyOverlay = z.infer<typeof VerificationPolicyConfig>;
+
 // ─── Top-Level Project Config ──────────────────────────────────────────────
 
 export const ProjectConfigSchema = z.object({
@@ -163,6 +229,7 @@ export const ProjectConfigSchema = z.object({
   plugins: PluginsConfig.optional(),
   prune: PruneConfig.optional(),
   checkpoint: CheckpointConfig.optional(),
+  verification: VerificationConfig.optional(),
   invariants: InvariantsConfigSchema.optional(),
 }).strict();
 

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.apply.test.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.apply.test.ts
@@ -29,12 +29,16 @@ import { fc } from '@fast-check/vitest';
 import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
+import { parse as parseYaml } from 'yaml';
 
-import { apply, type ApplyCtx } from './reconcile.js';
+import { apply, detectDesiredState, diff, type ApplyCtx } from './reconcile.js';
 import type { PlanStep, ReconcilePlan } from './types.js';
 import { ReconcileResultSchema } from './types.js';
 import { buildWriterDeps } from '../../orchestrate/init/probes.js';
 import type { RuntimeConfigWriter } from '../../orchestrate/init/writers/writer.js';
+import { loadExarchosConfig } from '../../config/load-exarchos-config.js';
+import { resolveVerificationRuntime } from '../../config/test-runtime-resolver.js';
+import type { CheckResult } from '../../orchestrate/doctor/schema.js';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -406,6 +410,132 @@ describe('apply', () => {
 
       expect(result.applied).toHaveLength(0);
       expect(result.residual.map((s) => s.key)).toContain('agent-mcp-registered');
+    } finally {
+      await cleanup(fx);
+    }
+  });
+
+  // ─── §4.5-seed — verification commands (mutation/lint) seeded into config ───
+  //
+  // The config-step path now seeds the WIDENED verification field set: a
+  // resolved-but-undeclared `mutation`/`lint` is written into `.exarchos.yml` via
+  // the SAME seeder test/typecheck/install use. These tests prove the seed lands
+  // at the config-direct tier (through the REAL loader, not YAML string-matching),
+  // is idempotent across a full detect→diff→apply→detect→diff cycle, and NEVER
+  // writes a `verification:` policy block (the gen-time-bake negative guarantee).
+
+  const ALL_PASS: CheckResult[] = [
+    { category: 'runtime', name: 'node-version', status: 'Pass', message: 'ok', durationMs: 1 },
+  ];
+
+  /**
+   * A temp repo with a Python toolchain marker — the registry seeds BOTH
+   * `mutation` (`mutmut run`) and `lint` (`ruff check`) for python, exercising
+   * the full widened field set (the node fixture only seeds mutation).
+   */
+  async function createPythonFixture(): Promise<Fixture> {
+    const base = await mkdtemp(path.join(tmpdir(), 'apply-py-'));
+    const repoRoot = path.join(base, 'repo');
+    await mkdir(repoRoot, { recursive: true });
+    await writeFile(
+      path.join(repoRoot, 'pyproject.toml'),
+      '[project]\nname = "fixture"\nversion = "0.0.0"\n',
+      'utf8',
+    );
+    return { repoRoot, base };
+  }
+
+  it('Apply_MutationConfigStep_SeedsExarchosYml', async () => {
+    const fx = await createPythonFixture();
+    try {
+      // Detect resolves mutation + lint from the python registry (tier 5); nothing
+      // is declared yet, so diff emits the verification-command config steps.
+      const desired = await detectDesiredState(fx.repoRoot, { detectRuntimes: async () => [] });
+      expect(desired.commands.mutation).toBe('mutmut run');
+      expect(desired.commands.lint).toBe('ruff check');
+
+      const plan = diff(desired, ALL_PASS, {});
+      expect(plan.steps.map((s) => s.key)).toEqual(
+        expect.arrayContaining(['verification-command-mutation', 'verification-command-lint']),
+      );
+
+      const ctx = makeCtx(fx);
+      const result = await apply(plan, ctx);
+
+      // The config step was applied (the seeder wrote the file).
+      expect(result.applied.map((s) => s.key)).toEqual(
+        expect.arrayContaining(['verification-command-mutation', 'verification-command-lint']),
+      );
+
+      // PROVE IT THROUGH THE LOADER, not the YAML text: the resolver now returns
+      // the seeded commands at the config-direct tier (source 'config' for the
+      // legacy three; mutation/lint resolve from the written config-direct keys).
+      const resolved = resolveVerificationRuntime(fx.repoRoot);
+      expect(resolved.mutation).toBe('mutmut run');
+      expect(resolved.lint).toBe('ruff check');
+      // The aggregate source is the config tier — the seed is the operator's
+      // explicit tier-2 declaration the resolver honors above detection.
+      expect(resolved.source).toBe('config');
+
+      // The written file parses through the REAL .exarchos.yml loader and carries
+      // the verification commands as top-level direct keys.
+      const loaded = loadExarchosConfig(fx.repoRoot);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.config.mutation).toBe('mutmut run');
+      expect(loaded!.config.lint).toBe('ruff check');
+    } finally {
+      await cleanup(fx);
+    }
+  });
+
+  it('Apply_ReRunAfterSeed_EmptyPlanIdempotent', async () => {
+    const fx = await createPythonFixture();
+    try {
+      // Cycle 1: detect → diff → apply (seeds the config).
+      const desired1 = await detectDesiredState(fx.repoRoot, { detectRuntimes: async () => [] });
+      const declared1 = (loadExarchosConfig(fx.repoRoot)?.config ?? {}) as {
+        mutation?: string;
+        lint?: string;
+      };
+      const plan1 = diff(desired1, ALL_PASS, declared1);
+      expect(plan1.steps.length).toBeGreaterThan(0);
+      await apply(plan1, makeCtx(fx));
+
+      // Cycle 2: re-detect → re-diff. The commands are now DECLARED (config-direct),
+      // so the verification-command steps disappear → empty plan (idempotence).
+      const desired2 = await detectDesiredState(fx.repoRoot, { detectRuntimes: async () => [] });
+      const declared2 = (loadExarchosConfig(fx.repoRoot)?.config ?? {}) as {
+        mutation?: string;
+        lint?: string;
+      };
+      const plan2 = diff(desired2, ALL_PASS, declared2);
+
+      expect(plan2).toEqual({ steps: [] });
+    } finally {
+      await cleanup(fx);
+    }
+  });
+
+  it('Apply_NeverWritesVerificationPolicyBlock', async () => {
+    const fx = await createPythonFixture();
+    try {
+      // A full apply over the verification-command config steps.
+      const desired = await detectDesiredState(fx.repoRoot, { detectRuntimes: async () => [] });
+      const plan = diff(desired, ALL_PASS, {});
+      await apply(plan, makeCtx(fx));
+
+      // The written .exarchos.yml parsed object has NO `verification` key —
+      // seeding the resolved POLICY would freeze today's builtin defaults into
+      // consumer config (the gen-time-bake trap, §4.5 negative guarantee). Only
+      // the resolved COMMANDS are seeded; policy is surfaced read-only via doctor.
+      const raw = await readFile(path.join(fx.repoRoot, CONFIG_FILE), 'utf8');
+      const parsed = parseYaml(raw) as Record<string, unknown>;
+      expect('verification' in parsed).toBe(false);
+
+      // The loader confirms it too (no verification block survives validation).
+      const loaded = loadExarchosConfig(fx.repoRoot);
+      expect(loaded).not.toBeNull();
+      expect('verification' in (loaded!.config as Record<string, unknown>)).toBe(false);
     } finally {
       await cleanup(fx);
     }

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.apply.test.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.apply.test.ts
@@ -488,6 +488,50 @@ describe('apply', () => {
     }
   });
 
+  it('Apply_MutationConfigStep_ExistingConfig_ResidualNotSilentlySkipped', async () => {
+    const fx = await createPythonFixture();
+    try {
+      // A pre-existing `.exarchos.yml` that declares NEITHER mutation nor lint.
+      // The create-only seeder will short-circuit on it (`already-exists`).
+      await writeFile(path.join(fx.repoRoot, CONFIG_FILE), 'test: pytest\n', 'utf8');
+
+      // mutation/lint resolve from the python registry but are undeclared in the
+      // existing config, so diff emits the verification-command steps.
+      const desired = await detectDesiredState(fx.repoRoot, { detectRuntimes: async () => [] });
+      const declared = (loadExarchosConfig(fx.repoRoot)?.config ?? {}) as {
+        mutation?: string;
+        lint?: string;
+      };
+      const plan = diff(desired, ALL_PASS, declared);
+      expect(plan.steps.map((s) => s.key)).toEqual(
+        expect.arrayContaining(['verification-command-mutation', 'verification-command-lint']),
+      );
+
+      const result = await apply(plan, makeCtx(fx));
+
+      // The create-only seeder cannot add keys to the existing file, so the
+      // commands are genuinely still absent. They MUST surface as residual (a
+      // re-diff resumes them), NOT silently `skipped` (which reads as a preserved
+      // hand-edit / success) and NOT `applied`.
+      expect(result.residual.map((s) => s.key)).toEqual(
+        expect.arrayContaining(['verification-command-mutation', 'verification-command-lint']),
+      );
+      expect(result.skipped.map((s) => s.key)).not.toContain('verification-command-mutation');
+      expect(result.skipped.map((s) => s.key)).not.toContain('verification-command-lint');
+      expect(result.applied.map((s) => s.key)).not.toContain('verification-command-mutation');
+      // Each un-seedable command carries an advisory naming the untouched file.
+      expect(result.advisories.length).toBeGreaterThanOrEqual(2);
+
+      // The existing file was NOT modified — mutation/lint still absent.
+      const loaded = loadExarchosConfig(fx.repoRoot);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.config.mutation).toBeUndefined();
+      expect(loaded!.config.lint).toBeUndefined();
+    } finally {
+      await cleanup(fx);
+    }
+  });
+
   it('Apply_ReRunAfterSeed_EmptyPlanIdempotent', async () => {
     const fx = await createPythonFixture();
     try {

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.characterization.test.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.characterization.test.ts
@@ -4,15 +4,23 @@
  * and adds a 13th doctor check) has a regression oracle.
  *
  * SCOPE — two pin surfaces:
- *   (a) `ResolvedCommandsSchema` field behavior: it currently accepts exactly
- *       `{test?, typecheck?, install?}` and SILENTLY STRIPS unknown keys (it does
- *       NOT reject — the plain `z.object` is non-strict). A sibling task that
- *       widens the schema (e.g. adds a `lint?` field, or makes it `.strict()`)
- *       trips THIS guard, forcing the change to be deliberate.
+ *   (a) `ResolvedCommandsSchema` field behavior. DELIBERATE CONTRACT CHANGE
+ *       (task 007, design §4.5-detect): the schema was WIDENED from the legacy
+ *       `{test?, typecheck?, install?}` triple to the verification-ladder set
+ *       `{test?, typecheck?, install?, mutation?, lint?}` so onboard/doctor
+ *       resolve mutation/lint. This T0 pin originally caught that widening (it
+ *       asserted `lint` was stripped); per the characterization protocol the
+ *       intentional break was UPDATED here — see the in-test comment. The pin now
+ *       guards the NEW five-field surface against accidental further drift.
  *   (b) `detectDesiredState` output shape for a representative fixture repo: a
  *       temp dir with a `package.json` declaring a `test:run` script, run through
  *       the REAL resolver/detector path. The full `DesiredState` object is pinned
- *       snapshot-style.
+ *       snapshot-style. This snapshot ALSO moved under task 007 — but for a
+ *       registry reason, not a schema one: the node toolchain seeds `mutation`
+ *       (`npx stryker run`) UNCONDITIONALLY, so widening detect to
+ *       `resolveVerificationRuntime` adds a `mutation` key to this node fixture's
+ *       `commands`. `lint` stays absent (node seeds no built-in lint) and
+ *       `runtimes`/`vcs` are untouched. See the in-test comment.
  *
  * This test MUST PASS against unmodified HEAD — it is a Feathers baseline, not a
  * spec for new behavior.
@@ -32,7 +40,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { detectDesiredState } from './reconcile.js';
-import { resolveTestRuntime } from '../../config/test-runtime-resolver.js';
+import {
+  resolveTestRuntime,
+  resolveVerificationRuntime,
+} from '../../config/test-runtime-resolver.js';
 import {
   DesiredStateSchema,
   ResolvedCommandsSchema,
@@ -40,13 +51,22 @@ import {
 } from './types.js';
 
 describe('reconcile characterization (T0 baseline)', () => {
-  describe('ResolvedCommandsSchema_CurrentFields_Pinned', () => {
-    it('accepts exactly {test?, typecheck?, install?} and silently strips unknown keys', () => {
-      // All three known fields parse and round-trip unchanged.
+  describe('ResolvedCommandsSchema_WidenedFields_Pinned', () => {
+    it('accepts exactly {test?, typecheck?, install?, mutation?, lint?} and silently strips unknown keys', () => {
+      // DELIBERATE CHARACTERIZATION-PIN UPDATE (task 007, design §4.5-detect):
+      // the T0 baseline pinned the legacy three-field surface and asserted `lint`
+      // was STRIPPED. The widening makes `mutation` + `lint` first-class fields, so
+      // this pin was updated to the NEW five-field surface — `lint` is now RETAINED
+      // and `mutation` is accepted. Per the characterization protocol an intentional
+      // contract break is UPDATED (this one); only an accidental break is a bug.
+
+      // All five known fields parse and round-trip unchanged.
       const known = ResolvedCommandsSchema.safeParse({
         test: 'npm run test:run',
         typecheck: 'npm run typecheck',
         install: 'npm install',
+        mutation: 'npx stryker run',
+        lint: 'eslint .',
       });
       expect(known.success).toBe(true);
       if (known.success) {
@@ -54,6 +74,8 @@ describe('reconcile characterization (T0 baseline)', () => {
           test: 'npm run test:run',
           typecheck: 'npm run typecheck',
           install: 'npm install',
+          mutation: 'npx stryker run',
+          lint: 'eslint .',
         });
       }
 
@@ -64,10 +86,10 @@ describe('reconcile characterization (T0 baseline)', () => {
         expect(empty.data).toEqual({});
       }
 
-      // PINNED CURRENT BEHAVIOR: an unknown key does NOT cause a parse failure —
+      // PINNED BEHAVIOR: a genuinely unknown key does NOT cause a parse failure —
       // the schema is the default (non-strict) z.object, which SILENTLY STRIPS
-      // unknown keys rather than rejecting them. (A sibling task that adds a new
-      // field, or switches to .strict(), changes this and trips the guard.)
+      // unknown keys rather than rejecting them. `lint` is now a KNOWN key (post
+      // widening) and is retained; `unknownFutureField` remains unknown and stripped.
       const withExtra = ResolvedCommandsSchema.safeParse({
         test: 'npm run test:run',
         lint: 'npm run lint',
@@ -75,20 +97,27 @@ describe('reconcile characterization (T0 baseline)', () => {
       });
       expect(withExtra.success).toBe(true);
       if (withExtra.success) {
-        // unknown keys stripped …
-        expect('lint' in withExtra.data).toBe(false);
+        // unknown key stripped …
         expect('unknownFutureField' in withExtra.data).toBe(false);
-        // … known key retained.
-        expect(withExtra.data).toEqual({ test: 'npm run test:run' });
+        // … known keys (incl. the now-first-class `lint`) retained.
+        expect(withExtra.data).toEqual({ test: 'npm run test:run', lint: 'npm run lint' });
       }
 
-      // The accepted field set is exactly these three (the shape's surface area).
+      // The accepted field set is exactly these five (the shape's surface area).
       const allFields = ResolvedCommandsSchema.parse({
         test: 't',
         typecheck: 'tc',
         install: 'i',
+        mutation: 'm',
+        lint: 'l',
       });
-      expect(Object.keys(allFields).sort()).toEqual(['install', 'test', 'typecheck']);
+      expect(Object.keys(allFields).sort()).toEqual([
+        'install',
+        'lint',
+        'mutation',
+        'test',
+        'typecheck',
+      ]);
     });
   });
 
@@ -122,6 +151,14 @@ describe('reconcile characterization (T0 baseline)', () => {
       expect(parsed.success).toBe(true);
 
       // Snapshot-style pin of the FULL object structure for this fixture.
+      //
+      // REGISTRY-DRIVEN PIN UPDATE (task 007): widening detect to
+      // `resolveVerificationRuntime` makes a node fixture surface its
+      // registry-seeded `mutation` command (`npx stryker run`) — the node
+      // toolchain seeds mutation UNCONDITIONALLY (no stryker-config gate). So even
+      // this "bare package.json" fixture now carries a `mutation` key in
+      // `commands`. `lint` stays absent (node has no built-in lint seed → null →
+      // omitted), and `runtimes`/`vcs` are untouched.
       const expected: DesiredState = {
         runtimes: [],
         vcs: 'none',
@@ -129,16 +166,24 @@ describe('reconcile characterization (T0 baseline)', () => {
           test: 'npm run test:run',
           typecheck: 'npm run typecheck',
           install: 'npm install',
+          mutation: 'npx stryker run',
         },
       };
       expect(desired).toEqual(expected);
 
-      // Provenance: the commands came from the SAME resolver, not a parallel
-      // derivation — proves the shape is the resolver's, not a transcription.
+      // Provenance: the legacy commands came from the SAME (delegated) resolver,
+      // not a parallel derivation — proves the shape is the resolver's, not a
+      // transcription. `resolveVerificationRuntime` delegates the legacy three to
+      // `resolveTestRuntime` verbatim, so both agree.
       const resolved = resolveTestRuntime(dir);
       expect(desired.commands.test).toBe(resolved.test ?? undefined);
       expect(desired.commands.typecheck).toBe(resolved.typecheck ?? undefined);
       expect(desired.commands.install).toBe(resolved.install ?? undefined);
+
+      // The mutation key likewise traces to the widened resolver (not fabricated).
+      const verification = resolveVerificationRuntime(dir);
+      expect(desired.commands.mutation).toBe(verification.mutation ?? undefined);
+      expect('lint' in desired.commands).toBe(false);
 
       // Top-level key surface of DesiredState is exactly these three.
       expect(Object.keys(desired).sort()).toEqual(['commands', 'runtimes', 'vcs']);

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.characterization.test.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.characterization.test.ts
@@ -1,0 +1,147 @@
+/**
+ * T0 characterization (epic task 006, design §4.7) — PINS the CURRENT reconciler
+ * shapes so the upcoming extension (a sibling task WIDENS `ResolvedCommandsSchema`
+ * and adds a 13th doctor check) has a regression oracle.
+ *
+ * SCOPE — two pin surfaces:
+ *   (a) `ResolvedCommandsSchema` field behavior: it currently accepts exactly
+ *       `{test?, typecheck?, install?}` and SILENTLY STRIPS unknown keys (it does
+ *       NOT reject — the plain `z.object` is non-strict). A sibling task that
+ *       widens the schema (e.g. adds a `lint?` field, or makes it `.strict()`)
+ *       trips THIS guard, forcing the change to be deliberate.
+ *   (b) `detectDesiredState` output shape for a representative fixture repo: a
+ *       temp dir with a `package.json` declaring a `test:run` script, run through
+ *       the REAL resolver/detector path. The full `DesiredState` object is pinned
+ *       snapshot-style.
+ *
+ * This test MUST PASS against unmodified HEAD — it is a Feathers baseline, not a
+ * spec for new behavior.
+ *
+ * NO COPIED LITERALS MASQUERADING AS PINS: the `DesiredState` is produced by the
+ * REAL `detectDesiredState` over a real temp-dir fixture (the same idiom as
+ * `reconcile.detect.test.ts`); we re-parse it through the REAL `DesiredStateSchema`
+ * loader before asserting. The only injection seam used is `detectRuntimes`
+ * (stubbed to `[]`) — required for determinism, because the real agent-host probe
+ * inspects `$HOME` and would make the fixture's `runtimes` host-dependent. The
+ * command derivation and VCS detection run through the genuine resolver/fs paths.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { detectDesiredState } from './reconcile.js';
+import { resolveTestRuntime } from '../../config/test-runtime-resolver.js';
+import {
+  DesiredStateSchema,
+  ResolvedCommandsSchema,
+  type DesiredState,
+} from './types.js';
+
+describe('reconcile characterization (T0 baseline)', () => {
+  describe('ResolvedCommandsSchema_CurrentFields_Pinned', () => {
+    it('accepts exactly {test?, typecheck?, install?} and silently strips unknown keys', () => {
+      // All three known fields parse and round-trip unchanged.
+      const known = ResolvedCommandsSchema.safeParse({
+        test: 'npm run test:run',
+        typecheck: 'npm run typecheck',
+        install: 'npm install',
+      });
+      expect(known.success).toBe(true);
+      if (known.success) {
+        expect(known.data).toEqual({
+          test: 'npm run test:run',
+          typecheck: 'npm run typecheck',
+          install: 'npm install',
+        });
+      }
+
+      // Every field is OPTIONAL — the empty object is valid and yields {}.
+      const empty = ResolvedCommandsSchema.safeParse({});
+      expect(empty.success).toBe(true);
+      if (empty.success) {
+        expect(empty.data).toEqual({});
+      }
+
+      // PINNED CURRENT BEHAVIOR: an unknown key does NOT cause a parse failure —
+      // the schema is the default (non-strict) z.object, which SILENTLY STRIPS
+      // unknown keys rather than rejecting them. (A sibling task that adds a new
+      // field, or switches to .strict(), changes this and trips the guard.)
+      const withExtra = ResolvedCommandsSchema.safeParse({
+        test: 'npm run test:run',
+        lint: 'npm run lint',
+        unknownFutureField: 'whatever',
+      });
+      expect(withExtra.success).toBe(true);
+      if (withExtra.success) {
+        // unknown keys stripped …
+        expect('lint' in withExtra.data).toBe(false);
+        expect('unknownFutureField' in withExtra.data).toBe(false);
+        // … known key retained.
+        expect(withExtra.data).toEqual({ test: 'npm run test:run' });
+      }
+
+      // The accepted field set is exactly these three (the shape's surface area).
+      const allFields = ResolvedCommandsSchema.parse({
+        test: 't',
+        typecheck: 'tc',
+        install: 'i',
+      });
+      expect(Object.keys(allFields).sort()).toEqual(['install', 'test', 'typecheck']);
+    });
+  });
+
+  describe('DetectDesiredState_FixtureRepo_CurrentShape', () => {
+    let dir: string;
+
+    beforeEach(() => {
+      // Representative fixture: a node repo declaring the `test:run` script the
+      // resolver keys on. No `.git` materialized → vcs resolves to 'none'.
+      dir = mkdtempSync(join(tmpdir(), 'reconcile-char-'));
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify({
+          scripts: { 'test:run': 'vitest run', typecheck: 'tsc --noEmit' },
+        }),
+      );
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('pins the full DesiredState shape for the fixture repo', async () => {
+      // REAL detection path. Only `detectRuntimes` is stubbed (determinism — the
+      // real probe reads $HOME); resolver + VCS detection are the genuine paths.
+      const desired = await detectDesiredState(dir, { detectRuntimes: async () => [] });
+
+      // The whole DesiredState satisfies the canonical schema (re-parse through
+      // the REAL loader, not a hand-built literal).
+      const parsed = DesiredStateSchema.safeParse(desired);
+      expect(parsed.success).toBe(true);
+
+      // Snapshot-style pin of the FULL object structure for this fixture.
+      const expected: DesiredState = {
+        runtimes: [],
+        vcs: 'none',
+        commands: {
+          test: 'npm run test:run',
+          typecheck: 'npm run typecheck',
+          install: 'npm install',
+        },
+      };
+      expect(desired).toEqual(expected);
+
+      // Provenance: the commands came from the SAME resolver, not a parallel
+      // derivation — proves the shape is the resolver's, not a transcription.
+      const resolved = resolveTestRuntime(dir);
+      expect(desired.commands.test).toBe(resolved.test ?? undefined);
+      expect(desired.commands.typecheck).toBe(resolved.typecheck ?? undefined);
+      expect(desired.commands.install).toBe(resolved.install ?? undefined);
+
+      // Top-level key surface of DesiredState is exactly these three.
+      expect(Object.keys(desired).sort()).toEqual(['commands', 'runtimes', 'vcs']);
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.detect.test.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.detect.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { detectDesiredState } from './reconcile.js';
-import { resolveTestRuntime } from '../../config/test-runtime-resolver.js';
+import {
+  resolveTestRuntime,
+  resolveVerificationRuntime,
+} from '../../config/test-runtime-resolver.js';
 import { DesiredStateSchema } from './types.js';
 
 /**
@@ -98,6 +101,76 @@ describe('DetectDesiredState_DerivesCommands_FromLayeredResolver', () => {
     } finally {
       rmSync(gitDir, { recursive: true, force: true });
     }
+  });
+
+  it('DetectDesiredState_NodeFixtureWithStryker_ResolvesMutationCommand', async () => {
+    // Task 007 (design §4.5-detect): detect now flows command derivation through
+    // `resolveVerificationRuntime`, which seeds a node repo's mutation command
+    // from the built-in registry tier (the node toolchain canonical
+    // `npx stryker run`). The fixture triggers the REAL registry tier — a node
+    // marker (package.json) — with NO stubbing of the resolver itself.
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ scripts: { 'test:run': 'vitest run', typecheck: 'tsc --noEmit' } }),
+    );
+
+    // Provenance precondition: the REAL widened resolver resolves the node
+    // mutation command (guards against a registry change silently breaking intent).
+    const resolved = resolveVerificationRuntime(dir);
+    expect(resolved.mutation).toBe('npx stryker run');
+
+    const desired = await detectDesiredState(dir, { detectRuntimes: async () => [] });
+
+    // detect surfaces EXACTLY what the widened resolver returns — same source of
+    // truth, no parallel derivation.
+    expect(desired.commands.mutation).toBe(resolved.mutation ?? undefined);
+    expect(desired.commands.mutation).toBe('npx stryker run');
+
+    // The whole DesiredState remains schema-valid with the new field present.
+    expect(DesiredStateSchema.safeParse(desired).success).toBe(true);
+  });
+
+  it('DetectDesiredState_UnresolvableMutation_LeavesFieldAbsent', async () => {
+    // A bare directory (no toolchain markers): the widened resolver leaves
+    // `mutation: null`. Per the omit-never-fabricate contract (INV-6), an
+    // unresolved mutation field is ABSENT from commands — not `null`, not a
+    // fabricated string.
+    const resolved = resolveVerificationRuntime(dir);
+    expect(resolved.mutation).toBeNull();
+
+    const desired = await detectDesiredState(dir, { detectRuntimes: async () => [] });
+
+    expect('mutation' in desired.commands).toBe(false);
+    expect(desired.commands.mutation).toBeUndefined();
+
+    // Lint is also unresolved here and must likewise be absent.
+    expect('lint' in desired.commands).toBe(false);
+    expect(desired.commands.lint).toBeUndefined();
+  });
+
+  it('DetectDesiredState_ExistingFields_ByteIdenticalToT0Pin', async () => {
+    // The T0 characterization fixture: a node repo declaring `test:run` +
+    // `typecheck`. Widening to `resolveVerificationRuntime` must NOT perturb the
+    // legacy test/typecheck/install fields — they stay byte-identical to the
+    // pre-change behavior (which `resolveTestRuntime` still defines verbatim,
+    // since `resolveVerificationRuntime` delegates the legacy three to it).
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ scripts: { 'test:run': 'vitest run', typecheck: 'tsc --noEmit' } }),
+    );
+
+    const legacy = resolveTestRuntime(dir);
+    const desired = await detectDesiredState(dir, { detectRuntimes: async () => [] });
+
+    // Byte-identical to the legacy resolver output (the pre-change source of truth).
+    expect(desired.commands.test).toBe(legacy.test ?? undefined);
+    expect(desired.commands.typecheck).toBe(legacy.typecheck ?? undefined);
+    expect(desired.commands.install).toBe(legacy.install ?? undefined);
+
+    // Concrete pin matching the T0 baseline snapshot (reconcile.characterization).
+    expect(desired.commands.test).toBe('npm run test:run');
+    expect(desired.commands.typecheck).toBe('npm run typecheck');
+    expect(desired.commands.install).toBe('npm install');
   });
 
   it('returns a string[] of runtimes and honors runtime/vcs overrides', async () => {

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.diff.test.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.diff.test.ts
@@ -169,4 +169,99 @@ describe('diff', () => {
       }),
     );
   });
+
+  // ─── §4.5-seed — verification commands resolved-but-undeclared ──────────────
+  //
+  // `diff` is also the home for desired-vs-declared command divergence: when the
+  // layered resolver resolved a `mutation`/`lint` command but it is NOT declared
+  // in the repo's `.exarchos.yml`, `diff` emits a `config`-kind PlanStep so
+  // `apply` can seed it (the SAME seed path test/typecheck use, no new kinds).
+  // The `declared` arg is the third input — the commands the repo already pins in
+  // `.exarchos.yml`; a resolved field present there contributes NO step (the
+  // idempotence precondition).
+
+  describe('verification-command seeding (§4.5-seed)', () => {
+    /** A clean, all-passing doctor roster — isolates the command-divergence path. */
+    const ALL_PASS: CheckResult[] = [pass('runtime', 'node-version')];
+
+    /** A desired state with mutation + lint both resolved by the resolver. */
+    const DESIRED_WITH_VERIFICATION: DesiredState = {
+      runtimes: ['claude-code'],
+      vcs: 'git',
+      commands: {
+        test: 'npm run test:run',
+        typecheck: 'tsc --noEmit',
+        install: 'npm install',
+        mutation: 'npx stryker run',
+        lint: 'eslint .',
+      },
+    };
+
+    it('Diff_ResolvedMutationMissingFromConfig_EmitsConfigStep', () => {
+      // mutation resolved, but the repo declares neither mutation nor lint.
+      const declared = { test: 'npm run test:run' };
+
+      const plan = diff(DESIRED_WITH_VERIFICATION, ALL_PASS, declared);
+
+      // The plan validates and carries a config step for each undeclared
+      // resolved verification command (mutation + lint here).
+      expect(() => ReconcilePlanSchema.parse(plan)).not.toThrow();
+
+      const byKey = new Map(plan.steps.map((s) => [s.key, s]));
+      const mutationStep = byKey.get('verification-command-mutation');
+      expect(mutationStep).toBeDefined();
+      // Same shape/surface as the test/typecheck config steps: config / any.
+      expect(mutationStep!.kind).toBe('config');
+      expect(mutationStep!.surface).toBe('any');
+      expect(mutationStep!.description.length).toBeGreaterThan(0);
+
+      const lintStep = byKey.get('verification-command-lint');
+      expect(lintStep).toBeDefined();
+      expect(lintStep!.kind).toBe('config');
+      expect(lintStep!.surface).toBe('any');
+    });
+
+    it('Diff_ResolvedMutationAlreadyDeclared_NoStep_Idempotent', () => {
+      // Both verification commands resolved AND already declared in
+      // `.exarchos.yml` ⇒ no config step (the seed already happened).
+      const declared = {
+        mutation: 'npx stryker run',
+        lint: 'eslint .',
+      };
+
+      const plan = diff(DESIRED_WITH_VERIFICATION, ALL_PASS, declared);
+
+      const keys = plan.steps.map((s) => s.key);
+      expect(keys).not.toContain('verification-command-mutation');
+      expect(keys).not.toContain('verification-command-lint');
+    });
+
+    it('Diff_UnresolvedVerificationCommand_NoStep', () => {
+      // The resolver left mutation/lint unresolved (omitted from desired.commands)
+      // ⇒ nothing to seed, no step. INV-6 omit-never-fabricate carries through:
+      // diff never invents a command the resolver did not surface.
+      const desiredNoVerification: DesiredState = {
+        runtimes: ['claude-code'],
+        vcs: 'git',
+        commands: { test: 'npm run test:run' },
+      };
+
+      const plan = diff(desiredNoVerification, ALL_PASS, {});
+
+      const keys = plan.steps.map((s) => s.key);
+      expect(keys).not.toContain('verification-command-mutation');
+      expect(keys).not.toContain('verification-command-lint');
+    });
+
+    it('Diff_DeclaredDefaultsToEmpty_BackwardCompatible', () => {
+      // Omitting the `declared` arg treats every resolved verification command as
+      // undeclared (seed-everything) — and the legacy two-arg call still works,
+      // so the doctor-check path is untouched.
+      const plan = diff(DESIRED_WITH_VERIFICATION, ALL_PASS);
+
+      const keys = plan.steps.map((s) => s.key);
+      expect(keys).toContain('verification-command-mutation');
+      expect(keys).toContain('verification-command-lint');
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.ts
@@ -15,15 +15,16 @@
  *   - INV-2: NO imports from `adapters/*` — behavior lives here, not in the
  *     presentation facades.
  *   - INV-6: command derivation flows EXCLUSIVELY through the Bundle B layered
- *     resolver (`resolveTestRuntime`). There is no `applyLanguageCustomizations`
- *     / npm string-rewrite in this path; an unresolved command field is OMITTED,
- *     never fabricated.
+ *     resolver (`resolveVerificationRuntime` — the widened verification-ladder
+ *     resolver covering test/typecheck/install PLUS mutation/lint). There is no
+ *     `applyLanguageCustomizations` / npm string-rewrite in this path; an
+ *     unresolved command field is OMITTED, never fabricated.
  */
 
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 
-import { resolveTestRuntime } from '../../config/test-runtime-resolver.js';
+import { resolveVerificationRuntime } from '../../config/test-runtime-resolver.js';
 import {
   detectAgentEnvironments,
   type AgentRuntimeName,
@@ -99,12 +100,17 @@ function deriveCommands(
   repoRoot: string,
   override?: DetectOptions['commandOverride'],
 ): ResolvedCommands {
-  const resolved = resolveTestRuntime(repoRoot, override ? { override: { ...override } } : undefined);
+  const resolved = resolveVerificationRuntime(
+    repoRoot,
+    override ? { override: { ...override } } : undefined,
+  );
 
   const commands: ResolvedCommands = {};
   if (resolved.test !== null) commands.test = resolved.test;
   if (resolved.typecheck !== null) commands.typecheck = resolved.typecheck;
   if (resolved.install !== null) commands.install = resolved.install;
+  if (resolved.mutation !== null) commands.mutation = resolved.mutation;
+  if (resolved.lint !== null) commands.lint = resolved.lint;
   return commands;
 }
 

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.ts
@@ -25,6 +25,7 @@ import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 
 import { resolveVerificationRuntime } from '../../config/test-runtime-resolver.js';
+import { loadExarchosConfig } from '../../config/load-exarchos-config.js';
 import {
   detectAgentEnvironments,
   type AgentRuntimeName,
@@ -112,6 +113,36 @@ function deriveCommands(
   if (resolved.mutation !== null) commands.mutation = resolved.mutation;
   if (resolved.lint !== null) commands.lint = resolved.lint;
   return commands;
+}
+
+// ─── Declared commands (§4.5-seed divergence) ───────────────────────────────
+
+/**
+ * Read the verification commands ALREADY DECLARED in the repo's `.exarchos.yml`
+ * (the direct top-level `mutation:`/`lint:` keys). This is the "actual" side of
+ * the §4.5-seed desired-vs-declared divergence: `diff` seeds a resolved command
+ * only when it is NOT already pinned here.
+ *
+ * Only the directly-declared keys count as "declared" — a command the resolver
+ * derived from detection (tier 5) is resolved-but-undeclared and IS a seed
+ * candidate. Reads via the shared `.exarchos.yml` loader; a missing/empty config
+ * yields `{}` (everything undeclared). Loader throws (malformed/invalid config)
+ * are swallowed to `{}` so a broken config can't crash the reconcile — the
+ * doctor checks own surfacing config validity.
+ */
+function declaredVerificationCommands(repoRoot: string): ResolvedCommands {
+  let config;
+  try {
+    config = loadExarchosConfig(repoRoot)?.config;
+  } catch {
+    return {};
+  }
+  if (!config) return {};
+
+  const declared: ResolvedCommands = {};
+  if (config.mutation !== undefined) declared.mutation = config.mutation;
+  if (config.lint !== undefined) declared.lint = config.lint;
+  return declared;
 }
 
 // ─── VCS detection ───────────────────────────────────────────────────────────
@@ -280,7 +311,65 @@ function toPlanStep(check: CheckResult): PlanStep {
 }
 
 /**
- * `diff(desired, actual)` — the structured `doctor` diff (DR-1 / DR-4).
+ * The widened verification commands `diff` seeds when they are resolved but not
+ * yet declared in `.exarchos.yml` (§4.5-seed). `test`/`typecheck`/`install` are
+ * NOT in this set: their seeding is already covered by the doctor-check config
+ * path + the fresh-create seeder, so adding them here would double-emit. Only
+ * the verification-ladder additions (`mutation`, `lint`) flow through the
+ * desired-vs-declared command divergence path.
+ */
+const SEEDABLE_VERIFICATION_FIELDS = ['mutation', 'lint'] as const;
+type SeedableVerificationField = (typeof SEEDABLE_VERIFICATION_FIELDS)[number];
+
+/**
+ * The stable PlanStep key for seeding one resolved-but-undeclared verification
+ * command. Distinct from the doctor-check keys so the two config-step families
+ * never collide and `apply` / `doctor --fix` can idempotence-match per field.
+ */
+function verificationCommandKey(field: SeedableVerificationField): string {
+  return `verification-command-${field}`;
+}
+
+/**
+ * Build the config-kind PlanSteps that seed resolved-but-undeclared verification
+ * commands into `.exarchos.yml` (§4.5-seed). A field contributes a step iff the
+ * resolver resolved it (it is present in `desired.commands`) AND it is NOT
+ * already declared in the repo's `.exarchos.yml` (`declared`). The step shape
+ * mirrors the test/typecheck config steps exactly — `kind: 'config'`,
+ * `surface: 'any'` — so `apply` routes it through the SAME seeder; no new kinds.
+ *
+ * Idempotence: once `apply` has seeded a field, a re-detect surfaces it as
+ * declared (config-direct tier), so the next `diff` omits the step → empty plan.
+ *
+ * NOTE (§4.5 negative guarantee): this seeds COMMANDS only. No `verification:`
+ * policy block is ever emitted — seeding the resolved policy default would freeze
+ * today's builtin table into consumer config (the gen-time-bake trap, #1483).
+ */
+function verificationCommandSteps(
+  desired: DesiredState,
+  declared: ResolvedCommands,
+): PlanStep[] {
+  const steps: PlanStep[] = [];
+  for (const field of SEEDABLE_VERIFICATION_FIELDS) {
+    const resolved = desired.commands[field];
+    // Resolved (the resolver surfaced a value) AND not already declared in
+    // `.exarchos.yml` (the operator hasn't pinned it). INV-6 omit-never-fabricate
+    // carries through: an unresolved field is absent from `desired.commands`, so
+    // it never becomes a step.
+    if (resolved !== undefined && declared[field] === undefined) {
+      steps.push({
+        kind: 'config',
+        surface: 'any',
+        key: verificationCommandKey(field),
+        description: `Seed the resolved ${field} command into .exarchos.yml: ${resolved}`,
+      });
+    }
+  }
+  return steps;
+}
+
+/**
+ * `diff(desired, actual, declared?)` — the structured `doctor` diff (DR-1 / DR-4).
  *
  * Turns the doctor check results into an EXECUTABLE {@link ReconcilePlan}: each
  * remediable (`Fail`/`Warning` with a `fix`) check becomes exactly one
@@ -288,19 +377,30 @@ function toPlanStep(check: CheckResult): PlanStep {
  * fully-configured repo (all checks `Pass`) ⇒ the empty plan `{ steps: [] }`,
  * which is the idempotence precondition for `apply` (task 007).
  *
+ * `diff` ALSO folds in desired-vs-declared command divergence (§4.5-seed): a
+ * verification command the resolver resolved (present in `desired.commands`) but
+ * NOT yet declared in the repo's `.exarchos.yml` (`declared`) becomes a
+ * `config`-kind step so `apply` seeds it via the SAME seeder test/typecheck use.
+ * `declared` defaults to `{}` (treat everything as undeclared) so the legacy
+ * two-arg call — the doctor-check path — keeps working unchanged.
+ *
  * Seam: `actual` is the doctor composer's own output — `readonly CheckResult[]`,
  * exactly what `handleDoctorWithChecks` produces by running the 11 checks. The
  * caller (doctor `--fix` / `onboard`) runs the probes; `diff` stays PURE (no fs,
- * no process) and only classifies. `desired` is accepted for forward-compatible
- * symmetry with the design's `diff(desired, actual)` signature and so future
- * desired-vs-actual command/runtime divergence can fold in here without a
- * signature change; today the plan is derived from the remediable checks alone.
+ * no process) and only classifies. `declared` is likewise supplied by the caller
+ * (read from `.exarchos.yml`), keeping `diff` free of I/O.
  *
- * Step order mirrors the input check order so callers can scan top-to-bottom.
+ * Step order: the doctor-check steps come first (mirroring input check order),
+ * then the verification-command seed steps, so callers can scan top-to-bottom.
  */
-export function diff(_desired: DesiredState, actual: readonly CheckResult[]): ReconcilePlan {
-  const steps = actual.filter(isRemediable).map(toPlanStep);
-  return { steps };
+export function diff(
+  desired: DesiredState,
+  actual: readonly CheckResult[],
+  declared: ResolvedCommands = {},
+): ReconcilePlan {
+  const checkSteps = actual.filter(isRemediable).map(toPlanStep);
+  const seedSteps = verificationCommandSteps(desired, declared);
+  return { steps: [...checkSteps, ...seedSteps] };
 }
 
 // ─── apply (DR-1 / DR-10) ─────────────────────────────────────────────────────
@@ -375,13 +475,33 @@ interface ResultAcc {
   readonly skipped: PlanStep[];
   readonly residual: PlanStep[];
   readonly advisories: Advisory[];
+  /**
+   * Did an EARLIER `config` step in THIS apply run already write `.exarchos.yml`?
+   * The single-file seeder writes the whole resolver-derived config in one shot,
+   * so once the first config step seeds the file, every later config step in the
+   * same plan (e.g. a second verification-command seed) finds it already present.
+   * That `already-exists` is CONVERGENCE (their field was just written by us),
+   * not a preserved hand-edit. Tracking it lets {@link applyConfigStep}
+   * distinguish the two — see its body.
+   */
+  configSeededThisRun: boolean;
 }
 
 /**
  * Route a `config` step through the (force-aware) seeder. A fresh write or a
- * forced overwrite ⇒ applied; an existing hand-edit preserved without force ⇒
- * skipped; an unresolved-no-fields seeder no-op ⇒ residual (still needs doing).
- * A forced overwrite additionally emits an advisory so the operator is told.
+ * forced overwrite ⇒ applied; an unresolved-no-fields seeder no-op ⇒ residual
+ * (still needs doing). A forced overwrite additionally emits an advisory.
+ *
+ * The `already-exists` no-op splits two ways (mirroring {@link applyGenerateStep}
+ * convergence, #1534): the single-file seeder writes the whole config in one
+ * shot, so multiple config steps in one plan (the test/typecheck doctor-check
+ * step PLUS the §4.5-seed verification-command steps) all hit the SAME file.
+ *   - If an EARLIER config step in this run already wrote it
+ *     ({@link ResultAcc.configSeededThisRun}), this step's field was just seeded
+ *     by us — it CONVERGED → `applied`. Marking it `skipped` would mis-report the
+ *     verification-command seed as "not run" even though it landed in the file.
+ *   - Otherwise the file pre-existed the run — a genuine hand-edit preserved by
+ *     the never-overwrite posture → `skipped`.
  */
 function applyConfigStep(step: PlanStep, ctx: ApplyCtx, acc: ResultAcc): void {
   const seed = ctx.seed ?? defaultSeed;
@@ -389,6 +509,7 @@ function applyConfigStep(step: PlanStep, ctx: ApplyCtx, acc: ResultAcc): void {
   const seedResult = seed(ctx.repoRoot, force);
 
   if (seedResult.wrote) {
+    acc.configSeededThisRun = true;
     acc.applied.push(step);
     if (force) {
       acc.advisories.push({
@@ -400,8 +521,14 @@ function applyConfigStep(step: PlanStep, ctx: ApplyCtx, acc: ResultAcc): void {
   }
 
   if (seedResult.reason === 'already-exists') {
-    // Hand-edit preserved (never-overwrite posture) — intentionally not run.
-    acc.skipped.push(step);
+    if (acc.configSeededThisRun) {
+      // An earlier config step in THIS run already seeded the file — this step's
+      // field is in it now. That is convergence, not a preserved hand-edit.
+      acc.applied.push(step);
+    } else {
+      // The file pre-existed the run — hand-edit preserved (never-overwrite).
+      acc.skipped.push(step);
+    }
     return;
   }
 
@@ -574,7 +701,13 @@ async function applyHookStep(
  * unhandled kind is a compile error, never a silent drop.
  */
 export async function apply(plan: ReconcilePlan, ctx: ApplyCtx): Promise<ReconcileResult> {
-  const acc: ResultAcc = { applied: [], skipped: [], residual: [], advisories: [] };
+  const acc: ResultAcc = {
+    applied: [],
+    skipped: [],
+    residual: [],
+    advisories: [],
+    configSeededThisRun: false,
+  };
 
   for (const step of plan.steps) {
     const kind: PlanStepKind = step.kind;
@@ -753,9 +886,13 @@ export async function reconcileWithEvents(
   const idempotencyKey = deriveIdempotencyKey(repoRoot, trigger);
 
   // detect → diff (always; needed for the dry-run plan AND the live re-diff).
+  // `declared` is the verification commands ALREADY pinned in `.exarchos.yml` —
+  // the "actual" side of the §4.5-seed divergence, so a re-run after a seed
+  // (commands now declared) re-diffs to an empty plan (idempotence).
   const desired = await detectDesiredState(repoRoot, input.detectOptions);
   const checks = await input.runDoctorChecks(repoRoot);
-  const plan = diff(desired, checks);
+  const declared = declaredVerificationCommands(repoRoot);
+  const plan = diff(desired, checks, declared);
 
   // Dry-run: surface the plan, but emit nothing and perform no side effect.
   if (input.dryRun) {

--- a/servers/exarchos-mcp/src/core/onboarding/reconcile.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/reconcile.ts
@@ -73,11 +73,19 @@ export interface DetectOptions {
   readonly runtimes?: readonly string[];
   /** Explicit VCS id (DR-2 `--vcs`). Bypasses `.git` probing. */
   readonly vcs?: string;
-  /** Command overrides threaded into the layered resolver's override tier. */
+  /**
+   * Command overrides threaded into the layered resolver's override tier. Covers
+   * the full verification-ladder field set — `deriveCommands` delegates to
+   * `resolveVerificationRuntime`, which resolves `mutation`/`lint` alongside the
+   * legacy triple, so the typed onboarding API must accept overrides for all of
+   * them (otherwise mutation/lint could only be overridden via a type escape).
+   */
   readonly commandOverride?: {
     readonly test?: string;
     readonly typecheck?: string;
     readonly install?: string;
+    readonly mutation?: string;
+    readonly lint?: string;
   };
   /**
    * Injection seam for the agent-host runtime probe (defaults to the real
@@ -322,12 +330,27 @@ const SEEDABLE_VERIFICATION_FIELDS = ['mutation', 'lint'] as const;
 type SeedableVerificationField = (typeof SEEDABLE_VERIFICATION_FIELDS)[number];
 
 /**
- * The stable PlanStep key for seeding one resolved-but-undeclared verification
- * command. Distinct from the doctor-check keys so the two config-step families
- * never collide and `apply` / `doctor --fix` can idempotence-match per field.
+ * The stable PlanStep key PREFIX for verification-command seed steps. Distinct
+ * from the doctor-check keys so the two config-step families never collide and
+ * `apply` / `doctor --fix` can idempotence-match per field. Shared by the key
+ * builder and {@link isVerificationCommandStep} so the two never drift.
  */
+const VERIFICATION_COMMAND_KEY_PREFIX = 'verification-command-';
+
+/** The stable PlanStep key for seeding one resolved-but-undeclared command. */
 function verificationCommandKey(field: SeedableVerificationField): string {
-  return `verification-command-${field}`;
+  return `${VERIFICATION_COMMAND_KEY_PREFIX}${field}`;
+}
+
+/**
+ * Is `step` a verification-command seed step (vs the whole-config seed step)?
+ * These steps are emitted ONLY for a resolved-but-UNDECLARED field, so a
+ * pre-existing `.exarchos.yml` provably does NOT already contain the command —
+ * which {@link applyConfigStep} uses to report an un-seedable field as residual
+ * rather than mis-classifying it as a preserved hand-edit.
+ */
+function isVerificationCommandStep(step: PlanStep): boolean {
+  return step.key.startsWith(VERIFICATION_COMMAND_KEY_PREFIX);
 }
 
 /**
@@ -525,8 +548,24 @@ function applyConfigStep(step: PlanStep, ctx: ApplyCtx, acc: ResultAcc): void {
       // An earlier config step in THIS run already seeded the file — this step's
       // field is in it now. That is convergence, not a preserved hand-edit.
       acc.applied.push(step);
+    } else if (isVerificationCommandStep(step)) {
+      // A verification-command step is emitted ONLY for a resolved-but-UNDECLARED
+      // field, so a pre-existing `.exarchos.yml` does NOT already contain it. The
+      // create-only seeder cannot add a single key to an existing file, so the
+      // command is genuinely still absent → RESIDUAL (a re-diff re-surfaces it),
+      // NOT `skipped`. Reporting it `skipped` would mis-classify a never-written
+      // verification command as a preserved hand-edit — a silent success that
+      // leaves the ladder on the built-in fallback (Sentry 14615676).
+      acc.residual.push(step);
+      acc.advisories.push({
+        surface: 'any',
+        message:
+          `${step.description} — the existing ${seedResult.path} was left untouched ` +
+          `(never-overwrite); add this key to it by hand to pin the command.`,
+      });
     } else {
-      // The file pre-existed the run — hand-edit preserved (never-overwrite).
+      // The whole-config seed step: the file pre-existed → hand-edit preserved
+      // by the never-overwrite posture.
       acc.skipped.push(step);
     }
     return;

--- a/servers/exarchos-mcp/src/core/onboarding/types.test.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/types.test.ts
@@ -6,12 +6,14 @@ import {
   ReconcilePlanSchema,
   ReconcileResultSchema,
   AdvisorySchema,
+  ResolvedCommandsSchema,
   type Surface,
   type PlanStep,
   type DesiredState,
   type ReconcilePlan,
   type ReconcileResult,
   type Advisory,
+  type ResolvedCommands,
 } from './types.js';
 
 // A valid PlanStep reused by several cases below.
@@ -123,6 +125,55 @@ describe('ReconcileTypes_PlanStepSurface_TaggedCliOnly', () => {
         commands: { test: 123 },
       }).success,
     ).toBe(false);
+  });
+
+  it('ResolvedCommandsSchema_MutationAndLint_Optional', () => {
+    // Task 007 (design §4.5-detect): the schema widens to the verification-ladder
+    // field set so onboard/doctor surface `mutation` and `lint`. Both new fields
+    // carry the SAME optionality semantics as the legacy three.
+
+    // Accepts BOTH new fields alongside the legacy three, round-tripping unchanged.
+    const both = ResolvedCommandsSchema.safeParse({
+      test: 'npm run test:run',
+      typecheck: 'tsc --noEmit',
+      install: 'npm install',
+      mutation: 'npx stryker run',
+      lint: 'eslint .',
+    });
+    expect(both.success).toBe(true);
+    if (both.success) {
+      expect(both.data).toEqual({
+        test: 'npm run test:run',
+        typecheck: 'tsc --noEmit',
+        install: 'npm install',
+        mutation: 'npx stryker run',
+        lint: 'eslint .',
+      });
+    }
+
+    // Accepts NEITHER new field — both are optional, so the legacy-only object
+    // (and the empty object) remain valid with the new fields simply absent.
+    const neither = ResolvedCommandsSchema.safeParse({ test: 'npm run test:run' });
+    expect(neither.success).toBe(true);
+    if (neither.success) {
+      expect('mutation' in neither.data).toBe(false);
+      expect('lint' in neither.data).toBe(false);
+      expect(neither.data).toEqual({ test: 'npm run test:run' });
+    }
+
+    // Accepts mutation alone (one new field present, the other absent).
+    const mutationOnly = ResolvedCommandsSchema.parse({ mutation: 'npx stryker run' });
+    expect(mutationOnly.mutation).toBe('npx stryker run');
+    expect('lint' in mutationOnly).toBe(false);
+
+    // Malformed: a new field must be a string when present (same as legacy).
+    expect(ResolvedCommandsSchema.safeParse({ mutation: 123 }).success).toBe(false);
+    expect(ResolvedCommandsSchema.safeParse({ lint: false }).success).toBe(false);
+
+    // Type-level: the inferred type carries optional mutation/lint of type string.
+    const typed: ResolvedCommands = { mutation: 'npx stryker run', lint: 'eslint .' };
+    expect(typed.mutation).toBe('npx stryker run');
+    expect(typed.lint).toBe('eslint .');
   });
 
   it('Advisory parses the cli-only install advisory and rejects malformed', () => {

--- a/servers/exarchos-mcp/src/core/onboarding/types.ts
+++ b/servers/exarchos-mcp/src/core/onboarding/types.ts
@@ -64,11 +64,20 @@ export type PlanStep = z.infer<typeof PlanStepSchema>;
  * the layered resolver (override > `.exarchos.yml` > user `toolchains:` >
  * task-runner > registry) may leave a field unresolved. The shape only — the
  * derivation lives in detect (task 005).
+ *
+ * The field set tracks the verification ladder, not just the legacy test
+ * triple: `mutation` and `lint` join `test`/`typecheck`/`install` so onboard /
+ * doctor resolve and surface the wider verification surface (task 007, design
+ * §4.5-detect). Both new fields carry the SAME optionality semantics as the
+ * legacy three — the resolver may leave either unresolved, in which case detect
+ * OMITS it (INV-6 omit-never-fabricate).
  */
 export const ResolvedCommandsSchema = z.object({
   test: z.string().optional(),
   typecheck: z.string().optional(),
   install: z.string().optional(),
+  mutation: z.string().optional(),
+  lint: z.string().optional(),
 });
 export type ResolvedCommands = z.infer<typeof ResolvedCommandsSchema>;
 

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -205,7 +205,19 @@ function adaptLadderGate<T>(
         `${handler.name}: ctx.eventStore required (handler dispatched without DispatchContext)`,
       );
     }
-    const result = await handler(args as unknown as T, stateDir, ctx.eventStore);
+    // task 004: thread the dispatch-time projectConfig into the handler args so
+    // its `resolvePolicySkip` self-skip routing consumes the SAME config-
+    // resolved policy the delegation stamp used. Without this the skip path
+    // would silently use the built-in table while the stamp honored a
+    // `.exarchos.yml` `verification:` cell — the exact desync this slice closes.
+    // Only inject when the args don't already carry `projectConfig` (an explicit
+    // arg-level override, e.g. from a test, still wins).
+    const enrichedArgs =
+      ctx.projectConfig !== undefined &&
+      (args as { projectConfig?: unknown }).projectConfig === undefined
+        ? { ...(args as Record<string, unknown>), projectConfig: ctx.projectConfig }
+        : args;
+    const result = await handler(enrichedArgs as unknown as T, stateDir, ctx.eventStore);
     const featureId = (args as { featureId?: string }).featureId;
     const workflowType = await resolveWorkflowTypeForGate(featureId, ctx.eventStore);
     return applyLadderGateSeverity(

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -217,13 +217,21 @@ function adaptLadderGate<T>(
       (args as { projectConfig?: unknown }).projectConfig === undefined
         ? { ...(args as Record<string, unknown>), projectConfig: ctx.projectConfig }
         : args;
+    // The config the handler actually resolved its self-skip routing against:
+    // an arg-level `projectConfig` override wins, else the injected ctx config.
+    // Severity post-processing MUST read the SAME config so skip routing and
+    // severity adaptation can never resolve against divergent configs in one
+    // dispatch (INV-2: identical DispatchContext + args ⇒ identical ToolResult).
+    const effectiveProjectConfig = (enrichedArgs as {
+      projectConfig?: DispatchContext['projectConfig'];
+    }).projectConfig;
     const result = await handler(enrichedArgs as unknown as T, stateDir, ctx.eventStore);
     const featureId = (args as { featureId?: string }).featureId;
     const workflowType = await resolveWorkflowTypeForGate(featureId, ctx.eventStore);
     return applyLadderGateSeverity(
       gateName,
       dimension,
-      ctx.projectConfig,
+      effectiveProjectConfig,
       result,
       workflowType,
     );

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -92,6 +92,8 @@ import type { HandleScaffoldArgs } from './invariants/scaffold.js';
 import { handleAdd } from './invariants/add.js';
 import type { HandleAddArgs } from './invariants/add.js';
 import { realScaffoldDeps } from './invariants/fs-deps.js';
+import { applyLadderGateSeverity } from './gate-utils.js';
+import { resolveWorkflowState } from './resolve-state.js';
 
 // ─── Action Router ──────────────────────────────────────────────────────────
 
@@ -148,6 +150,71 @@ function adaptWithEventStore<T>(
       );
     }
     return handler(args as unknown as T, stateDir, ctx.eventStore);
+  };
+}
+
+// ─── Verification-ladder severity dispatch (task 005) ────────────────────────
+//
+// The five verification-ladder gates are INV-5b advisory carriers
+// (`success:true, data.passed`). To apply per-workflow severity (e.g. oneshot
+// → warning) we resolve the ACTUAL workflowType from workflow state ONCE per
+// dispatch and post-process the handler's advisory result with
+// `applyLadderGateSeverity`. The `dimension` per gate mirrors the dimension
+// each handler stamps on its `gate.executed` event; it only matters as the
+// dimension-level severity FALLBACK, which the workflow default takes priority
+// over for these gates.
+
+/**
+ * Resolve a featureId's workflow type from workflow state, with the canonical
+ * event-store fallback (`resolveWorkflowState`). NEVER reads `.state.json`
+ * from disk directly. Returns `'feature'` when the type is absent or state is
+ * unreadable — mirrors `check-invariant-conformance`'s `'feature'` default so
+ * the non-oneshot path is unchanged on any resolution miss.
+ */
+async function resolveWorkflowTypeForGate(
+  featureId: string | undefined,
+  eventStore: EventStore,
+): Promise<string> {
+  if (!featureId) return 'feature';
+  try {
+    const resolved = await resolveWorkflowState({ featureId, eventStore });
+    if ('error' in resolved) return 'feature';
+    const wt = (resolved.state as { workflowType?: unknown }).workflowType;
+    return typeof wt === 'string' && wt.length > 0 ? wt : 'feature';
+  } catch {
+    return 'feature';
+  }
+}
+
+/**
+ * Adapter for a verification-ladder gate handler. Runs the underlying advisory
+ * handler, then resolves the workflow type and applies per-workflow severity
+ * to a failing advisory verdict via {@link applyLadderGateSeverity}. When the
+ * dispatch context carries no `projectConfig`, the result passes through
+ * unchanged (legacy / no-config behavior). The threading is centralized here so
+ * all five gates pick it up from one place.
+ */
+function adaptLadderGate<T>(
+  gateName: string,
+  dimension: string,
+  handler: (args: T, stateDir: string, eventStore: EventStore) => Promise<ToolResult>,
+): ActionHandler {
+  return async (args, stateDir, ctx) => {
+    if (!ctx?.eventStore) {
+      throw new Error(
+        `${handler.name}: ctx.eventStore required (handler dispatched without DispatchContext)`,
+      );
+    }
+    const result = await handler(args as unknown as T, stateDir, ctx.eventStore);
+    const featureId = (args as { featureId?: string }).featureId;
+    const workflowType = await resolveWorkflowTypeForGate(featureId, ctx.eventStore);
+    return applyLadderGateSeverity(
+      gateName,
+      dimension,
+      ctx.projectConfig,
+      result,
+      workflowType,
+    );
   };
 }
 
@@ -252,12 +319,17 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   check_design_completeness: adaptWithEventStore(handleDesignCompleteness),
   check_plan_coverage: adaptWithEventStore(handlePlanCoverage),
   check_tdd_compliance: adaptWithEventStore(handleTddCompliance),
-  check_test_adequacy: adaptWithEventStore(handleTestAdequacy),
-  check_contract_drift: adaptWithEventStore(handleContractDrift),
-  check_mock_boundary: adaptWithEventStore(handleMockBoundary),
+  // Verification-ladder gates (task 005): wrapped in adaptLadderGate so a
+  // failing advisory verdict picks up its per-workflow severity (oneshot →
+  // warning) from the resolved workflowType. The `dimension` mirrors each
+  // handler's stamped gate.executed dimension (fallback only — the workflow
+  // default takes priority for ladder gates).
+  check_test_adequacy: adaptLadderGate('check_test_adequacy', 'D1', handleTestAdequacy),
+  check_contract_drift: adaptLadderGate('check_contract_drift', 'D1', handleContractDrift),
+  check_mock_boundary: adaptLadderGate('check_mock_boundary', 'D1', handleMockBoundary),
   check_post_merge: adaptWithEventStore(handlePostMerge),
-  check_static_analysis: adaptWithEventStore(handleStaticAnalysis),
-  check_integration_suite: adaptWithEventStore(handleCheckIntegrationSuite),
+  check_static_analysis: adaptLadderGate('check_static_analysis', 'D2', handleStaticAnalysis),
+  check_integration_suite: adaptLadderGate('check_integration_suite', 'D2', handleCheckIntegrationSuite),
   check_security_scan: adaptWithEventStore(handleSecurityScan),
   check_context_economy: adaptWithEventStore(handleContextEconomy),
   check_operational_resilience: adaptWithEventStore(handleOperationalResilience),

--- a/servers/exarchos-mcp/src/orchestrate/config-gate-integration.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/config-gate-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { withConfigSeverity } from './gate-utils.js';
+import { withConfigSeverity, applyLadderGateSeverity } from './gate-utils.js';
 import { DEFAULTS } from '../config/resolve.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
 import type { ToolResult } from '../format.js';
@@ -101,5 +101,59 @@ describe('withConfigSeverity', () => {
 
     const result = await withConfigSeverity(ladderGate, 'D2', DEFAULTS, mockGateHandler, 'feature');
     expect(result.success).toBe(false);
+  });
+});
+
+// ─── applyLadderGateSeverity (advisory-carrier conversion) ───────────────────
+//
+// Ladder gates are INV-5b advisory carriers: a FAILING gate is
+// `success:true, data.passed:false`, NOT `success:false`. This helper applies
+// the resolved per-workflow severity to that advisory shape — converting a
+// `data.passed:false` to success-with-warning when severity is `warning`,
+// leaving the result untouched otherwise.
+
+const LADDER = VERIFICATION_GATE_NAMES[0]; // 'check_static_analysis'
+
+describe('applyLadderGateSeverity', () => {
+  it('ApplyLadderGateSeverity_OneshotFailingAdvisory_AddsWarning', () => {
+    const advisory: ToolResult = { success: true, data: { passed: false, report: 'r' } };
+    const result = applyLadderGateSeverity(LADDER, 'D2', DEFAULTS, advisory, 'oneshot');
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('warning-only')]),
+    );
+  });
+
+  it('ApplyLadderGateSeverity_OneshotPassingAdvisory_Unchanged', () => {
+    const advisory: ToolResult = { success: true, data: { passed: true } };
+    const result = applyLadderGateSeverity(LADDER, 'D2', DEFAULTS, advisory, 'oneshot');
+    expect(result).toEqual(advisory);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('ApplyLadderGateSeverity_FeatureFailingAdvisory_Unchanged', () => {
+    // Blocking severity (no oneshot table entry) leaves the advisory result as
+    // the handler returned it — the orchestrator reads data.passed to block.
+    const advisory: ToolResult = { success: true, data: { passed: false } };
+    const result = applyLadderGateSeverity(LADDER, 'D2', DEFAULTS, advisory, 'feature');
+    expect(result).toEqual(advisory);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('ApplyLadderGateSeverity_NoConfig_Unchanged', () => {
+    const advisory: ToolResult = { success: true, data: { passed: false } };
+    const result = applyLadderGateSeverity(LADDER, 'D2', undefined, advisory, 'oneshot');
+    expect(result).toEqual(advisory);
+  });
+
+  it('ApplyLadderGateSeverity_ErrorResult_Untouched', () => {
+    // A real error envelope (not an advisory carrier) is never downgraded — an
+    // INVALID_INPUT / MISWIRED_CONTEXT must still surface as a failure.
+    const errored: ToolResult = {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'featureId is required' },
+    };
+    const result = applyLadderGateSeverity(LADDER, 'D2', DEFAULTS, errored, 'oneshot');
+    expect(result).toEqual(errored);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/config-gate-integration.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/config-gate-integration.test.ts
@@ -3,6 +3,7 @@ import { withConfigSeverity } from './gate-utils.js';
 import { DEFAULTS } from '../config/resolve.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
 import type { ToolResult } from '../format.js';
+import { VERIFICATION_GATE_NAMES } from '../workflow/verification-policy.js';
 
 describe('withConfigSeverity', () => {
   const mockGateHandler = vi.fn<() => Promise<ToolResult>>();
@@ -71,5 +72,34 @@ describe('withConfigSeverity', () => {
 
     const result = await withConfigSeverity('test-gate', 'D1', DEFAULTS, mockGateHandler);
     expect(result.success).toBe(true);
+  });
+
+  it('GateHandler_OneshotLadderGate_FailureBecomesWarning', async () => {
+    // Task 005: a ladder-gate failure under an oneshot workflow is threaded as
+    // warning severity via the new trailing workflowType param — the failure is
+    // converted to success-with-warning rather than blocking.
+    const ladderGate = VERIFICATION_GATE_NAMES[0]; // 'check_static_analysis'
+    mockGateHandler.mockResolvedValue({
+      success: false,
+      error: { code: 'GATE_FAILED', message: 'Gate failed' },
+    });
+
+    const result = await withConfigSeverity(ladderGate, 'D2', DEFAULTS, mockGateHandler, 'oneshot');
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('warning-only')]),
+    );
+  });
+
+  it('GateHandler_FeatureLadderGate_FailureStillBlocks', async () => {
+    // A non-oneshot workflow keeps the ladder gate blocking (no table entry).
+    const ladderGate = VERIFICATION_GATE_NAMES[0];
+    mockGateHandler.mockResolvedValue({
+      success: false,
+      error: { code: 'GATE_FAILED', message: 'Gate failed' },
+    });
+
+    const result = await withConfigSeverity(ladderGate, 'D2', DEFAULTS, mockGateHandler, 'feature');
+    expect(result.success).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/contract-drift-handler.ts
+++ b/servers/exarchos-mcp/src/orchestrate/contract-drift-handler.ts
@@ -28,6 +28,7 @@ import {
   SKIPPED_BY_POLICY,
 } from './gate-utils.js';
 import type { RiskTier } from '../workflow/verification-policy.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { resolveVerificationRuntime } from '../config/test-runtime-resolver.js';
 import { splitCommand } from '../config/tokenize-command.js';
 import type { GitExec } from './pure/execute-merge.js';
@@ -75,6 +76,13 @@ export interface ContractDriftHandlerArgs {
   readonly riskTier?: RiskTier;
   /** The task's stamped boundary-touching flag. See {@link riskTier}. */
   readonly boundaryTouching?: boolean;
+  /**
+   * The resolved project config (task 004). Threaded by the dispatch adapter so
+   * the self-skip routing consumes the SAME config-resolved policy the
+   * delegation stamp uses. Omitted → the resolver falls through to the built-in
+   * table.
+   */
+  readonly projectConfig?: ResolvedProjectConfig;
 
   // ── Test seams (DI; production defaults below) ───────────────────────────
   readonly gitExec?: GitExec;
@@ -157,6 +165,7 @@ export async function handleContractDrift(
     gateName: 'check_contract_drift',
     riskTier: args.riskTier,
     boundaryTouching: args.boundaryTouching,
+    config: args.projectConfig,
   });
   if (policySkip) {
     try {

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/__shared__/make-stub-probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/__shared__/make-stub-probes.ts
@@ -35,6 +35,7 @@ export function makeStubProbes(overrides: Partial<DoctorProbes> = {}): DoctorPro
       runningVersion: throwing('plugin'),
     },
     invariants: { resolve: throwing('invariants') },
+    verificationToolchain: { resolve: throwing('verificationToolchain') },
   };
   return { ...base, ...overrides };
 }

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/verification-toolchain.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/verification-toolchain.test.ts
@@ -1,0 +1,157 @@
+/**
+ * verification-toolchain check — RED tests (design §4.6).
+ *
+ * The 13th doctor check reports whether the verification ladder's commands
+ * resolve at all, so unresolved toolchains stop degrading gates silently.
+ *
+ * Status contract under test:
+ *   - Pass    — test + typecheck + mutation all resolve (lint reported
+ *               informationally either way).
+ *   - Warning — any of that triple unresolved; `fix` MUST name BOTH remedies
+ *               (`exarchos doctor --fix` AND declaring the field in
+ *               `.exarchos.yml` / a `toolchains:` entry).
+ *   - Skipped — nothing detectable at all (empty repo); `reason` names what
+ *               detection looked for.
+ *
+ * The detail payload always carries the resolved-policy source per cell for
+ * all six (riskTier × boundaryTouching) cells — read-only visibility, the
+ * check NEVER writes anything.
+ *
+ * The probe is the disk seam: the check itself reaches for nothing but
+ * `probes.verificationToolchain.resolve()`. Tests stub that probe.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { makeStubProbes } from './__shared__/make-stub-probes.js';
+import { verificationToolchain } from './verification-toolchain.js';
+import type { VerificationToolchainResolution } from '../probes.js';
+
+const controller = () => new AbortController().signal;
+
+/** The six policy cells, always reported with a `builtin`/`config` source. */
+const ALL_SIX_CELLS: VerificationToolchainResolution['policyCells'] = [
+  { riskTier: 'low', boundaryTouching: false, source: 'builtin' },
+  { riskTier: 'low', boundaryTouching: true, source: 'builtin' },
+  { riskTier: 'medium', boundaryTouching: false, source: 'builtin' },
+  { riskTier: 'medium', boundaryTouching: true, source: 'builtin' },
+  { riskTier: 'high', boundaryTouching: false, source: 'builtin' },
+  { riskTier: 'high', boundaryTouching: true, source: 'builtin' },
+];
+
+/** A resolution where the full Pass triple resolves. */
+function fullyResolved(): VerificationToolchainResolution {
+  return {
+    detected: true,
+    runtime: {
+      test: 'npm run test:run',
+      typecheck: 'tsc --noEmit',
+      install: 'npm install',
+      mutation: 'npx stryker run',
+      lint: 'eslint .',
+    },
+    policyCells: ALL_SIX_CELLS,
+  };
+}
+
+describe('verificationToolchain', () => {
+  it('VerificationToolchain_AllTripleResolves_Pass', async () => {
+    const probes = makeStubProbes({
+      verificationToolchain: { resolve: async () => fullyResolved() },
+    });
+
+    const result = await verificationToolchain(probes, controller());
+
+    expect(result.category).toBe('verification');
+    expect(result.name).toBe('verification-toolchain');
+    expect(result.status).toBe('Pass');
+    expect(result.fix).toBeUndefined();
+    // lint is reported informationally in the Pass message.
+    expect(result.message).toContain('eslint .');
+  });
+
+  it('VerificationToolchain_MutationUnresolved_WarningWithBothRemedies', async () => {
+    const probes = makeStubProbes({
+      verificationToolchain: {
+        resolve: async () => ({
+          detected: true,
+          runtime: {
+            test: 'npm run test:run',
+            typecheck: 'tsc --noEmit',
+            install: 'npm install',
+            mutation: null, // the triple is incomplete
+            lint: 'eslint .',
+          },
+          policyCells: ALL_SIX_CELLS,
+        }),
+      },
+    });
+
+    const result = await verificationToolchain(probes, controller());
+
+    expect(result.status).toBe('Warning');
+    expect(result.fix).toBeDefined();
+    // BOTH remedies must be named: the reconciler fix path AND declaring the
+    // field where detection can't see it.
+    expect(result.fix).toContain('exarchos doctor --fix');
+    expect(result.fix).toContain('.exarchos.yml');
+    expect(result.fix).toContain('toolchains:');
+    // The unresolved field is named so the operator knows what to declare.
+    expect(result.message).toContain('mutation');
+  });
+
+  it('VerificationToolchain_NoToolchainDetected_SkippedWithReason', async () => {
+    const probes = makeStubProbes({
+      verificationToolchain: {
+        resolve: async () => ({
+          detected: false,
+          runtime: {
+            test: null,
+            typecheck: null,
+            install: null,
+            mutation: null,
+            lint: null,
+          },
+          policyCells: ALL_SIX_CELLS,
+        }),
+      },
+    });
+
+    const result = await verificationToolchain(probes, controller());
+
+    expect(result.status).toBe('Skipped');
+    expect(result.reason).toBeDefined();
+    expect(result.reason!.length).toBeGreaterThan(0);
+    // The reason names what detection looked for (project markers / config).
+    expect(result.reason).toMatch(/marker|\.exarchos\.yml|toolchain/i);
+    // No fix on a Skipped result.
+    expect(result.fix).toBeUndefined();
+  });
+
+  it('VerificationToolchain_DetailPayload_CarriesPolicySourcePerCell', async () => {
+    const mixedCells: VerificationToolchainResolution['policyCells'] = [
+      { riskTier: 'low', boundaryTouching: false, source: 'builtin' },
+      { riskTier: 'low', boundaryTouching: true, source: 'config' },
+      { riskTier: 'medium', boundaryTouching: false, source: 'builtin' },
+      { riskTier: 'medium', boundaryTouching: true, source: 'config' },
+      { riskTier: 'high', boundaryTouching: false, source: 'builtin' },
+      { riskTier: 'high', boundaryTouching: true, source: 'config' },
+    ];
+    const probes = makeStubProbes({
+      verificationToolchain: {
+        resolve: async () => ({
+          ...fullyResolved(),
+          policyCells: mixedCells,
+        }),
+      },
+    });
+
+    const result = await verificationToolchain(probes, controller());
+
+    // All six cells are reported, each with its builtin/config provenance.
+    expect(result.policyCells).toHaveLength(6);
+    expect(result.policyCells).toEqual(mixedCells);
+    // The message surfaces the mixed provenance so the payload is self-describing.
+    expect(result.message).toMatch(/builtin/i);
+    expect(result.message).toMatch(/config/i);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/verification-toolchain.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/verification-toolchain.ts
@@ -1,0 +1,109 @@
+/**
+ * verification-toolchain — does the verification ladder's runtime resolve, and
+ * where does each policy cell come from? (design §4.6)
+ *
+ * Today no doctor check reports whether the verification ladder's commands
+ * resolve, so an unresolved toolchain degrades the gates (test-adequacy,
+ * mutation, etc.) SILENTLY. This is the 13th check, closing that visibility gap.
+ *
+ * Status mapping over `probes.verificationToolchain.resolve()`:
+ *   - Pass    — `test`, `typecheck`, AND `mutation` all resolve. `lint` is
+ *               reported informationally in the message either way.
+ *   - Warning — any of that triple is unresolved. `fix` names BOTH remedies:
+ *               `exarchos doctor --fix` (seeds what detection found) AND
+ *               declaring the field in `.exarchos.yml` / a `toolchains:` entry
+ *               for what detection can't see.
+ *   - Skipped — no toolchain detectable at all (empty/unmarked repo); `reason`
+ *               names what detection looked for.
+ *
+ * The result ALWAYS carries `policyCells`: the six `(riskTier × boundaryTouching)`
+ * verification-policy cells with their `builtin`/`config` provenance, and the
+ * message summarizes that provenance. This is READ-ONLY visibility — the check
+ * never writes or seeds anything; the fix path stays the reconciler's.
+ */
+
+import type { CheckFn } from './__shared__/make-stub-probes.js';
+
+/** Format the `lint` cell for the informational message tail. */
+function lintNote(lint: string | null): string {
+  return lint !== null ? `lint resolves (\`${lint}\`)` : 'lint unresolved';
+}
+
+/** One-line provenance summary across the six policy cells. */
+function policyProvenanceSummary(
+  policyCells: ReadonlyArray<{ source: 'builtin' | 'config' }>,
+): string {
+  const builtin = policyCells.filter((c) => c.source === 'builtin').length;
+  const config = policyCells.filter((c) => c.source === 'config').length;
+  return `policy: ${builtin}/${policyCells.length} cells builtin, ${config}/${policyCells.length} config`;
+}
+
+export const verificationToolchain: CheckFn = async (probes, signal) => {
+  const start = Date.now();
+  const base = { category: 'verification' as const, name: 'verification-toolchain' };
+
+  const resolution = await probes.verificationToolchain.resolve(signal);
+  const { detected, runtime } = resolution;
+  // Copy the readonly probe cells into a fresh mutable array — `CheckResult`'s
+  // schema-derived `policyCells` is mutable, and the provenance is carried by
+  // value onto the result (read-only visibility, the check never mutates policy).
+  const policyCells = resolution.policyCells.map((c) => ({
+    riskTier: c.riskTier,
+    boundaryTouching: c.boundaryTouching,
+    source: c.source,
+  }));
+  const policyNote = policyProvenanceSummary(policyCells);
+
+  // Skipped — nothing detectable at all (empty/unmarked repo). DIM-2: the
+  // `reason` names what detection looked for so the skip is never silent.
+  if (!detected) {
+    return {
+      ...base,
+      status: 'Skipped' as const,
+      message: `No verification toolchain detected; ${policyNote}`,
+      reason:
+        'No project markers (package.json / a recognised toolchain) and no ' +
+        'test/typecheck/mutation entries in .exarchos.yml were detected, so no ' +
+        'verification runtime could be resolved. Add a project toolchain or ' +
+        'declare commands in .exarchos.yml to enable the verification ladder.',
+      durationMs: Date.now() - start,
+      policyCells,
+    };
+  }
+
+  // The Pass triple: test + typecheck + mutation must all resolve. lint is
+  // informational only (it never gates the status).
+  const unresolved = (['test', 'typecheck', 'mutation'] as const).filter(
+    (field) => runtime[field] === null,
+  );
+
+  if (unresolved.length > 0) {
+    return {
+      ...base,
+      status: 'Warning' as const,
+      message:
+        `Verification toolchain incomplete: ${unresolved.join(', ')} unresolved ` +
+        `(${lintNote(runtime.lint)}); ${policyNote}`,
+      // BOTH remedies, per the contract: the reconciler seeds what detection
+      // already found, and declaring the field covers what detection can't see.
+      fix:
+        'Run `exarchos doctor --fix` to seed the commands detection found, AND ' +
+        `declare the unresolved field(s) (${unresolved.join(', ')}) explicitly ` +
+        'in .exarchos.yml (e.g. `mutation: npx stryker run`) or via a ' +
+        '`toolchains:` entry for toolchains detection cannot infer.',
+      durationMs: Date.now() - start,
+      policyCells,
+    };
+  }
+
+  return {
+    ...base,
+    status: 'Pass' as const,
+    message:
+      `Verification toolchain resolves: test (\`${runtime.test}\`), ` +
+      `typecheck (\`${runtime.typecheck}\`), mutation (\`${runtime.mutation}\`); ` +
+      `${lintNote(runtime.lint)}; ${policyNote}`,
+    durationMs: Date.now() - start,
+    policyCells,
+  };
+};

--- a/servers/exarchos-mcp/src/orchestrate/doctor/doctor-roster.characterization.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/doctor-roster.characterization.test.ts
@@ -1,0 +1,168 @@
+/**
+ * T0 characterization (epic task 006, design §4.7) — PINS the CURRENT doctor
+ * roster surface so the upcoming reconciler/doctor extension (a sibling task
+ * adds a 13th check and widens `ResolvedCommandsSchema`) has a regression
+ * oracle.
+ *
+ * SCOPE — this file pins the STATIC roster export `ALL_CHECKS` at the roster
+ * level: how many checks ship, each check's stable `(name, category)`, and the
+ * status vocabulary the contract type declares. It is deliberately COMPLEMENTARY
+ * to `doctor.characterization.test.ts`, which pins the same identity set as
+ * observed through the full `handleDoctor` run + the `diagnostic.executed` event
+ * payload. Pinning the roster export directly (rather than only through the
+ * composer) means a sibling task that appends a 13th entry to `ALL_CHECKS` trips
+ * THIS guard at the roster boundary, before any handler wiring.
+ *
+ * This test MUST PASS against unmodified HEAD — it is a Feathers baseline, not
+ * a spec for new behavior.
+ *
+ * HOW IDENTITY IS READ (no copied literals masquerading as pins): each check in
+ * the REAL `ALL_CHECKS` is executed with a benign full-probe bundle and its
+ * `(name, category)` is read off the returned `CheckResult`. The bundle returns
+ * safe values for every probe a check might touch, so each check reaches its
+ * return statement and surfaces its own identity — we never hand-build a check
+ * result. The benign bundle is identity-only scaffolding; the pass/fail STATUS
+ * each check computes is host-dependent and intentionally NOT pinned here.
+ *
+ * The status VOCABULARY is pinned from the canonical `CheckStatusSchema` enum
+ * (schema.ts) — the source of truth the `CheckFn` result type derives from — so
+ * the pin tracks the type, not a transcribed copy.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { DoctorProbes } from './probes.js';
+import type { AgentEnvironment } from '../../runtime/agent-environment-detector.js';
+import type { IntegrityResult } from '../../event-store/store.js';
+import { CheckStatusSchema, CheckResultSchema, type CheckResult } from './schema.js';
+import { ALL_CHECKS } from './index.js';
+
+// ─── Pinned roster identity ──────────────────────────────────────────────────
+
+/**
+ * The TWELVE checks shipped today, pinned by `(category, name)` and ORDER.
+ * `ALL_CHECKS` order is part of the observable contract: the composer preserves
+ * it so callers scan top-to-bottom for the first Fail. A sibling task adding a
+ * 13th check must update this list (and the count) deliberately — that edit is
+ * the signal this guard exists to force.
+ */
+const PINNED_ROSTER: ReadonlyArray<{
+  category: CheckResult['category'];
+  name: string;
+}> = [
+  { category: 'runtime', name: 'node-version' },
+  { category: 'storage', name: 'state-dir' },
+  { category: 'storage', name: 'storage-sqlite-health' },
+  { category: 'env', name: 'variables' },
+  { category: 'vcs', name: 'git-available' },
+  { category: 'agent', name: 'agent-config-valid' },
+  { category: 'agent', name: 'agent-mcp-registered' },
+  { category: 'agent', name: 'session-start-hook' },
+  { category: 'plugin', name: 'plugin-skill-hash-sync' },
+  { category: 'plugin', name: 'plugin-version-match' },
+  { category: 'remote', name: 'remote-mcp' },
+  { category: 'invariants', name: 'invariants-catalog' },
+];
+
+// ─── Benign probe bundle (identity scaffolding only) ─────────────────────────
+
+/**
+ * A DoctorProbes bundle where every probe returns a SAFE value so each check
+ * reaches its return statement and surfaces its own `(name, category)`. We do
+ * NOT assert the resulting statuses — those depend on the (benign) probe values
+ * and are host-/scaffold-dependent; only the identity each check stamps on its
+ * result is pinned. This mirrors the real `DoctorProbes` field surface (see
+ * `make-stub-probes.ts`) without throwing, since here we WANT every check to
+ * run rather than fault on an unstubbed probe.
+ */
+function benignProbes(): DoctorProbes {
+  const emptyEnvironments: AgentEnvironment[] = [];
+  return {
+    fs: {
+      readFile: async () => '',
+      stat: (async () => ({
+        isDirectory: () => true,
+        isFile: () => false,
+      })) as unknown as DoctorProbes['fs']['stat'],
+      access: async () => undefined,
+    },
+    env: {},
+    git: {
+      which: async () => '/usr/bin/git',
+      isRepo: async () => true,
+      version: async () => 'git version 2.40.0',
+    },
+    sqlite: {
+      runIntegrityCheck: async (): Promise<IntegrityResult> => ({
+        ok: 'skipped',
+        reason: 'benign roster probe',
+      }),
+    },
+    detector: async () => emptyEnvironments,
+    eventStore: {
+      append: async () => ({}),
+    } as unknown as DoctorProbes['eventStore'],
+    runtime: { nodeVersion: process.version },
+    stateDir: '/tmp/doctor-roster-characterization',
+    skills: { guardStatus: async () => ({ inSync: true }) },
+    plugin: {
+      installedVersion: async () => null,
+      runningVersion: async () => null,
+    },
+    invariants: { resolve: async () => ({ configured: false, warnings: [] }) },
+  } as DoctorProbes;
+}
+
+/** Run every check in the REAL `ALL_CHECKS` and collect their results. */
+async function runRoster(): Promise<readonly CheckResult[]> {
+  const probes = benignProbes();
+  const controller = new AbortController();
+  return Promise.all(ALL_CHECKS.map((check) => check(probes, controller.signal)));
+}
+
+// ─── Characterization ────────────────────────────────────────────────────────
+
+describe('doctor roster characterization (T0 baseline)', () => {
+  it('DoctorRoster_CurrentBuild_ExactlyTwelveChecksWithStableNames', async () => {
+    // The static export ships exactly twelve checks, in pinned order.
+    expect(ALL_CHECKS).toHaveLength(12);
+    expect(PINNED_ROSTER).toHaveLength(12);
+
+    const results = await runRoster();
+    expect(results).toHaveLength(12);
+
+    // Each check, run through the REAL ALL_CHECKS, stamps its own identity —
+    // we read (category, name) off the returned result rather than transcribing.
+    const observedIdentity = results.map((r) => ({
+      category: r.category,
+      name: r.name,
+    }));
+    expect(observedIdentity).toEqual(PINNED_ROSTER);
+
+    // The name set is exactly the pinned set: no duplicates, no strays.
+    const observedNames = new Set(results.map((r) => r.name));
+    expect(observedNames.size).toBe(12);
+    for (const { name } of PINNED_ROSTER) {
+      expect(observedNames.has(name)).toBe(true);
+    }
+
+    // Every result satisfies the canonical CheckResult contract — proves each
+    // entry is a real check returning a schema-valid result, not a stub.
+    for (const r of results) {
+      expect(CheckResultSchema.safeParse(r).success).toBe(true);
+    }
+  });
+
+  it('DoctorRoster_CurrentBuild_StatusVocabularyPinned', () => {
+    // The status vocabulary is exactly these four values, sourced from the
+    // canonical CheckStatusSchema enum (the type CheckFn results derive from).
+    expect(CheckStatusSchema.options).toEqual(['Pass', 'Warning', 'Fail', 'Skipped']);
+
+    // Each vocabulary member round-trips through the schema (the enum is closed).
+    for (const status of ['Pass', 'Warning', 'Fail', 'Skipped'] as const) {
+      expect(CheckStatusSchema.safeParse(status).success).toBe(true);
+    }
+    // A value outside the vocabulary is rejected (the enum admits nothing else).
+    expect(CheckStatusSchema.safeParse('Unknown').success).toBe(false);
+    expect(CheckStatusSchema.safeParse('Ok').success).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/doctor/doctor-roster.characterization.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/doctor-roster.characterization.test.ts
@@ -39,11 +39,16 @@ import { ALL_CHECKS } from './index.js';
 // ─── Pinned roster identity ──────────────────────────────────────────────────
 
 /**
- * The TWELVE checks shipped today, pinned by `(category, name)` and ORDER.
+ * The THIRTEEN checks shipped today, pinned by `(category, name)` and ORDER.
  * `ALL_CHECKS` order is part of the observable contract: the composer preserves
- * it so callers scan top-to-bottom for the first Fail. A sibling task adding a
- * 13th check must update this list (and the count) deliberately — that edit is
- * the signal this guard exists to force.
+ * it so callers scan top-to-bottom for the first Fail. A task adding a check
+ * must update this list (and the count) deliberately — that edit is the signal
+ * this guard exists to force.
+ *
+ * DELIBERATE PIN UPDATE (task 009, design §4.6): the 13th entry
+ * `verification-toolchain` (category `verification`) was added as a CONSCIOUS
+ * act. This guard pinned EXACTLY 12 precisely so the addition could not slip in
+ * unnoticed; the count and roster below are updated 12 → 13 on purpose.
  */
 const PINNED_ROSTER: ReadonlyArray<{
   category: CheckResult['category'];
@@ -61,6 +66,7 @@ const PINNED_ROSTER: ReadonlyArray<{
   { category: 'plugin', name: 'plugin-version-match' },
   { category: 'remote', name: 'remote-mcp' },
   { category: 'invariants', name: 'invariants-catalog' },
+  { category: 'verification', name: 'verification-toolchain' },
 ];
 
 // ─── Benign probe bundle (identity scaffolding only) ─────────────────────────
@@ -109,6 +115,26 @@ function benignProbes(): DoctorProbes {
       runningVersion: async () => null,
     },
     invariants: { resolve: async () => ({ configured: false, warnings: [] }) },
+    verificationToolchain: {
+      resolve: async () => ({
+        detected: true,
+        runtime: {
+          test: 'npm run test:run',
+          typecheck: 'tsc --noEmit',
+          install: 'npm install',
+          mutation: 'npx stryker run',
+          lint: 'eslint .',
+        },
+        policyCells: [
+          { riskTier: 'low', boundaryTouching: false, source: 'builtin' },
+          { riskTier: 'low', boundaryTouching: true, source: 'builtin' },
+          { riskTier: 'medium', boundaryTouching: false, source: 'builtin' },
+          { riskTier: 'medium', boundaryTouching: true, source: 'builtin' },
+          { riskTier: 'high', boundaryTouching: false, source: 'builtin' },
+          { riskTier: 'high', boundaryTouching: true, source: 'builtin' },
+        ],
+      }),
+    },
   } as DoctorProbes;
 }
 
@@ -122,13 +148,14 @@ async function runRoster(): Promise<readonly CheckResult[]> {
 // ─── Characterization ────────────────────────────────────────────────────────
 
 describe('doctor roster characterization (T0 baseline)', () => {
-  it('DoctorRoster_CurrentBuild_ExactlyTwelveChecksWithStableNames', async () => {
-    // The static export ships exactly twelve checks, in pinned order.
-    expect(ALL_CHECKS).toHaveLength(12);
-    expect(PINNED_ROSTER).toHaveLength(12);
+  it('DoctorRoster_CurrentBuild_ExactlyThirteenChecksWithStableNames', async () => {
+    // The static export ships exactly thirteen checks, in pinned order. (12 → 13
+    // updated deliberately by task 009: the verification-toolchain check.)
+    expect(ALL_CHECKS).toHaveLength(13);
+    expect(PINNED_ROSTER).toHaveLength(13);
 
     const results = await runRoster();
-    expect(results).toHaveLength(12);
+    expect(results).toHaveLength(13);
 
     // Each check, run through the REAL ALL_CHECKS, stamps its own identity —
     // we read (category, name) off the returned result rather than transcribing.
@@ -140,7 +167,7 @@ describe('doctor roster characterization (T0 baseline)', () => {
 
     // The name set is exactly the pinned set: no duplicates, no strays.
     const observedNames = new Set(results.map((r) => r.name));
-    expect(observedNames.size).toBe(12);
+    expect(observedNames.size).toBe(13);
     for (const { name } of PINNED_ROSTER) {
       expect(observedNames.has(name)).toBe(true);
     }

--- a/servers/exarchos-mcp/src/orchestrate/doctor/doctor.characterization.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/doctor.characterization.test.ts
@@ -52,13 +52,20 @@ import { handleDoctor, ALL_CHECKS } from './index.js';
 // ─── Pinned canonical check identity ────────────────────────────────────────
 
 /**
- * The twelve checks, pinned by `(category, name)` and ORDER. `handleDoctor`
+ * The thirteen checks, pinned by `(category, name)` and ORDER. `handleDoctor`
  * preserves `ALL_CHECKS` order in its output (callers scan top-to-bottom for
  * the first Fail), so the order is part of the observable contract.
  *
  * DR-8 (#1485) added `session-start-hook` — the SessionStart binding presence
- * check — as the 12th entry, placed with the other `agent`-category checks so
- * its `diff` `hook` PlanStep lands when the binding is missing.
+ * check — placed with the other `agent`-category checks so its `diff` `hook`
+ * PlanStep lands when the binding is missing.
+ *
+ * DELIBERATE PIN UPDATE (task 009, design §4.6): the 13th entry
+ * `verification-toolchain` (category `verification`) was added consciously —
+ * the read-only check reporting whether the verification ladder's runtime
+ * resolves. The count + diagnostic.executed `checkCount` invariant below are
+ * updated 12 → 13 on purpose; this and the roster pin are the intended contract
+ * change of the task.
  */
 const PINNED_CHECKS: ReadonlyArray<{
   category: CheckResult['category'];
@@ -76,6 +83,7 @@ const PINNED_CHECKS: ReadonlyArray<{
   { category: 'plugin', name: 'plugin-version-match' },
   { category: 'remote', name: 'remote-mcp' },
   { category: 'invariants', name: 'invariants-catalog' },
+  { category: 'verification', name: 'verification-toolchain' },
 ];
 
 const VALID_STATUSES = ['Pass', 'Warning', 'Fail', 'Skipped'] as const;
@@ -118,7 +126,7 @@ async function flushMicrotasks(): Promise<void> {
 // ─── Characterization ───────────────────────────────────────────────────────
 
 describe('doctor characterization (DR-9 baseline)', () => {
-  it('Doctor_ElevenChecks_PinnedShape', async () => {
+  it('Doctor_ThirteenChecks_PinnedShape', async () => {
     // Arrange
     const { ctx, appendSpy } = fixtureContext();
 
@@ -136,9 +144,10 @@ describe('doctor characterization (DR-9 baseline)', () => {
     const output: DoctorOutput = DoctorOutputSchema.parse(result.data);
     const { checks, summary } = output;
 
-    // ── 1. The twelve checks, pinned by (category, name) and order ──────────
-    expect(ALL_CHECKS).toHaveLength(12);
-    expect(checks).toHaveLength(12);
+    // ── 1. The thirteen checks, pinned by (category, name) and order ────────
+    // (12 → 13 updated deliberately by task 009: verification-toolchain.)
+    expect(ALL_CHECKS).toHaveLength(13);
+    expect(checks).toHaveLength(13);
 
     const observedIdentity = checks.map((c) => ({
       category: c.category,
@@ -148,7 +157,7 @@ describe('doctor characterization (DR-9 baseline)', () => {
 
     // The name set is exactly the pinned set (no dupes, no strays).
     const observedNames = new Set(checks.map((c) => c.name));
-    expect(observedNames.size).toBe(12);
+    expect(observedNames.size).toBe(13);
     for (const { name } of PINNED_CHECKS) {
       expect(observedNames.has(name)).toBe(true);
     }
@@ -218,7 +227,7 @@ describe('doctor characterization (DR-9 baseline)', () => {
 
     // Pinned cross-field invariants between the event and the doctor output.
     expect(payload.checkCount).toBe(checks.length);
-    expect(payload.checkCount).toBe(12);
+    expect(payload.checkCount).toBe(13);
     expect(payload.summary).toEqual(summary);
     expect(payload.failedCheckNames).toEqual(
       checks.filter((c) => c.status === 'Fail').map((c) => c.name),

--- a/servers/exarchos-mcp/src/orchestrate/doctor/index.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/index.test.ts
@@ -10,8 +10,11 @@ import { describe, it, expect, vi } from 'vitest';
 import type { DispatchContext } from '../../core/dispatch.js';
 import { makeStubProbes } from './checks/__shared__/make-stub-probes.js';
 import type { CheckFn } from './checks/__shared__/make-stub-probes.js';
+import type { DoctorProbes } from './probes.js';
+import type { AgentEnvironment } from '../../runtime/agent-environment-detector.js';
+import type { IntegrityResult } from '../../event-store/store.js';
 import type { CheckResult } from './schema.js';
-import { handleDoctorWithChecks } from './index.js';
+import { handleDoctorWithChecks, ALL_CHECKS } from './index.js';
 
 // ─── Test helpers ───────────────────────────────────────────────────────────
 
@@ -310,5 +313,101 @@ describe('handleDoctor — parallel execution + timeout', () => {
         () => makeStubProbes(),
       ),
     ).rejects.toThrow(/abort/i);
+  });
+});
+
+// ─── Task 009 — verification-toolchain (13th check) dispatch-through ─────────
+
+/**
+ * A benign full-probe bundle so every REAL check in `ALL_CHECKS` reaches its
+ * return statement (mirrors the roster characterization's identity scaffold).
+ * We dispatch the genuine roster through `handleDoctorWithChecks` rather than
+ * unit-calling the CheckFn — per-handler tests bypass dispatch and have masked
+ * DOA-action bugs before; the 13th check must be reachable THROUGH the composer.
+ */
+function benignProbes(): DoctorProbes {
+  const emptyEnvironments: AgentEnvironment[] = [];
+  return {
+    fs: {
+      readFile: async () => '',
+      stat: (async () => ({
+        isDirectory: () => true,
+        isFile: () => false,
+      })) as unknown as DoctorProbes['fs']['stat'],
+      access: async () => undefined,
+    },
+    env: {},
+    git: {
+      which: async () => '/usr/bin/git',
+      isRepo: async () => true,
+      version: async () => 'git version 2.40.0',
+    },
+    sqlite: {
+      runIntegrityCheck: async (): Promise<IntegrityResult> => ({
+        ok: 'skipped',
+        reason: 'benign dispatch probe',
+      }),
+    },
+    detector: async () => emptyEnvironments,
+    eventStore: { append: async () => ({}) } as unknown as DoctorProbes['eventStore'],
+    runtime: { nodeVersion: process.version },
+    stateDir: '/tmp/doctor-verification-toolchain-dispatch',
+    skills: { guardStatus: async () => ({ inSync: true }) },
+    plugin: {
+      installedVersion: async () => null,
+      runningVersion: async () => null,
+    },
+    invariants: { resolve: async () => ({ configured: false, warnings: [] }) },
+    verificationToolchain: {
+      resolve: async () => ({
+        detected: true,
+        runtime: {
+          test: 'npm run test:run',
+          typecheck: 'tsc --noEmit',
+          install: 'npm install',
+          mutation: 'npx stryker run',
+          lint: 'eslint .',
+        },
+        policyCells: [
+          { riskTier: 'low', boundaryTouching: false, source: 'builtin' },
+          { riskTier: 'low', boundaryTouching: true, source: 'builtin' },
+          { riskTier: 'medium', boundaryTouching: false, source: 'builtin' },
+          { riskTier: 'medium', boundaryTouching: true, source: 'builtin' },
+          { riskTier: 'high', boundaryTouching: false, source: 'builtin' },
+          { riskTier: 'high', boundaryTouching: true, source: 'builtin' },
+        ],
+      }),
+    },
+  };
+}
+
+describe('handleDoctor — verification-toolchain roster (task 009)', () => {
+  it('HandleDoctorWithChecks_RosterIncludesVerificationToolchain_ThirteenChecks', async () => {
+    // Arrange — dispatch the REAL ALL_CHECKS through the composer.
+    const ctx = fakeContext();
+
+    // Act
+    const result = await handleDoctorWithChecks(
+      { timeoutMs: 5000 },
+      ctx,
+      ALL_CHECKS,
+      () => benignProbes(),
+    );
+
+    // Assert — the roster ships exactly 13 checks now, and the new one is
+    // present (by category + name) in the dispatched output, not just the
+    // static export.
+    expect(ALL_CHECKS).toHaveLength(13);
+    expect(result.success).toBe(true);
+    const data = result.data as { checks: CheckResult[] };
+    expect(data.checks).toHaveLength(13);
+
+    const vt = data.checks.find((c) => c.name === 'verification-toolchain');
+    expect(vt).toBeDefined();
+    expect(vt!.category).toBe('verification');
+    // Reached through the composer with the benign full-triple probe → Pass,
+    // and the six policy cells survive the DoctorOutputSchema.parse round-trip.
+    expect(vt!.status).toBe('Pass');
+    expect(vt!.policyCells).toHaveLength(6);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
@@ -1,5 +1,5 @@
 /**
- * handleDoctor — composes the 11 per-check modules into a single MCP
+ * handleDoctor — composes the 13 per-check modules into a single MCP
  * action.
  *
  * Design notes:
@@ -52,12 +52,15 @@ import { pluginSkillHashSync } from './checks/plugin-skill-hash-sync.js';
 import { pluginVersionMatch } from './checks/plugin-version-match.js';
 import { remoteMcpStub } from './checks/remote-mcp-stub.js';
 import { invariantsCatalog } from './checks/invariants-catalog.js';
+import { verificationToolchain } from './checks/verification-toolchain.js';
 
 // ─── Canonical check list ──────────────────────────────────────────────────
 
-/** All 12 checks. Order is preserved in the output — callers can scan
+/** All 13 checks. Order is preserved in the output — callers can scan
  * top-to-bottom for the first Fail. DR-8 added `session-start-hook` (#1485):
- * the SessionStart binding presence check that lands the default-on hook step. */
+ * the SessionStart binding presence check that lands the default-on hook step.
+ * Task 009 (design §4.6) added `verification-toolchain` (13th): the read-only
+ * check reporting whether the verification ladder's runtime resolves. */
 export const ALL_CHECKS: ReadonlyArray<CheckFn> = [
   runtimeNodeVersion,
   storageStateDir,
@@ -71,6 +74,7 @@ export const ALL_CHECKS: ReadonlyArray<CheckFn> = [
   pluginVersionMatch,
   remoteMcpStub,
   invariantsCatalog,
+  verificationToolchain,
 ];
 
 // ─── Per-check timeout ─────────────────────────────────────────────────────
@@ -188,7 +192,7 @@ export interface DoctorFixDeps {
    * Produces the doctor `actual` check results the reconciler's `diff`
    * classifies. The reconciler calls this for the plan; doctor re-runs the
    * checks itself for the post-fix residual report. The real composer runs the
-   * 12 checks; tests stub it.
+   * 13 checks; tests stub it.
    */
   readonly runDoctorChecks: (repoRoot: string) => Promise<readonly CheckResult[]>;
   /** Writer deps for GENERATE (real-fs in prod, fixture-redirected in tests). */
@@ -382,7 +386,7 @@ function buildFixApplyCtx(deps: DoctorFixDeps): ApplyCtx {
 
 /**
  * Production `doctor --fix` deps: the real init writers + writer deps + the real
- * doctor composer as `runDoctorChecks` (reusing the 12-check composer verbatim —
+ * doctor composer as `runDoctorChecks` (reusing the 13-check composer verbatim —
  * one check source, INV-2/DR-4). `repoRoot` is the dispatch cwd. The
  * `installHook`/`installStep` hooks default to the reconciler's no-ops until
  * tasks 012/015 supply the real binders.

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
@@ -471,7 +471,16 @@ export async function resolveVerificationToolchain(
   const loadConfig = deps.loadConfig ?? loadExarchosConfig;
   const resolvePolicy = deps.resolvePolicy ?? resolveVerificationPolicy;
 
-  const repoRoot = process.cwd();
+  // Normalize to the actual project root before resolving runtime/config. The
+  // `.exarchos.yml` (then `.git`) ancestor walk mirrors resolveInvariantsCatalog
+  // and load-exarchos-config's own fallback: when `doctor` runs from a nested
+  // directory, anchoring BOTH the runtime resolver and config load to the same
+  // repo root keeps a configured repo from misclassifying as Skipped/Warning
+  // with all-builtin provenance. Resolve from the USER's cwd, NOT this module's
+  // location (#1482 — in plugin mode the module lives in the plugin cache).
+  const cwd = process.cwd();
+  const repoRoot =
+    (await findRepoRoot('.exarchos.yml', cwd)) ?? (await findRepoRoot('.git', cwd)) ?? cwd;
 
   // Per-field runtime resolution (test/typecheck/install/mutation/lint).
   const runtime = resolveRuntime(repoRoot);

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
@@ -36,6 +36,10 @@ import {
 import { loadExarchosConfig } from '../../config/load-exarchos-config.js';
 import { resolveEffectiveCatalog } from '../../architecture/resolve-effective-catalog.js';
 import { ReservedNamespaceError } from '../../architecture/catalog-merge.js';
+import { resolveVerificationRuntime } from '../../config/test-runtime-resolver.js';
+import { resolveVerificationPolicy } from '../../workflow/verification-policy-resolver.js';
+import { resolveConfig, type ResolvedProjectConfig } from '../../config/resolve.js';
+import type { RiskTier } from '../../workflow/verification-policy.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -109,6 +113,52 @@ export interface DoctorInvariantsCatalog {
   resolve(signal?: AbortSignal): Promise<{ configured: boolean; warnings: string[] }>;
 }
 
+/**
+ * The resolved verification ladder the doctor check reports on (design §4.6):
+ * which runtime commands the per-field layered resolver returned, whether any
+ * toolchain was detectable at all, and the provenance of all six verification-
+ * policy cells.
+ *
+ * The probe does ALL the disk work (config load + per-field resolution + the
+ * six policy resolutions); the check stays disk-blind and only maps this shape
+ * to a Pass/Warning/Skipped CheckResult. This is read-only visibility — nothing
+ * here writes; the fix path remains the reconciler's.
+ */
+export interface VerificationToolchainResolution {
+  /** Whether ANY project toolchain was detected (false ⇒ empty/unmarked repo). */
+  readonly detected: boolean;
+  /** The resolved verification-runtime commands; `null` per field = unresolved. */
+  readonly runtime: {
+    readonly test: string | null;
+    readonly typecheck: string | null;
+    readonly install: string | null;
+    readonly mutation: string | null;
+    readonly lint: string | null;
+  };
+  /**
+   * All six `(riskTier × boundaryTouching)` policy cells with their resolved
+   * provenance — `builtin` (frozen base table) vs `config` (.exarchos.yml
+   * override). Read-only: the check NEVER mutates policy.
+   */
+  readonly policyCells: ReadonlyArray<{
+    readonly riskTier: 'low' | 'medium' | 'high';
+    readonly boundaryTouching: boolean;
+    readonly source: 'builtin' | 'config';
+  }>;
+}
+
+export interface DoctorVerificationToolchain {
+  /**
+   * Resolve the verification ladder's runtime + policy provenance from the
+   * consumer's project root. Reads `.exarchos.yml` and probes project markers
+   * via the shared `resolveVerificationRuntime` / `resolveVerificationPolicy`
+   * resolvers (the single sources of truth) and folds the result into a
+   * {@link VerificationToolchainResolution}. Must honor `signal` and stay
+   * within the 2000ms probe budget (DIM-7). Read-only — emits/writes nothing.
+   */
+  resolve(signal?: AbortSignal): Promise<VerificationToolchainResolution>;
+}
+
 export interface DoctorProbes {
   readonly fs: DoctorFs;
   readonly env: Readonly<Record<string, string | undefined>>;
@@ -121,6 +171,7 @@ export interface DoctorProbes {
   readonly skills: DoctorSkills;
   readonly plugin: DoctorPlugin;
   readonly invariants: DoctorInvariantsCatalog;
+  readonly verificationToolchain: DoctorVerificationToolchain;
 }
 
 const DEFAULT_FS: DoctorFs = {
@@ -381,6 +432,93 @@ export async function resolveInvariantsCatalog(
   }
 }
 
+/** The six `(riskTier × boundaryTouching)` policy cells, in stable order. */
+const POLICY_CELLS: ReadonlyArray<{ riskTier: RiskTier; boundaryTouching: boolean }> = [
+  { riskTier: 'low', boundaryTouching: false },
+  { riskTier: 'low', boundaryTouching: true },
+  { riskTier: 'medium', boundaryTouching: false },
+  { riskTier: 'medium', boundaryTouching: true },
+  { riskTier: 'high', boundaryTouching: false },
+  { riskTier: 'high', boundaryTouching: true },
+];
+
+/**
+ * Resolve the verification ladder's runtime + policy provenance from the USER's
+ * project root for the verification-toolchain doctor check (design §4.6).
+ *
+ * Reads from `process.cwd()` (a consumer-project artifact, mirroring the
+ * invariants probe's cwd reasoning — the module lives in the plugin cache in
+ * plugin mode). The per-field commands come from `resolveVerificationRuntime`
+ * (the single source of truth for runtime resolution); each of the six policy
+ * cells is resolved via `resolveVerificationPolicy` over the resolved project
+ * config (or the frozen built-ins when no config / a malformed config). This is
+ * a READ-ONLY probe — it never emits a `command.resolved` event (no eventStore
+ * is passed) and never writes. DIM-1: computed per call, no caching.
+ *
+ * The `resolveRuntime`/`loadConfig`/`resolvePolicy` seams are injected (defaults
+ * are the real resolvers) purely so the probe is unit-testable. Exported for
+ * testing. */
+export async function resolveVerificationToolchain(
+  signal?: AbortSignal,
+  deps: {
+    resolveRuntime?: typeof resolveVerificationRuntime;
+    loadConfig?: typeof loadExarchosConfig;
+    resolvePolicy?: typeof resolveVerificationPolicy;
+  } = {},
+): Promise<VerificationToolchainResolution> {
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+  const resolveRuntime = deps.resolveRuntime ?? resolveVerificationRuntime;
+  const loadConfig = deps.loadConfig ?? loadExarchosConfig;
+  const resolvePolicy = deps.resolvePolicy ?? resolveVerificationPolicy;
+
+  const repoRoot = process.cwd();
+
+  // Per-field runtime resolution (test/typecheck/install/mutation/lint).
+  const runtime = resolveRuntime(repoRoot);
+
+  // A resolution with an `unresolved` aggregate source AND every legacy field
+  // null is the "no project markers detected" signal — nothing the resolver
+  // could anchor on. Treat that as not-detected so the check Skips rather than
+  // Warns on a genuinely empty repo.
+  const detected = !(
+    runtime.source === 'unresolved' &&
+    runtime.test === null &&
+    runtime.typecheck === null &&
+    runtime.install === null &&
+    runtime.mutation === null &&
+    runtime.lint === null
+  );
+
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+
+  // Resolve project config for policy provenance. A missing/malformed config
+  // degrades to the frozen built-in table (INV-4) — never a hard failure.
+  let config: ResolvedProjectConfig | undefined;
+  try {
+    const loaded = loadConfig(repoRoot, { findRepoRoot: () => repoRoot });
+    config = loaded?.config ? resolveConfig(loaded.config) : undefined;
+  } catch {
+    config = undefined;
+  }
+
+  const policyCells = POLICY_CELLS.map(({ riskTier, boundaryTouching }) => {
+    const { source } = resolvePolicy(riskTier, boundaryTouching, config);
+    return { riskTier, boundaryTouching, source };
+  });
+
+  return {
+    detected,
+    runtime: {
+      test: runtime.test,
+      typecheck: runtime.typecheck,
+      install: runtime.install,
+      mutation: runtime.mutation,
+      lint: runtime.lint,
+    },
+    policyCells,
+  };
+}
+
 /**
  * Build a DoctorProbes bundle from a DispatchContext. Each probe field
  * binds to a real runtime surface; tests bypass this factory entirely
@@ -409,5 +547,8 @@ export function buildProbes(ctx: DispatchContext): DoctorProbes {
       runningVersion: defaultRunningVersion,
     },
     invariants: { resolve: (signal) => resolveInvariantsCatalog(signal) },
+    verificationToolchain: {
+      resolve: (signal) => resolveVerificationToolchain(signal),
+    },
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/doctor/schema.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/schema.test.ts
@@ -59,6 +59,69 @@ describe('CheckResultSchema', () => {
     expect(parsed.status).toBe('Fail');
     expect(parsed.fix).toContain('nvm install 20');
   });
+
+  // ─── policyCells provenance contract (verification-toolchain only) ──────────
+
+  const SIX_CELLS = [
+    { riskTier: 'low', boundaryTouching: false, source: 'builtin' },
+    { riskTier: 'low', boundaryTouching: true, source: 'builtin' },
+    { riskTier: 'medium', boundaryTouching: false, source: 'builtin' },
+    { riskTier: 'medium', boundaryTouching: true, source: 'config' },
+    { riskTier: 'high', boundaryTouching: false, source: 'builtin' },
+    { riskTier: 'high', boundaryTouching: true, source: 'config' },
+  ] as const;
+
+  it('CheckResultSchema_VerificationToolchainWithSixCells_ParsesSuccessfully', () => {
+    const input = {
+      category: 'verification',
+      name: 'verification-toolchain',
+      status: 'Pass',
+      message: 'Verification toolchain resolved.',
+      durationMs: 3,
+      policyCells: SIX_CELLS,
+    };
+
+    const parsed = CheckResultSchema.parse(input);
+    expect(parsed.policyCells).toHaveLength(6);
+  });
+
+  it('CheckResultSchema_VerificationToolchainMissingCells_ThrowsValidationError', () => {
+    const input = {
+      category: 'verification',
+      name: 'verification-toolchain',
+      status: 'Pass',
+      message: 'Verification toolchain resolved.',
+      durationMs: 3,
+    };
+
+    expect(() => CheckResultSchema.parse(input)).toThrow(/policyCells/i);
+  });
+
+  it('CheckResultSchema_VerificationToolchainWrongCellCount_ThrowsValidationError', () => {
+    const input = {
+      category: 'verification',
+      name: 'verification-toolchain',
+      status: 'Pass',
+      message: 'Verification toolchain resolved.',
+      durationMs: 3,
+      policyCells: SIX_CELLS.slice(0, 3),
+    };
+
+    expect(() => CheckResultSchema.parse(input)).toThrow();
+  });
+
+  it('CheckResultSchema_NonVerificationCheckWithCells_ThrowsValidationError', () => {
+    const input = {
+      category: 'runtime',
+      name: 'node-version',
+      status: 'Pass',
+      message: 'Node.js 20.11.0 detected.',
+      durationMs: 4,
+      policyCells: SIX_CELLS,
+    };
+
+    expect(() => CheckResultSchema.parse(input)).toThrow(/policyCells/i);
+  });
 });
 
 describe('DoctorOutputSchema', () => {

--- a/servers/exarchos-mcp/src/orchestrate/doctor/schema.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/schema.ts
@@ -54,13 +54,30 @@ export const CheckResultSchema = z
     fix: z.string().min(1).optional(),
     reason: z.string().min(1).optional(),
     durationMs: z.number().int().nonnegative(),
-    // Optional read-only detail carried by the verification-toolchain check:
-    // the six resolved policy cells with their builtin/config provenance.
-    // Other checks omit it; the field survives `DoctorOutputSchema.parse` so
-    // the provenance reaches MCP/CLI adapters intact.
-    policyCells: z.array(VerificationPolicyCellSchema).optional(),
+    // Read-only detail carried EXCLUSIVELY by the verification-toolchain check:
+    // the six resolved policy cells with their builtin/config provenance. The
+    // length is fixed at 6 — the (riskTier × boundaryTouching) cross-product —
+    // so a malformed provenance payload fails fast at the schema boundary rather
+    // than reaching MCP/CLI adapters as a silently-truncated contract (INV-5b).
+    // The superRefine below makes the field REQUIRED for verification-toolchain
+    // and FORBIDDEN elsewhere.
+    policyCells: z.array(VerificationPolicyCellSchema).length(6).optional(),
   })
   .superRefine((r, ctx) => {
+    if (r.name === 'verification-toolchain' && r.policyCells === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'policyCells is required for the verification-toolchain check',
+        path: ['policyCells'],
+      });
+    }
+    if (r.name !== 'verification-toolchain' && r.policyCells !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'policyCells is only valid on the verification-toolchain check',
+        path: ['policyCells'],
+      });
+    }
     if (r.status === 'Skipped' && (!r.reason || r.reason.length === 0)) {
       ctx.addIssue({
         code: 'custom',

--- a/servers/exarchos-mcp/src/orchestrate/doctor/schema.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/schema.ts
@@ -25,7 +25,25 @@ export const CheckCategorySchema = z.enum([
   'env',
   'remote',
   'invariants',
+  // `verification` — the verification-toolchain check (13th, design §4.6):
+  // does the verification ladder's runtime resolve, and what is each policy
+  // cell's provenance. Read-only visibility, never a fix surface.
+  'verification',
 ]);
+
+/**
+ * One resolved verification-policy cell — a `(riskTier, boundaryTouching)`
+ * profile plus whether its gate sequence came from the frozen built-in table
+ * or a `.exarchos.yml` override. Carried (read-only) on a verification-toolchain
+ * CheckResult so callers can see policy provenance without re-resolving. The
+ * `source` vocabulary mirrors `VerificationPolicySource` in
+ * `workflow/verification-policy-resolver.ts` (the single source of truth).
+ */
+export const VerificationPolicyCellSchema = z.object({
+  riskTier: z.enum(['low', 'medium', 'high']),
+  boundaryTouching: z.boolean(),
+  source: z.enum(['builtin', 'config']),
+});
 
 export const CheckResultSchema = z
   .object({
@@ -36,6 +54,11 @@ export const CheckResultSchema = z
     fix: z.string().min(1).optional(),
     reason: z.string().min(1).optional(),
     durationMs: z.number().int().nonnegative(),
+    // Optional read-only detail carried by the verification-toolchain check:
+    // the six resolved policy cells with their builtin/config provenance.
+    // Other checks omit it; the field survives `DoctorOutputSchema.parse` so
+    // the provenance reaches MCP/CLI adapters intact.
+    policyCells: z.array(VerificationPolicyCellSchema).optional(),
   })
   .superRefine((r, ctx) => {
     if (r.status === 'Skipped' && (!r.reason || r.reason.length === 0)) {
@@ -76,3 +99,4 @@ export const DoctorOutputSchema = z
 export type CheckResult = z.infer<typeof CheckResultSchema>;
 export type DoctorSummary = z.infer<typeof DoctorSummarySchema>;
 export type DoctorOutput = z.infer<typeof DoctorOutputSchema>;
+export type VerificationPolicyCell = z.infer<typeof VerificationPolicyCellSchema>;

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.test.ts
@@ -110,6 +110,16 @@ describe('resolveGateSeverity per-workflow severity', () => {
     expect(resolveGateSeverity('security-scan', 'D1', DEFAULTS, 'oneshot')).toBe('blocking');
   });
 
+  it('ResolveGateSeverity_OneshotLadderGate_ExplicitDimensionDisableWins', () => {
+    // An explicit `enabled: false` on the gate's dimension is a stronger
+    // statement than the oneshot ladder default — the gate resolves to
+    // 'disabled', NOT the warning the workflow default would otherwise apply.
+    const config = configWith({
+      dimensions: { ...DEFAULTS.review.dimensions, D2: { severity: 'blocking', enabled: false } },
+    });
+    expect(resolveGateSeverity(LADDER_GATE, 'D2', config, 'oneshot')).toBe('disabled');
+  });
+
   it('ResolveGateSeverity_FeatureWorkflow_UnchangedResolution', () => {
     // A non-oneshot workflow has no default-severity table entry — unchanged.
     expect(resolveGateSeverity(LADDER_GATE, 'D2', DEFAULTS, 'feature')).toBe('blocking');

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { resolveGateSeverity } from './gate-severity.js';
+import { resolveGateSeverity, WORKFLOW_DEFAULT_SEVERITY } from './gate-severity.js';
 import { DEFAULTS } from '../config/resolve.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { VERIFICATION_GATE_NAMES } from '../workflow/verification-policy.js';
 
 // Helper to create config with overrides
 function configWith(overrides: Partial<ResolvedProjectConfig['review']>): ResolvedProjectConfig {
@@ -70,5 +71,52 @@ describe('resolveGateSeverity', () => {
 
   it('resolveGateSeverity_UnknownDimension_DefaultsBlocking', () => {
     expect(resolveGateSeverity('some-gate', 'D99', DEFAULTS)).toBe('blocking');
+  });
+});
+
+// ─── Per-workflow severity (oneshot → advisory for ladder gates) ─────────────
+//
+// Task 005: a verification-ladder gate that would otherwise be blocking
+// resolves to `warning` when the workflow is `oneshot`, UNLESS the consumer
+// pins it explicitly via `review.gates[gateName]`. The mapping is a data table
+// (`WORKFLOW_DEFAULT_SEVERITY`) so future workflow types are additions, not
+// branching code. A non-ladder gate, a non-oneshot workflow, and an omitted
+// `workflowType` all resolve EXACTLY as before (legacy callers unaffected).
+
+const LADDER_GATE = VERIFICATION_GATE_NAMES[0]; // 'check_static_analysis'
+
+describe('resolveGateSeverity per-workflow severity', () => {
+  it('WORKFLOW_DEFAULT_SEVERITY_OneshotEntry_IsWarning', () => {
+    // The data table — not branching prose — drives the workflow default.
+    expect(WORKFLOW_DEFAULT_SEVERITY.oneshot).toBe('warning');
+  });
+
+  it('ResolveGateSeverity_OneshotLadderGate_DefaultsToWarning', () => {
+    // A ladder gate under an oneshot workflow downgrades blocking → warning by
+    // default (no gate-level override present).
+    expect(resolveGateSeverity(LADDER_GATE, 'D2', DEFAULTS, 'oneshot')).toBe('warning');
+  });
+
+  it('ResolveGateSeverity_OneshotWithExplicitGateOverride_OverrideWins', () => {
+    // An explicit `review.gates[gate]` blocking pin beats the oneshot default.
+    const config = configWith({
+      gates: { [LADDER_GATE]: { enabled: true, blocking: true, params: {} } },
+    });
+    expect(resolveGateSeverity(LADDER_GATE, 'D2', config, 'oneshot')).toBe('blocking');
+  });
+
+  it('ResolveGateSeverity_OneshotNonLadderGate_UnchangedResolution', () => {
+    // A non-ladder gate name ignores the workflow default — stays blocking.
+    expect(resolveGateSeverity('security-scan', 'D1', DEFAULTS, 'oneshot')).toBe('blocking');
+  });
+
+  it('ResolveGateSeverity_FeatureWorkflow_UnchangedResolution', () => {
+    // A non-oneshot workflow has no default-severity table entry — unchanged.
+    expect(resolveGateSeverity(LADDER_GATE, 'D2', DEFAULTS, 'feature')).toBe('blocking');
+  });
+
+  it('ResolveGateSeverity_NoWorkflowType_UnchangedResolution', () => {
+    // Omitting workflowType is exactly today's behavior (legacy callers).
+    expect(resolveGateSeverity(LADDER_GATE, 'D2', DEFAULTS)).toBe('blocking');
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
@@ -34,11 +34,14 @@ const LADDER_GATE_NAMES: ReadonlySet<string> = new Set(VERIFICATION_GATE_NAMES);
  *
  * Resolution order (highest precedence first):
  * 1. Gate-level override (`review.gates[gateName]`)
- * 2. Per-workflow ladder default: when `workflowType` is supplied, the gate is
+ * 2. Explicit dimension disable (`review.dimensions[dimension].enabled === false`
+ *    → `'disabled'`) — an explicit project off is a stronger statement than any
+ *    convention default and must win over the per-workflow ladder default below.
+ * 3. Per-workflow ladder default: when `workflowType` is supplied, the gate is
  *    a verification-ladder gate, AND `WORKFLOW_DEFAULT_SEVERITY[workflowType]`
  *    is defined → that severity (e.g. oneshot → warning).
- * 3. Dimension-level setting (`review.dimensions[dimension]`)
- * 4. Default: `'blocking'` (unknown dimensions)
+ * 4. Dimension-level severity (`review.dimensions[dimension].severity`)
+ * 5. Default: `'blocking'` (unknown dimensions)
  *
  * Omitting `workflowType` reproduces the pre-task-005 behavior exactly, so
  * legacy callers are unaffected.
@@ -57,6 +60,15 @@ export function resolveGateSeverity(
     return gateOverride.blocking ? 'blocking' : 'warning';
   }
 
+  // An EXPLICIT dimension disable is a stronger statement than any convention
+  // default: a consumer who pins `enabled: false` means "never run this gate".
+  // Checked BEFORE the per-workflow ladder default so that a project which
+  // disabled (e.g.) D1/D2 does not still see ladder gates execute as warning-only
+  // under an oneshot workflow.
+  const dimKey = dimension as DimensionKey;
+  const dimConfig = config.review.dimensions[dimKey];
+  if (dimConfig && !dimConfig.enabled) return 'disabled';
+
   // Per-workflow ladder default: applies ONLY to verification-ladder gates and
   // ONLY when the workflow type has a table entry. Data-driven so adding a
   // workflow type is an entry in WORKFLOW_DEFAULT_SEVERITY, not a code branch.
@@ -65,10 +77,7 @@ export function resolveGateSeverity(
     if (workflowDefault !== undefined) return workflowDefault;
   }
 
-  // Fall back to dimension-level setting
-  const dimKey = dimension as DimensionKey;
-  const dimConfig = config.review.dimensions[dimKey];
+  // Fall back to dimension-level severity.
   if (!dimConfig) return 'blocking'; // unknown dimension defaults to blocking
-  if (!dimConfig.enabled) return 'disabled';
   return dimConfig.severity;
 }

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
@@ -5,28 +5,64 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { VERIFICATION_GATE_NAMES } from '../workflow/verification-policy.js';
 
 type DimensionKey = 'D1' | 'D2' | 'D3' | 'D4' | 'D5';
 type Severity = 'blocking' | 'warning' | 'disabled';
+
+/**
+ * Per-workflow default severity for verification-LADDER gates (task 005).
+ *
+ * A DATA TABLE — not branching prose — mapping a workflow type to the severity
+ * its ladder-gate failures resolve to by default. `oneshot` workflows are quick,
+ * low-ceremony fixes where a ladder-gate miss should advise (warning), not block.
+ * Keeping this a table means future workflow types are a single-line ADDITION,
+ * never new control flow in {@link resolveGateSeverity}.
+ *
+ * Scope: this default ONLY applies to gates named in `VERIFICATION_GATE_NAMES`
+ * (the single source of truth) and is ALWAYS beaten by an explicit
+ * `review.gates[gateName]` override — a consumer who pins a gate wins.
+ */
+export const WORKFLOW_DEFAULT_SEVERITY: Readonly<Record<string, 'warning'>> =
+  Object.freeze({ oneshot: 'warning' });
+
+/** The ladder-gate name set, as a Set for O(1) membership (SoT is the tuple). */
+const LADDER_GATE_NAMES: ReadonlySet<string> = new Set(VERIFICATION_GATE_NAMES);
 
 /**
  * Resolves the effective severity for a named gate within a dimension.
  *
  * Resolution order (highest precedence first):
  * 1. Gate-level override (`review.gates[gateName]`)
- * 2. Dimension-level setting (`review.dimensions[dimension]`)
- * 3. Default: `'blocking'` (unknown dimensions)
+ * 2. Per-workflow ladder default: when `workflowType` is supplied, the gate is
+ *    a verification-ladder gate, AND `WORKFLOW_DEFAULT_SEVERITY[workflowType]`
+ *    is defined → that severity (e.g. oneshot → warning).
+ * 3. Dimension-level setting (`review.dimensions[dimension]`)
+ * 4. Default: `'blocking'` (unknown dimensions)
+ *
+ * Omitting `workflowType` reproduces the pre-task-005 behavior exactly, so
+ * legacy callers are unaffected.
  */
 export function resolveGateSeverity(
   gateName: string,
   dimension: string,
   config: ResolvedProjectConfig,
+  workflowType?: string,
 ): Severity {
-  // Gate-level override takes precedence
+  // Gate-level override takes precedence — an explicit pin always wins, even
+  // over the per-workflow ladder default below.
   const gateOverride = config.review.gates[gateName];
   if (gateOverride) {
     if (!gateOverride.enabled) return 'disabled';
     return gateOverride.blocking ? 'blocking' : 'warning';
+  }
+
+  // Per-workflow ladder default: applies ONLY to verification-ladder gates and
+  // ONLY when the workflow type has a table entry. Data-driven so adding a
+  // workflow type is an entry in WORKFLOW_DEFAULT_SEVERITY, not a code branch.
+  if (workflowType !== undefined && LADDER_GATE_NAMES.has(gateName)) {
+    const workflowDefault = WORKFLOW_DEFAULT_SEVERITY[workflowType];
+    if (workflowDefault !== undefined) return workflowDefault;
   }
 
   // Fall back to dimension-level setting

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.test.ts
@@ -1,8 +1,17 @@
 // ─── Gate Utils Tests ─────────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { emitGateEvent, resolveRepoRoot, AUTO_REPO_ROOT } from './gate-utils.js';
+import { emitGateEvent, resolveRepoRoot, AUTO_REPO_ROOT, resolvePolicySkip } from './gate-utils.js';
 import type { EventStore } from '../event-store/store.js';
+import { resolveConfig } from '../config/resolve.js';
+import type { VerificationPolicyOverlay } from '../config/yaml-schema.js';
+import {
+  VERIFICATION_GATE_NAMES,
+  resolveVerificationSequence,
+  type GateName,
+  type RiskTier,
+} from '../workflow/verification-policy.js';
+import { classifyTask } from './prepare-delegation.js';
 
 describe('emitGateEvent', () => {
   // ─── Test 1: Valid input appends gate.executed event ─────────────────────
@@ -133,5 +142,198 @@ describe('resolveRepoRoot', () => {
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain('task-9');
+  });
+});
+
+// ─── resolvePolicySkip (task 004) ───────────────────────────────────────────
+
+const ALL_TIERS: readonly RiskTier[] = ['low', 'medium', 'high'];
+const ALL_BOUNDARY: readonly boolean[] = [false, true];
+
+function configWith(policy: VerificationPolicyOverlay) {
+  return resolveConfig({ verification: { policy } });
+}
+
+describe('resolvePolicySkip', () => {
+  it('ResolvePolicySkip_ConfiguredCellExcludesGate_SkipsWithConfigSource', () => {
+    // A config cell that REPLACES the medium-base sequence with one that omits
+    // `check_test_adequacy` must produce a skip for that gate, and the reason
+    // must name the CONFIG source so a config-induced skip is never read as a
+    // builtin decision.
+    const overlay: VerificationPolicyOverlay = {
+      // medium normally clears [static_analysis, test_adequacy]; drop the latter.
+      medium: ['check_static_analysis'],
+    };
+    const config = configWith(overlay);
+
+    const skip = resolvePolicySkip({
+      gateName: 'check_test_adequacy',
+      riskTier: 'medium',
+      boundaryTouching: false,
+      config,
+    });
+    expect(skip).not.toBeNull();
+    expect(skip?.reason).toContain('policy: config');
+    expect(skip?.reason).not.toContain('policy: builtin');
+
+    // A gate that the config cell DOES include must still run (no skip).
+    const noSkip = resolvePolicySkip({
+      gateName: 'check_static_analysis',
+      riskTier: 'medium',
+      boundaryTouching: false,
+      config,
+    });
+    expect(noSkip).toBeNull();
+  });
+
+  it('ResolvePolicySkip_BuiltinDecision_ReasonNamesBuiltinSource', () => {
+    // No config (or a config whose cell is unset) → the builtin table decides.
+    // A gate not in the builtin sequence for the profile is skipped, and the
+    // reason names the BUILTIN source.
+    const skip = resolvePolicySkip({
+      gateName: 'check_integration_suite',
+      riskTier: 'low',
+      boundaryTouching: false,
+    });
+    expect(skip).not.toBeNull();
+    expect(skip?.reason).toContain('policy: builtin');
+    expect(skip?.reason).not.toContain('policy: config');
+
+    // Same result when a config is present but its relevant cell is unset —
+    // the builtin table still decides, source stays builtin.
+    const config = configWith({ high: ['check_static_analysis'] });
+    const skipUnsetCell = resolvePolicySkip({
+      gateName: 'check_integration_suite',
+      riskTier: 'low',
+      boundaryTouching: false,
+      config,
+    });
+    expect(skipUnsetCell).not.toBeNull();
+    expect(skipUnsetCell?.reason).toContain('policy: builtin');
+  });
+
+  it('ResolvePolicySkip_PartialStamp_StillRunsUnconditionally', () => {
+    // Characterization rail: a partial stamp (either field absent) returns null
+    // so the gate runs unconditionally — preserved byte-identically. Config
+    // presence must NOT change this (absent stamp dominates).
+    const config = configWith({ medium: [] });
+
+    expect(
+      resolvePolicySkip({ gateName: 'check_test_adequacy', boundaryTouching: false }),
+    ).toBeNull();
+    expect(
+      resolvePolicySkip({ gateName: 'check_test_adequacy', riskTier: 'medium' }),
+    ).toBeNull();
+    expect(resolvePolicySkip({ gateName: 'check_test_adequacy' })).toBeNull();
+
+    // Same, with a config that would otherwise exclude the gate — the absent
+    // stamp still dominates and the gate runs.
+    expect(
+      resolvePolicySkip({ gateName: 'check_test_adequacy', riskTier: 'medium', config }),
+    ).toBeNull();
+    expect(
+      resolvePolicySkip({ gateName: 'check_test_adequacy', boundaryTouching: false, config }),
+    ).toBeNull();
+  });
+
+  it('ResolvePolicySkip_BothStampsAbsent_ReasonAbsentByteIdenticalToNull', () => {
+    // No config threaded: behavior must match the pre-task-004 absent-stamp path
+    // exactly (null when either stamp is absent).
+    for (const gate of VERIFICATION_GATE_NAMES) {
+      expect(resolvePolicySkip({ gateName: gate })).toBeNull();
+    }
+  });
+});
+
+// ─── Round-trip: stamp ⇔ skip consistency (task 004) ────────────────────────
+
+describe('StampAndSkip consistency', () => {
+  it('StampAndSkip_SameConfig_NeverDisagree', () => {
+    // For a matrix of (tier × boundary × config-variant), the stamped sequence
+    // (`classifyTask`) and the per-gate skip decisions (`resolvePolicySkip`)
+    // must be mutually consistent: a gate is skipped IFF it is NOT in the
+    // stamped sequence. The two surfaces now share `resolveVerificationPolicy`,
+    // so they can never diverge.
+    type Variant = { readonly label: string; readonly config: ReturnType<typeof configWith> | undefined };
+
+    for (const tier of ALL_TIERS) {
+      for (const boundary of ALL_BOUNDARY) {
+        // Per-cell config variants:
+        //  - no config (builtin table)
+        //  - a custom non-empty cell for THIS exact (tier, boundary) cell
+        //  - an explicit empty cell for THIS exact (tier, boundary) cell
+        const customCell: GateName[] = ['check_static_analysis', 'check_mock_boundary'];
+        const custom = boundary
+          ? ({ boundary: { [tier]: customCell } } as VerificationPolicyOverlay)
+          : ({ [tier]: customCell } as VerificationPolicyOverlay);
+        const empty = boundary
+          ? ({ boundary: { [tier]: [] } } as VerificationPolicyOverlay)
+          : ({ [tier]: [] } as VerificationPolicyOverlay);
+
+        const variants: readonly Variant[] = [
+          { label: 'no-config', config: undefined },
+          { label: 'custom-cell', config: configWith(custom) },
+          { label: 'empty-cell', config: configWith(empty) },
+        ];
+
+        for (const variant of variants) {
+          // Stamp via the delegation classifier with explicit tier/boundary
+          // overrides (so the derived profile is exactly this cell).
+          const classification = classifyTask(
+            {
+              id: `t-${tier}-${boundary}`,
+              title: 'round-trip task',
+              riskTier: tier,
+              boundaryTouching: boundary,
+            },
+            undefined,
+            variant.config,
+          );
+          const stamped = classification.verificationSequence;
+
+          // The classification's stamped profile must equal (tier, boundary).
+          expect(classification.riskTier).toBe(tier);
+          expect(classification.boundaryTouching).toBe(boundary);
+
+          // For EVERY gate, skip ⇔ not-in-stamped-sequence.
+          for (const gate of VERIFICATION_GATE_NAMES) {
+            const skip = resolvePolicySkip({
+              gateName: gate,
+              riskTier: tier,
+              boundaryTouching: boundary,
+              config: variant.config,
+            });
+            const inSequence = stamped.includes(gate);
+            const message =
+              `tier=${tier} boundary=${boundary} variant=${variant.label} gate=${gate}: ` +
+              `stamped=[${stamped.join(',')}] skip=${skip ? 'SKIP' : 'RUN'}`;
+            // skipped IFF not in the stamped sequence.
+            expect(skip === null, message).toBe(inSequence);
+          }
+        }
+      }
+    }
+  });
+
+  it('StampAndSkip_NoConfig_MatchesBuiltinTable', () => {
+    // Belt-and-suspenders: with no config, the stamped sequence is exactly the
+    // builtin table, and every skip decision agrees with it.
+    for (const tier of ALL_TIERS) {
+      for (const boundary of ALL_BOUNDARY) {
+        const builtin = resolveVerificationSequence(tier, boundary);
+        const stamped = classifyTask({
+          id: 't',
+          title: 'x',
+          riskTier: tier,
+          boundaryTouching: boundary,
+        }).verificationSequence;
+        expect(stamped).toEqual(builtin);
+
+        for (const gate of VERIFICATION_GATE_NAMES) {
+          const skip = resolvePolicySkip({ gateName: gate, riskTier: tier, boundaryTouching: boundary });
+          expect(skip === null).toBe(builtin.includes(gate));
+        }
+      }
+    }
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
@@ -204,19 +204,24 @@ export async function resolveRepoRoot(
  * - **blocking**: Executes handler; failures remain failures (default behaviour)
  *
  * When `config` is `undefined`, defaults to blocking (backwards compatible).
+ *
+ * `workflowType` (task 005) is threaded to {@link resolveGateSeverity} so a
+ * verification-ladder gate can pick up its per-workflow default severity (e.g.
+ * oneshot → warning). Omitting it preserves the pre-task-005 resolution.
  */
 export async function withConfigSeverity(
   gateName: string,
   dimension: string,
   config: ResolvedProjectConfig | undefined,
   handler: () => Promise<ToolResult>,
+  workflowType?: string,
 ): Promise<ToolResult> {
   // When no config, default to blocking (backwards compat)
   if (!config) {
     return handler();
   }
 
-  const severity = resolveGateSeverity(gateName, dimension, config);
+  const severity = resolveGateSeverity(gateName, dimension, config, workflowType);
 
   if (severity === 'disabled') {
     return {

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
@@ -9,10 +9,10 @@ import type { ToolResult } from '../format.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { resolveGateSeverity } from './gate-severity.js';
 import {
-  resolveVerificationSequence,
   type GateName,
   type RiskTier,
 } from '../workflow/verification-policy.js';
+import { resolveVerificationPolicy } from '../workflow/verification-policy-resolver.js';
 import type { GitExec } from './pure/execute-merge.js';
 
 /**
@@ -301,27 +301,43 @@ export const SKIPPED_BY_POLICY = 'skipped-by-policy';
 
 /**
  * Decide whether a gate should self-skip given the task's stamped verification
- * profile. The SINGLE SOURCE OF TRUTH for which gates run is the policy table
- * (`resolveVerificationSequence`, INV-6) — this helper reads it, it does NOT
- * re-derive sequences.
+ * profile.
+ *
+ * The SINGLE SOURCE OF TRUTH for which gates run is the config-resolved policy
+ * ({@link resolveVerificationPolicy}, the declared only composer of config +
+ * the frozen built-in table) — this helper reads it, it does NOT re-derive
+ * sequences or touch the table directly. Consuming the SAME resolver the
+ * delegation stamp uses ({@link classifyTask}) guarantees stamp and skip can
+ * never disagree: a `.exarchos.yml` `verification:` cell that excludes a gate
+ * makes BOTH the stamp drop it AND this helper skip it.
+ *
+ * When `config` is omitted (or its relevant cell is unset) the resolver
+ * delegates to the built-in table, so the skip decision is byte-identical to
+ * the pre-config behavior.
  *
  * Returns a skip decision ONLY when BOTH stamped fields are present AND the
  * resolved sequence for that profile does not contain `gateName`. When either
  * stamp is absent (legacy callers that don't thread the profile) it returns
- * `null` → the handler runs unconditionally, preserving current behavior.
+ * `null` → the handler runs unconditionally, preserving current behavior
+ * EXACTLY (config presence does not change the absent-stamp path).
+ *
+ * The skip `reason` names the policy SOURCE (`config` vs `builtin`) so a
+ * config-induced skip is never mistaken for a built-in decision.
  */
 export function resolvePolicySkip(args: {
   readonly gateName: GateName;
   readonly riskTier?: RiskTier;
   readonly boundaryTouching?: boolean;
+  readonly config?: ResolvedProjectConfig;
 }): { readonly reason: string } | null {
-  const { gateName, riskTier, boundaryTouching } = args;
+  const { gateName, riskTier, boundaryTouching, config } = args;
   // Both stamps required — a partial stamp is treated as "no stamp" so we never
-  // skip on a half-resolved profile.
+  // skip on a half-resolved profile. This guard runs BEFORE any config read so
+  // the absent-stamp path is byte-identical regardless of config presence.
   if (riskTier === undefined || boundaryTouching === undefined) {
     return null;
   }
-  const sequence = resolveVerificationSequence(riskTier, boundaryTouching);
+  const { sequence, source } = resolveVerificationPolicy(riskTier, boundaryTouching, config);
   if (sequence.includes(gateName)) {
     return null;
   }
@@ -329,6 +345,6 @@ export function resolvePolicySkip(args: {
     reason:
       `skipped by verification policy — ${gateName} is not in the resolved ` +
       `sequence for riskTier='${riskTier}', boundaryTouching=${boundaryTouching} ` +
-      `(sequence: ${sequence.join(', ') || 'none'})`,
+      `(sequence: ${sequence.join(', ') || 'none'}; policy: ${source})`,
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
@@ -248,6 +248,52 @@ export async function withConfigSeverity(
   return result;
 }
 
+/**
+ * Apply per-workflow severity to a verification-LADDER gate's ADVISORY-carrier
+ * result (task 005).
+ *
+ * Ladder gates (INV-5b) never return `success:false` for a gate-failure verdict
+ * — a failing gate is `{ success: true, data: { passed: false } }`, so
+ * {@link withConfigSeverity}'s `success:false`-only conversion does not apply.
+ * This helper resolves the gate's effective severity via
+ * {@link resolveGateSeverity} (threading `workflowType`) and, ONLY when that
+ * severity is `'warning'` and the advisory result reports a failing verdict
+ * (`data.passed === false`), annotates it with a warning. In every other case
+ * the result is returned UNCHANGED:
+ *   - `severity !== 'warning'` (e.g. blocking for a feature workflow) → unchanged,
+ *     so the orchestrator still reads `data.passed:false` and blocks;
+ *   - `config` absent → unchanged (legacy / no-config callers);
+ *   - a passing verdict → unchanged;
+ *   - a real error envelope (`success:false`) → unchanged (an INVALID_INPUT /
+ *     MISWIRED_CONTEXT must never be downgraded to a warning).
+ */
+export function applyLadderGateSeverity(
+  gateName: string,
+  dimension: string,
+  config: ResolvedProjectConfig | undefined,
+  result: ToolResult,
+  workflowType?: string,
+): ToolResult {
+  // No config, or a real error envelope, or a non-advisory shape — leave as-is.
+  if (!config || !result.success) return result;
+
+  const data = result.data as { passed?: unknown } | undefined;
+  // Only an explicit failing verdict is a candidate for downgrade. A passing or
+  // shape-less advisory carrier is returned verbatim.
+  if (!data || data.passed !== false) return result;
+
+  const severity = resolveGateSeverity(gateName, dimension, config, workflowType);
+  if (severity !== 'warning') return result;
+
+  return {
+    ...result,
+    warnings: [
+      ...(result.warnings ?? []),
+      `Gate '${gateName}' failed but is configured as warning-only`,
+    ],
+  };
+}
+
 // ─── Verification-ladder self-routing (FIX-1a) ──────────────────────────────
 
 /** The discriminant carried by a gate skipped because the policy excludes it. */

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.test.ts
@@ -11,24 +11,34 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
-import type { ResolvedRuntime } from '../../config/test-runtime-resolver.js';
+import type { ResolvedVerificationRuntime } from '../../config/test-runtime-resolver.js';
 import { loadExarchosConfig } from '../../config/load-exarchos-config.js';
 import { seedExarchosConfig } from './seed-exarchos-config.js';
 
-function npmResolve(): ResolvedRuntime {
+// The seeder resolves the WIDENED verification field set (§4.5-seed): the legacy
+// test/typecheck/install PLUS mutation/lint/contract. These stubs mirror the
+// resolver's `ResolvedVerificationRuntime` shape — mutation/lint default to null
+// (the unresolved-no-fields gate now considers them too).
+function npmResolve(): ResolvedVerificationRuntime {
   return {
     test: 'npm run test:run',
     typecheck: 'tsc --noEmit',
     install: 'npm install',
+    mutation: null,
+    lint: null,
+    contract: null,
     source: 'detection',
   };
 }
 
-function bunResolve(): ResolvedRuntime {
+function bunResolve(): ResolvedVerificationRuntime {
   return {
     test: 'bun test',
     typecheck: 'tsc --noEmit',
     install: 'bun install',
+    mutation: null,
+    lint: null,
+    contract: null,
     source: 'detection',
   };
 }
@@ -91,6 +101,9 @@ describe('seedExarchosConfig', () => {
         test: null,
         typecheck: null,
         install: null,
+        mutation: null,
+        lint: null,
+        contract: null,
         source: 'unresolved',
         remediation: 'No project markers detected.',
       }),
@@ -110,6 +123,9 @@ describe('seedExarchosConfig', () => {
         test: 'pytest',
         typecheck: null,
         install: null,
+        mutation: null,
+        lint: null,
+        contract: null,
         source: 'detection',
       }),
     });
@@ -120,6 +136,60 @@ describe('seedExarchosConfig', () => {
     expect(body).toContain('test: pytest');
     expect(body).not.toMatch(/^typecheck:/m);
     expect(body).not.toMatch(/^install:/m);
+  });
+
+  it('seed_NoExistingConfig_VerificationCommandsResolved_WritesMutationAndLint', () => {
+    // §4.5-seed: when the widened resolver resolves mutation + lint, the seeder
+    // writes them as top-level direct keys (tier 2) alongside the legacy triple.
+    const writes: Array<{ p: string; contents: string }> = [];
+    const result = seedExarchosConfig('/repo', {
+      exists: () => false,
+      write: (p, contents) => writes.push({ p, contents }),
+      resolve: () => ({
+        test: 'pytest',
+        typecheck: null,
+        install: null,
+        mutation: 'mutmut run',
+        lint: 'ruff check',
+        contract: null,
+        source: 'detection',
+      }),
+    });
+
+    expect(result.wrote).toBe(true);
+    const body = writes[0].contents;
+    expect(body).toContain('test: pytest');
+    expect(body).toContain('mutation: mutmut run');
+    expect(body).toContain('lint: ruff check');
+    // NEGATIVE GUARANTEE (§4.5): commands only — no `verification:` policy block.
+    expect(body).not.toMatch(/^verification:/m);
+  });
+
+  it('seed_NoExistingConfig_OnlyVerificationCommandResolves_StillWrites', () => {
+    // mutation/lint can resolve even when the legacy triple is unresolved (a
+    // toolchain with a mutation runner but no conventional test command). The
+    // unresolved-no-fields gate must consider the widened fields, else a
+    // resolvable verification command would be silently dropped.
+    const writes: Array<{ p: string; contents: string }> = [];
+    const result = seedExarchosConfig('/repo', {
+      exists: () => false,
+      write: (p, contents) => writes.push({ p, contents }),
+      resolve: () => ({
+        test: null,
+        typecheck: null,
+        install: null,
+        mutation: 'npx stryker run',
+        lint: null,
+        contract: null,
+        source: 'unresolved',
+        remediation: 'No test command, but mutation resolved.',
+      }),
+    });
+
+    expect(result.wrote).toBe(true);
+    const body = writes[0].contents;
+    expect(body).toContain('mutation: npx stryker run');
+    expect(body).not.toMatch(/^test:/m);
   });
 
   it('seed_HeaderCommentPresent', () => {

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.test.ts
@@ -202,8 +202,9 @@ describe('seedExarchosConfig', () => {
 
     const body = writes[0].contents;
     expect(body).toContain('# .exarchos.yml — Exarchos project configuration.');
-    expect(body).toContain('# use for gates and worktree setup. Auto-seeded from detection at workflow');
-    expect(body).toContain('# init time. Edit freely; subsequent inits will not overwrite it.');
+    expect(body).toContain('# This file declares the commands Exarchos uses for gates and worktree setup —');
+    expect(body).toContain('# test, typecheck, install, plus the verification-ladder commands mutation and');
+    expect(body).toContain('# at workflow init time. Edit freely; subsequent inits will not overwrite it.');
     expect(body).toContain('https://github.com/lvlup-sw/exarchos/issues/1199');
   });
 
@@ -261,14 +262,17 @@ describe('seedExarchosConfig', () => {
   it('seed_RoundTripsThroughLoader', async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), 'seed-roundtrip-'));
     try {
-      // Capture seeded contents using the injected write hook.
+      // Capture seeded contents using the injected write hook. The resolver stub
+      // also resolves mutation/lint so the round-trip covers the WIDENED command
+      // surface — a regression where `loadExarchosConfig` drops or rejects
+      // mutation/lint must fail here, not pass against the legacy keys alone.
       let seeded = '';
       const result = seedExarchosConfig(tempDir, {
         exists: () => false,
         write: (_p, contents) => {
           seeded = contents;
         },
-        resolve: () => npmResolve(),
+        resolve: () => ({ ...npmResolve(), mutation: 'npx stryker run', lint: 'eslint .' }),
       });
       expect(result.wrote).toBe(true);
 
@@ -284,6 +288,9 @@ describe('seedExarchosConfig', () => {
       expect(load!.config.test).toBe('npm run test:run');
       expect(load!.config.typecheck).toBe('tsc --noEmit');
       expect(load!.config.install).toBe('npm install');
+      // The widened verification-ladder commands survive the seed → load round-trip.
+      expect(load!.config.mutation).toBe('npx stryker run');
+      expect(load!.config.lint).toBe('eslint .');
     } finally {
       await rm(tempDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
@@ -16,8 +16,8 @@ import * as path from 'node:path';
 import { stringify as stringifyYaml } from 'yaml';
 
 import {
-  resolveTestRuntime,
-  type ResolvedRuntime,
+  resolveVerificationRuntime,
+  type ResolvedVerificationRuntime,
 } from '../../config/test-runtime-resolver.js';
 
 const CONFIG_FILENAME = '.exarchos.yml';
@@ -67,8 +67,8 @@ export interface SeedOptions {
   exists?: (p: string) => boolean;
   /** Inject for tests. Defaults to fs.writeFileSync. */
   write?: (p: string, contents: string) => void;
-  /** Inject for tests. Defaults to the real resolver. */
-  resolve?: (repoRoot: string) => ResolvedRuntime;
+  /** Inject for tests. Defaults to the real widened verification resolver. */
+  resolve?: (repoRoot: string) => ResolvedVerificationRuntime;
 }
 
 export function seedExarchosConfig(
@@ -78,7 +78,11 @@ export function seedExarchosConfig(
   const target = path.join(repoRoot, CONFIG_FILENAME);
   const exists = options?.exists ?? existsSync;
   const write = options?.write ?? ((p, contents) => writeFileSync(p, contents, 'utf8'));
-  const resolve = options?.resolve ?? ((root: string) => resolveTestRuntime(root));
+  // Widened resolver (verification-ladder slice 2, §4.5-seed): resolves the
+  // legacy test/typecheck/install PLUS the verification commands mutation/lint,
+  // so the seeded `.exarchos.yml` pins what onboarding/doctor resolved across the
+  // whole verification surface — the same per-field layered precedence.
+  const resolve = options?.resolve ?? ((root: string) => resolveVerificationRuntime(root));
 
   if (exists(target)) {
     return { wrote: false, path: target, reason: 'already-exists' };
@@ -86,21 +90,37 @@ export function seedExarchosConfig(
 
   const result = resolve(repoRoot);
 
+  // Nothing resolved across the WIDENED field set ⇒ no fields to seed. mutation
+  // and lint can resolve even when the legacy triple is unresolved (e.g. a
+  // toolchain with a mutation runner but no conventional test command), so the
+  // no-op gate must consider them too — otherwise a resolvable verification
+  // command would be silently dropped.
   if (
     result.source === 'unresolved' &&
     result.test === null &&
     result.typecheck === null &&
-    result.install === null
+    result.install === null &&
+    result.mutation === null &&
+    result.lint === null
   ) {
     return { wrote: false, path: target, reason: 'unresolved-no-fields' };
   }
 
   // Build YAML body from non-null fields only — preserves ordering for
-  // human readability (test, typecheck, install).
+  // human readability (test, typecheck, install, then the verification-ladder
+  // commands mutation, lint). These are top-level DIRECT keys (tier 2) the
+  // resolver honors above detection.
+  //
+  // NEGATIVE GUARANTEE (§4.5): only resolved COMMANDS are written. No
+  // `verification:` policy block is ever emitted — seeding the resolved policy
+  // default would freeze today's builtin table into consumer config (the
+  // gen-time-bake trap, #1483). Policy is surfaced read-only via doctor.
   const body: Record<string, string> = {};
   if (result.test !== null) body.test = result.test;
   if (result.typecheck !== null) body.typecheck = result.typecheck;
   if (result.install !== null) body.install = result.install;
+  if (result.mutation !== null) body.mutation = result.mutation;
+  if (result.lint !== null) body.lint = result.lint;
 
   const yamlBody = stringifyYaml(body);
   const contents = HEADER + yamlBody + INVARIANTS_STANZA;

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
@@ -24,9 +24,10 @@ const CONFIG_FILENAME = '.exarchos.yml';
 
 const HEADER = `# .exarchos.yml — Exarchos project configuration.
 #
-# This file declares the test/typecheck/install commands Exarchos should
-# use for gates and worktree setup. Auto-seeded from detection at workflow
-# init time. Edit freely; subsequent inits will not overwrite it.
+# This file declares the commands Exarchos uses for gates and worktree setup —
+# test, typecheck, install, plus the verification-ladder commands mutation and
+# lint (each seeded only when detection resolved one). Auto-seeded from detection
+# at workflow init time. Edit freely; subsequent inits will not overwrite it.
 #
 # Set any field to override detection. Unset fields fall back to detection.
 # Docs: https://github.com/lvlup-sw/exarchos/issues/1199

--- a/servers/exarchos-mcp/src/orchestrate/mock-boundary-handler.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mock-boundary-handler.ts
@@ -99,6 +99,15 @@ export interface MockBoundaryHandlerArgs {
   readonly riskTier?: RiskTier;
   /** The task's stamped boundary-touching flag. See {@link riskTier}. */
   readonly boundaryTouching?: boolean;
+  /**
+   * The resolved project config (task 004). Threaded by the dispatch adapter so
+   * the self-skip routing consumes the SAME config-resolved policy the
+   * delegation stamp uses. Distinct from the per-worktree {@link loadConfig}
+   * seam (ownership globs / review-gate severity): this is the dispatch-time
+   * config that drives the policy SEQUENCE. Omitted → the resolver falls
+   * through to the built-in table.
+   */
+  readonly projectConfig?: ResolvedProjectConfig;
 
   // ── Test seams (DI; production defaults below) ───────────────────────────
   readonly gitExec?: GitExec;
@@ -219,6 +228,7 @@ export async function handleMockBoundary(
     gateName: 'check_mock_boundary',
     riskTier: args.riskTier,
     boundaryTouching: args.boundaryTouching,
+    config: args.projectConfig,
   });
   if (policySkip) {
     try {

--- a/servers/exarchos-mcp/src/orchestrate/onboard/index.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/onboard/index.test.ts
@@ -47,8 +47,17 @@ interface Fixture {
 }
 
 /** A temp repo (Node toolchain marker so the seed resolves commands) + an
- * isolated EventStore state dir, wired into a minimal DispatchContext. */
-async function createFixture(): Promise<Fixture> {
+ * isolated EventStore state dir, wired into a minimal DispatchContext.
+ *
+ * `declareConfig` (default `true`) pre-writes an `.exarchos.yml` declaring the
+ * verification commands the node toolchain resolves (`mutation: npx stryker run`).
+ * Without it, the §4.5-seed divergence path would add a `verification-command-*`
+ * config step to EVERY plan (the node fixture resolves mutation from detection,
+ * undeclared), which is orthogonal to these doctor-check-drift tests. Pre-
+ * declaring it makes the verification command already-declared (no seed step), so
+ * each test's plan reflects only its INJECTED doctor-check drift. The one test
+ * that asserts the repo has NO `.exarchos.yml` (dry-run) opts out. */
+async function createFixture(declareConfig = true): Promise<Fixture> {
   const base = await mkdtemp(path.join(tmpdir(), 'onboard-'));
   const repoRoot = path.join(base, 'repo');
   const stateDir = path.join(base, 'state');
@@ -62,6 +71,13 @@ async function createFixture(): Promise<Fixture> {
     ),
     'utf8',
   );
+  if (declareConfig) {
+    await writeFile(
+      path.join(repoRoot, '.exarchos.yml'),
+      'test: npm run test:run\nmutation: npx stryker run\n',
+      'utf8',
+    );
+  }
   const eventStore = new EventStore(stateDir);
   await eventStore.initialize();
   const ctx: DispatchContext = { stateDir, eventStore, enableTelemetry: false };
@@ -227,7 +243,9 @@ describe('handleOnboard (DR-2 — onboard verb + pipeline)', () => {
   });
 
   it('Onboard_DryRun_PrintsPlanWritesNothing', async () => {
-    const fx = await createFixture();
+    // Opt out of the pre-declared `.exarchos.yml` — this test asserts the repo
+    // has NO config file after the dry-run (proving zero writes).
+    const fx = await createFixture(false);
     try {
       const seed = vi.fn(() => ({ wrote: true, path: path.join(fx.repoRoot, '.exarchos.yml') }));
       const installStep = vi.fn().mockResolvedValue(undefined);

--- a/servers/exarchos-mcp/src/orchestrate/onboard/onboard.parity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/onboard/onboard.parity.test.ts
@@ -209,9 +209,17 @@ describe('exarchos onboard CLI/MCP parity (DR-6)', () => {
       expect(normalizedCli).toEqual(normalizedMcp);
       expect(JSON.stringify(normalizedCli)).toEqual(JSON.stringify(normalizedMcp));
 
-      // Sanity — the plan reconciled the config step on both arms (no install).
-      const cliData = cliResult.data as { plan: { steps: { kind: string }[] } };
-      expect(cliData.plan.steps.map((s) => s.kind)).toEqual(['config']);
+      // Sanity — the plan reconciled config steps on both arms (no install).
+      // Two config steps: the injected `state-dir` doctor-check drift PLUS the
+      // §4.5-seed `verification-command-mutation` step (the node fixture resolves
+      // `npx stryker run` from detection, undeclared in `.exarchos.yml`). Both
+      // arms produce the identical plan — parity is unaffected by the new seeding.
+      const cliData = cliResult.data as { plan: { steps: { kind: string; key: string }[] } };
+      expect(cliData.plan.steps.map((s) => s.kind)).toEqual(['config', 'config']);
+      expect(cliData.plan.steps.map((s) => s.key)).toEqual([
+        'state-dir',
+        'verification-command-mutation',
+      ]);
     } finally {
       await cleanup(cliFx);
       await cleanup(mcpFx);

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -79,6 +79,9 @@ import {
 import { shouldEnforceCheckpoint } from '../workflow/checkpoint.js';
 import { assertWorktreeBaseRefPinned } from './worktree-baseref.js';
 import { DEFAULTS } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { resolveVerificationSequence } from '../workflow/verification-policy.js';
+import type { GateName } from '../workflow/verification-policy.js';
 
 const STATE_DIR = '/tmp/test-state';
 
@@ -1631,7 +1634,100 @@ describe('handlePrepareDelegation', () => {
     });
   });
 
+  // ─── Verification-policy stamp (vls1-b2 / task 003) ───────────────────────
+  //
+  // classifyTask must stamp the CONFIG-RESOLVED verification sequence
+  // (resolveVerificationPolicy) rather than the frozen built-in table
+  // (resolveVerificationSequence). When no config is supplied the stamp must
+  // be byte-identical to the built-in path.
+  describe('classifyTask — verification-policy stamp', () => {
+    /** A deep-mutable config seeded from DEFAULTS with a custom medium cell. */
+    function configWithMediumPolicy(sequence: readonly GateName[]): ResolvedProjectConfig {
+      const config = structuredClone(DEFAULTS) as ResolvedProjectConfig;
+      // structuredClone drops nothing here; override only the medium cell so
+      // the boundary axis + other cells still fall through to the base table.
+      (config.verification.policy as { medium?: readonly GateName[] }).medium = [...sequence];
+      return config;
+    }
+
+    it('ClassifyTask_NoVerificationConfig_StampsBuiltinSequence', () => {
+      // Arrange — a medium-risk, non-boundary task (default heuristic), no config.
+      const task: TaskInput = { id: 'T-100', title: 'Implement feature X' };
+
+      // Act
+      const classification = classifyTask(task);
+
+      // Assert — characterization: byte-identical to the built-in table.
+      const expected = resolveVerificationSequence(
+        classification.riskTier,
+        classification.boundaryTouching,
+      );
+      expect(classification.verificationSequence).toEqual(expected);
+    });
+
+    it('ClassifyTask_ConfiguredPolicyCell_StampsConfigResolvedSequence', () => {
+      // Arrange — task derives to medium/non-boundary; config overrides medium.
+      const customSequence: readonly GateName[] = [
+        'check_static_analysis',
+        'check_mock_boundary',
+      ];
+      const task: TaskInput = { id: 'T-101', title: 'Implement feature Y' };
+      const config = configWithMediumPolicy(customSequence);
+
+      // Pre-assert the task lands in the medium cell so the override applies.
+      const baseline = classifyTask(task);
+      expect(baseline.riskTier).toBe('medium');
+      expect(baseline.boundaryTouching).toBe(false);
+
+      // Act
+      const classification = classifyTask(task, DEFAULTS.agents, config);
+
+      // Assert — the configured cell is stamped verbatim (full replacement).
+      expect(classification.verificationSequence).toEqual(customSequence);
+      // And it diverges from the built-in table the no-config path would stamp.
+      expect(classification.verificationSequence).not.toEqual(baseline.verificationSequence);
+    });
+  });
+
   describe('handler config threading', () => {
+    it('PrepareDelegation_ConfiguredPolicy_StampsConfigSequenceOnClassifications', async () => {
+      // R7-inheritance proof: the config-resolved sequence flows onto the
+      // taskClassifications records the handler returns (prompt assembly
+      // downstream reads exactly this stamp).
+      // Arrange
+      const state = readyWorkflowState();
+      setupMaterializer(state);
+      vi.mocked(generateQualityHints).mockReturnValue([]);
+      const customSequence: readonly GateName[] = [
+        'check_static_analysis',
+        'check_contract_drift',
+      ];
+      const config = structuredClone(DEFAULTS) as ResolvedProjectConfig;
+      (config.verification.policy as { medium?: readonly GateName[] }).medium = [...customSequence];
+
+      const args = {
+        featureId: 'test-feature',
+        // A title with no scaffolding keywords / deps / files derives to medium.
+        tasks: [{ id: 'task-1', title: 'Implement widget' }],
+      };
+      const ctx = {
+        stateDir: STATE_DIR,
+        eventStore: mockStore as never,
+        enableTelemetry: false,
+        projectConfig: config,
+      };
+
+      // Act
+      const result = await handlePrepareDelegation(args, STATE_DIR, ctx as never);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as { taskClassifications: TaskClassification[] };
+      const stamped = data.taskClassifications[0];
+      expect(stamped.riskTier).toBe('medium');
+      expect(stamped.verificationSequence).toEqual(customSequence);
+    });
+
     it('PrepareDelegation_WithTasks_ClassificationsIncludeRecommendedModel', async () => {
       // Arrange
       const state = readyWorkflowState();

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -50,8 +50,8 @@ import {
 } from '../workflow/checkpoint.js';
 import type { CheckpointEnforcementConfig } from '../workflow/checkpoint.js';
 import { globToRegExp } from '../architecture/glob-to-regexp.js';
-import { resolveVerificationSequence } from '../workflow/verification-policy.js';
 import type { GateName } from '../workflow/verification-policy.js';
+import { resolveVerificationPolicy } from '../workflow/verification-policy-resolver.js';
 
 // ─── Result Interface ────────────────────────────────────────────────────────
 
@@ -385,7 +385,14 @@ function classifyTaskCore(
  * verification-ladder fields:
  *   - `riskTier`           — {@link deriveRiskTier} (honors explicit override)
  *   - `boundaryTouching`   — {@link deriveBoundaryTouching} (honors override)
- *   - `verificationSequence` — {@link resolveVerificationSequence} over the two
+ *   - `verificationSequence` — {@link resolveVerificationPolicy} over the two
+ *
+ * vls1-b2 (task 003): the verification sequence is stamped from the
+ * CONFIG-RESOLVED policy ({@link resolveVerificationPolicy}), not the frozen
+ * built-in table directly. When `config` is omitted (or its relevant cell is
+ * unset) the resolver delegates to the built-in table, so behavior is
+ * byte-identical to the pre-config stamp. A `.exarchos.yml` `verification:`
+ * cell override therefore changes what gets stamped onto the delegation record.
  *
  * The legacy `complexity`/`effort` axis is preserved unchanged — `riskTier` is
  * a SEPARATE, blast-radius-driven axis (a scaffolding task can be low-effort
@@ -394,6 +401,7 @@ function classifyTaskCore(
 export function classifyTask(
   task: TaskInput,
   agentConfig: ResolvedProjectConfig['agents'] = DEFAULTS.agents,
+  config?: ResolvedProjectConfig,
 ): TaskClassification {
   const core = classifyTaskCore(task, agentConfig);
   const riskTier = deriveRiskTier(task);
@@ -402,7 +410,7 @@ export function classifyTask(
     ...core,
     riskTier,
     boundaryTouching,
-    verificationSequence: resolveVerificationSequence(riskTier, boundaryTouching),
+    verificationSequence: resolveVerificationPolicy(riskTier, boundaryTouching, config).sequence,
   };
 }
 
@@ -983,10 +991,22 @@ export async function handlePrepareDelegation(
       });
     } catch { /* fire-and-forget */ }
 
-    // Compute task classifications when tasks are provided (advisory)
+    // Compute task classifications when tasks are provided (advisory).
+    // vls1-b2 (task 003): thread the resolved project config so the
+    // verification sequence stamped on each classification honors any
+    // `.exarchos.yml` `verification:` cell override. When absent, the
+    // resolver falls through to the byte-identical built-in table.
+    //
+    // The resolver reads `config.verification.policy`; only forward a config
+    // whose `verification` overlay is actually present so a partial/legacy
+    // config object (one that predates the overlay) cannot throw — that path
+    // is equivalent to "no config" (built-in table).
     const agentConfig = ctx?.projectConfig?.agents ?? DEFAULTS.agents;
+    const projectConfig = ctx?.projectConfig?.verification
+      ? ctx.projectConfig
+      : undefined;
     const taskClassifications = args.tasks
-      ? args.tasks.map(t => classifyTask(t, agentConfig))
+      ? args.tasks.map(t => classifyTask(t, agentConfig, projectConfig))
       : undefined;
 
     const result: PrepareDelegationResult = {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -997,14 +997,14 @@ export async function handlePrepareDelegation(
     // `.exarchos.yml` `verification:` cell override. When absent, the
     // resolver falls through to the byte-identical built-in table.
     //
-    // The resolver reads `config.verification.policy`; only forward a config
-    // whose `verification` overlay is actually present so a partial/legacy
-    // config object (one that predates the overlay) cannot throw — that path
-    // is equivalent to "no config" (built-in table).
+    // task 004: forward the config UNCONDITIONALLY — the resolver now
+    // optional-chains on `config?.verification?.policy`, so a present-but-
+    // partial config (one predating the `verification` overlay) is handled as
+    // no-config inside the resolver rather than throwing. The earlier call-site
+    // guard that forwarded config only when `verification` was present is no
+    // longer needed.
     const agentConfig = ctx?.projectConfig?.agents ?? DEFAULTS.agents;
-    const projectConfig = ctx?.projectConfig?.verification
-      ? ctx.projectConfig
-      : undefined;
+    const projectConfig = ctx?.projectConfig;
     const taskClassifications = args.tasks
       ? args.tasks.map(t => classifyTask(t, agentConfig, projectConfig))
       : undefined;

--- a/servers/exarchos-mcp/src/orchestrate/test-adequacy-handler.ts
+++ b/servers/exarchos-mcp/src/orchestrate/test-adequacy-handler.ts
@@ -28,6 +28,7 @@ import {
 import { resolveTestRuntime } from '../config/test-runtime-resolver.js';
 import { splitCommand } from '../config/tokenize-command.js';
 import { detectToolchain, testGlobsForToolchain } from '../config/toolchains.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
 import type { RiskTier } from '../workflow/verification-policy.js';
 import type { GitExec } from './pure/execute-merge.js';
 import { runProbe, type ProbeResult, type TestRunFn } from './test-adequacy.js';
@@ -64,6 +65,14 @@ export interface TestAdequacyArgs {
   readonly riskTier?: RiskTier;
   /** The task's stamped boundary-touching flag. See {@link riskTier}. */
   readonly boundaryTouching?: boolean;
+  /**
+   * The resolved project config (task 004). Threaded by the dispatch adapter so
+   * the self-skip routing consumes the SAME config-resolved policy the
+   * delegation stamp uses — a `.exarchos.yml` `verification:` cell that excludes
+   * this gate makes the stamp drop it AND this handler skip it (they can never
+   * disagree). Omitted → the resolver falls through to the built-in table.
+   */
+  readonly projectConfig?: ResolvedProjectConfig;
 
   // ── Test seams (DI; production defaults below) ───────────────────────────
   /** Git executor. Defaults to a 30s-ceiling shell-out. */
@@ -188,6 +197,7 @@ export async function handleTestAdequacy(
     gateName: 'check_test_adequacy',
     riskTier: args.riskTier,
     boundaryTouching: args.boundaryTouching,
+    config: args.projectConfig,
   });
   if (policySkip) {
     try {

--- a/servers/exarchos-mcp/src/orchestrate/test-adequacy.handler.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/test-adequacy.handler.test.ts
@@ -25,6 +25,7 @@ vi.mock('./test-adequacy.js', async (importOriginal) => {
 import { EventStore } from '../event-store/store.js';
 import type { DispatchContext } from '../core/dispatch.js';
 import { handleOrchestrate } from './composite.js';
+import { DEFAULTS } from '../config/resolve.js';
 
 function passResult() {
   return {
@@ -125,6 +126,47 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
     expect(data.passed).toBe(true);
     expect(data.discriminant).toBe('no-new-tests');
     expect(data.report).toContain('nothing to probe');
+  });
+
+  it('HandleOrchestrate_OneshotTestAdequacyFailure_ResolvesAdvisory', async () => {
+    // Task 005: an oneshot workflow's FAILING ladder gate (advisory carrier:
+    // success:true, data.passed:false) resolves to warning severity — the
+    // dispatch surfaces the failure as a NON-blocking advisory (success:true
+    // with a warning), threading the ACTUAL workflowType from workflow state.
+    const ctx = await makeCtx();
+
+    // Seed an oneshot workflow into the event store so the dispatch resolver
+    // reads workflowType='oneshot' for this featureId.
+    await ctx.eventStore.append('feat-oneshot', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-oneshot', workflowType: 'oneshot' },
+    });
+
+    // The probe reports a FAILED verdict (a real kill).
+    mockRunProbe.mockResolvedValue({
+      passed: false,
+      probedTests: ['src/calc.test.js'],
+      redObserved: false,
+      restoredClean: true,
+      report: 'vacuous test survived mutation',
+    });
+
+    const result = await handleOrchestrate(
+      {
+        action: 'check_test_adequacy',
+        featureId: 'feat-oneshot',
+        taskId: 'T-oneshot',
+        repoRoot: '/fake/repo',
+      },
+      // Provide projectConfig so config-aware severity resolution engages.
+      { ...ctx, projectConfig: DEFAULTS } as DispatchContext,
+    );
+
+    // Advisory resolution: NOT blocked — surfaced as success-with-warning.
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('warning-only')]),
+    );
   });
 
   it('GateEvent_SameOperationId_IdempotencyCollapses', async () => {

--- a/servers/exarchos-mcp/src/workflow/__tests__/single-composer-guard.test.ts
+++ b/servers/exarchos-mcp/src/workflow/__tests__/single-composer-guard.test.ts
@@ -49,11 +49,17 @@ const ALLOWED_BASENAMES = new Set([
 ]);
 
 /**
- * Returns true iff `source` imports the named symbol `resolveVerificationSequence`
- * from a module whose specifier ends in `verification-policy.js`, in ANY of the
- * import/re-export forms TypeScript supports (static value/type import, named
- * re-export). A side-effect or default import cannot name this symbol, so the
- * named-binding forms are exhaustive for this symbol.
+ * Returns true iff `source` reaches `resolveVerificationSequence` from a module
+ * whose specifier ends in `verification-policy.js`, in ANY import/re-export form
+ * TypeScript supports:
+ *   - named import / aliased named import (`import { x }`, `import { x as y }`)
+ *   - named re-export (`export { x } from`)
+ *   - NAMESPACE import (`import * as ns from`) — binds every export, so
+ *     `ns.resolveVerificationSequence(...)` bypasses the rule
+ *   - EXPORT-ALL (`export * from`, `export * as ns from`) — re-exports the
+ *     forbidden table function transitively
+ * Only a plain side-effect import (`import '…'`) and a default import cannot name
+ * this symbol; every binding form that CAN reach it is matched.
  */
 function importsForbiddenTableFn(source: string): boolean {
   const sf = ts.createSourceFile(
@@ -71,37 +77,50 @@ function importsForbiddenTableFn(source: string): boolean {
   const visit = (node: ts.Node): void => {
     if (found) return;
 
-    // import { resolveVerificationSequence, … } from '…/verification-policy.js'
-    // import type { resolveVerificationSequence } from '…' (type position too)
-    if (
-      ts.isImportDeclaration(node) &&
-      specifierMatches(node.moduleSpecifier) &&
-      node.importClause?.namedBindings &&
-      ts.isNamedImports(node.importClause.namedBindings)
-    ) {
-      for (const el of node.importClause.namedBindings.elements) {
-        // `propertyName` is the original name in `import { orig as alias }`.
-        const original = el.propertyName?.text ?? el.name.text;
-        if (original === FORBIDDEN_NAMED_IMPORT) {
-          found = true;
-          return;
+    if (ts.isImportDeclaration(node) && specifierMatches(node.moduleSpecifier)) {
+      const namedBindings = node.importClause?.namedBindings;
+      // import * as verificationPolicy from '…/verification-policy.js'
+      // A namespace binding exposes EVERY export — including the forbidden table
+      // function — so `ns.resolveVerificationSequence(...)` bypasses the rule.
+      if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+        found = true;
+        return;
+      }
+      // import { resolveVerificationSequence, … } from '…/verification-policy.js'
+      // import type { resolveVerificationSequence } from '…' (type position too)
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        for (const el of namedBindings.elements) {
+          // `propertyName` is the original name in `import { orig as alias }`.
+          const original = el.propertyName?.text ?? el.name.text;
+          if (original === FORBIDDEN_NAMED_IMPORT) {
+            found = true;
+            return;
+          }
         }
       }
     }
 
-    // export { resolveVerificationSequence } from '…/verification-policy.js'
     if (
       ts.isExportDeclaration(node) &&
       node.moduleSpecifier &&
-      specifierMatches(node.moduleSpecifier) &&
-      node.exportClause &&
-      ts.isNamedExports(node.exportClause)
+      specifierMatches(node.moduleSpecifier)
     ) {
-      for (const el of node.exportClause.elements) {
-        const original = el.propertyName?.text ?? el.name.text;
-        if (original === FORBIDDEN_NAMED_IMPORT) {
-          found = true;
-          return;
+      // export * from '…/verification-policy.js'  (exportClause === undefined)
+      // export * as ns from '…/verification-policy.js'  (NamespaceExport)
+      // Either form re-exports the forbidden table function transitively, so a
+      // consumer importing from the re-exporter reaches it without naming it.
+      if (node.exportClause === undefined || ts.isNamespaceExport(node.exportClause)) {
+        found = true;
+        return;
+      }
+      // export { resolveVerificationSequence } from '…/verification-policy.js'
+      if (ts.isNamedExports(node.exportClause)) {
+        for (const el of node.exportClause.elements) {
+          const original = el.propertyName?.text ?? el.name.text;
+          if (original === FORBIDDEN_NAMED_IMPORT) {
+            found = true;
+            return;
+          }
         }
       }
     }
@@ -208,6 +227,22 @@ describe('single-composer guard', () => {
         name: 'named re-export',
         src: `export { resolveVerificationSequence } from './verification-policy.js';\n`,
       },
+      {
+        name: 'namespace import',
+        src: `import * as verificationPolicy from './verification-policy.js';\nverificationPolicy.resolveVerificationSequence();\n`,
+      },
+      {
+        name: 'namespace import among a default binding',
+        src: `import def, * as vp from '../workflow/verification-policy.js';\n`,
+      },
+      {
+        name: 'export-all',
+        src: `export * from './verification-policy.js';\n`,
+      },
+      {
+        name: 'aliased export-all',
+        src: `export * as verificationPolicy from './verification-policy.js';\n`,
+      },
     ];
 
     const NEGATIVE: ReadonlyArray<{ name: string; src: string }> = [
@@ -218,6 +253,14 @@ describe('single-composer guard', () => {
       {
         name: 'same symbol from an unrelated module',
         src: `import { resolveVerificationSequence } from './some-other-module.js';\n`,
+      },
+      {
+        name: 'namespace import of an unrelated module',
+        src: `import * as other from './some-other-module.js';\n`,
+      },
+      {
+        name: 'export-all of an unrelated module',
+        src: `export * from './some-other-module.js';\n`,
       },
       {
         name: 'string literal mentioning the symbol but no import',

--- a/servers/exarchos-mcp/src/workflow/__tests__/single-composer-guard.test.ts
+++ b/servers/exarchos-mcp/src/workflow/__tests__/single-composer-guard.test.ts
@@ -1,0 +1,239 @@
+// ─── Single-Composer Guard (repo conformance) ───────────────────────────────
+//
+// `resolveVerificationPolicy` (verification-policy-resolver.ts) is the DECLARED
+// only composer of config + the frozen built-in table. Every consumer that
+// needs "which gates run for a task" MUST import the resolver — never call the
+// frozen table function `resolveVerificationSequence` (verification-policy.ts)
+// directly. A direct import re-introduces the stamp/skip desync this slice
+// closes: the delegation stamp would route through config while a direct-table
+// consumer (e.g. the gate self-skip path) would silently ignore it.
+//
+// This guard scans the production source tree and FAILS if any file other than
+// the resolver + table modules themselves imports `resolveVerificationSequence`
+// from `./verification-policy.js`. It mirrors the AST-based scanner pattern in
+// `storage/__tests__/no-legacy-runtime-deps.test.ts` so a side-effect, dynamic,
+// or re-export form cannot slip past a naive regex.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve, sep, basename } from 'node:path';
+import ts from 'typescript';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// servers/exarchos-mcp/src/workflow/__tests__/ → servers/exarchos-mcp/src/
+const SRC_DIR = resolve(__dirname, '../../');
+
+/** The frozen-table symbol no consumer may import directly. */
+const FORBIDDEN_NAMED_IMPORT = 'resolveVerificationSequence';
+/**
+ * The module specifier the forbidden symbol is exported from. We match on the
+ * trailing `verification-policy.js` (ESM/NodeNext extension) so a relative path
+ * from any depth (`./verification-policy.js`, `../workflow/verification-policy.js`)
+ * is caught.
+ */
+const FORBIDDEN_MODULE_TAIL = 'verification-policy.js';
+
+/**
+ * The ONLY two files permitted to import `resolveVerificationSequence` directly:
+ *   - `verification-policy.ts`          — the table module itself (defines it)
+ *   - `verification-policy-resolver.ts` — the single composer that layers config
+ *                                         on top of the table
+ */
+const ALLOWED_BASENAMES = new Set([
+  'verification-policy.ts',
+  'verification-policy-resolver.ts',
+]);
+
+/**
+ * Returns true iff `source` imports the named symbol `resolveVerificationSequence`
+ * from a module whose specifier ends in `verification-policy.js`, in ANY of the
+ * import/re-export forms TypeScript supports (static value/type import, named
+ * re-export). A side-effect or default import cannot name this symbol, so the
+ * named-binding forms are exhaustive for this symbol.
+ */
+function importsForbiddenTableFn(source: string): boolean {
+  const sf = ts.createSourceFile(
+    'scan.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TS,
+  );
+
+  const specifierMatches = (spec: ts.Expression): boolean =>
+    ts.isStringLiteral(spec) && spec.text.endsWith(FORBIDDEN_MODULE_TAIL);
+
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+
+    // import { resolveVerificationSequence, … } from '…/verification-policy.js'
+    // import type { resolveVerificationSequence } from '…' (type position too)
+    if (
+      ts.isImportDeclaration(node) &&
+      specifierMatches(node.moduleSpecifier) &&
+      node.importClause?.namedBindings &&
+      ts.isNamedImports(node.importClause.namedBindings)
+    ) {
+      for (const el of node.importClause.namedBindings.elements) {
+        // `propertyName` is the original name in `import { orig as alias }`.
+        const original = el.propertyName?.text ?? el.name.text;
+        if (original === FORBIDDEN_NAMED_IMPORT) {
+          found = true;
+          return;
+        }
+      }
+    }
+
+    // export { resolveVerificationSequence } from '…/verification-policy.js'
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      specifierMatches(node.moduleSpecifier) &&
+      node.exportClause &&
+      ts.isNamedExports(node.exportClause)
+    ) {
+      for (const el of node.exportClause.elements) {
+        const original = el.propertyName?.text ?? el.name.text;
+        if (original === FORBIDDEN_NAMED_IMPORT) {
+          found = true;
+          return;
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+type WalkerFs = {
+  readdirSync: (dir: string) => string[];
+  statSync: (full: string) => { isDirectory: () => boolean; isFile: () => boolean };
+};
+
+const REAL_WALKER_FS: WalkerFs = { readdirSync, statSync };
+
+/**
+ * Walk the production tree under `src/`, collecting every `.ts` file that is
+ * not a `.test.ts` or `.d.ts` file and not under a `__tests__` directory.
+ * Re-throws walk failures with path context so a partial walk can never
+ * false-negative-pass the guard.
+ */
+function collectProductionTsFiles(rootDir: string, fs: WalkerFs = REAL_WALKER_FS): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch (err) {
+      throw new Error(`walker readdirSync failed at ${dir}: ${(err as Error).message}`, {
+        cause: err,
+      });
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      let st;
+      try {
+        st = fs.statSync(full);
+      } catch (err) {
+        throw new Error(`walker statSync failed at ${full}: ${(err as Error).message}`, {
+          cause: err,
+        });
+      }
+      if (st.isDirectory()) {
+        if (entry === '__tests__' || entry === 'node_modules') continue;
+        stack.push(full);
+        continue;
+      }
+      if (!st.isFile()) continue;
+      if (!entry.endsWith('.ts')) continue;
+      if (entry.endsWith('.test.ts')) continue;
+      if (entry.endsWith('.d.ts')) continue;
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('single-composer guard', () => {
+  it('RepoConformance_ResolveVerificationSequence_OnlyImportedByResolverAndTableTests', () => {
+    const productionFiles = collectProductionTsFiles(SRC_DIR);
+    // Sanity: the walker must actually find a substantial source tree.
+    expect(productionFiles.length).toBeGreaterThan(50);
+
+    const offenders: string[] = [];
+    for (const file of productionFiles) {
+      if (ALLOWED_BASENAMES.has(basename(file))) continue;
+      const content = readFileSync(file, 'utf-8');
+      if (importsForbiddenTableFn(content)) {
+        offenders.push(file.split(`${sep}src${sep}`).pop() ?? file);
+      }
+    }
+
+    expect(
+      offenders,
+      `Production code must compose verification sequences through ` +
+        `\`resolveVerificationPolicy\` (verification-policy-resolver.ts), never import ` +
+        `\`${FORBIDDEN_NAMED_IMPORT}\` from \`${FORBIDDEN_MODULE_TAIL}\` directly. ` +
+        `Found direct table imports in: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  // Scanner-form coverage — proves the AST scanner catches the named-import and
+  // named-re-export forms and does not flag the resolver's own delegated call
+  // or an unrelated string literal.
+  describe('scanner-form coverage', () => {
+    const POSITIVE: ReadonlyArray<{ name: string; src: string }> = [
+      {
+        name: 'named import',
+        src: `import { resolveVerificationSequence } from './verification-policy.js';\n`,
+      },
+      {
+        name: 'named import among siblings',
+        src: `import { type GateName, resolveVerificationSequence, type RiskTier } from '../workflow/verification-policy.js';\n`,
+      },
+      {
+        name: 'aliased named import',
+        src: `import { resolveVerificationSequence as resolveSeq } from './verification-policy.js';\n`,
+      },
+      {
+        name: 'named re-export',
+        src: `export { resolveVerificationSequence } from './verification-policy.js';\n`,
+      },
+    ];
+
+    const NEGATIVE: ReadonlyArray<{ name: string; src: string }> = [
+      {
+        name: 'resolver import (the sanctioned composer surface)',
+        src: `import { resolveVerificationPolicy } from './verification-policy-resolver.js';\n`,
+      },
+      {
+        name: 'same symbol from an unrelated module',
+        src: `import { resolveVerificationSequence } from './some-other-module.js';\n`,
+      },
+      {
+        name: 'string literal mentioning the symbol but no import',
+        src: `const note = 'see resolveVerificationSequence in verification-policy.js';\nconsole.log(note);\n`,
+      },
+    ];
+
+    for (const f of POSITIVE) {
+      it(`flags ${f.name}`, () => {
+        expect(importsForbiddenTableFn(f.src)).toBe(true);
+      });
+    }
+    for (const f of NEGATIVE) {
+      it(`does not flag ${f.name}`, () => {
+        expect(importsForbiddenTableFn(f.src)).toBe(false);
+      });
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/describe-config.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.ts
@@ -106,5 +106,11 @@ export function buildConfigDescription(config: ResolvedProjectConfig) {
         enabled: annotate(config.plugins.impeccable.enabled, DEFAULTS.plugins.impeccable.enabled),
       },
     },
+    verification: {
+      // The per-cell policy overlay (R2 / task 001). Default is the empty
+      // overlay (`{}`) — "override nothing"; any cell present means the consumer
+      // replaced that cell's gate sequence.
+      policy: annotate(config.verification.policy, DEFAULTS.verification.policy),
+    },
   };
 }

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -1,21 +1,25 @@
 import { getRequiredReviewsPrerequisite } from './review-contract.js';
 import { getRegisteredEventTypes } from '../projections/rehydration/reducer.js';
 import { EVENT_EMISSION_REGISTRY, type EventType } from '../event-store/schemas.js';
-import { resolveVerificationSequence } from './verification-policy.js';
+import { resolveVerificationPolicy } from './verification-policy-resolver.js';
 
 // ─── Verification-Ladder Gate Guidance (vls1-b1, task 008) ──────────────────
 //
 // The delegate-phase guidance advertises the verification-ladder gates a task
-// must clear. Those gate names are SOURCED FROM the verification policy
-// (`resolveVerificationSequence`) — never hand-written — so any change to the
-// policy table propagates into the playbook text automatically. The medium
-// tier base sequence is the minimum ladder a non-trivial task clears; the
+// must clear. Those gate names are SOURCED FROM the verification policy via the
+// single composer (`resolveVerificationPolicy`) — never hand-written, and never
+// the frozen table directly (task 004 single-composer rule) — so any change to
+// the policy propagates into the playbook text automatically. This guidance is
+// config-blind by intent (no project config is in scope at module-load render
+// time), so the resolver falls through to the built-in table here, leaving the
+// rendered text byte-identical to the pre-task-004 table call. The medium tier
+// base sequence is the minimum ladder a non-trivial task clears; the
 // medium+boundary sequence surfaces the additional contract/mock gates that
 // boundary-touching tasks pick up.
 
 function verificationLadderGuidance(): string {
-  const mediumGates = resolveVerificationSequence('medium', false);
-  const boundaryGates = resolveVerificationSequence('medium', true);
+  const mediumGates = resolveVerificationPolicy('medium', false).sequence;
+  const boundaryGates = resolveVerificationPolicy('medium', true).sequence;
   // The boundary-only delta — gates a boundary-touching task adds on top.
   const boundaryDelta = boundaryGates.filter((g) => !mediumGates.includes(g));
   const base = `Verification ladder (by riskTier/boundaryTouching): medium clears ${mediumGates.join(' → ')}`;
@@ -440,8 +444,9 @@ register({
   validationScripts: ['post_delegation_check'],
   humanCheckpoint: false,
   // vls1-b1 (task 008): the verification-ladder gate names are appended from
-  // `verificationLadderGuidance()`, which sources them from the policy table
-  // (`resolveVerificationSequence`) — changing the table changes this text.
+  // `verificationLadderGuidance()`, which sources them from the policy via the
+  // single composer (`resolveVerificationPolicy`) — changing the policy changes
+  // this text.
   compactGuidance:
     'Dispatch implementation tasks. Emit task.assigned via exarchos_event per dispatch. Complete tasks via exarchos_orchestrate task_complete (emits event, syncs state). Use exarchos_workflow update only for metadata/phase transitions. Before task_complete, run check_tdd_compliance (per-task) and check_static_analysis (once) — mandatory gates. Run post-delegation-check.sh when all tasks finish. Transition to review when complete. Call exarchos_event describe(eventTypes: [...]) before first emission of any event type. Parallel vs sequential dispatch; self-contained subagent prompts. Anti-pattern: referencing plan without pasting context. Escalate: same task fails 3x or scope exceeds declared module. Build context packages via runbook(task-classification). ' +
     verificationLadderGuidance(),

--- a/servers/exarchos-mcp/src/workflow/verification-policy-resolver.test.ts
+++ b/servers/exarchos-mcp/src/workflow/verification-policy-resolver.test.ts
@@ -113,6 +113,28 @@ describe('resolveVerificationPolicy', () => {
     }).toThrow();
   });
 
+  it('ResolveVerificationPolicy_PartialConfigWithoutVerification_BehavesAsNoConfig', () => {
+    // task 004: a present-but-partial config object — one that predates the
+    // `verification` overlay (legacy/partial shape) — must NOT throw. The
+    // resolver optional-chains on `config?.verification?.policy`, so a config
+    // whose `verification` block is genuinely absent behaves identically to
+    // "no config" (the built-in table), source: 'builtin'. Hand-build the
+    // partial object (the production `resolveConfig` path always synthesises a
+    // `verification` block, so it cannot reproduce the legacy shape).
+    const partial = { agents: {} } as unknown as ResolvedProjectConfig;
+
+    for (const tier of ALL_TIERS) {
+      for (const boundary of ALL_BOUNDARY) {
+        let result!: ReturnType<typeof resolveVerificationPolicy>;
+        expect(() => {
+          result = resolveVerificationPolicy(tier, boundary, partial);
+        }).not.toThrow();
+        expect(result.source).toBe('builtin');
+        expect(result.sequence).toEqual(resolveVerificationSequence(tier, boundary));
+      }
+    }
+  });
+
   it('ResolveVerificationPolicy_NoConfigSweep_ExtensionallyEqualsSlice1Table', () => {
     // Acceptance line: with no config, resolution is deep-equal to the slice-1
     // table for ALL six cells (3 tiers x 2 boundary values) — additive change,

--- a/servers/exarchos-mcp/src/workflow/verification-policy-resolver.test.ts
+++ b/servers/exarchos-mcp/src/workflow/verification-policy-resolver.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveVerificationSequence,
+  type GateName,
+  type RiskTier,
+} from './verification-policy.js';
+import { resolveConfig } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import type { VerificationPolicyOverlay } from '../config/yaml-schema.js';
+import { resolveVerificationPolicy } from './verification-policy-resolver.js';
+
+// Build a real ResolvedProjectConfig threaded with the given overlay, going
+// through the production `resolveConfig` path so the fixture matches what a
+// caller actually passes (deep-cloned + frozen overlay), not a hand-rolled stub.
+function configWith(policy: VerificationPolicyOverlay): ResolvedProjectConfig {
+  return resolveConfig({ verification: { policy } });
+}
+
+const ALL_TIERS: readonly RiskTier[] = ['low', 'medium', 'high'];
+const ALL_BOUNDARY: readonly boolean[] = [false, true];
+
+describe('resolveVerificationPolicy', () => {
+  it('ResolveVerificationPolicy_NoConfig_DelegatesToBuiltinTable', () => {
+    // No config at all → builtin table verbatim, source: 'builtin'.
+    const result = resolveVerificationPolicy('medium', false);
+    expect(result.sequence).toEqual(resolveVerificationSequence('medium', false));
+    expect(result.source).toBe('builtin');
+  });
+
+  it('ResolveVerificationPolicy_ConfiguredCell_WinsVerbatim', () => {
+    const overlay: VerificationPolicyOverlay = {
+      medium: ['check_static_analysis', 'check_integration_suite'],
+    };
+    const result = resolveVerificationPolicy('medium', false, configWith(overlay));
+    expect(result.sequence).toEqual(['check_static_analysis', 'check_integration_suite']);
+    expect(result.source).toBe('config');
+  });
+
+  it('ResolveVerificationPolicy_AbsentCell_FallsBackPerCell', () => {
+    // Config sets ONLY medium (base). low / high / all boundary cells unset →
+    // each independently resolves to the builtin table.
+    const overlay: VerificationPolicyOverlay = {
+      medium: ['check_mock_boundary'],
+    };
+    const config = configWith(overlay);
+
+    const medium = resolveVerificationPolicy('medium', false, config);
+    expect(medium.source).toBe('config');
+    expect(medium.sequence).toEqual(['check_mock_boundary']);
+
+    const low = resolveVerificationPolicy('low', false, config);
+    expect(low.source).toBe('builtin');
+    expect(low.sequence).toEqual(resolveVerificationSequence('low', false));
+
+    const high = resolveVerificationPolicy('high', false, config);
+    expect(high.source).toBe('builtin');
+    expect(high.sequence).toEqual(resolveVerificationSequence('high', false));
+
+    // Boundary cells untouched by a base-tier override.
+    for (const tier of ALL_TIERS) {
+      const boundary = resolveVerificationPolicy(tier, true, config);
+      expect(boundary.source).toBe('builtin');
+      expect(boundary.sequence).toEqual(resolveVerificationSequence(tier, true));
+    }
+  });
+
+  it('ResolveVerificationPolicy_EmptyCell_ResolvesToEmptySequence', () => {
+    // Explicit empty array is the legitimate "run nothing" override — it wins
+    // over the builtin table with source: 'config'.
+    const overlay: VerificationPolicyOverlay = { medium: [] };
+    const result = resolveVerificationPolicy('medium', false, configWith(overlay));
+    expect(result.sequence).toEqual([]);
+    expect(result.source).toBe('config');
+
+    // And it does NOT collapse to the (non-empty) builtin sequence.
+    expect(result.sequence).not.toEqual(resolveVerificationSequence('medium', false));
+  });
+
+  it('ResolveVerificationPolicy_BoundaryCell_ResolvesIndependentlyOfBase', () => {
+    // boundary.medium configured, base medium NOT: boundary uses config, base
+    // resolution still uses the builtin table.
+    const overlay: VerificationPolicyOverlay = {
+      boundary: { medium: ['check_contract_drift'] },
+    };
+    const config = configWith(overlay);
+
+    const boundary = resolveVerificationPolicy('medium', true, config);
+    expect(boundary.source).toBe('config');
+    expect(boundary.sequence).toEqual(['check_contract_drift']);
+
+    const base = resolveVerificationPolicy('medium', false, config);
+    expect(base.source).toBe('builtin');
+    expect(base.sequence).toEqual(resolveVerificationSequence('medium', false));
+  });
+
+  it('ResolveVerificationPolicy_Output_IsFrozen', () => {
+    // Builtin-sourced output is frozen.
+    const builtin = resolveVerificationPolicy('high', true);
+    expect(Object.isFrozen(builtin.sequence)).toBe(true);
+    expect(() => {
+      (builtin.sequence as GateName[]).push('check_mock_boundary');
+    }).toThrow();
+
+    // Config-sourced output is frozen and not aliased to a caller-mutable array.
+    const overlay: VerificationPolicyOverlay = {
+      low: ['check_static_analysis'],
+    };
+    const config = configWith(overlay);
+    const configured = resolveVerificationPolicy('low', false, config);
+    expect(Object.isFrozen(configured.sequence)).toBe(true);
+    expect(() => {
+      (configured.sequence as GateName[]).push('check_test_adequacy');
+    }).toThrow();
+  });
+
+  it('ResolveVerificationPolicy_NoConfigSweep_ExtensionallyEqualsSlice1Table', () => {
+    // Acceptance line: with no config, resolution is deep-equal to the slice-1
+    // table for ALL six cells (3 tiers x 2 boundary values) — additive change,
+    // no default behavior shift.
+    for (const tier of ALL_TIERS) {
+      for (const boundary of ALL_BOUNDARY) {
+        const result = resolveVerificationPolicy(tier, boundary);
+        expect(result.source).toBe('builtin');
+        expect(result.sequence).toEqual(resolveVerificationSequence(tier, boundary));
+      }
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/verification-policy-resolver.ts
+++ b/servers/exarchos-mcp/src/workflow/verification-policy-resolver.ts
@@ -65,7 +65,12 @@ export function resolveVerificationPolicy(
   boundaryTouching: boolean,
   config?: ResolvedProjectConfig,
 ): ResolvedVerificationPolicy {
-  const policy = config?.verification.policy;
+  // Optional-chain through `verification` too: a present-but-partial config
+  // object (one predating the `verification` overlay) must behave as no-config
+  // rather than throw. `config?.verification.policy` would TypeError when
+  // `verification` is absent; `config?.verification?.policy` degrades to the
+  // built-in table. (task 004)
+  const policy = config?.verification?.policy;
   const cell = boundaryTouching ? policy?.boundary?.[riskTier] : policy?.[riskTier];
 
   // Cell PRESENT (including an explicit empty array) → full replacement.

--- a/servers/exarchos-mcp/src/workflow/verification-policy-resolver.ts
+++ b/servers/exarchos-mcp/src/workflow/verification-policy-resolver.ts
@@ -1,0 +1,83 @@
+// ─── Verification Policy Resolver (config-over-builtin composer) ─────────────
+//
+// This module is the ONE AND ONLY place that composes `.exarchos.yml`
+// verification overrides with the frozen built-in policy table in
+// `workflow/verification-policy.ts`. Every consumer that needs "which gates run
+// for a task" — the delegation stamp, gate self-skip, the phase playbooks —
+// MUST import `resolveVerificationPolicy` from THIS module and NEVER call
+// `resolveVerificationSequence` directly. The base table (slice 1) is config-
+// blind by design; the override layer composes ON TOP of it here. A sibling
+// repo-conformance guard test enforces the "import the resolver, not the table"
+// rule across the codebase.
+//
+// ── Resolution semantics (cell-wise FULL replacement, NO delta merging) ─────
+// A task profile is one of six cells: (riskTier ∈ {low,medium,high}) ×
+// (boundaryTouching ∈ {false,true}). For each cell, resolution is all-or-
+// nothing:
+//   - `boundaryTouching === false` selects `policy[riskTier]`;
+//     `boundaryTouching === true` selects `policy.boundary?.[riskTier]`.
+//   - If that cell is PRESENT in config — INCLUDING an explicit empty array,
+//     which is the legitimate "run nothing for this cell" override — its value
+//     is returned verbatim (frozen), `source: 'config'`. The base table's
+//     sequence for that cell is fully REPLACED, never merged.
+//   - If the cell is unset (or there is no config / no `verification` block),
+//     resolution delegates to `resolveVerificationSequence(...)` and reports
+//     `source: 'builtin'`.
+//
+// The function is synchronous, pure, and does NO I/O: it reads no filesystem
+// and loads no config — the caller resolves and passes `ResolvedProjectConfig`
+// in. The returned `sequence` is ALWAYS frozen and is never aliased to a
+// caller-mutable array.
+// ────────────────────────────────────────────────────────────────────────────
+
+import {
+  resolveVerificationSequence,
+  type GateName,
+  type RiskTier,
+} from './verification-policy.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+/** Where a resolved verification sequence came from. */
+export type VerificationPolicySource = 'builtin' | 'config';
+
+/** A resolved verification sequence plus its provenance. */
+export interface ResolvedVerificationPolicy {
+  /** Ordered, frozen gate sequence for the requested task profile. */
+  readonly sequence: readonly GateName[];
+  /** `'config'` if an `.exarchos.yml` cell won; `'builtin'` if the base table did. */
+  readonly source: VerificationPolicySource;
+}
+
+/**
+ * Resolve the verification gate sequence for a `(riskTier, boundaryTouching)`
+ * task profile, layering the project config overlay over the frozen built-in
+ * table. See the module header for the full cell-wise replacement semantics.
+ *
+ * @param riskTier         the task's blast-radius tier
+ * @param boundaryTouching whether the task crosses an I/O / schema boundary
+ * @param config           the resolved project config (overlay source); omit
+ *                         (or pass a config whose cell is unset) to fall through
+ *                         to the built-in table
+ * @returns the frozen, ordered gate sequence plus its `source` provenance
+ */
+export function resolveVerificationPolicy(
+  riskTier: RiskTier,
+  boundaryTouching: boolean,
+  config?: ResolvedProjectConfig,
+): ResolvedVerificationPolicy {
+  const policy = config?.verification.policy;
+  const cell = boundaryTouching ? policy?.boundary?.[riskTier] : policy?.[riskTier];
+
+  // Cell PRESENT (including an explicit empty array) → full replacement.
+  // Copy before freezing so the returned sequence is never aliased to the
+  // caller's overlay array.
+  if (cell !== undefined) {
+    return { sequence: Object.freeze([...cell]), source: 'config' };
+  }
+
+  // Cell unset / no config → the built-in table (already frozen by slice 1).
+  return {
+    sequence: resolveVerificationSequence(riskTier, boundaryTouching),
+    source: 'builtin',
+  };
+}


### PR DESCRIPTION
## Summary

Slice 2 of the risk-proportional verification pipeline (epic #1515) — completes epic **Phase 1** and is the final feature slice before the **v2.11.0-preview.1** cut.

- **R2 (#1517)** — config-resolved verification policy: a strict `verification:` block in `.exarchos.yml` overrides the ladder's gate sequences per `(riskTier × boundaryTouching)` cell, layered over slice 1's frozen built-in table by a new single-composer resolver. Oneshot workflows resolve ladder-gate failures to advisory by default.
- **R9 (#1524)** — onboarding integration: the reconciler's detect/diff/apply now resolves and seeds `mutation`/`lint` commands (commands only — the resolved *policy* is surfaced read-only via doctor, never written into consumer config), plus a new 13th doctor check `verification-toolchain`.

Design: `docs/designs/2026-06-11-verification-ladder-slice2.md` · Plan: `docs/plans/2026-06-11-verification-ladder-slice2.md`

## Changes

**R2 — policy resolution**
- `config/yaml-schema.ts` + `config/resolve.ts`: strict `verification.policy` block (six cells, gate names enum-constrained to `VERIFICATION_GATE_NAMES`, duplicate-free, empty-cell-valid), threaded onto `ResolvedProjectConfig` with an empty-overlay default.
- `workflow/verification-policy-resolver.ts` (new): `resolveVerificationPolicy` — cell-wise full replacement, `source: builtin|config` discriminant, frozen outputs, partial-config-safe; slice 1's frozen table is byte-identical.
- Consumer rewiring: `prepare_delegation` stamps the config-resolved sequence; `resolvePolicySkip` consumes the same resolver and names the policy source in skip reasons; `playbooks.ts` guidance routed through the resolver.
- **Single-composer guard** (`workflow/__tests__/single-composer-guard.test.ts`): AST-based repo-conformance test — production code may not import `resolveVerificationSequence` directly (caught and fixed `playbooks.ts` during implementation).
- Per-workflow severity: `WORKFLOW_DEFAULT_SEVERITY` data table (`oneshot → warning` for ladder gates), explicit `review.gates` override wins; ladder gates wired through a new `adaptLadderGate`/`applyLadderGateSeverity` adapter (the gates are advisory carriers and never routed through `withConfigSeverity`); `workflowType` resolved from workflow state — **zero new action input fields**.

**R9 — onboarding**
- `core/onboarding/types.ts` + `reconcile.ts`: `ResolvedCommandsSchema` widened with `mutation`/`lint`; `detectDesiredState` resolves via `resolveVerificationRuntime`; `diff` emits config steps for resolved-but-undeclared commands; `apply`/`doctor --fix` seeds them via the existing `seed-exarchos-config.ts` writer; idempotent re-run; `Apply_NeverWritesVerificationPolicyBlock` proves the gen-time-bake negative guarantee.
- `orchestrate/doctor/checks/verification-toolchain.ts` (new, 13th check): Pass/Warning/Skipped over the test+typecheck+mutation triple; fix names both remedies; detail payload carries per-cell policy source.
- T0 characterization pins (doctor roster, reconciler shapes) landed first; three pin updates in the slice are deliberate and documented in-test (schema widening, node-mutation registry seed, 12→13 roster).

**Docs**
- New `docs/guides/exarchos-yml-verification.md`; `docs/guides/toolchain-resolution.md` widening note.

**Design reframes vs. issue text** (recorded on #1524): DesiredState does not carry seeded policy defaults — policy is resolved at runtime and surfaced read-only via doctor (gen-time-placeholder trap); the doctor roster was already 12, so this adds the 13th check, not the 12th.

## Test Plan

- ~50 new tests across 10 TDD tasks (RED commits witnessed per task; `check_tdd_compliance` green on every task branch).
- Property sweep: no-config resolution extensionally equals the slice-1 table for all six cells (#1517's "additive" acceptance line).
- `StampAndSkip_SameConfig_NeverDisagree`: 18-combination round-trip matrix (tier × boundary × config-variant) proving stamp/skip consistency, including explicit empty-cell.
- Dispatch-through tests for the oneshot-advisory path and the 13-check doctor roster (`handleDoctorWithChecks`).
- Onboard seed round-trip re-parses the written `.exarchos.yml` through the real loader and asserts tier-2 (config-direct) resolution.
- Full suites on the final tip: MCP `7569 passed` (619 files), root `822 passed` (97 files), typecheck clean. Per-task gates: static-analysis PASS ×10, kill-probe PASS ×7 (+2 manual verifications where the probe hit its new-file `revert-conflict` limitation — see review notes), operational-resilience PASS.

**Review verdict: APPROVED** (0 high / 2 medium / 2 low). Mediums recorded for follow-up: a focused unit test for the `configSeededThisRun` convergence branch; an overstated comment on `adaptLadderGate`'s config injection for the two gates without `resolvePolicySkip`.

**Known follow-ups** (non-blocking): `check_test_adequacy` false-negatives (`revert-conflict`) on new-file-only diffs — observed twice, issue to be filed; stale "11 checks" JSDoc in `reconcile.ts` (comment-only fix dropped to keep the docs commit gate-clean); seeder never-overwrite posture for configs that exist but lack `mutation:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
