### PR TITLE
feat: phase-kind binding - resolve verification obligations by PhaseKind at the phase boundary

### DIFF
--- a/docs/designs/2026-06-16-phase-kind-binding.md
+++ b/docs/designs/2026-06-16-phase-kind-binding.md
@@ -1,0 +1,180 @@
+# Design: Phase-Kind Binding — obligation layer (steps 1–2)
+
+- **Date:** 2026-06-16
+- **Epic:** #1546 (phase-kind binding — compositional gate/phase/capability model)
+- **Slices in scope:** S1 (#1547, foundation) + S2 (#1548, ladder on every IMPLEMENT phase)
+- **Deferred to follow-on design:** S3 (#1549, migrate PLAN/REVIEW/SYNTHESIZE off playbooks) and S4 (#1550, POLA capability bundle + resolve-then-freeze events)
+- **Design input:** discovery spike `docs/research/2026-06-16-phase-kind-binding-architecture.md`
+- **Completes the thesis of:** #1515 (risk-proportional verification ladder)
+- **Down-payment on:** #1258 (Workflow SDK, v3.0)
+
+## Problem Statement
+
+Exarchos has one genuinely compositional verification primitive — `resolveVerificationSequence(riskTier, boundaryTouching)` (`workflow/verification-policy.ts`), a pure function over a frozen `Record<RiskTier, GateName[]>` table, with a config-override layer (`verification-policy-resolver.ts`) composed on top. It is consumed at exactly one phase boundary: `prepare-delegation.ts` (the `delegate` / `overhaul-delegate` phases). The proof is the playbook helper signature `delegatePhaseEvents(phase: 'delegate' | 'overhaul-delegate')` (`playbooks.ts:240`).
+
+Every other code-bearing phase binds gates by a hand-written `${workflowType}:${phase}` playbook registration and hardcodes verification *prose* instead of resolving the ladder:
+
+- `debug:debug-implement` (`playbooks.ts:728`) — *"Follow TDD — write failing test first… Anti-pattern: fixing without a failing test."*
+- `debug:hotfix-implement` (`playbooks.ts:791`) — hardcoded TDD prose.
+- `refactor:polish-implement` (`playbooks.ts:955`) — *"Follow TDD if changing behavior,"* no gate resolution.
+- `oneshot:implementing` (`playbooks.ts:1288`) — *"write failing test first… TDD rules remain mandatory."*
+
+So the ladder reaches **2 of ~5 implement phases**, and the mandatory uniform red-green-refactor that epic #1515 set out to retire survives on the debug/polish/oneshot tracks. Patching each playbook individually accretes more snowflakes and leaves the asymmetry intact.
+
+## Chosen Approach
+
+Introduce a **phase-kind layer** (Option 1, thin dispatcher — see exploration): a closed `PhaseKind` union, a frozen `KIND_OBLIGATIONS` table, and one resolver `resolveGateSet(kind, ctx)` that delegates to the *existing* ladder resolver behind `IMPLEMENT`. Tag every HSM state with a `kind` (behavior-neutral, S1). Then route every `kind: IMPLEMENT` phase's verification through `resolveGateSet`, delete the hardcoded TDD prose, and let the four currently-uncovered implement phases inherit the ladder by construction (S2). This is INV-6 (workload-agnosticism) made type-level: the obligation attaches to the *kind*, so it composes across all workflow types — including future ones — without new playbook code.
+
+## Approaches Considered
+
+The discovery spike already settled the *macro* decision — a structural phase-kind layer **(B)** over per-bug playbook patching **(A)** (spike §11). The remaining fork is how `resolveGateSet` relates to the existing ladder resolver.
+
+### Option 1: Thin dispatcher over existing resolvers (chosen)
+
+**Approach:** `resolveGateSet(kind, ctx)` reads `KIND_OBLIGATIONS[kind].gates.resolver` and delegates — `IMPLEMENT` → the existing `resolveVerificationPolicy` (config-override wrapper over `resolveVerificationSequence`); `GATHER` → `[]`; PLAN/REVIEW/SYNTHESIZE registered but inert until S3. `verification-policy.ts` is untouched.
+
+**Pros:**
+- S1 is strictly behavior-neutral; the parity test (DR-3) is trivial.
+- Zero risk to the one working compositional primitive.
+- S3/S4 slot in by filling resolver slots, not reshaping a table.
+
+**Cons:**
+- Two indirection layers (kind → resolver → table) until S3 collapses the playbook bindings.
+
+**Best when:** Migrating onto a proven primitive without destabilizing it.
+
+### Option 2: Unified key-space table
+
+**Approach:** Widen the verification table itself to `Record<(PhaseKind, RiskTier, boundaryTouching), GateName[]>` — one table keyed by all three axes.
+
+**Pros:**
+- Single lookup, no dispatcher indirection.
+
+**Cons:**
+- Forces PLAN/REVIEW/SYNTHESIZE gate-sets into a risk-tier shape they don't fit.
+- Reshapes the working `verification-policy.ts` in S1, breaking behavior-neutrality and coupling S1 to S3's concerns.
+
+**Best when:** All kinds share the risk-tier axis — they don't.
+
+**Recommendation:** Option 1. It keeps S1 genuinely behavior-neutral (the explicit acceptance bar in #1547), isolates risk to the dispatcher, and expresses the `(phaseKind, riskTier, boundaryTouching)` key-space as *dispatch* rather than a flattened table.
+
+## Requirements
+
+### DR-1: `PhaseKind` union + frozen `KIND_OBLIGATIONS` table
+
+A closed discriminated union `PhaseKind = 'IMPLEMENT' | 'PLAN' | 'REVIEW' | 'SYNTHESIZE' | 'GATHER'` and a single grant-point table `KIND_OBLIGATIONS` typed `as const satisfies Record<PhaseKind, PhaseObligations>`. Each row carries `{ gates: GateObligation | null; posture: 'read-only' | 'task-isolated' | 'shared-mutating' }`. The full table shape is defined now (including `posture`) so S4 need not reshape it; in this design `posture` is a **declared, inert** field — it is not yet wired to a capability bundle.
+
+**Acceptance criteria:**
+- The table compiles only when every `PhaseKind` member has a row (`satisfies Record<PhaseKind, …>`); deleting a row is a compile error (test: a type-level fixture / `tsc --noEmit` proves exhaustiveness).
+- Every `switch (kind)` dispatch site ends in `assertNever(kind)`; adding a sixth kind breaks compilation at each unhandled site.
+- The table names no workflow type, phase name, or transition — only kind-universal obligations (reviewed assertion + INV-6 lint clean).
+
+### DR-2: kind-tag every HSM state (behavior-neutral)
+
+Extend the HSM `State` shape in `workflow/hsm-definitions.ts` with a **non-optional** `kind: PhaseKind` field and tag all states across the five HSMs (`feature` / `debug` / `refactor` / `oneshot` / `discovery`). The five implement snowflakes (`delegate`, `overhaul-delegate`, `debug-implement`, `hotfix-implement`, `polish-implement`, `implementing`) all map to `IMPLEMENT`; plan/rca/design → `PLAN`; review phases → `REVIEW`; synthesize → `SYNTHESIZE`; triage/investigate/gathering/explore → `GATHER`. Names and transitions stay bespoke (INV-6 variation layer); only the `kind` tag crosses into the obligation layer.
+
+**Acceptance criteria:**
+- The `State` type makes an untagged state a compile error.
+- A characterization test asserts the complete `state → kind` mapping for all ~30 states (Feathers-style: lock current classification before any behavior change).
+- No transition table, guard, or `next_actions` output changes (INV-9 held; diff touches only the `kind` field and the resolver module).
+
+### DR-3: `resolveGateSet(phaseKind, ctx)` resolver (behavior-neutral)
+
+A pure resolver in the shared dispatch core: `resolveGateSet(kind, ctx)` reads `KIND_OBLIGATIONS[kind].gates`; `null` → `[]` (GATHER); otherwise dispatches by resolver name. `IMPLEMENT` delegates to the existing `resolveVerificationPolicy(ctx)` (the config-override wrapper over `resolveVerificationSequence`). `PLAN` / `REVIEW` / `SYNTHESIZE` resolvers are registered but **inert** in this design (their gate selection still flows through today's playbook bindings until S3).
+
+**Acceptance criteria:**
+- Given the same `ctx`, `resolveGateSet('IMPLEMENT', ctx)` returns a sequence byte-identical to today's `resolveVerificationPolicy(ctx)` (parity test over the low/medium/high × boundaryTouching matrix).
+- `resolveGateSet('GATHER', ctx)` returns `[]`.
+- The resolver lives in the shared core and is reachable identically from CLI and MCP dispatch (INV-2; no logic added to adapters).
+
+### DR-4: route every IMPLEMENT phase through the resolver
+
+Give the four currently-uncovered implement phases (`debug-implement`, `hotfix-implement`, `polish-implement`, `oneshot:implementing`) an equivalent non-optional `resolveGateSet('IMPLEMENT', ctx)` call at their phase boundary — the same PDP query `prepare-delegation.ts` already makes for `delegate`. The resolver call is structural: a phase cannot opt out because verification no longer lives in playbook prose.
+
+**Acceptance criteria:**
+- Given a `medium`-tier task entering `debug-implement`, `hotfix-implement`, `polish-implement`, or `oneshot:implementing`, when its boundary is prepared, then it resolves the same gate sequence as a `medium`-tier `feature:delegate` task.
+- Given a `high`-tier, boundary-touching task on any IMPLEMENT phase, then `check_integration_suite` and the boundary gates appear in its sequence (proves #1537's integration-suite gate now reaches debug/refactor).
+- No IMPLEMENT phase reaches its work step without a recorded `resolveGateSet` result.
+
+### DR-5: delete hardcoded TDD prose from implement playbooks
+
+Remove the mandatory failing-test-first prose from `playbooks.ts:728` (debug-implement), `:791` (hotfix-implement), `:955` (polish-implement), and `:1288` (oneshot:implementing). The verification obligation now lives in the `IMPLEMENT` row; the playbook prose retains only workflow-specific guidance (scope, escalation, transition criteria).
+
+**Acceptance criteria:**
+- No implement-phase playbook string contains mandatory "write failing test first" / "fixing without a failing test" / "TDD rules remain mandatory" prose (guard: a grep-based unit assertion over the implement playbook entries).
+- The retained playbook prose still names the correct transition target and escalation rule for each phase (characterization test unchanged on those fields).
+
+### DR-6: severity + audit→enforce graduation
+
+Ladder outcomes honor the existing per-workflow severity rules and the `review.gates.<gate>` config override surface (unchanged). Newly-covered phases land in **audit mode** first — they emit gate findings as events without blocking — and graduate to **enforce** per the epic's severity policy: **advisory** for `oneshot`, **blocking** for `feature` / `debug` / `refactor`.
+
+**Acceptance criteria:**
+- A failing ladder gate on `oneshot:implementing` is advisory (workflow proceeds, finding surfaced); the same failure on `debug-implement` blocks (enforce mode).
+- In audit mode, a failing gate emits a finding event and does **not** block the transition.
+- A `review.gates.<gate>` override in `.exarchos.yml` changes the resolved sequence for IMPLEMENT phases identically to how it does for `feature:delegate` today (INV-4: resolved at runtime, nothing baked).
+
+### DR-7: Error handling, fail-closed resolution, and invariant guards
+
+The resolver is fail-closed and the kind layer must not leak past its intended surface.
+
+**Acceptance criteria:**
+- Given `resolveGateSet` throws or its underlying resolver errors, when a phase boundary is prepared, then the handler appends `phase.blocked` with a visible skip reason and does **not** silently proceed (single-machine analog of `failurePolicy: Fail`).
+- An unknown / malformed `kind` is unrepresentable: the union + `assertNever` make it a compile error, not a runtime branch.
+- When the config-override layer supplies no override, `resolveGateSet('IMPLEMENT', …)` falls back to the frozen base table (no crash on absent config).
+- **INV-5a/5d guard:** no new visible MCP tool and no new top-level CLI verb are added; the phase-kind registry stays internal to the existing four composite tools (assertion over `registry.ts` visible-tool count, unchanged).
+
+## Technical Design
+
+```
+                         phase boundary (prepare step)
+  ┌────────────────────────────────────────────────────────────────┐
+  │  state.kind ──► resolveGateSet(kind, ctx)        [shared core]   │
+  │                   │                                              │
+  │     KIND_OBLIGATIONS[kind].gates                                 │
+  │        IMPLEMENT  → resolveVerificationPolicy(ctx) ──► [gates]   │
+  │        GATHER     → null ──► []                                  │
+  │        PLAN/REVIEW/SYNTHESIZE → registered, inert (S3)           │
+  └────────────────────────────────────────────────────────────────┘
+        ▲ delegate/overhaul-delegate    ▲ debug/hotfix/polish/oneshot
+          (already routed today)          (DR-4 routes them now)
+```
+
+New module `workflow/phase-kind.ts`: the `PhaseKind` union, `PhaseObligations` interface, frozen `KIND_OBLIGATIONS`, and `resolveGateSet`. It *imports* `resolveVerificationPolicy`; it does not modify `verification-policy.ts` (Option 1). `hsm-definitions.ts` gains the `kind` field on `State`. The DR-4 routing reuses the `prepare-delegation.ts` resolver-call shape; if a phase lacks a prepare step today, the resolver call is added at its phase-entry handler.
+
+## Integration Points
+
+- **`workflow/verification-policy.ts` / `verification-policy-resolver.ts`** — consumed unchanged; `IMPLEMENT`'s resolver slot points at `resolveVerificationPolicy`.
+- **`orchestrate/prepare-delegation.ts`** — the existing PDP call becomes `resolveGateSet('IMPLEMENT', ctx)`; the template for DR-4's other phases.
+- **`workflow/hsm-definitions.ts`** — `kind`-tagged states (DR-2).
+- **`workflow/playbooks.ts`** — TDD prose removed (DR-5); verification prose no longer authored here.
+- **`.exarchos.yml: review.gates.*`** — override surface unchanged (DR-6).
+
+## Testing Strategy
+
+- **Characterization first** (DR-2): lock the `state → kind` map and current implement-phase gate outputs before any behavior change.
+- **Parity** (DR-3): `resolveGateSet('IMPLEMENT')` ≡ `resolveVerificationPolicy` across the full tier × boundary matrix.
+- **Reachability** (DR-4): a medium-tier task on each newly-covered phase resolves the feature:delegate sequence.
+- **Prose guard** (DR-5): assertion that no implement playbook carries mandatory failing-test-first prose.
+- **Severity / audit** (DR-6): oneshot advisory vs debug blocking; audit-mode non-blocking.
+- **Fail-closed + tool-ceiling** (DR-7): injected resolver error → `phase.blocked`; visible-tool count unchanged.
+- Root + `servers/exarchos-mcp` suites, `npm run typecheck`, and `npm run lint:invariants` green at each slice boundary.
+
+## Invariant Conformance
+
+| Invariant | Effect | Verdict |
+|---|---|---|
+| **INV-6** workload-agnosticism | Kind table = the invariant made type-level; ladder holds for every workflow type. | **Central win** |
+| **INV-1** event-sourcing | Audit-mode findings are appended events; `phase.blocked` on failure (resolve-then-freeze `phase.entered` events deferred to S4). | Held |
+| **INV-2** facade-equivalence | Resolver in shared core; CLI/MCP observe identical gate-sets. | Held |
+| **INV-9** HSM authority | Only a `kind` field added; transitions/guards unchanged. | Held |
+| **INV-4** resolve-don't-bake | Gate commands resolve at runtime via the layered resolver. | Held |
+| **INV-15** single-machine | Synchronous in-process resolver; no queue/worker/saga. | Held |
+| **INV-5a/5d** tool ceiling | Internal only — **must not** expose the registry as a tool (DR-7 guard). | Held |
+| **INV-11** posture | `posture` declared in the table but inert here; capability bundle is S4. | Deferred |
+
+## Open Questions
+
+1. **Kind granularity.** Five kinds is a deliberate guess (spike §10). `PLAN` covers feature `plan-review` *and* debug `rca`/`design`; if those need materially different obligations the union grows — watch for combinatorial pressure during S3 (the signal is to factor kind-vs-workflow harder, not to add kinds). In scope here only as the tag; resolver divergence is S3.
+2. **Posture vs kind coupling.** `IMPLEMENT` is tagged `task-isolated`, but is every implement phase isolated? Verify against the worktree-isolation work (#1512) before S4 wires `posture` to a capability bundle. Inert here.
+3. **`oneshot:implementing` enforcement point.** It has no `prepare-delegation`-style step today; DR-4 must decide whether to add a prepare step or call the resolver at phase-entry. Recommended: phase-entry resolver call, advisory per DR-6.
+4. **Brand-cast discipline.** If a `resolvePhase` smart constructor is introduced, confine the cast to one module with a lint rule (spike §10). Optional in S1+S2; likely needed by S4.

--- a/docs/designs/2026-06-16-phase-kind-binding.md
+++ b/docs/designs/2026-06-16-phase-kind-binding.md
@@ -71,10 +71,10 @@ A closed discriminated union `PhaseKind = 'IMPLEMENT' | 'PLAN' | 'REVIEW' | 'SYN
 
 ### DR-2: kind-tag every HSM state (behavior-neutral)
 
-Extend the HSM `State` shape in `workflow/hsm-definitions.ts` with a **non-optional** `kind: PhaseKind` field and tag all states across the five HSMs (`feature` / `debug` / `refactor` / `oneshot` / `discovery`). The five implement snowflakes (`delegate`, `overhaul-delegate`, `debug-implement`, `hotfix-implement`, `polish-implement`, `implementing`) all map to `IMPLEMENT`; plan/rca/design → `PLAN`; review phases → `REVIEW`; synthesize → `SYNTHESIZE`; triage/investigate/gathering/explore → `GATHER`. Names and transitions stay bespoke (INV-6 variation layer); only the `kind` tag crosses into the obligation layer.
+Make the HSM `State` type (`workflow/state-machine.ts`) a **discriminated union**: the `atomic` variant carries a **required** `kind: PhaseKind`, while the `compound` and `final` variants carry **no** `kind` — they are container/terminal states an agent never occupies, so they bear no obligations. Tag every atomic state across the five HSMs (`feature` / `debug` / `refactor` / `oneshot` / `discovery`) in `workflow/hsm-definitions.ts`. The six implement snowflakes (`delegate`, `overhaul-delegate`, `debug-implement`, `hotfix-implement`, `polish-implement`, `implementing`) all map to `IMPLEMENT`; plan/rca/design → `PLAN`; review phases → `REVIEW`; synthesize → `SYNTHESIZE`; triage/investigate/gathering/explore → `GATHER`. Names and transitions stay bespoke (INV-6 variation layer); only the `kind` tag crosses into the obligation layer.
 
 **Acceptance criteria:**
-- The `State` type makes an untagged state a compile error.
+- The `State` type makes an untagged **atomic** state a compile error (`compound`/`final` variants are `kind`-free by construction).
 - A characterization test asserts the complete `state → kind` mapping for all ~30 states (Feathers-style: lock current classification before any behavior change).
 - No transition table, guard, or `next_actions` output changes (INV-9 held; diff touches only the `kind` field and the resolver module).
 

--- a/docs/plans/2026-06-16-phase-kind-binding-traceability.md
+++ b/docs/plans/2026-06-16-phase-kind-binding-traceability.md
@@ -1,0 +1,29 @@
+## Spec Traceability
+
+### Traceability Matrix
+
+| Design Section | Key Requirements | Task ID(s) | Status |
+|----------------|-----------------|------------|--------|
+| Problem Statement | (to be filled) | — | Uncovered |
+| Chosen Approach | (to be filled) | — | Uncovered |
+| Approaches Considered | (to be filled) | — | Uncovered |
+| Option 1: Thin dispatcher over existing resolvers (chosen) | (to be filled) | — | Uncovered |
+| Option 2: Unified key-space table | (to be filled) | — | Uncovered |
+| Requirements | (to be filled) | — | Uncovered |
+| DR-1: `PhaseKind` union + frozen `KIND_OBLIGATIONS` table | (to be filled) | — | Uncovered |
+| DR-2: kind-tag every HSM state (behavior-neutral) | (to be filled) | — | Uncovered |
+| DR-3: `resolveGateSet(phaseKind, ctx)` resolver (behavior-neutral) | (to be filled) | — | Uncovered |
+| DR-4: route every IMPLEMENT phase through the resolver | (to be filled) | — | Uncovered |
+| DR-5: delete hardcoded TDD prose from implement playbooks | (to be filled) | — | Uncovered |
+| DR-6: severity + audit→enforce graduation | (to be filled) | — | Uncovered |
+| DR-7: Error handling, fail-closed resolution, and invariant guards | (to be filled) | — | Uncovered |
+| Technical Design | (to be filled) | — | Uncovered |
+| Integration Points | (to be filled) | — | Uncovered |
+| Testing Strategy | (to be filled) | — | Uncovered |
+| Invariant Conformance | (to be filled) | — | Uncovered |
+| Open Questions | (to be filled) | — | Uncovered |
+
+### Scope Declaration
+
+**Target:** (to be filled)
+**Excluded:** (to be filled)

--- a/docs/plans/2026-06-16-phase-kind-binding-traceability.md
+++ b/docs/plans/2026-06-16-phase-kind-binding-traceability.md
@@ -4,26 +4,29 @@
 
 | Design Section | Key Requirements | Task ID(s) | Status |
 |----------------|-----------------|------------|--------|
-| Problem Statement | (to be filled) | — | Uncovered |
-| Chosen Approach | (to be filled) | — | Uncovered |
-| Approaches Considered | (to be filled) | — | Uncovered |
-| Option 1: Thin dispatcher over existing resolvers (chosen) | (to be filled) | — | Uncovered |
-| Option 2: Unified key-space table | (to be filled) | — | Uncovered |
-| Requirements | (to be filled) | — | Uncovered |
-| DR-1: `PhaseKind` union + frozen `KIND_OBLIGATIONS` table | (to be filled) | — | Uncovered |
-| DR-2: kind-tag every HSM state (behavior-neutral) | (to be filled) | — | Uncovered |
-| DR-3: `resolveGateSet(phaseKind, ctx)` resolver (behavior-neutral) | (to be filled) | — | Uncovered |
-| DR-4: route every IMPLEMENT phase through the resolver | (to be filled) | — | Uncovered |
-| DR-5: delete hardcoded TDD prose from implement playbooks | (to be filled) | — | Uncovered |
-| DR-6: severity + audit→enforce graduation | (to be filled) | — | Uncovered |
-| DR-7: Error handling, fail-closed resolution, and invariant guards | (to be filled) | — | Uncovered |
-| Technical Design | (to be filled) | — | Uncovered |
-| Integration Points | (to be filled) | — | Uncovered |
-| Testing Strategy | (to be filled) | — | Uncovered |
-| Invariant Conformance | (to be filled) | — | Uncovered |
-| Open Questions | (to be filled) | — | Uncovered |
+| Problem Statement | Phases are snowflakes; the verification ladder reaches only 2/5 implement phases | task-001..007 | Covered |
+| Chosen Approach (Option 1) | Thin dispatcher — bind each phase to a `PhaseKind`, resolve obligations from a frozen kind table at the boundary | task-001, task-003, task-004 | Done |
+| Approaches Considered | Documented in design §"Approaches Considered" | — | Covered |
+| Option 1: Thin dispatcher over existing resolvers (chosen) | Reuse `resolveVerificationPolicy` behind a kind-keyed resolver | task-002, task-004 | Done |
+| Option 2: Unified key-space table | Rejected — heavier; couples kind to workflow type | — | N/A (not chosen) |
+| Requirements | DR-1..DR-7 | task-001..007 | Done |
+| DR-1: `PhaseKind` union + frozen `KIND_OBLIGATIONS` table | Closed union + `satisfies Record<PhaseKind,…>`; INV-6 (no workflow/phase literals) | task-001 | Done |
+| DR-2: kind-tag every HSM state (behavior-neutral) | `State` discriminated union; `kind` required on atomic states only; full state→kind map; zero transition diff | task-003 | Done |
+| DR-3: `resolveGateSet(phaseKind, ctx)` resolver (behavior-neutral) | IMPLEMENT delegates verbatim to `resolveVerificationPolicy`; GATHER→[]; deferred resolvers throw | task-002 | Done |
+| DR-4: route every IMPLEMENT phase through the resolver | `classifyTask` → `resolveGateSet('IMPLEMENT')`; reachability for all 6 implement phases | task-004 | Done |
+| DR-5: delete hardcoded TDD prose from implement playbooks | 4 work-implement playbooks → risk-proportional ladder; transition/escalation retained | task-005 | Done |
+| DR-6: severity + audit→enforce graduation | Per-workflow severity + `IMPLEMENT_PHASE_MODE` (oneshot→audit, feature/debug/refactor→enforce); reuses `review.gates.*`; kept out of `KIND_OBLIGATIONS` (INV-6) | task-006 | Done |
+| DR-7: Error handling, fail-closed resolution, and invariant guards | Resolver throw → `phase.blocked` + refuse; absent config → base table; visible tool count unchanged | task-007 | Done |
+| Technical Design | `phase-kind.ts` (union+table+resolver), `state-machine.ts` (discriminated union), `gate-utils.ts`/`composite.ts` (severity+mode), `prepare-delegation.ts` (fail-closed), `event-store/schemas.ts` (`phase.blocked`) | task-001..007 | Done |
+| Integration Points | `classifyTask` boundary; ladder severity/mode post-processing; `phase.blocked` event | task-004, task-006, task-007 | Done |
+| Testing Strategy | Kind-table exhaustiveness, full state→kind map, tier×boundary parity, IMPLEMENT reachability, prose guard, severity/audit (incl. no-config), fail-closed boundary, registry tool-count fence, phase-kind drift guard | task-001..007 | Done |
+| Invariant Conformance | INV-6 (kind table holds no workflow/phase literals; severity/mode out of `KIND_OBLIGATIONS`), INV-5b (advisory-carrier downgrade clears `data.passed`), INV-5d (visible tool count unchanged) | task-001, task-006, task-007 | Done |
+| Open Questions | Mode default for newly-covered phases reconciled to the design's binding AC (oneshot→audit, feature/debug/refactor→enforce); S3/S4 deferred | task-006 | Resolved |
 
 ### Scope Declaration
 
-**Target:** (to be filled)
-**Excluded:** (to be filled)
+**Target:** S1 + S2 — DR-1..DR-7 (foundation + verification-ladder reach on every IMPLEMENT phase).
+
+**Excluded:**
+- **S3** (#1549) — PLAN/REVIEW/SYNTHESIZE resolver wiring; the inert resolver slots stay throwers (`not-yet-wired`).
+- **S4** (#1550) — POLA capability bundle + resolve-then-freeze `phase.entered`/`phase.exited` events; the `posture` field is authored but inert.

--- a/docs/plans/2026-06-16-phase-kind-binding.md
+++ b/docs/plans/2026-06-16-phase-kind-binding.md
@@ -1,0 +1,214 @@
+# Implementation Plan: Phase-Kind Binding (steps 1–2)
+
+- **Date:** 2026-06-16
+- **Design:** `docs/designs/2026-06-16-phase-kind-binding.md`
+- **Epic:** #1546 — slices S1 (#1547) + S2 (#1548)
+- **Integration branch:** `feature/phase-kind-binding`
+- **Scope declaration:** **Partial epic.** Implements DR-1..DR-7 (foundation + ladder on every IMPLEMENT phase). Defers S3 (#1549, PLAN/REVIEW/SYNTHESIZE migration off playbooks) and S4 (#1550, POLA capability bundle + resolve-then-freeze events). The `posture` field is authored in the table (DR-1) but stays inert.
+
+## Working directory
+
+All paths are under `servers/exarchos-mcp/src/`. New module: `workflow/phase-kind.ts` (+ co-located `workflow/phase-kind.test.ts`).
+
+## Phase-kind classification (locked by DR-2's characterization test)
+
+**Correctness-critical (must be `IMPLEMENT` — these drive S2):**
+
+| State | HSM | Kind |
+|---|---|---|
+| `delegate` | feature | IMPLEMENT |
+| `overhaul-delegate` | refactor | IMPLEMENT |
+| `debug-implement` | debug | IMPLEMENT |
+| `hotfix-implement` | debug | IMPLEMENT |
+| `polish-implement` | refactor | IMPLEMENT |
+| `implementing` | oneshot | IMPLEMENT |
+
+**Remaining atomic states (exact kind locked but behavior-inert in S1+S2 — only IMPLEMENT is wired):**
+
+| Kind | States |
+|---|---|
+| PLAN | `plan`, `plan-review` (feature); `rca`, `design` (debug); `brief`, `overhaul-plan`, `overhaul-plan-review` (refactor); `plan` (oneshot) |
+| REVIEW | `review` (feature); `debug-validate`, `debug-review`, `hotfix-validate` (debug); `polish-validate`, `overhaul-review` (refactor) |
+| SYNTHESIZE | `synthesize` (feature/debug/refactor/oneshot); `merge-pending` (feature) |
+| GATHER | `ideate`, `blocked` (feature); `triage`, `investigate` (debug); `explore` (refactor); `gathering`, `synthesizing` (discovery); `polish-update-docs`, `overhaul-update-docs` (refactor) |
+
+`compound` container states (`implementation`, `thorough-track`, `hotfix-track`, `polish-track`, `overhaul-track`) and `final` states (`completed`, `cancelled`) are **exempt** — they are not phases an agent occupies and carry no obligations. **Decision:** make `State` a discriminated union so `kind` is required on `type: 'atomic'` states only (compound/final exempt). `merge-pending`, the `*-validate`, `*-update-docs`, and `synthesizing` classifications are the spike §10 granularity-tension cases — locked here, revisited in S3.
+
+---
+
+## Tasks
+
+### Task 001: Define the new phase-kind discriminated union and the frozen kind obligations table module
+
+**Implements:** DR-1
+**Phase:** RED → GREEN → REFACTOR
+**Risk tier:** high · **boundaryTouching:** true (new shared type contract) · **testingStrategy:** example + type-level · **propertyTests:** no · **benchmarks:** no
+
+1. [RED] `workflow/phase-kind.test.ts`
+   - `KindObligations_EveryKind_HasARow` — assert `Object.keys(KIND_OBLIGATIONS).sort()` equals `['GATHER','IMPLEMENT','PLAN','REVIEW','SYNTHESIZE']`.
+   - `KindObligations_ImplementRow_PointsAtVerificationLadder` — `KIND_OBLIGATIONS.IMPLEMENT.gates?.resolver === 'verification-ladder'`.
+   - `KindObligations_GatherRow_HasNullGates` — `KIND_OBLIGATIONS.GATHER.gates === null`.
+   - Expected failure: module/table does not exist.
+2. [GREEN] `workflow/phase-kind.ts` — `export type PhaseKind = 'IMPLEMENT' | 'PLAN' | 'REVIEW' | 'SYNTHESIZE' | 'GATHER'`; `interface PhaseObligations { readonly gates: { readonly resolver: string } | null; readonly posture: 'read-only' | 'task-isolated' | 'shared-mutating' }`; `export const KIND_OBLIGATIONS = { … } as const satisfies Record<PhaseKind, PhaseObligations>`. Posture: IMPLEMENT→task-isolated, PLAN/REVIEW/GATHER→read-only, SYNTHESIZE→shared-mutating.
+3. [REFACTOR] Add a `// no workflow names / phase ids / transitions here` invariant comment; confirm INV-6 lint clean.
+
+**Acceptance:** table compiles only when all kinds present (removing a row → `tsc --noEmit` error); no workflow/phase literals in the module.
+**Dependencies:** None · **Parallelizable:** No (foundation)
+
+---
+
+### Task 002: Implement the resolve-gate-set resolver delegating to the verification ladder behind implement
+
+**Implements:** DR-3
+**Phase:** RED → GREEN → REFACTOR
+**Risk tier:** high · **boundaryTouching:** false · **testingStrategy:** example (table-driven parity matrix) · **propertyTests:** yes (parity over full tier × boundary product) · **benchmarks:** no
+
+1. [RED] `workflow/phase-kind.test.ts`
+   - `ResolveGateSet_Implement_MatchesVerificationPolicy` — for every `(riskTier ∈ low|medium|high) × (boundaryTouching ∈ false|true)`, assert `resolveGateSet('IMPLEMENT', ctx)` deep-equals `resolveVerificationPolicy(riskTier, boundaryTouching, ctx.config).sequence`.
+   - `ResolveGateSet_Gather_ReturnsEmpty` — `resolveGateSet('GATHER', ctx)` returns `[]`.
+   - `ResolveGateSet_UnknownResolverName_AssertsNever` — dispatch exhaustiveness compile guard.
+   - Expected failure: `resolveGateSet` not implemented.
+2. [GREEN] In `workflow/phase-kind.ts`: `export function resolveGateSet(kind: PhaseKind, ctx: { riskTier: RiskTier; boundaryTouching: boolean; config?: ResolvedProjectConfig }): readonly GateName[]`. Read `KIND_OBLIGATIONS[kind].gates`; `null → []`; switch on `gates.resolver`: `'verification-ladder' → resolveVerificationPolicy(ctx.riskTier, ctx.boundaryTouching, ctx.config).sequence`; default `assertNever`. PLAN/REVIEW/SYNTHESIZE resolver names registered but throw `not-yet-wired` (inert; S3) — guarded so they are never reached at an IMPLEMENT boundary.
+3. [REFACTOR] Extract `GATE_RESOLVERS` map keyed by resolver-name for S3 extensibility.
+
+**Acceptance:** `resolveGateSet('IMPLEMENT')` byte-identical to today's resolver across all six cells; lives in shared core (no adapter import).
+**Dependencies:** Task 001 · **Parallelizable:** Yes (with Task 003 — disjoint files)
+
+---
+
+### Task 003: Make the state type a discriminated union and tag every atomic state with its kind
+
+**Implements:** DR-2
+**Phase:** RED → GREEN → REFACTOR
+**Risk tier:** high · **boundaryTouching:** true (shared `State` schema reshape) · **testingStrategy:** example (full characterization map) · **propertyTests:** no · **benchmarks:** no
+
+1. [RED] `workflow/hsm-definitions.test.ts` (or co-located characterization test)
+   - `HsmStates_EveryAtomicState_CarriesKind` — across all five HSM factories, every state with `type === 'atomic'` has a defined `kind`.
+   - `HsmStates_ImplementSnowflakes_AllTaggedImplement` — `delegate`, `overhaul-delegate`, `debug-implement`, `hotfix-implement`, `polish-implement`, `implementing` each `kind === 'IMPLEMENT'`.
+   - `HsmStates_KindMap_MatchesLockedClassification` — full `state→kind` assertion per the table above.
+   - Expected failure: `kind` field does not exist on `State`.
+2. [GREEN] `workflow/state-machine.ts` — make `State` a discriminated union: `atomic` variant requires `kind: PhaseKind`; `compound`/`final` variants have no `kind`. `workflow/hsm-definitions.ts` — add `kind` to every atomic state per the locked table.
+3. [REFACTOR] Confirm no transition/guard/`next_actions` diff; `tsc --noEmit` proves every atomic state is tagged (untagged → compile error).
+
+**Acceptance:** untagged atomic state is a compile error; characterization map green; zero behavior change (transitions/guards untouched).
+**Dependencies:** Task 001 · **Parallelizable:** Yes (with Task 002)
+
+---
+
+### Task 004: Route every implement phase boundary through the shared gate-set resolver call
+
+**Implements:** DR-4
+**Phase:** RED → GREEN → REFACTOR
+**Risk tier:** high · **boundaryTouching:** false · **testingStrategy:** example (per-phase reachability) · **propertyTests:** no · **benchmarks:** no
+
+1. [RED] `orchestrate/prepare-delegation.test.ts` + new `workflow/implement-obligations.test.ts`
+   - `ImplementObligations_DelegatePhase_Unchanged` — `feature:delegate` medium-tier resolves the same sequence as before (behavior-neutral for the already-covered phase).
+   - `ImplementObligations_DebugImplement_ResolvesLadder` — a `medium`-tier `debug-implement` task resolves the same sequence as a `medium`-tier `delegate` task.
+   - Same for `hotfix-implement`, `polish-implement`, `oneshot:implementing`.
+   - `ImplementObligations_HighTierBoundary_IncludesIntegrationSuite` — high-tier boundary-touching IMPLEMENT phase includes `check_integration_suite` + boundary gates (proves #1537 reach).
+   - Expected failure: non-delegate implement phases don't call the resolver.
+2. [GREEN] Introduce `resolveImplementObligations(ctx)` wrapping `resolveGateSet('IMPLEMENT', ctx)`. Replace the direct `resolveVerificationPolicy` call in `prepare-delegation.ts` with it (behavior-neutral). Surface the resolved sequence as the verification obligation in the implement-phase playbook guidance for `debug-implement`/`hotfix-implement`/`polish-implement`/`implementing` (the same surface that holds the TDD prose today). For `oneshot:implementing` (no prepare step), call the resolver at phase-entry guidance generation (advisory per Task 006).
+3. [REFACTOR] Collapse duplicate obligation-surfacing into one helper shared by all implement phases.
+
+**Acceptance:** every IMPLEMENT phase resolves the `feature:delegate` sequence for an equal task profile; no implement phase reaches its work step without a recorded `resolveGateSet` result.
+**Dependencies:** Tasks 002, 003 · **Parallelizable:** No (integration point)
+
+---
+
+### Task 005: Delete the hardcoded mandatory test-first prose from every implement-phase playbook entry
+
+**Implements:** DR-5
+**Phase:** RED → GREEN → REFACTOR
+**Risk tier:** medium · **boundaryTouching:** false · **testingStrategy:** example (prose guard) · **propertyTests:** no · **benchmarks:** no
+
+1. [RED] `workflow/playbooks.test.ts`
+   - `Playbooks_ImplementPhases_NoMandatoryTddProse` — assert no implement-phase playbook string matches `/write failing test first|fixing without a failing test|TDD rules remain mandatory/i`.
+   - `Playbooks_ImplementPhases_RetainTransitionAndEscalation` — each implement playbook still names its correct transition target + escalation rule.
+   - Expected failure: prose still present at `playbooks.ts:728/791/955/1288`.
+2. [GREEN] Remove the mandatory failing-test-first prose from `debug-implement` (`:728`), `hotfix-implement` (`:791`), `polish-implement` (`:955`), `oneshot:implementing` (`:1288`). Keep scope/escalation/transition guidance; the verification obligation now flows from Task 004.
+3. [REFACTOR] None expected.
+
+**Acceptance:** no implement playbook carries mandatory TDD prose; transition/escalation fields unchanged (characterization green).
+**Dependencies:** Task 004 · **Parallelizable:** No (same file region as Task 004's playbook edits)
+
+---
+
+### Task 006: Thread per-workflow severity and the audit-to-enforce graduation mode through the obligation surface
+
+**Implements:** DR-6
+**Phase:** RED → GREEN → REFACTOR
+**Risk tier:** high · **boundaryTouching:** false · **testingStrategy:** example · **propertyTests:** no · **benchmarks:** no
+
+1. [RED] `workflow/implement-obligations.test.ts`
+   - `ImplementSeverity_Oneshot_Advisory` — a failing ladder gate on `oneshot:implementing` is advisory (proceeds, finding surfaced).
+   - `ImplementSeverity_FeatureDebugRefactor_Blocking` — same failure on `debug-implement`/`delegate`/`polish-implement` blocks.
+   - `ImplementMode_AuditMode_DoesNotBlock` — in audit mode a failing gate emits a finding event without blocking the transition.
+   - `ImplementOverride_ReviewGatesConfig_AppliesToImplementPhases` — a `.exarchos.yml review.gates.<gate>` override changes the resolved sequence for IMPLEMENT phases identically to `feature:delegate`.
+   - Expected failure: severity/mode not honored on newly-covered phases.
+2. [GREEN] Thread per-workflow severity (advisory: oneshot; blocking: feature/debug/refactor) and a per-binding `mode: 'audit' | 'enforce'` through the obligation surface; newly-covered phases default to audit. Reuse the existing `review.gates.*` override (config already resolved via `resolveVerificationPolicy`).
+3. [REFACTOR] Centralize the severity map next to `KIND_OBLIGATIONS` consumers (not in the kind table — severity is workflow-specific, not kind-universal; keep it out of `KIND_OBLIGATIONS` to preserve INV-6).
+
+**Acceptance:** oneshot advisory vs feature/debug/refactor blocking; audit-mode non-blocking; config override parity with delegate.
+**Dependencies:** Task 004 · **Parallelizable:** Yes (with Task 007 — disjoint test/impl regions)
+
+---
+
+### Task 007: Make gate resolution fail closed and guard the visible tool ceiling (error and edge cases)
+
+**Implements:** DR-7
+**Phase:** RED → GREEN → REFACTOR
+**Risk tier:** high · **boundaryTouching:** false · **testingStrategy:** example (error injection + structural assertion) · **propertyTests:** no · **benchmarks:** no
+
+1. [RED]
+   - `workflow/implement-obligations.test.ts` → `ResolveGateSet_ResolverThrows_AppendsPhaseBlocked` — inject a resolver error at a phase boundary; assert a `phase.blocked` event with a visible skip reason is appended and the transition does **not** proceed.
+   - `workflow/phase-kind.test.ts` → `ResolveGateSet_NoConfigOverride_FallsBackToBaseTable` — absent config resolves the frozen base table (no throw).
+   - `registry.test.ts` → `Registry_VisibleToolCount_UnchangedByPhaseKind` — visible MCP tool count and top-level CLI verbs are unchanged (phase-kind registry is internal).
+   - Expected failure: errors propagate / silent proceed; (the tool-count guard should pass already and acts as a regression fence).
+2. [GREEN] Wrap the boundary resolver call: on throw, append `phase.blocked` (fail-closed, single-machine `failurePolicy: Fail` analog) instead of proceeding. Confirm no new entry is added to `registry.ts`'s visible tool list.
+3. [REFACTOR] Extract the fail-closed wrapper so every IMPLEMENT phase boundary shares it.
+
+**Acceptance:** injected resolver error → `phase.blocked` (no silent proceed); absent config → base table; visible-tool count unchanged.
+**Dependencies:** Tasks 002, 004 · **Parallelizable:** Yes (with Task 006)
+
+---
+
+## Dependency graph & parallelization
+
+```
+Task 001 (union+table)
+   ├─► Task 002 (resolveGateSet) ─┐
+   └─► Task 003 (State.kind+tag) ─┤
+                                  ▼
+                          Task 004 (route IMPLEMENT)
+                                  ├─► Task 005 (delete prose)   [serial: shares playbook region w/ 004]
+                                  ├─► Task 006 (severity/audit) ┐
+                                  └─► Task 007 (fail-closed+guard)┘  [006 ∥ 007]
+```
+
+- **Wave 1:** Task 001 (foundation, solo).
+- **Wave 2:** Tasks 002 ∥ 003 (disjoint files: `phase-kind.ts` vs `state-machine.ts`/`hsm-definitions.ts`).
+- **Wave 3:** Task 004 (integration point, solo).
+- **Wave 4:** Task 005 (serial after 004 — same playbook region), then Tasks 006 ∥ 007.
+
+## Verification gates (per slice boundary)
+
+- Root + `servers/exarchos-mcp` suites green; `npm run typecheck`; `npm run lint:invariants`.
+- Behavior-neutrality proof for S1 (Tasks 001–003): parity test (002) + zero transition diff (003).
+- S2 reachability + prose-removal + fail-closed (Tasks 004–007).
+
+## Traceability
+
+| DR | Task(s) |
+|---|---|
+| DR-1 | 001 |
+| DR-2 | 003 |
+| DR-3 | 002 |
+| DR-4 | 004 |
+| DR-5 | 005 |
+| DR-6 | 006 |
+| DR-7 | 007 |
+
+## Deferred (not in this plan)
+
+- **S3 (#1549):** PLAN/REVIEW/SYNTHESIZE resolvers become authoritative (the inert resolver slots from Task 002 get wired); remove `(workflowType:phase)` gate selection from playbooks.
+- **S4 (#1550):** `posture` → POLA capability bundle; resolve-then-freeze `phase.entered`/`phase.exited` events.

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -469,7 +469,10 @@ describe('EventTypes', () => {
     // verification-ladder slice 1 (task 020): bumped 120 → 122 to include the
     // mutation-run liveness pair `mutation.executing_started` +
     // `mutation.executed`, emitted by the `exarchos run-mutation` CLI verb.
-    expect(EventTypes).toHaveLength(122);
+    // phase-kind binding DR-7 (task 007): bumped 122 → 123 to include
+    // `phase.blocked`, the fail-closed marker appended when the IMPLEMENT
+    // gate-set resolver throws at a phase boundary (orchestrate/prepare-delegation.ts).
+    expect(EventTypes).toHaveLength(123);
     // Explicit membership pin: a future replacement that swaps one event
     // for another would keep the length stable but silently lose the
     // migration progress type. The membership assert catches that.

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -22,9 +22,11 @@ import {
   WorkflowCircuitOpenData,
   BenchmarkCompletedData,
   EventTypes,
+  PhaseBlockedKindSchema,
   type EventType,
 } from '../../event-store/schemas.js';
 import { extendWorkflowTypeEnum, unextendWorkflowTypeEnum } from '../../workflow/schemas.js';
+import { KIND_OBLIGATIONS } from '../../workflow/phase-kind.js';
 
 // ─── Base Event Schema ──────────────────────────────────────────────────────
 
@@ -484,8 +486,20 @@ describe('EventTypes', () => {
     expect(EventTypes).toContain('onboard.executed');
     expect(EventTypes).toContain('mutation.executing_started');
     expect(EventTypes).toContain('mutation.executed');
+    expect(EventTypes).toContain('phase.blocked');
     // Retirement guard: init.executed removed in DR-5 (task 018).
     expect(EventTypes as readonly string[]).not.toContain('init.executed');
+  });
+
+  it('PhaseBlockedKind_MatchesPhaseKindUnion', () => {
+    // Drift guard: `phase.blocked.kind` is an inlined z.enum in
+    // event-store/schemas.ts (kept free of a workflow/config import). Pin it to
+    // the single source of truth — `KIND_OBLIGATIONS` keys ARE the `PhaseKind`
+    // union (enforced by `satisfies Record<PhaseKind, …>`), so adding a kind
+    // without updating the event schema turns this assertion red.
+    expect([...PhaseBlockedKindSchema.options].sort()).toEqual(
+      Object.keys(KIND_OBLIGATIONS).sort(),
+    );
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -545,11 +545,16 @@ describe('EventTypes', () => {
     // Bumped 120 → 122: mutation.executing_started + mutation.executed
     //   (verification-ladder slice 1 task 020 — the run-mutation liveness pair,
     //   INV-10, emitted by the `exarchos run-mutation` CLI verb).
-    expect(EventTypes).toHaveLength(122);
+    // Bumped 122 → 123: phase.blocked (phase-kind binding DR-7, epic #1546 —
+    //   fail-closed at the gate-set boundary; emitted by the wave-dispatch
+    //   boundary when the IMPLEMENT-kind gate-set resolver throws, refusing the
+    //   dispatch instead of failing open).
+    expect(EventTypes).toHaveLength(123);
     expect(EventTypes).toContain('onboard.requested');
     expect(EventTypes).toContain('onboard.executed');
     expect(EventTypes).toContain('mutation.executing_started');
     expect(EventTypes).toContain('mutation.executed');
+    expect(EventTypes).toContain('phase.blocked');
     // Retirement guard: init.executed removed in DR-5 (task 018).
     expect(EventTypes as readonly string[]).not.toContain('init.executed');
   });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -131,6 +131,12 @@ export const EventTypes = [
   'hsm.deprecated_action_invoked',
   'spec.legacy_capabilities_array',
   'phase.contract_missing',
+  // Phase-kind binding (DR-7, epic #1546) — fail-closed at the gate-set
+  // boundary. Emitted when the IMPLEMENT-kind gate-set resolver throws while
+  // stamping a wave's verification sequence: the dispatch is REFUSED (fail
+  // closed) and this durable event records why, so an operator sees the
+  // blocked phase instead of a silently-failed-open dispatch.
+  'phase.blocked',
   'migration.legacy_jsonl_imported',
   'migration.completed',
   'migration.failed',
@@ -493,6 +499,10 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // contract (#1259 T03 / DR-7). Drives the phase-contract migration
   // telemetry.
   'phase.contract_missing': 'auto',
+
+  // auto — emitted by the wave-dispatch boundary (DR-7, epic #1546) when the
+  // IMPLEMENT-kind gate-set resolver throws; the dispatch fails closed.
+  'phase.blocked': 'auto',
 
   // auto — emitted by the JSONL→SQLite migration importer (#1259 T04 / DR-9).
   // Per-file completion event during the import; the `migration.completed`
@@ -1757,6 +1767,34 @@ export const PhaseContractMissingData = z.object({
 });
 
 /**
+ * phase.blocked — fail-closed at the gate-set boundary (DR-7, epic #1546).
+ *
+ * Emitted by the wave-dispatch boundary (`handlePrepareDelegation` →
+ * `classifyTasksFailClosed`) when the kind-keyed gate-set resolver
+ * (`resolveGateSet(kind, …)`) throws while stamping a wave's verification
+ * sequence. Rather than letting the exception propagate and fail the dispatch
+ * OPEN / silently, the boundary REFUSES to proceed and records this durable
+ * event so an operator sees the blocked phase and why.
+ *
+ * Required-string fields (`min(1)`) so a blocked-dispatch record without an
+ * actionable reason fails at the schema boundary rather than landing an empty
+ * audit row. `kind` is the {@link PhaseKind} whose resolver faulted; `phase` is
+ * the lifecycle phase the dispatch was at; `error` carries the underlying
+ * resolver fault so the failure is debuggable from the event log alone.
+ */
+export const PhaseBlockedData = z.object({
+  phase: z.string().min(1).describe('Lifecycle phase the dispatch was blocked at'),
+  kind: z.string().min(1).describe('Phase kind whose gate-set resolver faulted'),
+  reason: z.string().min(1).describe('Operator-visible skip reason for the blocked dispatch'),
+  error: z
+    .object({
+      code: z.string().min(1).describe('Stable error code for the resolver fault'),
+      message: z.string().min(1).describe('Underlying resolver error message'),
+    })
+    .describe('The underlying gate-set resolver fault that triggered the block'),
+});
+
+/**
  * migration.legacy_jsonl_imported — per-file completion event from the
  * JSONL→SQLite migration importer (T04, DR-9 / DR-10).
  *
@@ -2257,6 +2295,7 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'hsm.deprecated_action_invoked': HsmDeprecatedActionInvokedData,
   'spec.legacy_capabilities_array': SpecLegacyCapabilitiesArrayData,
   'phase.contract_missing': PhaseContractMissingData,
+  'phase.blocked': PhaseBlockedData,
   'migration.legacy_jsonl_imported': MigrationLegacyJsonlImportedData,
   'migration.completed': MigrationCompletedData,
   'migration.failed': MigrationFailedData,
@@ -2381,6 +2420,7 @@ export type MergeCompleted = z.infer<typeof MergeCompletedData>;
 export type HsmDeprecatedActionInvoked = z.infer<typeof HsmDeprecatedActionInvokedData>;
 export type SpecLegacyCapabilitiesArray = z.infer<typeof SpecLegacyCapabilitiesArrayData>;
 export type PhaseContractMissing = z.infer<typeof PhaseContractMissingData>;
+export type PhaseBlocked = z.infer<typeof PhaseBlockedData>;
 export type MigrationLegacyJsonlImported = z.infer<typeof MigrationLegacyJsonlImportedData>;
 export type MigrationCompleted = z.infer<typeof MigrationCompletedData>;
 export type MigrationFailed = z.infer<typeof MigrationFailedData>;
@@ -2504,6 +2544,7 @@ export type EventDataMap = {
   'hsm.deprecated_action_invoked': HsmDeprecatedActionInvoked;
   'spec.legacy_capabilities_array': SpecLegacyCapabilitiesArray;
   'phase.contract_missing': PhaseContractMissing;
+  'phase.blocked': PhaseBlocked;
   'migration.legacy_jsonl_imported': MigrationLegacyJsonlImported;
   'migration.completed': MigrationCompleted;
   'migration.failed': MigrationFailed;

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1782,9 +1782,25 @@ export const PhaseContractMissingData = z.object({
  * the lifecycle phase the dispatch was at; `error` carries the underlying
  * resolver fault so the failure is debuggable from the event log alone.
  */
+/**
+ * The closed phase-kind set, mirrored from `workflow/phase-kind.ts`'s `PhaseKind`
+ * union. Inlined (not imported) to keep this low-level event-store layer free of
+ * a workflow/config dependency — `phase-kind.ts` transitively pulls in the
+ * verification-policy + config resolvers, which must not become event-store deps.
+ * A drift-guard test pins these options to `KIND_OBLIGATIONS` so the two cannot
+ * silently diverge.
+ */
+export const PhaseBlockedKindSchema = z.enum([
+  'IMPLEMENT',
+  'PLAN',
+  'REVIEW',
+  'SYNTHESIZE',
+  'GATHER',
+]);
+
 export const PhaseBlockedData = z.object({
   phase: z.string().min(1).describe('Lifecycle phase the dispatch was blocked at'),
-  kind: z.string().min(1).describe('Phase kind whose gate-set resolver faulted'),
+  kind: PhaseBlockedKindSchema.describe('Phase kind whose gate-set resolver faulted'),
   reason: z.string().min(1).describe('Operator-visible skip reason for the blocked dispatch'),
   error: z
     .object({

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -193,11 +193,12 @@ async function resolveWorkflowTypeForGate(
  * AND the IMPLEMENT-phase graduation mode (DR-6) to a failing advisory verdict
  * via {@link applyLadderGateSeverity}. The mode (`audit` | `enforce`) is
  * resolved from the SAME workflow type the severity uses
- * ({@link resolveImplementMode}) — a newly-covered phase (oneshot/debug/
- * refactor) is in `audit` and records its `gate.executed` finding without
- * blocking; `feature:delegate` is in `enforce`. When the dispatch context
- * carries no `projectConfig`, the result passes through unchanged (legacy /
- * no-config behavior). The threading is centralized here so all five gates pick
+ * ({@link resolveImplementMode}) — per the DR-6 mode table only `oneshot` is in
+ * `audit` (records its `gate.executed` finding without blocking); `feature`,
+ * `debug`, and `refactor` are in `enforce`. Without a `projectConfig` an
+ * `enforce` gate passes through unchanged (legacy / no-config severity
+ * passthrough), while an `audit` gate still downgrades — audit mode is
+ * config-INDEPENDENT. The threading is centralized here so all five gates pick
  * it up from one place.
  */
 function adaptLadderGate<T>(
@@ -236,9 +237,10 @@ function adaptLadderGate<T>(
     const workflowType = await resolveWorkflowTypeForGate(featureId, ctx.eventStore);
     // DR-6: the IMPLEMENT-phase graduation mode is resolved from the SAME
     // workflow type the severity uses, so mode and severity can never resolve
-    // against divergent workflow types in one dispatch (INV-2). A newly-covered
-    // phase resolves to `audit` (records the finding, never blocks); the handler
-    // already emitted its `gate.executed` finding above.
+    // against divergent workflow types in one dispatch (INV-2). Only `oneshot`
+    // resolves to `audit` (records the finding, never blocks); feature/debug/
+    // refactor are `enforce`. The handler already emitted its `gate.executed`
+    // finding above.
     const mode = resolveImplementMode(workflowType);
     return applyLadderGateSeverity(
       gateName,

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -93,7 +93,7 @@ import type { HandleScaffoldArgs } from './invariants/scaffold.js';
 import { handleAdd } from './invariants/add.js';
 import type { HandleAddArgs } from './invariants/add.js';
 import { realScaffoldDeps } from './invariants/fs-deps.js';
-import { applyLadderGateSeverity } from './gate-utils.js';
+import { applyLadderGateSeverity, resolveImplementMode } from './gate-utils.js';
 import { resolveWorkflowState } from './resolve-state.js';
 
 // ─── Action Router ──────────────────────────────────────────────────────────
@@ -190,10 +190,15 @@ async function resolveWorkflowTypeForGate(
 /**
  * Adapter for a verification-ladder gate handler. Runs the underlying advisory
  * handler, then resolves the workflow type and applies per-workflow severity
- * to a failing advisory verdict via {@link applyLadderGateSeverity}. When the
- * dispatch context carries no `projectConfig`, the result passes through
- * unchanged (legacy / no-config behavior). The threading is centralized here so
- * all five gates pick it up from one place.
+ * AND the IMPLEMENT-phase graduation mode (DR-6) to a failing advisory verdict
+ * via {@link applyLadderGateSeverity}. The mode (`audit` | `enforce`) is
+ * resolved from the SAME workflow type the severity uses
+ * ({@link resolveImplementMode}) — a newly-covered phase (oneshot/debug/
+ * refactor) is in `audit` and records its `gate.executed` finding without
+ * blocking; `feature:delegate` is in `enforce`. When the dispatch context
+ * carries no `projectConfig`, the result passes through unchanged (legacy /
+ * no-config behavior). The threading is centralized here so all five gates pick
+ * it up from one place.
  */
 function adaptLadderGate<T>(
   gateName: string,
@@ -229,12 +234,19 @@ function adaptLadderGate<T>(
     const result = await handler(enrichedArgs as unknown as T, stateDir, ctx.eventStore);
     const featureId = (args as { featureId?: string }).featureId;
     const workflowType = await resolveWorkflowTypeForGate(featureId, ctx.eventStore);
+    // DR-6: the IMPLEMENT-phase graduation mode is resolved from the SAME
+    // workflow type the severity uses, so mode and severity can never resolve
+    // against divergent workflow types in one dispatch (INV-2). A newly-covered
+    // phase resolves to `audit` (records the finding, never blocks); the handler
+    // already emitted its `gate.executed` finding above.
+    const mode = resolveImplementMode(workflowType);
     return applyLadderGateSeverity(
       gateName,
       dimension,
       effectiveProjectConfig,
       result,
       workflowType,
+      mode,
     );
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
@@ -22,6 +22,12 @@ type Severity = 'blocking' | 'warning' | 'disabled';
  * Scope: this default ONLY applies to gates named in `VERIFICATION_GATE_NAMES`
  * (the single source of truth) and is ALWAYS beaten by an explicit
  * `review.gates[gateName]` override — a consumer who pins a gate wins.
+ *
+ * SEVERITY (advisory vs blocking) is one of the two workflow-keyed axes the
+ * IMPLEMENT-phase obligation surface composes; the orthogonal MODE axis
+ * (audit→enforce graduation) is `IMPLEMENT_PHASE_MODE` in `gate-utils.ts` (DR-6).
+ * Both are workflow-specific — NOT kind-universal — so neither belongs in
+ * `KIND_OBLIGATIONS` (INV-6).
  */
 export const WORKFLOW_DEFAULT_SEVERITY: Readonly<Record<string, 'warning'>> =
   Object.freeze({ oneshot: 'warning' });

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
@@ -194,6 +194,63 @@ export async function resolveRepoRoot(
   };
 }
 
+// ─── Implement-phase graduation mode (DR-6) ─────────────────────────────────
+//
+// The audit→enforce graduation knob for the IMPLEMENT-kind phase obligation
+// surface. Distinct from SEVERITY (advisory vs blocking): mode is whether a
+// failing gate is *consulted at all* as a transition blocker, or only RECORDED
+// (the handler's `gate.executed` finding is emitted in BOTH modes; audit just
+// never lets a failure re-assert a blocking verdict).
+//
+// CRITICAL INV-6: this map is WORKFLOW-specific, NOT kind-universal. It lives
+// here next to the KIND_OBLIGATIONS *consumers* — it must NEVER move into
+// `KIND_OBLIGATIONS` (phase-kind.ts), because an obligation that attaches to a
+// kind composes across every workflow type, whereas a graduation mode is a
+// per-workflow rollout decision.
+
+/** The audit→enforce graduation mode for an IMPLEMENT-phase gate binding. */
+export type ImplementMode = 'audit' | 'enforce';
+
+/**
+ * Per-workflow IMPLEMENT-phase graduation mode (DR-6).
+ *
+ * A DATA TABLE — not branching prose — keyed by workflow type. Mode is the
+ * audit→enforce rollout axis; SEVERITY (advisory vs blocking) is the orthogonal
+ * axis resolved by {@link resolveGateSeverity}. The two compose: a phase blocks
+ * only when its mode is `enforce` AND its severity is `blocking`.
+ *
+ * Live defaults per the epic severity policy + DR-6 acceptance criteria:
+ *   - `oneshot`  (oneshot:implementing) → audit
+ *       Its severity is already advisory (WORKFLOW_DEFAULT_SEVERITY.oneshot), so
+ *       audit is the natural rollout home: findings recorded, never blocking.
+ *   - `feature`  (delegate)             → enforce  (already covered pre-DR-4)
+ *   - `debug`    (debug-implement)      → enforce  (DR-6 AC: "blocks (enforce mode)")
+ *   - `refactor` (polish-implement)     → enforce  (epic policy: blocking)
+ *
+ * The `audit` mode itself is a first-class, exercised mechanism (a phase can be
+ * graduated/demoted by editing one cell here); a workflow type without an entry
+ * falls back to `enforce` (the safe default — a missing entry must NEVER
+ * silently stop a gate from blocking). Adding a workflow type is a single-line
+ * ADDITION, never new control flow in {@link resolveImplementMode}.
+ */
+export const IMPLEMENT_PHASE_MODE: Readonly<Record<string, ImplementMode>> =
+  Object.freeze({
+    oneshot: 'audit',
+    feature: 'enforce',
+    debug: 'enforce',
+    refactor: 'enforce',
+  });
+
+/**
+ * Resolve the IMPLEMENT-phase graduation mode for a workflow type.
+ *
+ * Reads {@link IMPLEMENT_PHASE_MODE}; an unmapped workflow type defaults to
+ * `'enforce'` so a phase is never silently downgraded by an unknown type.
+ */
+export function resolveImplementMode(workflowType: string): ImplementMode {
+  return IMPLEMENT_PHASE_MODE[workflowType] ?? 'enforce';
+}
+
 // ─── Config-Aware Gate Wrapper ──────────────────────────────────────────────
 
 /**
@@ -256,16 +313,24 @@ export async function withConfigSeverity(
  * — a failing gate is `{ success: true, data: { passed: false } }`, so
  * {@link withConfigSeverity}'s `success:false`-only conversion does not apply.
  * This helper resolves the gate's effective severity via
- * {@link resolveGateSeverity} (threading `workflowType`) and, ONLY when that
- * severity is `'warning'` and the advisory result reports a failing verdict
- * (`data.passed === false`), annotates it with a warning. In every other case
- * the result is returned UNCHANGED:
- *   - `severity !== 'warning'` (e.g. blocking for a feature workflow) → unchanged,
- *     so the orchestrator still reads `data.passed:false` and blocks;
+ * {@link resolveGateSeverity} (threading `workflowType`) and downgrades a
+ * failing advisory verdict (`data.passed === false`) to a warning when EITHER:
+ *   - the resolved severity is `'warning'`; OR
+ *   - the binding's graduation `mode` is `'audit'` (DR-6) — an audit-mode gate
+ *     RECORDS its finding (the handler already emitted `gate.executed`) but is
+ *     never consulted as a transition blocker, regardless of severity.
+ *
+ * In every other case the result is returned UNCHANGED:
+ *   - `mode === 'enforce'` (or omitted) AND `severity !== 'warning'` (e.g.
+ *     blocking for a feature workflow) → unchanged, so the orchestrator still
+ *     reads `data.passed:false` and blocks;
  *   - `config` absent → unchanged (legacy / no-config callers);
  *   - a passing verdict → unchanged;
  *   - a real error envelope (`success:false`) → unchanged (an INVALID_INPUT /
  *     MISWIRED_CONTEXT must never be downgraded to a warning).
+ *
+ * `mode` defaults to `'enforce'`, so legacy callers that don't thread it see
+ * exactly the pre-DR-6 severity-only resolution.
  */
 export function applyLadderGateSeverity(
   gateName: string,
@@ -273,6 +338,7 @@ export function applyLadderGateSeverity(
   config: ResolvedProjectConfig | undefined,
   result: ToolResult,
   workflowType?: string,
+  mode: ImplementMode = 'enforce',
 ): ToolResult {
   // No config, or a real error envelope, or a non-advisory shape — leave as-is.
   if (!config || !result.success) return result;
@@ -282,15 +348,20 @@ export function applyLadderGateSeverity(
   // shape-less advisory carrier is returned verbatim.
   if (!data || data.passed !== false) return result;
 
+  // Audit mode downgrades regardless of severity; otherwise the per-workflow
+  // severity must resolve to warning. A real error envelope was already excluded
+  // above, so audit mode only ever softens a genuine gate-failure verdict.
   const severity = resolveGateSeverity(gateName, dimension, config, workflowType);
-  if (severity !== 'warning') return result;
+  if (mode !== 'audit' && severity !== 'warning') return result;
+
+  const reason =
+    mode === 'audit'
+      ? `Gate '${gateName}' failed but the implement phase is in audit mode (finding recorded, non-blocking)`
+      : `Gate '${gateName}' failed but is configured as warning-only`;
 
   return {
     ...result,
-    warnings: [
-      ...(result.warnings ?? []),
-      `Gate '${gateName}' failed but is configured as warning-only`,
-    ],
+    warnings: [...(result.warnings ?? []), reason],
   };
 }
 

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
@@ -312,19 +312,22 @@ export async function withConfigSeverity(
  * Ladder gates (INV-5b) never return `success:false` for a gate-failure verdict
  * — a failing gate is `{ success: true, data: { passed: false } }`, so
  * {@link withConfigSeverity}'s `success:false`-only conversion does not apply.
- * This helper resolves the gate's effective severity via
- * {@link resolveGateSeverity} (threading `workflowType`) and downgrades a
- * failing advisory verdict (`data.passed === false`) to a warning when EITHER:
- *   - the resolved severity is `'warning'`; OR
+ * This helper downgrades a failing advisory verdict (`data.passed === false`)
+ * to a warning when EITHER:
  *   - the binding's graduation `mode` is `'audit'` (DR-6) — an audit-mode gate
  *     RECORDS its finding (the handler already emitted `gate.executed`) but is
- *     never consulted as a transition blocker, regardless of severity.
+ *     never consulted as a transition blocker, regardless of severity OR config.
+ *     Audit mode is resolved from the workflow type (config-INDEPENDENT), so this
+ *     downgrade applies even on the no-config path; OR
+ *   - a config is present and the resolved severity (via {@link resolveGateSeverity},
+ *     threading `workflowType`) is `'warning'`.
  *
  * In every other case the result is returned UNCHANGED:
  *   - `mode === 'enforce'` (or omitted) AND `severity !== 'warning'` (e.g.
  *     blocking for a feature workflow) → unchanged, so the orchestrator still
  *     reads `data.passed:false` and blocks;
- *   - `config` absent → unchanged (legacy / no-config callers);
+ *   - `mode !== 'audit'` AND `config` absent → unchanged (legacy / no-config
+ *     severity passthrough — severity reads `config.review.gates.*`);
  *   - a passing verdict → unchanged;
  *   - a real error envelope (`success:false`) → unchanged (an INVALID_INPUT /
  *     MISWIRED_CONTEXT must never be downgraded to a warning).
@@ -340,28 +343,43 @@ export function applyLadderGateSeverity(
   workflowType?: string,
   mode: ImplementMode = 'enforce',
 ): ToolResult {
-  // No config, or a real error envelope, or a non-advisory shape — leave as-is.
-  if (!config || !result.success) return result;
+  // A real error envelope (success:false) or a non-advisory shape — leave as-is.
+  // An INVALID_INPUT / MISWIRED_CONTEXT must never be softened to a warning.
+  if (!result.success) return result;
 
   const data = result.data as { passed?: unknown } | undefined;
   // Only an explicit failing verdict is a candidate for downgrade. A passing or
   // shape-less advisory carrier is returned verbatim.
   if (!data || data.passed !== false) return result;
 
-  // Audit mode downgrades regardless of severity; otherwise the per-workflow
-  // severity must resolve to warning. A real error envelope was already excluded
-  // above, so audit mode only ever softens a genuine gate-failure verdict.
-  const severity = resolveGateSeverity(gateName, dimension, config, workflowType);
-  if (mode !== 'audit' && severity !== 'warning') return result;
+  // Audit mode is resolved from the workflow type (IMPLEMENT_PHASE_MODE) — it is
+  // CONFIG-INDEPENDENT, so it downgrades a failing verdict whether or not a
+  // project config is present. The handler already emitted its `gate.executed`
+  // finding; audit mode only stops that failure from re-asserting a blocking
+  // verdict. This MUST precede the `!config` guard below (DR-6 fix): severity
+  // reads `config`, but mode does not.
+  if (mode === 'audit') {
+    return {
+      ...result,
+      warnings: [
+        ...(result.warnings ?? []),
+        `Gate '${gateName}' failed but the implement phase is in audit mode (finding recorded, non-blocking)`,
+      ],
+    };
+  }
 
-  const reason =
-    mode === 'audit'
-      ? `Gate '${gateName}' failed but the implement phase is in audit mode (finding recorded, non-blocking)`
-      : `Gate '${gateName}' failed but is configured as warning-only`;
+  // Severity-based downgrade reads `config.review.gates.*`, so it requires a
+  // resolved config; absent one, this is the legacy / no-config passthrough.
+  if (!config) return result;
+  const severity = resolveGateSeverity(gateName, dimension, config, workflowType);
+  if (severity !== 'warning') return result;
 
   return {
     ...result,
-    warnings: [...(result.warnings ?? []), reason],
+    warnings: [
+      ...(result.warnings ?? []),
+      `Gate '${gateName}' failed but is configured as warning-only`,
+    ],
   };
 }
 

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
@@ -310,10 +310,15 @@ export async function withConfigSeverity(
  * result (task 005).
  *
  * Ladder gates (INV-5b) never return `success:false` for a gate-failure verdict
- * — a failing gate is `{ success: true, data: { passed: false } }`, so
- * {@link withConfigSeverity}'s `success:false`-only conversion does not apply.
- * This helper downgrades a failing advisory verdict (`data.passed === false`)
- * to a warning when EITHER:
+ * — a failing gate is `{ success: true, data: { passed: false } }`, where
+ * `data.passed:false` is the blocking signal the orchestrator reads. So
+ * {@link withConfigSeverity}'s `success:false`-only conversion does not apply;
+ * the ladder analogue is to clear `data.passed` (false → true) the same way the
+ * sibling clears `success`.
+ *
+ * This helper DOWNGRADES a failing advisory verdict (`data.passed === false`) to
+ * non-blocking — clearing the blocking signal (`data.passed → true`) AND
+ * attaching an explanatory warning — when EITHER:
  *   - the binding's graduation `mode` is `'audit'` (DR-6) — an audit-mode gate
  *     RECORDS its finding (the handler already emitted `gate.executed`) but is
  *     never consulted as a transition blocker, regardless of severity OR config.
@@ -321,6 +326,11 @@ export async function withConfigSeverity(
  *     downgrade applies even on the no-config path; OR
  *   - a config is present and the resolved severity (via {@link resolveGateSeverity},
  *     threading `workflowType`) is `'warning'`.
+ *
+ * The truthful failing verdict survives in the `gate.executed` event the handler
+ * emitted before this post-processing; only the returned ToolResult's block
+ * signal is normalized — so an audit/warning gate cannot still block on a stale
+ * `data.passed:false`.
  *
  * In every other case the result is returned UNCHANGED:
  *   - `mode === 'enforce'` (or omitted) AND `severity !== 'warning'` (e.g.
@@ -361,6 +371,9 @@ export function applyLadderGateSeverity(
   if (mode === 'audit') {
     return {
       ...result,
+      // Clear the blocking signal — `data.passed:false` is what the orchestrator
+      // reads to block, so the warning alone would not actually unblock.
+      data: { ...(data as Record<string, unknown>), passed: true },
       warnings: [
         ...(result.warnings ?? []),
         `Gate '${gateName}' failed but the implement phase is in audit mode (finding recorded, non-blocking)`,
@@ -376,6 +389,8 @@ export function applyLadderGateSeverity(
 
   return {
     ...result,
+    // Clear the blocking signal alongside the warning (see the audit branch).
+    data: { ...(data as Record<string, unknown>), passed: true },
     warnings: [
       ...(result.warnings ?? []),
       `Gate '${gateName}' failed but is configured as warning-only`,

--- a/servers/exarchos-mcp/src/orchestrate/implement-severity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/implement-severity.test.ts
@@ -65,8 +65,11 @@ describe('DR-6 implement-phase severity', () => {
       ONESHOT,
       'enforce',
     );
-    // Still an advisory carrier (never throws), but now annotated warning-only.
+    // Still an advisory carrier (never throws), now downgraded NON-blocking: the
+    // blocking signal is cleared (data.passed → true) and a warning carries the
+    // finding. data.passed is the exact field the orchestrator consumes.
     expect(result.success).toBe(true);
+    expect((result.data as { passed?: unknown }).passed).toBe(true);
     expect(result.warnings).toBeDefined();
     expect(result.warnings!.length).toBeGreaterThan(0);
   });
@@ -106,6 +109,9 @@ describe('DR-6 implement-phase severity', () => {
       // Audit mode never blocks: a warning carries the finding, and the result
       // is no longer a re-asserted blocking failure for the orchestrator.
       expect(result.success).toBe(true);
+      // The blocking signal must actually be cleared, not merely annotated —
+      // data.passed:false is what the orchestrator reads to block.
+      expect((result.data as { passed?: unknown }).passed).toBe(true);
       expect(result.warnings).toBeDefined();
       expect(result.warnings!.length).toBeGreaterThan(0);
     }
@@ -129,6 +135,9 @@ describe('DR-6 implement-phase severity', () => {
         'audit',
       );
       expect(result.success).toBe(true);
+      // The blocking signal must actually be cleared, not merely annotated —
+      // data.passed:false is what the orchestrator reads to block.
+      expect((result.data as { passed?: unknown }).passed).toBe(true);
       expect(result.warnings).toBeDefined();
       expect(result.warnings!.length).toBeGreaterThan(0);
     }
@@ -176,10 +185,13 @@ describe('DR-6 implement-phase severity', () => {
       'debug', // debug-implement, newly covered
       'enforce',
     );
-    // Override downgrades to advisory on both — identical resolved behavior.
+    // Override downgrades to advisory on both — identical resolved behavior:
+    // blocking signal cleared (data.passed → true) + warning attached.
     expect(feature.success).toBe(true);
+    expect((feature.data as { passed?: unknown }).passed).toBe(true);
     expect(feature.warnings!.length).toBeGreaterThan(0);
     expect(debug.success).toBe(true);
+    expect((debug.data as { passed?: unknown }).passed).toBe(true);
     expect(debug.warnings!.length).toBeGreaterThan(0);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/implement-severity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/implement-severity.test.ts
@@ -111,6 +111,46 @@ describe('DR-6 implement-phase severity', () => {
     }
   });
 
+  it('ImplementMode_AuditMode_NoConfig_StillDoesNotBlock', () => {
+    // DR-6 fix: audit mode is resolved from the workflow type
+    // (IMPLEMENT_PHASE_MODE) — config-INDEPENDENT — so a failing ladder gate is
+    // downgraded to advisory even when NO project config is resolved (the
+    // optional `DispatchContext.projectConfig` / legacy path). Before the fix the
+    // `!config` early-return made audit mode silently inert here, letting a
+    // newly-covered implement phase surface a blocking verdict in a no-config
+    // project.
+    for (const workflowType of [ONESHOT, 'debug'] as const) {
+      const result = applyLadderGateSeverity(
+        LADDER_GATE,
+        'D2',
+        undefined, // no resolved project config
+        failingVerdict(),
+        workflowType,
+        'audit',
+      );
+      expect(result.success).toBe(true);
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ImplementSeverity_NoConfig_EnforceStillBlocks', () => {
+    // Contrast that bounds the fix: severity-based downgrade reads
+    // `config.review.gates.*`, so without a config an `enforce` binding cannot
+    // downgrade — the verdict still blocks (legacy / no-config severity
+    // passthrough). Only audit mode, being config-independent, escapes it.
+    const result = applyLadderGateSeverity(
+      LADDER_GATE,
+      'D2',
+      undefined,
+      failingVerdict(),
+      ONESHOT,
+      'enforce',
+    );
+    expect((result.data as { passed?: unknown }).passed).toBe(false);
+    expect(result.warnings ?? []).toHaveLength(0);
+  });
+
   it('ImplementOverride_ReviewGatesConfig_AppliesToImplementPhases', () => {
     // A `.exarchos.yml review.gates.<gate>` override changes the resolved
     // behavior for IMPLEMENT phases identically to `feature:delegate`. Pin the

--- a/servers/exarchos-mcp/src/orchestrate/implement-severity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/implement-severity.test.ts
@@ -1,0 +1,167 @@
+// ─── DR-6: per-workflow severity + audit→enforce graduation (implement phases) ─
+//
+// task-006 (epic #1546). These tests prove the IMPLEMENT-phase obligation
+// surface honors:
+//  1. per-workflow SEVERITY — `oneshot:implementing` is advisory; the same
+//     ladder-gate failure on `debug-implement`/`delegate`/`polish-implement`
+//     (debug/feature/refactor) BLOCKS (the graduated `enforce`-mode end state);
+//  2. a per-binding MODE (`audit` | `enforce`) — in `audit` a failing ladder
+//     gate is downgraded to advisory (finding already emitted as the handler's
+//     `gate.executed`) WITHOUT blocking, regardless of severity; newly-covered
+//     phases default to `audit`;
+//  3. the existing `.exarchos.yml review.gates.<gate>` override — it changes the
+//     resolved behavior for IMPLEMENT phases identically to `feature:delegate`.
+//
+// The obligation surface under test is `applyLadderGateSeverity` (the block-vs-
+// advise decision a ladder verdict flows through) plus the workflow-type→mode
+// map. Severity itself is workflow-specific, NOT kind-universal (INV-6): the
+// map lives next to the KIND_OBLIGATIONS *consumers* here, never in the kind
+// table.
+
+import { describe, it, expect } from 'vitest';
+import {
+  applyLadderGateSeverity,
+  resolveImplementMode,
+  IMPLEMENT_PHASE_MODE,
+} from './gate-utils.js';
+import { DEFAULTS } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { VERIFICATION_GATE_NAMES } from '../workflow/verification-policy.js';
+
+// A real verification-ladder gate name — these are the only gates the
+// per-workflow severity default applies to.
+const LADDER_GATE = VERIFICATION_GATE_NAMES[0]; // 'check_static_analysis'
+
+/** A failing ladder verdict — the INV-5b advisory carrier shape. */
+function failingVerdict(): { success: true; data: { passed: false } } {
+  return { success: true, data: { passed: false } };
+}
+
+function configWith(overrides: Partial<ResolvedProjectConfig['review']>): ResolvedProjectConfig {
+  return { ...DEFAULTS, review: { ...DEFAULTS.review, ...overrides } };
+}
+
+// The workflow type each newly-covered (and the already-covered) IMPLEMENT
+// phase resolves to, per DR-4 routing:
+//   oneshot:implementing → 'oneshot'   (advisory)
+//   debug-implement      → 'debug'     (blocking)
+//   delegate             → 'feature'   (blocking, already covered)
+//   polish-implement     → 'refactor'  (blocking)
+const ONESHOT = 'oneshot';
+const BLOCKING_WORKFLOWS = ['debug', 'feature', 'refactor'] as const;
+
+describe('DR-6 implement-phase severity', () => {
+  it('ImplementSeverity_Oneshot_Advisory', () => {
+    // A failing ladder gate on `oneshot:implementing` is advisory: the workflow
+    // proceeds (no blocking `passed:false` envelope is *re-asserted as failure*)
+    // and a warning carries the finding. We exercise the graduated end state by
+    // putting the binding in `enforce` mode so the only thing that can downgrade
+    // it is the per-workflow severity (oneshot → warning).
+    const result = applyLadderGateSeverity(
+      LADDER_GATE,
+      'D2',
+      DEFAULTS,
+      failingVerdict(),
+      ONESHOT,
+      'enforce',
+    );
+    // Still an advisory carrier (never throws), but now annotated warning-only.
+    expect(result.success).toBe(true);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.length).toBeGreaterThan(0);
+  });
+
+  it('ImplementSeverity_FeatureDebugRefactor_Blocking', () => {
+    // The SAME failing ladder verdict on debug/feature/refactor, under the
+    // graduated `enforce` mode, is NOT downgraded — the orchestrator still reads
+    // `data.passed:false` and blocks. No warning is attached.
+    for (const workflowType of BLOCKING_WORKFLOWS) {
+      const result = applyLadderGateSeverity(
+        LADDER_GATE,
+        'D2',
+        DEFAULTS,
+        failingVerdict(),
+        workflowType,
+        'enforce',
+      );
+      expect((result.data as { passed?: unknown }).passed).toBe(false);
+      expect(result.warnings ?? []).toHaveLength(0);
+    }
+  });
+
+  it('ImplementMode_AuditMode_DoesNotBlock', () => {
+    // In `audit` mode a failing ladder gate is downgraded to advisory REGARDLESS
+    // of severity — including a blocking workflow type. The `gate.executed`
+    // finding is emitted by the handler itself (before this post-processing), so
+    // audit mode surfaces the finding without re-asserting a blocking verdict.
+    for (const workflowType of BLOCKING_WORKFLOWS) {
+      const result = applyLadderGateSeverity(
+        LADDER_GATE,
+        'D2',
+        DEFAULTS,
+        failingVerdict(),
+        workflowType,
+        'audit',
+      );
+      // Audit mode never blocks: a warning carries the finding, and the result
+      // is no longer a re-asserted blocking failure for the orchestrator.
+      expect(result.success).toBe(true);
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ImplementOverride_ReviewGatesConfig_AppliesToImplementPhases', () => {
+    // A `.exarchos.yml review.gates.<gate>` override changes the resolved
+    // behavior for IMPLEMENT phases identically to `feature:delegate`. Pin the
+    // ladder gate to warning-only: even on a blocking workflow type in `enforce`
+    // mode the verdict downgrades to advisory — parity with how the override
+    // behaves for the already-covered `feature:delegate` phase.
+    const config = configWith({
+      gates: { [LADDER_GATE]: { enabled: true, blocking: false, params: {} } },
+    });
+    const feature = applyLadderGateSeverity(
+      LADDER_GATE,
+      'D2',
+      config,
+      failingVerdict(),
+      'feature', // delegate
+      'enforce',
+    );
+    const debug = applyLadderGateSeverity(
+      LADDER_GATE,
+      'D2',
+      config,
+      failingVerdict(),
+      'debug', // debug-implement, newly covered
+      'enforce',
+    );
+    // Override downgrades to advisory on both — identical resolved behavior.
+    expect(feature.success).toBe(true);
+    expect(feature.warnings!.length).toBeGreaterThan(0);
+    expect(debug.success).toBe(true);
+    expect(debug.warnings!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('DR-6 implement-phase mode map', () => {
+  it('ImplementPhaseMode_OneshotAudit_BlockingWorkflowsEnforce', () => {
+    // INV-6: the mode map is workflow-specific, keyed by workflow type, NOT by
+    // kind. Per the DR-6 severity policy + acceptance criteria, `oneshot` (whose
+    // severity is already advisory) lands in `audit`; the blocking workflows —
+    // `feature:delegate` (already covered), `debug-implement`, `polish-implement`
+    // — are `enforce` so a failing gate still blocks.
+    expect(resolveImplementMode('oneshot')).toBe('audit');
+    expect(resolveImplementMode('feature')).toBe('enforce');
+    expect(resolveImplementMode('debug')).toBe('enforce');
+    expect(resolveImplementMode('refactor')).toBe('enforce');
+    // An unknown workflow type falls back to the safe enforce default.
+    expect(resolveImplementMode('unknown-future-type')).toBe('enforce');
+  });
+
+  it('ImplementPhaseMode_TableIsFrozen', () => {
+    // The map is a frozen DATA TABLE — adding a workflow type is a single-line
+    // entry, never new control flow.
+    expect(Object.isFrozen(IMPLEMENT_PHASE_MODE)).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
@@ -602,7 +602,10 @@ describe('mutation-adequacy advisory verdict + threshold', () => {
 
   it('MutationAdequacy_NoThresholdConfig_DefaultsToSoftAdvisory', async () => {
     // No threshold config → soft default (~0.40); a sub-default score warns,
-    // never blocks (advisory severity from the resolved default).
+    // never blocks (advisory severity from the resolved default). The warning-only
+    // downgrade CLEARS the blocking signal (data.passed → true) and carries the
+    // finding as a warning — leaving data.passed:false would still block the
+    // dispatch (the contract the orchestrator reads). See the DR-6 review fix.
     const advisoryConfig = configWith({} as Partial<ProjectConfig>);
     const result = (await dispatchMutation({
       projectConfig: advisoryConfig,
@@ -612,7 +615,7 @@ describe('mutation-adequacy advisory verdict + threshold', () => {
       },
     })) as { success: boolean; data: MutationData; warnings?: string[] };
     expect(result.success).toBe(true);
-    expect(result.data.passed).toBe(false);
+    expect(result.data.passed).toBe(true);
     const warnings = (result as { warnings?: string[] }).warnings ?? [];
     expect(warnings.some((w) => /warning-only/.test(w))).toBe(true);
   });

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -81,7 +81,8 @@ import { assertWorktreeBaseRefPinned } from './worktree-baseref.js';
 import { DEFAULTS } from '../config/resolve.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { resolveVerificationSequence } from '../workflow/verification-policy.js';
-import type { GateName } from '../workflow/verification-policy.js';
+import type { GateName, RiskTier } from '../workflow/verification-policy.js';
+import { resolveVerificationPolicy } from '../workflow/verification-policy-resolver.js';
 
 const STATE_DIR = '/tmp/test-state';
 
@@ -1686,6 +1687,44 @@ describe('handlePrepareDelegation', () => {
       expect(classification.verificationSequence).toEqual(customSequence);
       // And it diverges from the built-in table the no-config path would stamp.
       expect(classification.verificationSequence).not.toEqual(baseline.verificationSequence);
+    });
+  });
+
+  // task-004 (DR-4): classifyTask now resolves its verification sequence by
+  // routing through resolveGateSet('IMPLEMENT', …) instead of calling
+  // resolveVerificationPolicy directly. Because the IMPLEMENT kind's resolver is
+  // wired to delegate verbatim to resolveVerificationPolicy, the stamped
+  // sequence must remain byte-identical across representative task profiles —
+  // i.e. the routing is purely behavior-neutral plumbing.
+  describe('classifyTask — resolver-routing behavior-neutrality (task-004)', () => {
+    const profiles: ReadonlyArray<{
+      readonly label: string;
+      readonly riskTier: RiskTier;
+      readonly boundaryTouching: boolean;
+    }> = [
+      { label: 'low / no-boundary', riskTier: 'low', boundaryTouching: false },
+      { label: 'medium / no-boundary', riskTier: 'medium', boundaryTouching: false },
+      { label: 'high / boundary', riskTier: 'high', boundaryTouching: true },
+    ];
+
+    it('ClassifyTask_VerificationSequence_UnchangedByResolverRouting', () => {
+      for (const { label, riskTier, boundaryTouching } of profiles) {
+        // Arrange — explicit risk/boundary overrides pin the profile so the
+        // derivation heuristic does not influence the comparison.
+        const task: TaskInput = {
+          id: `T-NEUTRAL-${label}`,
+          title: 'Implement feature under neutrality check',
+          riskTier,
+          boundaryTouching,
+        };
+
+        // Act
+        const classification = classifyTask(task);
+
+        // Assert — byte-identical to the pre-routing builtin behavior.
+        const expected = resolveVerificationPolicy(riskTier, boundaryTouching).sequence;
+        expect(classification.verificationSequence, label).toEqual(expected);
+      }
     });
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -273,6 +273,24 @@ describe('handlePrepareDelegation', () => {
     expect(result.error?.message).toContain('featureId');
   });
 
+  it('PrepareDelegation_MalformedTaskShape_ReturnsInvalidInputNotPhaseBlocked', async () => {
+    // A non-MCP caller can hand `tasks` through an unchecked cast. A task whose
+    // optional `files` is a non-array would crash `files.some(...)` downstream;
+    // caught by the fail-closed wrapper it would masquerade as a `phase.blocked`
+    // RESOLVER fault. The shape guard must reject it as INVALID_INPUT first.
+    const args = {
+      featureId: 'feat-malformed',
+      tasks: [{ id: 't1', title: 'ok', files: 'src/not-an-array.ts' }],
+    } as unknown as { featureId: string; tasks?: TaskInput[] };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.code).not.toBe('PHASE_BLOCKED');
+    expect(result.error?.message).toMatch(/files|blockedBy|array/i);
+  });
+
   it('PrepareDelegation_NotReady_ReturnsBlockers', async () => {
     // Arrange
     const state = notReadyWorkflowState();

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -50,6 +50,16 @@ vi.mock('../workflow/checkpoint.js', () => ({
   CHECKPOINT_OPERATION_THRESHOLD: 20,
 }));
 
+// DR-7: partially mock the phase-kind boundary so a single test can force the
+// IMPLEMENT-kind gate-set resolver to throw (simulating a deferred-kind
+// 'not-yet-wired' fault or any resolver error). The default implementation
+// delegates to the real resolver so every other test exercises the genuine
+// ladder; only the fail-closed test overrides it via `mockImplementationOnce`.
+vi.mock('../workflow/phase-kind.js', async (importActual) => {
+  const actual = await importActual<typeof import('../workflow/phase-kind.js')>();
+  return { ...actual, resolveGateSet: vi.fn(actual.resolveGateSet) };
+});
+
 import {
   getOrCreateMaterializer,
   queryDeltaEvents,
@@ -83,6 +93,7 @@ import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { resolveVerificationSequence } from '../workflow/verification-policy.js';
 import type { GateName, RiskTier } from '../workflow/verification-policy.js';
 import { resolveVerificationPolicy } from '../workflow/verification-policy-resolver.js';
+import { resolveGateSet } from '../workflow/phase-kind.js';
 
 const STATE_DIR = '/tmp/test-state';
 
@@ -1852,6 +1863,69 @@ describe('handlePrepareDelegation', () => {
       const implementerTask = data.taskClassifications.find(tc => tc.recommendedAgent === 'implementer');
       expect(scaffolderTask?.recommendedModel).toBe('haiku');   // DEFAULTS.agents.models.scaffolder
       expect(implementerTask?.recommendedModel).toBe('opus');   // DEFAULTS.agents.defaultModel
+    });
+  });
+
+  // ─── DR-7: Fail-Closed at the Gate-Set Boundary ──────────────────────────
+  //
+  // The wave-dispatch boundary stamps each task's verification sequence by
+  // routing through `resolveGateSet('IMPLEMENT', …)`. That call was previously
+  // UNGUARDED: a resolver throw (e.g. a deferred-kind 'not-yet-wired' fault, or
+  // any resolver error) propagated out of the handler and the dispatch failed
+  // OPEN / silently. DR-7 makes the boundary FAIL CLOSED: append a
+  // `phase.blocked` event carrying a visible skip reason, and refuse to proceed
+  // (structured error envelope, NO task classifications stamped).
+  describe('fail-closed gate-set boundary (DR-7)', () => {
+    it('ResolveGateSet_ResolverThrows_AppendsPhaseBlocked', async () => {
+      // Arrange: a ready workflow with a single implement task. Force the
+      // IMPLEMENT-kind resolver to throw at the dispatch boundary.
+      const state = readyWorkflowState();
+      setupMaterializer(state);
+      vi.mocked(generateQualityHints).mockReturnValue([]);
+      const localStore = {
+        query: vi.fn().mockResolvedValue([]),
+        append: vi.fn().mockResolvedValue(undefined),
+        listStreams: vi.fn().mockReturnValue(null),
+      };
+      const boom = new Error(
+        "resolveGateSet: resolver 'plan-structure' is not wired yet (deferred to S3)",
+      );
+      vi.mocked(resolveGateSet).mockImplementationOnce(() => {
+        throw boom;
+      });
+      const args = {
+        featureId: 'test-feature',
+        tasks: [{ id: 'task-1', title: 'Implement widget' }],
+      };
+
+      // Act
+      const result = await handlePrepareDelegation(
+        args,
+        STATE_DIR,
+        makeCtx(localStore, STATE_DIR),
+      );
+
+      // Assert: dispatch did NOT proceed — structured error envelope, and
+      // CRUCIALLY no taskClassifications were stamped (fail closed).
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('PHASE_BLOCKED');
+      // Visible skip reason surfaced to the operator.
+      expect(result.error?.message).toMatch(/gate|resolve|blocked|verification/i);
+      const data = (result.data ?? {}) as { taskClassifications?: unknown };
+      expect(data.taskClassifications).toBeUndefined();
+
+      // A `phase.blocked` event was appended carrying a visible skip reason.
+      const blockedCall = localStore.append.mock.calls.find(
+        (c) => (c[1] as { type?: string }).type === 'phase.blocked',
+      );
+      expect(blockedCall, 'expected a phase.blocked event to be appended').toBeDefined();
+      const blockedEvent = blockedCall![1] as {
+        type: string;
+        data: { phase: string; kind: string; reason: string; error: { code: string; message: string } };
+      };
+      expect(blockedEvent.data.kind).toBe('IMPLEMENT');
+      expect(blockedEvent.data.reason.length).toBeGreaterThan(0);
+      expect(blockedEvent.data.error.message).toContain('not wired');
     });
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -274,21 +274,33 @@ describe('handlePrepareDelegation', () => {
   });
 
   it('PrepareDelegation_MalformedTaskShape_ReturnsInvalidInputNotPhaseBlocked', async () => {
-    // A non-MCP caller can hand `tasks` through an unchecked cast. A task whose
-    // optional `files` is a non-array would crash `files.some(...)` downstream;
-    // caught by the fail-closed wrapper it would masquerade as a `phase.blocked`
-    // RESOLVER fault. The shape guard must reject it as INVALID_INPUT first.
-    const args = {
-      featureId: 'feat-malformed',
-      tasks: [{ id: 't1', title: 'ok', files: 'src/not-an-array.ts' }],
-    } as unknown as { featureId: string; tasks?: TaskInput[] };
+    // A non-MCP caller can hand `tasks` through an unchecked cast. Any malformed
+    // planner field that the heuristics / resolver consume would otherwise crash
+    // downstream — e.g. `files.some(...)` on a non-array, or a bad `riskTier`
+    // reaching resolveVerificationSequence — and, caught by the fail-closed
+    // wrapper, masquerade as a `phase.blocked` RESOLVER fault. The shape guard
+    // must reject every such field as INVALID_INPUT first.
+    const malformed: Array<Record<string, unknown>> = [
+      { id: 't1', title: 'ok', files: 'src/not-an-array.ts' }, // files: non-array (crash path)
+      { id: 't2', title: 'ok', blockedBy: [1, 2] }, // blockedBy: non-string elements
+      { id: 't3', title: 'ok', riskTier: 'critical' }, // riskTier: not a RiskTier (resolver throw)
+      { id: 't4', title: 'ok', boundaryTouching: 'yes' }, // boundaryTouching: non-boolean
+      { id: 't5', title: 'ok', testLayer: 'e2e' }, // testLayer: not in the enum
+      { id: 7, title: 'ok' }, // id: non-string
+    ];
 
-    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+    for (const bad of malformed) {
+      const args = {
+        featureId: 'feat-malformed',
+        tasks: [bad],
+      } as unknown as { featureId: string; tasks?: TaskInput[] };
 
-    expect(result.success).toBe(false);
-    expect(result.error?.code).toBe('INVALID_INPUT');
-    expect(result.error?.code).not.toBe('PHASE_BLOCKED');
-    expect(result.error?.message).toMatch(/files|blockedBy|array/i);
+      const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+      expect(result.success, `expected INVALID_INPUT for ${JSON.stringify(bad)}`).toBe(false);
+      expect(result.error?.code).toBe('INVALID_INPUT');
+      expect(result.error?.code).not.toBe('PHASE_BLOCKED');
+    }
   });
 
   it('PrepareDelegation_NotReady_ReturnsBlockers', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -52,6 +52,7 @@ import type { CheckpointEnforcementConfig } from '../workflow/checkpoint.js';
 import { globToRegExp } from '../architecture/glob-to-regexp.js';
 import type { GateName } from '../workflow/verification-policy.js';
 import { resolveGateSet } from '../workflow/phase-kind.js';
+import type { PhaseKind } from '../workflow/phase-kind.js';
 
 // ─── Result Interface ────────────────────────────────────────────────────────
 
@@ -416,6 +417,94 @@ export function classifyTask(
     boundaryTouching,
     verificationSequence: resolveGateSet('IMPLEMENT', { riskTier, boundaryTouching, config }),
   };
+}
+
+// ─── DR-7: Fail-Closed at the Gate-Set Boundary ─────────────────────────────
+//
+// `classifyTask` routes each task's verification sequence through
+// `resolveGateSet(kind, …)`. That resolver can THROW — a deferred kind whose
+// resolver is not yet wired ('not-yet-wired'), or any other resolver fault.
+// Mapping the wave with a raw `.map(classifyTask)` lets such a throw propagate
+// out of the dispatch handler and fail the dispatch OPEN / silently.
+//
+// DR-7 makes the boundary FAIL CLOSED: the entire wave's classification is run
+// inside one guard. On ANY resolver throw, NO task classifications are stamped
+// (all-or-nothing — a partially-classified wave would be a fail-open hazard),
+// and the wrapper returns a structured `blocked` result the handler turns into
+// a `phase.blocked` event + an error envelope. On success it returns the
+// stamped classifications unchanged.
+//
+// The boundary phase kind is always `IMPLEMENT` here (the delegate/wave-dispatch
+// boundary). The kind is surfaced on the result so every IMPLEMENT-kind phase
+// boundary that adopts this wrapper records the same diagnostic shape.
+
+/** The phase kind bound to the wave-dispatch boundary. */
+const DISPATCH_PHASE_KIND: PhaseKind = 'IMPLEMENT';
+
+/** Stable error code for a fail-closed gate-set boundary block. */
+export const PHASE_BLOCKED_CODE = 'PHASE_BLOCKED';
+
+/**
+ * The diagnostic payload of a fail-closed gate-set boundary block. Field shape
+ * matches the `phase.blocked` event schema (`event-store/schemas.ts`):
+ * `{ phase, kind, reason, error: { code, message } }`.
+ */
+export interface PhaseBlockedInfo {
+  readonly phase: string;
+  readonly kind: PhaseKind;
+  readonly reason: string;
+  readonly error: { readonly code: string; readonly message: string };
+}
+
+/**
+ * Discriminated result of the fail-closed classification boundary:
+ * - `{ ok: true, classifications }`  — every task classified cleanly.
+ * - `{ ok: false, blocked }`         — a resolver threw; nothing was stamped.
+ */
+export type ClassifyTasksResult =
+  | { readonly ok: true; readonly classifications: TaskClassification[] }
+  | { readonly ok: false; readonly blocked: PhaseBlockedInfo };
+
+/**
+ * Classify a whole wave of tasks at the gate-set boundary, FAILING CLOSED.
+ *
+ * Wraps the per-task {@link classifyTask} call (which routes through
+ * {@link resolveGateSet}) so a resolver throw never propagates out of the
+ * dispatch boundary. The guard is wave-wide and all-or-nothing: a single throw
+ * blocks the entire wave (no partial classification) and yields a
+ * {@link PhaseBlockedInfo} the caller records as a `phase.blocked` event.
+ *
+ * Pure: no I/O. The caller owns event emission and the response envelope.
+ *
+ * @param tasks the wave's tasks
+ * @param agentConfig resolved agent config (model routing)
+ * @param config resolved project config (verification overlay); absence is the
+ *   ordinary built-in-table path — it MUST NOT trigger a fail-closed block
+ * @param phase the lifecycle phase the dispatch is at (for the diagnostic)
+ */
+export function classifyTasksFailClosed(
+  tasks: readonly TaskInput[],
+  agentConfig: ResolvedProjectConfig['agents'] = DEFAULTS.agents,
+  config?: ResolvedProjectConfig,
+  phase = 'delegate',
+): ClassifyTasksResult {
+  try {
+    return {
+      ok: true,
+      classifications: tasks.map(t => classifyTask(t, agentConfig, config)),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      blocked: {
+        phase,
+        kind: DISPATCH_PHASE_KIND,
+        reason: `dispatch blocked: ${DISPATCH_PHASE_KIND} gate-set resolution failed — ${message}`,
+        error: { code: PHASE_BLOCKED_CODE, message },
+      },
+    };
+  }
 }
 
 // ─── Worktree Blocker Patterns ──────────────────────────────────────────────
@@ -1009,9 +1098,37 @@ export async function handlePrepareDelegation(
     // longer needed.
     const agentConfig = ctx?.projectConfig?.agents ?? DEFAULTS.agents;
     const projectConfig = ctx?.projectConfig;
-    const taskClassifications = args.tasks
-      ? args.tasks.map(t => classifyTask(t, agentConfig, projectConfig))
-      : undefined;
+
+    // DR-7: classify the wave through the fail-closed boundary. A resolver
+    // throw (e.g. a deferred-kind 'not-yet-wired' fault) no longer propagates
+    // and fails the dispatch OPEN; instead the boundary records `phase.blocked`
+    // and refuses to proceed (no task classifications stamped).
+    let taskClassifications: TaskClassification[] | undefined;
+    if (args.tasks) {
+      const classified = classifyTasksFailClosed(
+        args.tasks,
+        agentConfig,
+        projectConfig,
+        workflowState.phase ?? 'delegate',
+      );
+      if (!classified.ok) {
+        const { blocked } = classified;
+        await emitAuditEvent(store, streamId, {
+          type: 'phase.blocked',
+          data: {
+            phase: blocked.phase,
+            kind: blocked.kind,
+            reason: blocked.reason,
+            error: { code: blocked.error.code, message: blocked.error.message },
+          },
+        });
+        return {
+          success: false,
+          error: { code: PHASE_BLOCKED_CODE, message: blocked.reason },
+        };
+      }
+      taskClassifications = classified.classifications;
+    }
 
     const result: PrepareDelegationResult = {
       ready: true,

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -697,6 +697,33 @@ export async function handlePrepareDelegation(
     };
   }
 
+  // The MCP router hands `tasks` through an unchecked cast, so the declared
+  // `TaskInput[]` type is not a runtime guarantee. Validate the shape HERE with
+  // an explicit INVALID_INPUT — otherwise a malformed task throws downstream in
+  // computeScopedWorktrees / classifyTaskCore and surfaces as a misleading
+  // PREPARE_DELEGATION_FAILED or, worse, a fail-closed `phase.blocked` event.
+  // `phase.blocked` must stay reserved for genuine gate-set RESOLVER faults.
+  const tasksInput: unknown = args.tasks;
+  if (
+    tasksInput !== undefined &&
+    (!Array.isArray(tasksInput) ||
+      tasksInput.some(
+        (task) =>
+          task === null ||
+          typeof task !== 'object' ||
+          typeof (task as { id?: unknown }).id !== 'string' ||
+          typeof (task as { title?: unknown }).title !== 'string',
+      ))
+  ) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'tasks must be an array of objects each with a string id and string title',
+      },
+    };
+  }
+
   try {
     const materializer = getOrCreateMaterializer(stateDir);
     if (!ctx?.eventStore) {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -51,7 +51,7 @@ import {
 import type { CheckpointEnforcementConfig } from '../workflow/checkpoint.js';
 import { globToRegExp } from '../architecture/glob-to-regexp.js';
 import type { GateName } from '../workflow/verification-policy.js';
-import { resolveVerificationPolicy } from '../workflow/verification-policy-resolver.js';
+import { resolveGateSet } from '../workflow/phase-kind.js';
 
 // ─── Result Interface ────────────────────────────────────────────────────────
 
@@ -385,14 +385,18 @@ function classifyTaskCore(
  * verification-ladder fields:
  *   - `riskTier`           — {@link deriveRiskTier} (honors explicit override)
  *   - `boundaryTouching`   — {@link deriveBoundaryTouching} (honors override)
- *   - `verificationSequence` — {@link resolveVerificationPolicy} over the two
+ *   - `verificationSequence` — {@link resolveGateSet} for the IMPLEMENT kind
  *
- * vls1-b2 (task 003): the verification sequence is stamped from the
- * CONFIG-RESOLVED policy ({@link resolveVerificationPolicy}), not the frozen
- * built-in table directly. When `config` is omitted (or its relevant cell is
- * unset) the resolver delegates to the built-in table, so behavior is
- * byte-identical to the pre-config stamp. A `.exarchos.yml` `verification:`
- * cell override therefore changes what gets stamped onto the delegation record.
+ * task-004 (DR-4): the sequence is resolved by routing through
+ * {@link resolveGateSet} keyed on the IMPLEMENT *kind*, not by calling the
+ * verification-policy resolver directly. This makes the kind (not the
+ * `delegate` phase name) the binding, so every IMPLEMENT-kind phase resolves
+ * the same ladder by construction. The IMPLEMENT resolver delegates verbatim to
+ * the CONFIG-RESOLVED verification policy, so the stamp is byte-identical to the
+ * prior direct call: when `config` is omitted (or its relevant cell is unset)
+ * the policy falls through to the frozen built-in table, and a `.exarchos.yml`
+ * `verification:` cell override still changes what gets stamped onto the
+ * delegation record.
  *
  * The legacy `complexity`/`effort` axis is preserved unchanged — `riskTier` is
  * a SEPARATE, blast-radius-driven axis (a scaffolding task can be low-effort
@@ -410,7 +414,7 @@ export function classifyTask(
     ...core,
     riskTier,
     boundaryTouching,
-    verificationSequence: resolveVerificationPolicy(riskTier, boundaryTouching, config).sequence,
+    verificationSequence: resolveGateSet('IMPLEMENT', { riskTier, boundaryTouching, config }),
   };
 }
 

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -710,6 +710,9 @@ export async function handlePrepareDelegation(
   const tasksInput: unknown = args.tasks;
   const isOptionalStringArray = (v: unknown): boolean =>
     v === undefined || (Array.isArray(v) && v.every((x) => typeof x === 'string'));
+  const isOptionalOneOf = (v: unknown, allowed: readonly string[]): boolean =>
+    v === undefined || (typeof v === 'string' && allowed.includes(v));
+  const isOptionalBoolean = (v: unknown): boolean => v === undefined || typeof v === 'boolean';
   if (
     tasksInput !== undefined &&
     (!Array.isArray(tasksInput) ||
@@ -720,12 +723,23 @@ export async function handlePrepareDelegation(
           title?: unknown;
           files?: unknown;
           blockedBy?: unknown;
+          testLayer?: unknown;
+          riskTier?: unknown;
+          boundaryTouching?: unknown;
         };
+        // Validate EVERY planner-supplied field the heuristics / resolver consume,
+        // not just id/title: a bad `riskTier` reaches resolveVerificationSequence
+        // (BASE_SEQUENCE_BY_TIER[riskTier] → throw), and a non-array `files`
+        // crashes the risk/boundary heuristics — both would otherwise be caught by
+        // the fail-closed wrapper and misreported as `phase.blocked`.
         return (
           typeof t.id !== 'string' ||
           typeof t.title !== 'string' ||
           !isOptionalStringArray(t.files) ||
-          !isOptionalStringArray(t.blockedBy)
+          !isOptionalStringArray(t.blockedBy) ||
+          !isOptionalOneOf(t.testLayer, ['acceptance', 'integration', 'unit', 'property']) ||
+          !isOptionalOneOf(t.riskTier, ['low', 'medium', 'high']) ||
+          !isOptionalBoolean(t.boundaryTouching)
         );
       }))
   ) {
@@ -734,7 +748,7 @@ export async function handlePrepareDelegation(
       error: {
         code: 'INVALID_INPUT',
         message:
-          'tasks must be an array of objects each with a string id and title, plus optional string-array files and blockedBy',
+          'tasks must be an array of objects each with a string id and title; optional fields must be well-typed (files/blockedBy: string[]; testLayer: acceptance|integration|unit|property; riskTier: low|medium|high; boundaryTouching: boolean)',
       },
     };
   }

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -697,29 +697,44 @@ export async function handlePrepareDelegation(
     };
   }
 
-  // The MCP router hands `tasks` through an unchecked cast, so the declared
-  // `TaskInput[]` type is not a runtime guarantee. Validate the shape HERE with
-  // an explicit INVALID_INPUT — otherwise a malformed task throws downstream in
-  // computeScopedWorktrees / classifyTaskCore and surfaces as a misleading
+  // Non-MCP callers (CLI / direct / tests) hand `tasks` through an unchecked
+  // cast, so the declared `TaskInput[]` type is not a runtime guarantee. (The MCP
+  // adapter's registration schema strips unknown keys, but those paths do not.)
+  // Validate the shape HERE with an explicit INVALID_INPUT — otherwise a
+  // malformed task throws downstream in computeScopedWorktrees / classifyTaskCore
+  // (e.g. `files.some(...)` on a non-array `files`) and surfaces as a misleading
   // PREPARE_DELEGATION_FAILED or, worse, a fail-closed `phase.blocked` event.
-  // `phase.blocked` must stay reserved for genuine gate-set RESOLVER faults.
+  // `phase.blocked` must stay reserved for genuine gate-set RESOLVER faults, so
+  // the guard also covers the optional STRING-ARRAY fields the heuristics call
+  // array methods on (`files`, `blockedBy`), not just `id`/`title`.
   const tasksInput: unknown = args.tasks;
+  const isOptionalStringArray = (v: unknown): boolean =>
+    v === undefined || (Array.isArray(v) && v.every((x) => typeof x === 'string'));
   if (
     tasksInput !== undefined &&
     (!Array.isArray(tasksInput) ||
-      tasksInput.some(
-        (task) =>
-          task === null ||
-          typeof task !== 'object' ||
-          typeof (task as { id?: unknown }).id !== 'string' ||
-          typeof (task as { title?: unknown }).title !== 'string',
-      ))
+      tasksInput.some((task) => {
+        if (task === null || typeof task !== 'object') return true;
+        const t = task as {
+          id?: unknown;
+          title?: unknown;
+          files?: unknown;
+          blockedBy?: unknown;
+        };
+        return (
+          typeof t.id !== 'string' ||
+          typeof t.title !== 'string' ||
+          !isOptionalStringArray(t.files) ||
+          !isOptionalStringArray(t.blockedBy)
+        );
+      }))
   ) {
     return {
       success: false,
       error: {
         code: 'INVALID_INPUT',
-        message: 'tasks must be an array of objects each with a string id and string title',
+        message:
+          'tasks must be an array of objects each with a string id and title, plus optional string-array files and blockedBy',
       },
     };
   }

--- a/servers/exarchos-mcp/src/orchestrate/test-adequacy.handler.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/test-adequacy.handler.test.ts
@@ -129,10 +129,12 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
   });
 
   it('HandleOrchestrate_OneshotTestAdequacyFailure_ResolvesAdvisory', async () => {
-    // Task 005: an oneshot workflow's FAILING ladder gate (advisory carrier:
-    // success:true, data.passed:false) resolves to warning severity — the
-    // dispatch surfaces the failure as a NON-blocking advisory (success:true
-    // with a warning), threading the ACTUAL workflowType from workflow state.
+    // An oneshot workflow's FAILING ladder gate (advisory carrier: success:true,
+    // data.passed:false) resolves to a NON-blocking advisory (success:true with a
+    // warning), threading the ACTUAL workflowType from workflow state. Since DR-6
+    // oneshot:implementing is in audit mode, so the non-blocking reason is now
+    // attributed to audit mode rather than warning-severity; the invariant under
+    // test is the non-blocking advisory outcome, asserted by gate-name + success.
     const ctx = await makeCtx();
 
     // Seed an oneshot workflow into the event store so the dispatch resolver
@@ -163,9 +165,13 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
     );
 
     // Advisory resolution: NOT blocked — surfaced as success-with-warning.
+    // Assert the robust invariant (gate-failure surfaced, non-blocking) rather
+    // than the exact downgrade-reason phrasing, which is severity/mode-dependent.
     expect(result.success).toBe(true);
     expect(result.warnings).toEqual(
-      expect.arrayContaining([expect.stringContaining('warning-only')]),
+      expect.arrayContaining([
+        expect.stringContaining("Gate 'check_test_adequacy' failed"),
+      ]),
     );
   });
 

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -524,6 +524,29 @@ describe('TOOL_REGISTRY', () => {
     );
   });
 
+  // DR-7 (phase-kind binding, epic #1546): the phase-kind work — the closed
+  // PhaseKind union, the KIND_OBLIGATIONS grant-table, the gate-set resolver,
+  // and the fail-closed boundary that appends `phase.blocked` — is an internal
+  // verification-routing change. It MUST NOT grow the visible MCP tool surface
+  // (INV-5d) nor introduce a new top-level CLI verb (composite). This is a
+  // regression fence: the visible composite count and the exact visible-tool
+  // name set stay exactly what they were before phase-kind landed.
+  it('Registry_VisibleToolCount_UnchangedByPhaseKind', () => {
+    // exarchos_sync is the sole hidden composite; the four user-facing
+    // composites are the top-level CLI verbs / visible MCP tools.
+    const visibleTools = TOOL_REGISTRY.filter((t) => !t.hidden);
+    expect(visibleTools.length).toBe(4);
+    expect(visibleTools.length).toBeLessThanOrEqual(15);
+    expect(visibleTools.map((t) => t.name).sort()).toEqual([
+      'exarchos_event',
+      'exarchos_orchestrate',
+      'exarchos_view',
+      'exarchos_workflow',
+    ]);
+    // Phase-kind added no hidden composite either — the total stays at 5.
+    expect(TOOL_REGISTRY).toHaveLength(5);
+  });
+
   describe('exarchos_workflow', () => {
     it('should have 10 actions: init, get, transition, update, cancel, cleanup, reconcile, rehydrate, checkpoint, describe', () => {
       // T5a.1/DR-4 (#1259, v2.11): `set` action removed (hard-cut from the

--- a/servers/exarchos-mcp/src/workflow/hsm-definitions.kind.test.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-definitions.kind.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createFeatureHSM,
+  createDebugHSM,
+  createOneshotHSM,
+  createDiscoveryHSM,
+  createRefactorHSM,
+} from './hsm-definitions.js';
+import type { HSMDefinition, State } from './state-machine.js';
+import type { PhaseKind } from './phase-kind.js';
+
+// ─── Task 003 (DR-2): characterization of the kind-tag classification ────────
+//
+// These tests LOCK the current state → kind classification before any behavior
+// change (Feathers-style). The `kind` tag lives on the obligation layer; the
+// state names/transitions remain bespoke (INV-6 variation layer). Compound and
+// final states are exempt — only `type === 'atomic'` states carry a `kind`.
+
+const ALL_KINDS: readonly PhaseKind[] = ['IMPLEMENT', 'PLAN', 'REVIEW', 'SYNTHESIZE', 'GATHER'];
+
+const ALL_HSMS: Record<string, HSMDefinition> = {
+  feature: createFeatureHSM(),
+  debug: createDebugHSM(),
+  oneshot: createOneshotHSM(),
+  discovery: createDiscoveryHSM(),
+  refactor: createRefactorHSM(),
+};
+
+/** Read `kind` off a state without narrowing-induced compile coupling in tests. */
+function kindOf(state: State): string | undefined {
+  return (state as { kind?: string }).kind;
+}
+
+// The complete, locked state-id → kind classification per HSM (compound + final
+// states are intentionally absent — they carry no kind).
+const LOCKED_CLASSIFICATION: Record<string, Record<string, PhaseKind>> = {
+  feature: {
+    ideate: 'GATHER',
+    plan: 'PLAN',
+    'plan-review': 'PLAN',
+    delegate: 'IMPLEMENT',
+    review: 'REVIEW',
+    'merge-pending': 'SYNTHESIZE',
+    synthesize: 'SYNTHESIZE',
+    blocked: 'GATHER',
+  },
+  debug: {
+    triage: 'GATHER',
+    investigate: 'GATHER',
+    rca: 'PLAN',
+    design: 'PLAN',
+    'debug-implement': 'IMPLEMENT',
+    'debug-validate': 'REVIEW',
+    'debug-review': 'REVIEW',
+    'hotfix-implement': 'IMPLEMENT',
+    'hotfix-validate': 'REVIEW',
+    synthesize: 'SYNTHESIZE',
+    blocked: 'GATHER',
+  },
+  oneshot: {
+    plan: 'PLAN',
+    implementing: 'IMPLEMENT',
+    synthesize: 'SYNTHESIZE',
+  },
+  discovery: {
+    gathering: 'GATHER',
+    synthesizing: 'GATHER',
+  },
+  refactor: {
+    explore: 'GATHER',
+    brief: 'PLAN',
+    'polish-implement': 'IMPLEMENT',
+    'polish-validate': 'REVIEW',
+    'polish-update-docs': 'GATHER',
+    'overhaul-plan': 'PLAN',
+    'overhaul-plan-review': 'PLAN',
+    'overhaul-delegate': 'IMPLEMENT',
+    'overhaul-review': 'REVIEW',
+    'overhaul-update-docs': 'GATHER',
+    synthesize: 'SYNTHESIZE',
+    blocked: 'GATHER',
+  },
+};
+
+// The six implement snowflakes (DR-2): each lives in a different HSM/track but
+// all must resolve to the single IMPLEMENT kind so S2 reaches every one.
+const IMPLEMENT_SNOWFLAKES: ReadonlyArray<{ hsm: string; state: string }> = [
+  { hsm: 'feature', state: 'delegate' },
+  { hsm: 'refactor', state: 'overhaul-delegate' },
+  { hsm: 'debug', state: 'debug-implement' },
+  { hsm: 'debug', state: 'hotfix-implement' },
+  { hsm: 'refactor', state: 'polish-implement' },
+  { hsm: 'oneshot', state: 'implementing' },
+];
+
+describe('HsmStates kind tagging (DR-2)', () => {
+  it('HsmStates_EveryAtomicState_CarriesKind', () => {
+    for (const [hsmName, hsm] of Object.entries(ALL_HSMS)) {
+      for (const state of Object.values(hsm.states)) {
+        if (state.type !== 'atomic') continue;
+        const kind = kindOf(state);
+        expect(
+          ALL_KINDS.includes(kind as PhaseKind),
+          `${hsmName}.${state.id} kind '${String(kind)}' must be one of ${ALL_KINDS.join(', ')}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('HsmStates_ImplementSnowflakes_AllTaggedImplement', () => {
+    for (const { hsm, state } of IMPLEMENT_SNOWFLAKES) {
+      const s = ALL_HSMS[hsm].states[state];
+      expect(s, `${hsm}.${state} must exist`).toBeDefined();
+      expect(s.type, `${hsm}.${state} must be atomic`).toBe('atomic');
+      expect(kindOf(s), `${hsm}.${state} must be kind IMPLEMENT`).toBe('IMPLEMENT');
+    }
+  });
+
+  it('HsmStates_KindMap_MatchesLockedClassification', () => {
+    for (const [hsmName, expectedMap] of Object.entries(LOCKED_CLASSIFICATION)) {
+      const hsm = ALL_HSMS[hsmName];
+      const actualMap: Record<string, string | undefined> = {};
+      for (const state of Object.values(hsm.states)) {
+        if (state.type === 'atomic') {
+          actualMap[state.id] = kindOf(state);
+        }
+      }
+      expect(actualMap, `${hsmName} atomic state → kind map`).toEqual(expectedMap);
+    }
+  });
+
+  it('HsmStates_CompoundAndFinal_HaveNoKind', () => {
+    for (const [hsmName, hsm] of Object.entries(ALL_HSMS)) {
+      for (const state of Object.values(hsm.states)) {
+        if (state.type === 'atomic') continue;
+        expect(
+          Object.prototype.hasOwnProperty.call(state, 'kind'),
+          `${hsmName}.${state.id} (${state.type}) must NOT carry a kind`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
@@ -159,9 +159,9 @@ const mergePendingExit: Guard = {
 
 export function createFeatureHSM(): HSMDefinition {
   const states: Record<string, State> = {
-    ideate: { id: 'ideate', type: 'atomic' },
-    plan: { id: 'plan', type: 'atomic' },
-    'plan-review': { id: 'plan-review', type: 'atomic' },
+    ideate: { id: 'ideate', type: 'atomic', kind: 'GATHER' },
+    plan: { id: 'plan', type: 'atomic', kind: 'PLAN' },
+    'plan-review': { id: 'plan-review', type: 'atomic', kind: 'PLAN' },
     implementation: {
       id: 'implementation',
       type: 'compound',
@@ -170,8 +170,8 @@ export function createFeatureHSM(): HSMDefinition {
       onEntry: ['log'],
       onExit: ['log'],
     },
-    delegate: { id: 'delegate', type: 'atomic', parent: 'implementation' },
-    review: { id: 'review', type: 'atomic', parent: 'implementation' },
+    delegate: { id: 'delegate', type: 'atomic', kind: 'IMPLEMENT', parent: 'implementation' },
+    review: { id: 'review', type: 'atomic', kind: 'REVIEW', parent: 'implementation' },
     // T17: substate entered when a delegated subagent worktree task completes
     // and an autonomous merge is required before progressing. Exits back to
     // `delegate` once `merge.executed` / `merge.rollback` / `merge.aborted`
@@ -179,12 +179,13 @@ export function createFeatureHSM(): HSMDefinition {
     'merge-pending': {
       id: 'merge-pending',
       type: 'atomic',
+      kind: 'SYNTHESIZE',
       parent: 'implementation',
     },
-    synthesize: { id: 'synthesize', type: 'atomic' },
+    synthesize: { id: 'synthesize', type: 'atomic', kind: 'SYNTHESIZE' },
     completed: { id: 'completed', type: 'final' },
     cancelled: { id: 'cancelled', type: 'final' },
-    blocked: { id: 'blocked', type: 'atomic' },
+    blocked: { id: 'blocked', type: 'atomic', kind: 'GATHER' },
   };
 
   const transitions: Transition[] = [
@@ -231,8 +232,8 @@ export function createFeatureHSM(): HSMDefinition {
 
 export function createDebugHSM(): HSMDefinition {
   const states: Record<string, State> = {
-    triage: { id: 'triage', type: 'atomic' },
-    investigate: { id: 'investigate', type: 'atomic' },
+    triage: { id: 'triage', type: 'atomic', kind: 'GATHER' },
+    investigate: { id: 'investigate', type: 'atomic', kind: 'GATHER' },
 
     // Thorough track compound
     'thorough-track': {
@@ -243,21 +244,24 @@ export function createDebugHSM(): HSMDefinition {
       onEntry: ['log'],
       onExit: ['log'],
     },
-    rca: { id: 'rca', type: 'atomic', parent: 'thorough-track' },
-    design: { id: 'design', type: 'atomic', parent: 'thorough-track' },
+    rca: { id: 'rca', type: 'atomic', kind: 'PLAN', parent: 'thorough-track' },
+    design: { id: 'design', type: 'atomic', kind: 'PLAN', parent: 'thorough-track' },
     'debug-implement': {
       id: 'debug-implement',
       type: 'atomic',
+      kind: 'IMPLEMENT',
       parent: 'thorough-track',
     },
     'debug-validate': {
       id: 'debug-validate',
       type: 'atomic',
+      kind: 'REVIEW',
       parent: 'thorough-track',
     },
     'debug-review': {
       id: 'debug-review',
       type: 'atomic',
+      kind: 'REVIEW',
       parent: 'thorough-track',
     },
 
@@ -272,18 +276,20 @@ export function createDebugHSM(): HSMDefinition {
     'hotfix-implement': {
       id: 'hotfix-implement',
       type: 'atomic',
+      kind: 'IMPLEMENT',
       parent: 'hotfix-track',
     },
     'hotfix-validate': {
       id: 'hotfix-validate',
       type: 'atomic',
+      kind: 'REVIEW',
       parent: 'hotfix-track',
     },
 
-    synthesize: { id: 'synthesize', type: 'atomic' },
+    synthesize: { id: 'synthesize', type: 'atomic', kind: 'SYNTHESIZE' },
     completed: { id: 'completed', type: 'final' },
     cancelled: { id: 'cancelled', type: 'final' },
-    blocked: { id: 'blocked', type: 'atomic' },
+    blocked: { id: 'blocked', type: 'atomic', kind: 'GATHER' },
   };
 
   const transitions: Transition[] = [
@@ -366,9 +372,9 @@ export const oneshotTransitions: readonly Transition[] = [
 
 export function createOneshotHSM(): HSMDefinition {
   const states: Record<string, State> = {
-    plan: { id: 'plan', type: 'atomic' },
-    implementing: { id: 'implementing', type: 'atomic' },
-    synthesize: { id: 'synthesize', type: 'atomic' },
+    plan: { id: 'plan', type: 'atomic', kind: 'PLAN' },
+    implementing: { id: 'implementing', type: 'atomic', kind: 'IMPLEMENT' },
+    synthesize: { id: 'synthesize', type: 'atomic', kind: 'SYNTHESIZE' },
     completed: { id: 'completed', type: 'final' },
     cancelled: { id: 'cancelled', type: 'final' },
   };
@@ -380,8 +386,8 @@ export function createOneshotHSM(): HSMDefinition {
 
 export function createDiscoveryHSM(): HSMDefinition {
   const states: Record<string, State> = {
-    gathering:    { id: 'gathering', type: 'atomic' },
-    synthesizing: { id: 'synthesizing', type: 'atomic' },
+    gathering:    { id: 'gathering', type: 'atomic', kind: 'GATHER' },
+    synthesizing: { id: 'synthesizing', type: 'atomic', kind: 'GATHER' },
     completed:    { id: 'completed', type: 'final' },
     cancelled:    { id: 'cancelled', type: 'final' },
   };
@@ -398,8 +404,8 @@ export function createDiscoveryHSM(): HSMDefinition {
 
 export function createRefactorHSM(): HSMDefinition {
   const states: Record<string, State> = {
-    explore: { id: 'explore', type: 'atomic' },
-    brief: { id: 'brief', type: 'atomic' },
+    explore: { id: 'explore', type: 'atomic', kind: 'GATHER' },
+    brief: { id: 'brief', type: 'atomic', kind: 'PLAN' },
 
     // Polish track compound
     'polish-track': {
@@ -412,16 +418,19 @@ export function createRefactorHSM(): HSMDefinition {
     'polish-implement': {
       id: 'polish-implement',
       type: 'atomic',
+      kind: 'IMPLEMENT',
       parent: 'polish-track',
     },
     'polish-validate': {
       id: 'polish-validate',
       type: 'atomic',
+      kind: 'REVIEW',
       parent: 'polish-track',
     },
     'polish-update-docs': {
       id: 'polish-update-docs',
       type: 'atomic',
+      kind: 'GATHER',
       parent: 'polish-track',
     },
 
@@ -437,33 +446,38 @@ export function createRefactorHSM(): HSMDefinition {
     'overhaul-plan': {
       id: 'overhaul-plan',
       type: 'atomic',
+      kind: 'PLAN',
       parent: 'overhaul-track',
     },
     'overhaul-plan-review': {
       id: 'overhaul-plan-review',
       type: 'atomic',
+      kind: 'PLAN',
       parent: 'overhaul-track',
     },
     'overhaul-delegate': {
       id: 'overhaul-delegate',
       type: 'atomic',
+      kind: 'IMPLEMENT',
       parent: 'overhaul-track',
     },
     'overhaul-review': {
       id: 'overhaul-review',
       type: 'atomic',
+      kind: 'REVIEW',
       parent: 'overhaul-track',
     },
     'overhaul-update-docs': {
       id: 'overhaul-update-docs',
       type: 'atomic',
+      kind: 'GATHER',
       parent: 'overhaul-track',
     },
 
-    synthesize: { id: 'synthesize', type: 'atomic' },
+    synthesize: { id: 'synthesize', type: 'atomic', kind: 'SYNTHESIZE' },
     completed: { id: 'completed', type: 'final' },
     cancelled: { id: 'cancelled', type: 'final' },
-    blocked: { id: 'blocked', type: 'atomic' },
+    blocked: { id: 'blocked', type: 'atomic', kind: 'GATHER' },
   };
 
   const transitions: Transition[] = [

--- a/servers/exarchos-mcp/src/workflow/implement-reachability.test.ts
+++ b/servers/exarchos-mcp/src/workflow/implement-reachability.test.ts
@@ -1,0 +1,86 @@
+// ─── IMPLEMENT-kind reachability (DR-4 / epic #1546, slice S2) ───────────────
+//
+// The heart of the phase-kind binding: verification is an obligation of the
+// IMPLEMENT *kind*, not of the `delegate` phase name. These tests prove that
+// every implement-kind phase across every workflow type resolves the SAME
+// verification ladder as the canonical `delegate` boundary does — by
+// construction, because `resolveGateSet` keys on `kind` alone.
+//
+// Before DR-4, only the `delegate` / `overhaul-delegate` phases had a per-task
+// classification call site that stamped the ladder; the debug/hotfix/polish/
+// oneshot implement phases surfaced verification only through playbook prose
+// and so could not reach the integration-suite + boundary gates (#1537). The
+// kind binding closes that gap: any phase whose `kind` is `'IMPLEMENT'` resolves
+// the full ladder.
+
+import { describe, it, expect } from 'vitest';
+import { resolveGateSet, type ResolveGateSetCtx } from './phase-kind.js';
+import type { State, HSMDefinition } from './state-machine.js';
+import {
+  createFeatureHSM,
+  createDebugHSM,
+  createOneshotHSM,
+  createRefactorHSM,
+} from './hsm-definitions.js';
+
+/**
+ * Narrow an HSM state to the atomic variant so its `kind` is accessible. Throws
+ * (failing the test loudly) if the named state is missing or not atomic — both
+ * would silently void the kind guarantee this suite exists to prove.
+ */
+function atomicState(hsm: HSMDefinition, id: string): Extract<State, { type: 'atomic' }> {
+  const state = hsm.states[id];
+  expect(state, `state '${id}' must exist in HSM '${hsm.id}'`).toBeDefined();
+  expect(state?.type, `state '${id}' must be atomic`).toBe('atomic');
+  // Narrowed by the assertion above; re-narrow for the type system.
+  if (state === undefined || state.type !== 'atomic') {
+    throw new Error(`state '${id}' is not an atomic state`);
+  }
+  return state;
+}
+
+describe('IMPLEMENT-kind reachability (DR-4)', () => {
+  // The six implement-kind phases and the factory each is declared in. Only
+  // IMPLEMENT phases belong here — every one must resolve the delegate ladder.
+  const implementPhases: ReadonlyArray<{
+    readonly phase: string;
+    readonly hsm: HSMDefinition;
+  }> = [
+    { phase: 'delegate', hsm: createFeatureHSM() },
+    { phase: 'overhaul-delegate', hsm: createRefactorHSM() },
+    { phase: 'debug-implement', hsm: createDebugHSM() },
+    { phase: 'hotfix-implement', hsm: createDebugHSM() },
+    { phase: 'polish-implement', hsm: createRefactorHSM() },
+    { phase: 'implementing', hsm: createOneshotHSM() },
+  ];
+
+  it('ImplementPhases_AllResolveTheSameLadderAsDelegate', () => {
+    // A representative medium / non-boundary context — the same profile the
+    // delegate boundary resolves through `resolveGateSet('IMPLEMENT', …)`.
+    const ctx: ResolveGateSetCtx = { riskTier: 'medium', boundaryTouching: false };
+    const delegateLadder = resolveGateSet('IMPLEMENT', ctx);
+
+    for (const { phase, hsm } of implementPhases) {
+      const state = atomicState(hsm, phase);
+
+      // First the kind itself — the binding surface.
+      expect(state.kind, `${phase} kind`).toBe('IMPLEMENT');
+
+      // Then the resolved sequence: keyed on the phase's own kind, it must match
+      // the canonical delegate ladder cell-for-cell.
+      expect(resolveGateSet(state.kind, ctx), `${phase} ladder`).toEqual(delegateLadder);
+    }
+  });
+
+  it('ImplementPhases_HighTierBoundary_IncludesIntegrationAndBoundaryGates', () => {
+    // The #1537 win: a high-risk, boundary-touching IMPLEMENT phase reaches the
+    // integration-suite + boundary gates. Because every implement phase resolves
+    // the IMPLEMENT kind, the debug/refactor implement phases now reach these
+    // gates too — not just `delegate`.
+    const ladder = resolveGateSet('IMPLEMENT', { riskTier: 'high', boundaryTouching: true });
+
+    expect(ladder).toContain('check_integration_suite');
+    expect(ladder).toContain('check_contract_drift');
+    expect(ladder).toContain('check_mock_boundary');
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { KIND_OBLIGATIONS } from './phase-kind.js';
+
+describe('KIND_OBLIGATIONS', () => {
+  it('KindObligations_EveryKind_HasARow', () => {
+    expect(Object.keys(KIND_OBLIGATIONS).sort()).toEqual([
+      'GATHER',
+      'IMPLEMENT',
+      'PLAN',
+      'REVIEW',
+      'SYNTHESIZE',
+    ]);
+  });
+
+  it('KindObligations_ImplementRow_PointsAtVerificationLadder', () => {
+    expect(KIND_OBLIGATIONS.IMPLEMENT.gates?.resolver).toBe('verification-ladder');
+  });
+
+  it('KindObligations_GatherRow_HasNullGates', () => {
+    expect(KIND_OBLIGATIONS.GATHER.gates).toBeNull();
+  });
+
+  it('KindObligations_ReviewRow_IsReadOnly', () => {
+    expect(KIND_OBLIGATIONS.REVIEW.posture).toBe('read-only');
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { KIND_OBLIGATIONS } from './phase-kind.js';
+import { KIND_OBLIGATIONS, resolveGateSet } from './phase-kind.js';
+import { resolveVerificationPolicy } from './verification-policy-resolver.js';
+import type { RiskTier } from './verification-policy.js';
 
 describe('KIND_OBLIGATIONS', () => {
   it('KindObligations_EveryKind_HasARow', () => {
@@ -22,5 +24,34 @@ describe('KIND_OBLIGATIONS', () => {
 
   it('KindObligations_ReviewRow_IsReadOnly', () => {
     expect(KIND_OBLIGATIONS.REVIEW.posture).toBe('read-only');
+  });
+});
+
+describe('resolveGateSet', () => {
+  const RISK_TIERS: readonly RiskTier[] = ['low', 'medium', 'high'];
+  const BOUNDARY_VALUES: readonly boolean[] = [false, true];
+
+  it('ResolveGateSet_Implement_MatchesVerificationPolicy', () => {
+    // No config → builtin path; the IMPLEMENT cell must be behavior-identical to
+    // the verification policy resolver across all six (riskTier × boundary) cells.
+    for (const riskTier of RISK_TIERS) {
+      for (const boundaryTouching of BOUNDARY_VALUES) {
+        expect(resolveGateSet('IMPLEMENT', { riskTier, boundaryTouching })).toEqual(
+          resolveVerificationPolicy(riskTier, boundaryTouching).sequence,
+        );
+      }
+    }
+  });
+
+  it('ResolveGateSet_Gather_ReturnsEmpty', () => {
+    expect(resolveGateSet('GATHER', { riskTier: 'low', boundaryTouching: false })).toEqual([]);
+  });
+
+  it('ResolveGateSet_InertResolver_ThrowsNotYetWired', () => {
+    for (const kind of ['PLAN', 'REVIEW', 'SYNTHESIZE'] as const) {
+      expect(() => resolveGateSet(kind, { riskTier: 'low', boundaryTouching: false })).toThrow(
+        /not wired|S3/,
+      );
+    }
   });
 });

--- a/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
@@ -54,4 +54,23 @@ describe('resolveGateSet', () => {
       );
     }
   });
+
+  // DR-7: the fail-closed guard must distinguish a genuine resolver error from
+  // the ordinary "no config supplied" path. With NO `config` in ctx, the
+  // IMPLEMENT resolver MUST fall through to the frozen built-in table and
+  // resolve cleanly across every (riskTier × boundary) cell — it must NOT
+  // throw. Only a real resolver fault is allowed to fail the dispatch closed.
+  it('ResolveGateSet_NoConfigOverride_FallsBackToBaseTable', () => {
+    for (const riskTier of RISK_TIERS) {
+      for (const boundaryTouching of BOUNDARY_VALUES) {
+        // No `config` field at all in ctx — the absent-config path.
+        const ctx = { riskTier, boundaryTouching };
+        expect(() => resolveGateSet('IMPLEMENT', ctx)).not.toThrow();
+        // The resolved sequence is the byte-identical built-in table cell.
+        expect(resolveGateSet('IMPLEMENT', ctx)).toEqual(
+          resolveVerificationPolicy(riskTier, boundaryTouching).sequence,
+        );
+      }
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/workflow/phase-kind.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.ts
@@ -32,8 +32,20 @@ export type PhaseKind = 'IMPLEMENT' | 'PLAN' | 'REVIEW' | 'SYNTHESIZE' | 'GATHER
  *   shape is stable, but **inert** in this layer: it is not yet wired to a
  *   capability bundle.
  */
+/**
+ * The closed set of gate-resolver names. Typing `gates.resolver` as this union
+ * (not `string`) makes a resolver typo in `KIND_OBLIGATIONS` — or a name with no
+ * `GATE_RESOLVERS` entry — a COMPILE error instead of a runtime-only fault, so
+ * the table and the resolver registry cannot drift apart silently.
+ */
+export type GateResolverName =
+  | 'verification-ladder'
+  | 'plan-structure'
+  | 'review-contract'
+  | 'synthesis-readiness';
+
 export interface PhaseObligations {
-  readonly gates: { readonly resolver: string } | null;
+  readonly gates: { readonly resolver: GateResolverName } | null;
   readonly posture: 'read-only' | 'task-isolated' | 'shared-mutating';
 }
 
@@ -80,7 +92,7 @@ export interface ResolveGateSetCtx {
  * runtime path.
  */
 const GATE_RESOLVERS: Readonly<
-  Record<string, (ctx: ResolveGateSetCtx) => readonly GateName[]>
+  Record<GateResolverName, (ctx: ResolveGateSetCtx) => readonly GateName[]>
 > = Object.freeze({
   'verification-ladder': (ctx) =>
     resolveVerificationPolicy(ctx.riskTier, ctx.boundaryTouching, ctx.config).sequence,

--- a/servers/exarchos-mcp/src/workflow/phase-kind.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.ts
@@ -10,6 +10,10 @@
 // INV-6 GUARD: no workflow names / phase ids / transitions here — only
 // kind-universal obligations. (The resolver wiring lives in later tasks.)
 
+import { resolveVerificationPolicy } from './verification-policy-resolver.js';
+import { type GateName, type RiskTier } from './verification-policy.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
 /**
  * The closed set of phase kinds. Adding or removing a member is a breaking
  * change that must be reflected in `KIND_OBLIGATIONS` (enforced by the
@@ -47,3 +51,75 @@ export const KIND_OBLIGATIONS = {
   SYNTHESIZE: { gates: { resolver: 'synthesis-readiness' }, posture: 'shared-mutating' },
   GATHER: { gates: null, posture: 'read-only' },
 } as const satisfies Record<PhaseKind, PhaseObligations>;
+
+// ─── Gate-Set Resolver (kind → ordered gate sequence) ───────────────────────
+//
+// Behavior-neutral dispatch from a phase kind to its ordered gate sequence. The
+// kind layer holds no gate logic of its own: it reads the kind's `gates.resolver`
+// name from `KIND_OBLIGATIONS` and dispatches to a named resolver. In this slice
+// only `'verification-ladder'` (IMPLEMENT) is wired — it delegates verbatim to
+// `resolveVerificationPolicy`, so an IMPLEMENT boundary resolves to EXACTLY the
+// same sequence it does today (proven cell-by-cell in the test). The remaining
+// resolver names are registered but inert; wiring them is deferred to S3.
+
+/** Context a gate resolver needs to compute the sequence for a phase. */
+export interface ResolveGateSetCtx {
+  readonly riskTier: RiskTier;
+  readonly boundaryTouching: boolean;
+  readonly config?: ResolvedProjectConfig;
+}
+
+/**
+ * Named gate-resolver registry, keyed by the `gates.resolver` string in
+ * `KIND_OBLIGATIONS`. Centralising dispatch here keeps the kind layer
+ * extensible for S3: wiring a deferred kind is replacing its thrower entry,
+ * not editing `resolveGateSet`'s control flow.
+ *
+ * The inert entries fail LOUD on purpose — they are never reached at an
+ * IMPLEMENT boundary in S1/S2, so any call is a wiring mistake, not a valid
+ * runtime path.
+ */
+const GATE_RESOLVERS: Readonly<
+  Record<string, (ctx: ResolveGateSetCtx) => readonly GateName[]>
+> = Object.freeze({
+  'verification-ladder': (ctx) =>
+    resolveVerificationPolicy(ctx.riskTier, ctx.boundaryTouching, ctx.config).sequence,
+  'plan-structure': () => {
+    throw new Error("resolveGateSet: resolver 'plan-structure' is not wired yet (deferred to S3)");
+  },
+  'review-contract': () => {
+    throw new Error("resolveGateSet: resolver 'review-contract' is not wired yet (deferred to S3)");
+  },
+  'synthesis-readiness': () => {
+    throw new Error(
+      "resolveGateSet: resolver 'synthesis-readiness' is not wired yet (deferred to S3)",
+    );
+  },
+});
+
+/**
+ * Resolve the ordered gate sequence a phase of the given `kind` must run.
+ *
+ * Pure and synchronous: it does NO I/O. The verification ladder reads config
+ * from the `ResolvedProjectConfig` the caller threads through `ctx`, never the
+ * filesystem.
+ *
+ * @param kind the phase kind whose obligations to resolve
+ * @param ctx  the task profile (risk tier, boundary-touching) plus optional
+ *             resolved project config for the verification overlay
+ * @returns the ordered gate sequence, or `[]` for a kind with no gates (GATHER)
+ */
+export function resolveGateSet(kind: PhaseKind, ctx: ResolveGateSetCtx): readonly GateName[] {
+  const gates = KIND_OBLIGATIONS[kind].gates;
+  if (gates === null) {
+    return [];
+  }
+
+  const resolver = GATE_RESOLVERS[gates.resolver];
+  if (resolver === undefined) {
+    // Defensive default: a `gates.resolver` name with no registry entry is a
+    // table/registry desync, not a valid runtime state.
+    throw new Error(`resolveGateSet: unknown resolver '${gates.resolver}'`);
+  }
+  return resolver(ctx);
+}

--- a/servers/exarchos-mcp/src/workflow/phase-kind.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.ts
@@ -1,0 +1,49 @@
+// ─── Phase-Kind Obligation Layer (single grant-point) ───────────────────────
+//
+// A closed `PhaseKind` union and a frozen `KIND_OBLIGATIONS` table — the one
+// place where kind-universal obligations are granted. The table is keyed only
+// by kind, never by workflow type, phase id, or transition. This is INV-6
+// (workload-agnosticism) made type-level: an obligation attaches to the *kind*,
+// so it composes across every workflow type — present and future — without new
+// playbook code. See `docs/designs/2026-06-16-phase-kind-binding.md` (DR-1).
+//
+// INV-6 GUARD: no workflow names / phase ids / transitions here — only
+// kind-universal obligations. (The resolver wiring lives in later tasks.)
+
+/**
+ * The closed set of phase kinds. Adding or removing a member is a breaking
+ * change that must be reflected in `KIND_OBLIGATIONS` (enforced by the
+ * `satisfies Record<PhaseKind, …>` constraint below).
+ */
+export type PhaseKind = 'IMPLEMENT' | 'PLAN' | 'REVIEW' | 'SYNTHESIZE' | 'GATHER';
+
+/**
+ * The obligations granted to a phase by virtue of its kind.
+ *
+ * - `gates`  — the gate-resolver binding for this kind, or `null` when the kind
+ *   carries no verification gates (e.g. GATHER). The `resolver` is a name the
+ *   gate-set resolver dispatches on (wired in a later task); the kind layer
+ *   itself holds no resolver logic.
+ * - `posture` — the execution posture for the kind. Declared now so the table
+ *   shape is stable, but **inert** in this layer: it is not yet wired to a
+ *   capability bundle.
+ */
+export interface PhaseObligations {
+  readonly gates: { readonly resolver: string } | null;
+  readonly posture: 'read-only' | 'task-isolated' | 'shared-mutating';
+}
+
+/**
+ * The single grant-point: one obligation row per phase kind.
+ *
+ * `satisfies Record<PhaseKind, PhaseObligations>` is load-bearing — removing a
+ * kind row (or adding a kind without a row) is a COMPILE error, which keeps the
+ * union and the table exhaustively in lock-step.
+ */
+export const KIND_OBLIGATIONS = {
+  IMPLEMENT: { gates: { resolver: 'verification-ladder' }, posture: 'task-isolated' },
+  PLAN: { gates: { resolver: 'plan-structure' }, posture: 'read-only' },
+  REVIEW: { gates: { resolver: 'review-contract' }, posture: 'read-only' },
+  SYNTHESIZE: { gates: { resolver: 'synthesis-readiness' }, posture: 'shared-mutating' },
+  GATHER: { gates: null, posture: 'read-only' },
+} as const satisfies Record<PhaseKind, PhaseObligations>;

--- a/servers/exarchos-mcp/src/workflow/playbooks.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.test.ts
@@ -818,3 +818,49 @@ describe('PlaybookDelegatePhase_GateGuidance_SourcedFromVerificationPolicy', () 
     expect(playbook.compactGuidance).toContain(contractDrift!);
   });
 });
+
+// ─── Task 005: implement-phase mandatory-TDD prose removed (DR-5) ────────────
+
+describe('Task 005: implement-phase mandatory-TDD prose removed (DR-5)', () => {
+  // The four work-implement phases an agent actually occupies while implementing.
+  // (delegate / overhaul-delegate are dispatch phases — their check_tdd_compliance
+  // gate-running guidance is orchestrator-facing and intentionally retained.)
+  const IMPLEMENT_WORK_PHASES = [
+    { wf: 'debug', phase: 'debug-implement', transition: 'debug-validate', escalation: true },
+    { wf: 'debug', phase: 'hotfix-implement', transition: 'hotfix-validate', escalation: true },
+    { wf: 'refactor', phase: 'polish-implement', transition: 'polish-validate', escalation: true },
+    { wf: 'oneshot', phase: 'implementing', transition: 'synthesize', escalation: false },
+  ] as const;
+
+  // The verification obligation now flows from the kind resolver (Task 004),
+  // not from hardcoded test-first prose baked into the playbook string.
+  const MANDATORY_TDD_PROSE =
+    /write failing test first|fixing without a failing test|TDD rules remain mandatory|Follow TDD/i;
+
+  it('Playbooks_ImplementPhases_NoMandatoryTddProse', () => {
+    for (const { wf, phase } of IMPLEMENT_WORK_PHASES) {
+      const playbook = getPlaybook(wf, phase);
+      expect(playbook, `${wf}:${phase} playbook should exist`).not.toBeNull();
+      expect(
+        MANDATORY_TDD_PROSE.test(playbook!.compactGuidance),
+        `${wf}:${phase} still carries hardcoded mandatory-TDD prose`,
+      ).toBe(false);
+    }
+  });
+
+  it('Playbooks_ImplementPhases_RetainTransitionAndEscalation', () => {
+    for (const { wf, phase, transition, escalation } of IMPLEMENT_WORK_PHASES) {
+      const playbook = getPlaybook(wf, phase)!;
+      expect(
+        playbook.transitionCriteria,
+        `${wf}:${phase} should retain its transition target`,
+      ).toContain(transition);
+      if (escalation) {
+        expect(
+          playbook.compactGuidance,
+          `${wf}:${phase} should retain its escalation rule`,
+        ).toMatch(/Escalate/i);
+      }
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -725,7 +725,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are implementing the fix based on the design. Use exarchos_workflow update to record implementation progress. Follow TDD — write failing test first, then implement fix. Transition to debug-validate when implementation is complete. Key decision: test-first verification — the failing test must reproduce the exact bug before writing the fix. Anti-pattern: fixing without a failing test that reproduces the bug. Escalate: implementation touches >5 files, consider splitting.',
+    'You are implementing the fix based on the design. Use exarchos_workflow update to record implementation progress. Verification is risk-proportional — apply the gate ladder resolved for this phase (by task risk tier and boundary), reproducing the bug at a depth that matches its blast radius. Transition to debug-validate when implementation is complete. Key decision: match verification depth to the blast radius of the bug. Anti-pattern: shipping a fix without a regression check proportionate to its risk. Escalate: implementation touches >5 files, consider splitting.',
 });
 
 register({
@@ -788,7 +788,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are implementing a hotfix. Use exarchos_workflow update to record implementation progress. This is the fast-track — apply minimal targeted fix within a 15-minute time budget. Transition to hotfix-validate when implementation is complete. Key decision: stay minimal and targeted within the time budget. Anti-pattern: hotfix growing into a full fix — if scope expands, switch to thorough track via rca. Escalate: time limit exceeded without a working fix.',
+    'You are implementing a hotfix. Use exarchos_workflow update to record implementation progress. This is the fast-track — apply minimal targeted fix within a 15-minute time budget. Verification is risk-proportional: apply the resolved gate ladder for this phase, kept minimal to fit the time budget. Transition to hotfix-validate when implementation is complete. Key decision: stay minimal and targeted within the time budget. Anti-pattern: hotfix growing into a full fix — if scope expands, switch to thorough track via rca. Escalate: time limit exceeded without a working fix.',
 });
 
 register({
@@ -952,7 +952,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are implementing polish-track refactoring changes directly. Use exarchos_workflow update to record progress. Follow TDD if changing behavior. Stay within brief scope. Transition to polish-validate when implementation is complete. Key decision: stay strictly within the brief scope for each change. Anti-pattern: scope creep beyond the brief — resist adding improvements not in the brief. Escalate: changes cascade beyond the declared scope, consider switching to overhaul track.',
+    'You are implementing polish-track refactoring changes directly. Use exarchos_workflow update to record progress. Verification is risk-proportional — apply the gate ladder resolved for this phase to any behavior change, sized to the risk of the change. Stay within brief scope. Transition to polish-validate when implementation is complete. Key decision: stay strictly within the brief scope for each change. Anti-pattern: scope creep beyond the brief — resist adding improvements not in the brief. Escalate: changes cascade beyond the declared scope, consider switching to overhaul track.',
 });
 
 register({
@@ -1285,7 +1285,7 @@ export const oneshotPlaybook: readonly PhasePlaybook[] = [
     validationScripts: [],
     humanCheckpoint: false,
     compactGuidance:
-      'In-session TDD implementation for a oneshot workflow. Write failing test first, then implement, then refactor — TDD rules remain mandatory. After tests pass, the main agent resolves the choice state using pure guards over (synthesisPolicy, synthesize.requested events). If opting into the synthesize path at runtime, append a synthesize.requested event via exarchos_event append. The HSM evaluates the choice state on the next transition attempt. Follow the oneshot-workflow skill for the full procedure.',
+      'In-session implementation for a oneshot workflow. Verification is risk-proportional — apply the gate ladder resolved for this phase (advisory severity for oneshot), sized to the risk of the change. After the resolved checks pass, the main agent resolves the choice state using pure guards over (synthesisPolicy, synthesize.requested events). If opting into the synthesize path at runtime, append a synthesize.requested event via exarchos_event append. The HSM evaluates the choice state on the next transition attempt. Follow the oneshot-workflow skill for the full procedure.',
   },
   {
     phase: 'synthesize',

--- a/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -1,5 +1,6 @@
 import type { Guard, GuardResult } from './guards.js';
 import { guards } from './guards.js';
+import type { PhaseKind } from './phase-kind.js';
 import {
   createFeatureHSM,
   createDebugHSM,
@@ -15,15 +16,24 @@ export type { Guard, GuardResult };
 
 export type Effect = 'checkpoint' | 'log' | 'increment-fix-cycle';
 
-export interface State {
+// All shared/optional fields live on the base so existing `.initial` /
+// `.maxFixCycles` / `.parent` reads keep compiling without narrowing. Only the
+// `atomic` variant carries `kind` — an atomic state literal without `kind` is a
+// COMPILE error (DR-2), while compound/final states are exempt (they have no
+// kind in the obligation layer). See docs/designs/2026-06-16-phase-kind-binding.md.
+interface StateBase {
   readonly id: string;
-  readonly type: 'atomic' | 'compound' | 'final';
   readonly parent?: string;
   readonly initial?: string;
   readonly onEntry?: readonly Effect[];
   readonly onExit?: readonly Effect[];
   readonly maxFixCycles?: number;
 }
+
+export type State =
+  | (StateBase & { readonly type: 'atomic'; readonly kind: PhaseKind })
+  | (StateBase & { readonly type: 'compound' })
+  | (StateBase & { readonly type: 'final' });
 
 export interface Transition {
   readonly from: string;
@@ -292,10 +302,13 @@ function convertToHSM(name: string, definition: WorkflowDefinition): HSMDefiniti
     baseTransitions = [...parent.transitions];
   }
 
-  // Add custom phases as atomic states
+  // Add custom phases as atomic states. A user-defined phase carries no
+  // inherent kind, so it defaults to GATHER — the only kind whose obligation
+  // row has `gates: null`, i.e. no kind-driven verification gates. This is
+  // behavior-neutral: custom phases never had kind-driven gates before DR-2.
   for (const phase of definition.phases) {
     if (!baseStates[phase]) {
-      baseStates[phase] = { id: phase, type: 'atomic' };
+      baseStates[phase] = { id: phase, type: 'atomic', kind: 'GATHER' };
     }
   }
 


### PR DESCRIPTION
## Summary

Phase-kind binding (epic #1546, slices S1+S2 / #1547 + #1548). Phases were "snowflakes": the verification ladder reached only 2 of 5 implement phases. This binds every phase to a `PhaseKind` and resolves verification obligations from a frozen kind→obligations table at the phase boundary, so all IMPLEMENT-kind phases inherit the same ladder by construction.

Implements DR-1..DR-7. Defers **S3** (#1549, PLAN/REVIEW/SYNTHESIZE resolver wiring) and **S4** (#1550, POLA capability bundle + resolve-then-freeze events) — the `posture` field is authored but inert; deferred-kind resolvers throw `not-yet-wired`.

## Changes

- **DR-1** — `PhaseKind` union + frozen `KIND_OBLIGATIONS` table (`workflow/phase-kind.ts`). INV-6: no workflow/phase/transition literals in the kind module; exhaustiveness via `as const satisfies Record<PhaseKind, …>`.
- **DR-2** — `State` is now a discriminated union; every atomic HSM state is kind-tagged (an untagged atomic state is a compile error). Zero transition/guard/next_actions behavior change.
- **DR-3** — `resolveGateSet('IMPLEMENT', ctx)` delegates to the verification ladder, byte-identical across every (riskTier × boundaryTouching) cell; `GATHER → []`; deferred resolvers throw.
- **DR-4** — every IMPLEMENT phase boundary routes through `resolveGateSet` via `classifyTask`; reachability proven for delegate / debug-implement / hotfix-implement / polish-implement / oneshot:implementing.
- **DR-5** — removed hardcoded mandatory test-first prose from the 4 work-implement playbooks → risk-proportional ladder language; transition targets + escalation retained (guarded by a prose test).
- **DR-6** — per-workflow severity + audit→enforce `mode` (`IMPLEMENT_PHASE_MODE`: oneshot→audit, feature/debug/refactor→enforce); reuses the `.exarchos.yml review.gates.*` override; kept out of `KIND_OBLIGATIONS` (INV-6).
- **DR-7** — fail-closed at the gate-set boundary: a resolver throw appends a new `phase.blocked` event and refuses to proceed (all-or-nothing, no partial classification); absent config falls back to the frozen base table; visible MCP tool count + CLI verbs unchanged.

## Test Plan

- MCP server suite: **7640 passed / 0 failed**; root workspace suite: **828 passed / 0 failed**; `tsc --noEmit` clean.
- New coverage: kind-table exhaustiveness, full state→kind characterization map, tier×boundary parity matrix, IMPLEMENT reachability across all 6 phases, playbook prose guard, per-workflow severity + audit mode (incl. the no-config path), fail-closed `phase.blocked` boundary, and a registry visible-tool-count regression fence.
- Two-stage review: spec **PASS** (7/7 DRs MET; 2 LOW cosmetic), quality **PASS** (2 MEDIUM found and fixed — DR-6 audit-mode was intended config-independent but gated behind `!config`; fixed with regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
