### PR TITLE
refactor(shepherd): make address-all-feedback + invariant-anchoring the default

### DIFF
--- a/commands/shepherd.md
+++ b/commands/shepherd.md
@@ -19,6 +19,15 @@ This command operates as an **iteration loop within the synthesize phase**. The 
 
 Follow the shepherd skill: `@skills/shepherd/SKILL.md`
 
+## Default Objective
+
+`/exarchos:shepherd` (with no extra instructions) already does two things by default — appending them to the invocation is redundant:
+
+1. **Address all feedback on the PR.** Every CI failure, `CHANGES_REQUESTED` review, and inline comment — including minor/nit-level — is fixed and/or replied to. Approval is requested only once every thread has a response. See the skill's *Default Objective*.
+2. **Apply `.exarchos/invariants.md` when evaluating changes.** Before composing fixes, each change is anchored to the architectural invariant catalog (see Step 2, devCatalog-gated).
+
+So `/exarchos:shepherd address all feedback; when evaluating changes, apply .exarchos/invariants.md` is equivalent to plain `/exarchos:shepherd`.
+
 ## Prerequisites
 
 - [ ] Active workflow with PRs published
@@ -54,13 +63,15 @@ mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
 
 Act on the `recommendation`:
 - `fix-and-resubmit` — Proceed to Step 2
-- `request-approval` — Skip to Step 4
+- `request-approval` — Skip to Step 4 **only if every `comment-reply` item is addressed**; otherwise treat as `fix-and-resubmit` and address remaining comments first (see Default Objective). The recommendation is advisory — it forces `fix-and-resubmit` only on critical/major items.
 - `wait` — Inform user, pause, re-assess after delay
 - `escalate` — Report to user with escalation context
 
 ### Step 2: Fix Issues
 
-Address each `actionItem` from the assessment:
+**Constraints (evaluation-time).** Before composing any change, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each change against them. This is the shepherd evaluation-time equivalent of `/exarchos:ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly.
+
+Address each `actionItem` from the assessment (every inline comment — including minor — gets a fix and/or reply; see Default Objective):
 - `ci-fix` — Read CI logs, reproduce locally, fix, commit
 - `comment-reply` — Read context, compose response, post via GitHub MCP
 - `review-address` — Fix code for CHANGES_REQUESTED, reply to each thread

--- a/skills-src/brainstorming/references/constraint-anchoring.md
+++ b/skills-src/brainstorming/references/constraint-anchoring.md
@@ -1,8 +1,8 @@
-# Constraint anchoring — design-time Constraints selection rules
+# Constraint anchoring — Constraints selection rules (design-time and evaluation-time)
 
-This is the **single source of truth** for the design-time "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), and `/debug` (rca + design phases). Each design-time surface loads this reference rather than duplicating the selection rules.
+This is the **single source of truth** for the "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), `/debug` (rca + design phases), and `/shepherd` (when evaluating PR feedback and composing fixes). Each surface loads this reference rather than duplicating the selection rules.
 
-**Goal:** Surface the architectural invariants relevant to the proposal *before* committing to an approach, so the design is anchored to load-bearing constraints from the first turn.
+**Goal:** Surface the architectural invariants relevant to the work *before* committing to an approach or a change, so it is anchored to load-bearing constraints rather than re-discovering them mid-flight. Design-time surfaces (`/ideate`, `/refactor`, `/debug`) anchor the *proposal* before choosing an approach; `/shepherd` anchors the *changes it composes to address feedback* — same selection rules and devCatalog gating, applied at evaluation time instead of design time.
 
 ## Source of truth
 
@@ -28,7 +28,7 @@ The catalog tags every entry with a `cost-of-load` field. It governs whether an 
 | Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
 | Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
 
-## Emit format (before the clarifying / brief / design step)
+## Emit format (before the clarifying / brief / design step — or, for `/shepherd`, before composing fixes)
 
 ```markdown
 ## Constraints

--- a/skills-src/shepherd/SKILL.md
+++ b/skills-src/shepherd/SKILL.md
@@ -29,6 +29,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `{{MCP_PREFIX}}exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `{{COMMAND_PREFIX}}ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/skills/claude/brainstorming/references/constraint-anchoring.md
+++ b/skills/claude/brainstorming/references/constraint-anchoring.md
@@ -1,8 +1,8 @@
-# Constraint anchoring — design-time Constraints selection rules
+# Constraint anchoring — Constraints selection rules (design-time and evaluation-time)
 
-This is the **single source of truth** for the design-time "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), and `/debug` (rca + design phases). Each design-time surface loads this reference rather than duplicating the selection rules.
+This is the **single source of truth** for the "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), `/debug` (rca + design phases), and `/shepherd` (when evaluating PR feedback and composing fixes). Each surface loads this reference rather than duplicating the selection rules.
 
-**Goal:** Surface the architectural invariants relevant to the proposal *before* committing to an approach, so the design is anchored to load-bearing constraints from the first turn.
+**Goal:** Surface the architectural invariants relevant to the work *before* committing to an approach or a change, so it is anchored to load-bearing constraints rather than re-discovering them mid-flight. Design-time surfaces (`/ideate`, `/refactor`, `/debug`) anchor the *proposal* before choosing an approach; `/shepherd` anchors the *changes it composes to address feedback* — same selection rules and devCatalog gating, applied at evaluation time instead of design time.
 
 ## Source of truth
 
@@ -28,7 +28,7 @@ The catalog tags every entry with a `cost-of-load` field. It governs whether an 
 | Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
 | Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
 
-## Emit format (before the clarifying / brief / design step)
+## Emit format (before the clarifying / brief / design step — or, for `/shepherd`, before composing fixes)
 
 ```markdown
 ## Constraints

--- a/skills/claude/shepherd/SKILL.md
+++ b/skills/claude/shepherd/SKILL.md
@@ -29,6 +29,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `mcp__plugin_exarchos_exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `/exarchos:ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/skills/codex/brainstorming/references/constraint-anchoring.md
+++ b/skills/codex/brainstorming/references/constraint-anchoring.md
@@ -1,8 +1,8 @@
-# Constraint anchoring — design-time Constraints selection rules
+# Constraint anchoring — Constraints selection rules (design-time and evaluation-time)
 
-This is the **single source of truth** for the design-time "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), and `/debug` (rca + design phases). Each design-time surface loads this reference rather than duplicating the selection rules.
+This is the **single source of truth** for the "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), `/debug` (rca + design phases), and `/shepherd` (when evaluating PR feedback and composing fixes). Each surface loads this reference rather than duplicating the selection rules.
 
-**Goal:** Surface the architectural invariants relevant to the proposal *before* committing to an approach, so the design is anchored to load-bearing constraints from the first turn.
+**Goal:** Surface the architectural invariants relevant to the work *before* committing to an approach or a change, so it is anchored to load-bearing constraints rather than re-discovering them mid-flight. Design-time surfaces (`/ideate`, `/refactor`, `/debug`) anchor the *proposal* before choosing an approach; `/shepherd` anchors the *changes it composes to address feedback* — same selection rules and devCatalog gating, applied at evaluation time instead of design time.
 
 ## Source of truth
 
@@ -28,7 +28,7 @@ The catalog tags every entry with a `cost-of-load` field. It governs whether an 
 | Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
 | Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
 
-## Emit format (before the clarifying / brief / design step)
+## Emit format (before the clarifying / brief / design step — or, for `/shepherd`, before composing fixes)
 
 ```markdown
 ## Constraints

--- a/skills/codex/shepherd/SKILL.md
+++ b/skills/codex/shepherd/SKILL.md
@@ -29,6 +29,16 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/skills/copilot/brainstorming/references/constraint-anchoring.md
+++ b/skills/copilot/brainstorming/references/constraint-anchoring.md
@@ -1,8 +1,8 @@
-# Constraint anchoring — design-time Constraints selection rules
+# Constraint anchoring — Constraints selection rules (design-time and evaluation-time)
 
-This is the **single source of truth** for the design-time "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), and `/debug` (rca + design phases). Each design-time surface loads this reference rather than duplicating the selection rules.
+This is the **single source of truth** for the "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), `/debug` (rca + design phases), and `/shepherd` (when evaluating PR feedback and composing fixes). Each surface loads this reference rather than duplicating the selection rules.
 
-**Goal:** Surface the architectural invariants relevant to the proposal *before* committing to an approach, so the design is anchored to load-bearing constraints from the first turn.
+**Goal:** Surface the architectural invariants relevant to the work *before* committing to an approach or a change, so it is anchored to load-bearing constraints rather than re-discovering them mid-flight. Design-time surfaces (`/ideate`, `/refactor`, `/debug`) anchor the *proposal* before choosing an approach; `/shepherd` anchors the *changes it composes to address feedback* — same selection rules and devCatalog gating, applied at evaluation time instead of design time.
 
 ## Source of truth
 
@@ -28,7 +28,7 @@ The catalog tags every entry with a `cost-of-load` field. It governs whether an 
 | Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
 | Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
 
-## Emit format (before the clarifying / brief / design step)
+## Emit format (before the clarifying / brief / design step — or, for `/shepherd`, before composing fixes)
 
 ```markdown
 ## Constraints

--- a/skills/copilot/shepherd/SKILL.md
+++ b/skills/copilot/shepherd/SKILL.md
@@ -29,6 +29,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `/ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/skills/cursor/brainstorming/references/constraint-anchoring.md
+++ b/skills/cursor/brainstorming/references/constraint-anchoring.md
@@ -1,8 +1,8 @@
-# Constraint anchoring — design-time Constraints selection rules
+# Constraint anchoring — Constraints selection rules (design-time and evaluation-time)
 
-This is the **single source of truth** for the design-time "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), and `/debug` (rca + design phases). Each design-time surface loads this reference rather than duplicating the selection rules.
+This is the **single source of truth** for the "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), `/debug` (rca + design phases), and `/shepherd` (when evaluating PR feedback and composing fixes). Each surface loads this reference rather than duplicating the selection rules.
 
-**Goal:** Surface the architectural invariants relevant to the proposal *before* committing to an approach, so the design is anchored to load-bearing constraints from the first turn.
+**Goal:** Surface the architectural invariants relevant to the work *before* committing to an approach or a change, so it is anchored to load-bearing constraints rather than re-discovering them mid-flight. Design-time surfaces (`/ideate`, `/refactor`, `/debug`) anchor the *proposal* before choosing an approach; `/shepherd` anchors the *changes it composes to address feedback* — same selection rules and devCatalog gating, applied at evaluation time instead of design time.
 
 ## Source of truth
 
@@ -28,7 +28,7 @@ The catalog tags every entry with a `cost-of-load` field. It governs whether an 
 | Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
 | Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
 
-## Emit format (before the clarifying / brief / design step)
+## Emit format (before the clarifying / brief / design step — or, for `/shepherd`, before composing fixes)
 
 ```markdown
 ## Constraints

--- a/skills/cursor/shepherd/SKILL.md
+++ b/skills/cursor/shepherd/SKILL.md
@@ -29,6 +29,16 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/skills/generic/brainstorming/references/constraint-anchoring.md
+++ b/skills/generic/brainstorming/references/constraint-anchoring.md
@@ -1,8 +1,8 @@
-# Constraint anchoring — design-time Constraints selection rules
+# Constraint anchoring — Constraints selection rules (design-time and evaluation-time)
 
-This is the **single source of truth** for the design-time "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), and `/debug` (rca + design phases). Each design-time surface loads this reference rather than duplicating the selection rules.
+This is the **single source of truth** for the "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), `/debug` (rca + design phases), and `/shepherd` (when evaluating PR feedback and composing fixes). Each surface loads this reference rather than duplicating the selection rules.
 
-**Goal:** Surface the architectural invariants relevant to the proposal *before* committing to an approach, so the design is anchored to load-bearing constraints from the first turn.
+**Goal:** Surface the architectural invariants relevant to the work *before* committing to an approach or a change, so it is anchored to load-bearing constraints rather than re-discovering them mid-flight. Design-time surfaces (`/ideate`, `/refactor`, `/debug`) anchor the *proposal* before choosing an approach; `/shepherd` anchors the *changes it composes to address feedback* — same selection rules and devCatalog gating, applied at evaluation time instead of design time.
 
 ## Source of truth
 
@@ -28,7 +28,7 @@ The catalog tags every entry with a `cost-of-load` field. It governs whether an 
 | Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
 | Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
 
-## Emit format (before the clarifying / brief / design step)
+## Emit format (before the clarifying / brief / design step — or, for `/shepherd`, before composing fixes)
 
 ```markdown
 ## Constraints

--- a/skills/generic/shepherd/SKILL.md
+++ b/skills/generic/shepherd/SKILL.md
@@ -29,6 +29,16 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/skills/opencode/brainstorming/references/constraint-anchoring.md
+++ b/skills/opencode/brainstorming/references/constraint-anchoring.md
@@ -1,8 +1,8 @@
-# Constraint anchoring — design-time Constraints selection rules
+# Constraint anchoring — Constraints selection rules (design-time and evaluation-time)
 
-This is the **single source of truth** for the design-time "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), and `/debug` (rca + design phases). Each design-time surface loads this reference rather than duplicating the selection rules.
+This is the **single source of truth** for the "Constraints" step shared by `/ideate` (Phase 0), `/refactor` (brief phase), `/debug` (rca + design phases), and `/shepherd` (when evaluating PR feedback and composing fixes). Each surface loads this reference rather than duplicating the selection rules.
 
-**Goal:** Surface the architectural invariants relevant to the proposal *before* committing to an approach, so the design is anchored to load-bearing constraints from the first turn.
+**Goal:** Surface the architectural invariants relevant to the work *before* committing to an approach or a change, so it is anchored to load-bearing constraints rather than re-discovering them mid-flight. Design-time surfaces (`/ideate`, `/refactor`, `/debug`) anchor the *proposal* before choosing an approach; `/shepherd` anchors the *changes it composes to address feedback* — same selection rules and devCatalog gating, applied at evaluation time instead of design time.
 
 ## Source of truth
 
@@ -28,7 +28,7 @@ The catalog tags every entry with a `cost-of-load` field. It governs whether an 
 | Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
 | Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
 
-## Emit format (before the clarifying / brief / design step)
+## Emit format (before the clarifying / brief / design step — or, for `/shepherd`, before composing fixes)
 
 ```markdown
 ## Constraints

--- a/skills/opencode/shepherd/SKILL.md
+++ b/skills/opencode/shepherd/SKILL.md
@@ -29,6 +29,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `/ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/test/migration/__fixtures__/batch-baselines/shepherd.md
+++ b/test/migration/__fixtures__/batch-baselines/shepherd.md
@@ -29,6 +29,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every `CHANGES_REQUESTED` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+`assess_stack` is advisory: its `computeRecommendation` only forces `fix-and-resubmit` on critical/major items, so it can return `request-approval` while minor `comment-reply` items remain. **Do not treat that as license to skip them** — only request approval once every `comment-reply` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When `mcp__plugin_exarchos_exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -88,12 +98,14 @@ Review the returned `actionItems` and `recommendation`:
 
 | Recommendation | Action |
 |----------------|--------|
-| `request-approval` | Skip to Step 4 |
+| `request-approval` | Skip to Step 4 **only if every `comment-reply` item is addressed**. If any inline comment is still unaddressed, treat as `fix-and-resubmit` and address it first (see [Default Objective](#default-objective)). |
 | `fix-and-resubmit` | Proceed to Step 2 |
 | `wait` | Inform user, pause, re-assess after delay |
 | `escalate` | See `references/escalation-criteria.md` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load `.exarchos/invariants.md` (entries marked `cost-of-load: always-load`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of `/exarchos:ideate`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: `@skills/brainstorming/references/constraint-anchoring.md`. **devCatalog-gated:** when `.exarchos.yml: invariants.devCatalog: enabled` is unset or `disabled`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply `.exarchos/invariants.md`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call `classify_review_items` on
@@ -175,6 +187,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When `assess_stack` returns `recommendation: 'request-approval'` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining `comment-reply` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    ```
@@ -272,6 +286,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use `assess_stack` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because `assess_stack` said `request-approval` | Address every `comment-reply` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to `.exarchos/invariants.md` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit `remediation.attempted` / `remediation.succeeded` for every fix |
 | Push directly to main | All fixes go through stack branches |

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -4017,6 +4017,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every \`CHANGES_REQUESTED\` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+\`assess_stack\` is advisory: its \`computeRecommendation\` only forces \`fix-and-resubmit\` on critical/major items, so it can return \`request-approval\` while minor \`comment-reply\` items remain. **Do not treat that as license to skip them** — only request approval once every \`comment-reply\` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When \`mcp__plugin_exarchos_exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -4076,12 +4086,14 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 | Recommendation | Action |
 |----------------|--------|
-| \`request-approval\` | Skip to Step 4 |
+| \`request-approval\` | Skip to Step 4 **only if every \`comment-reply\` item is addressed**. If any inline comment is still unaddressed, treat as \`fix-and-resubmit\` and address it first (see [Default Objective](#default-objective)). |
 | \`fix-and-resubmit\` | Proceed to Step 2 |
 | \`wait\` | Inform user, pause, re-assess after delay |
 | \`escalate\` | See \`references/escalation-criteria.md\` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load \`.exarchos/invariants.md\` (entries marked \`cost-of-load: always-load\`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of \`/exarchos:ideate\`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: \`@skills/brainstorming/references/constraint-anchoring.md\`. **devCatalog-gated:** when \`.exarchos.yml: invariants.devCatalog: enabled\` is unset or \`disabled\`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply \`.exarchos/invariants.md\`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call \`classify_review_items\` on
@@ -4163,6 +4175,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When \`assess_stack\` returns \`recommendation: 'request-approval'\` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining \`comment-reply\` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    \`\`\`
@@ -4260,6 +4274,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use \`assess_stack\` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because \`assess_stack\` said \`request-approval\` | Address every \`comment-reply\` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to \`.exarchos/invariants.md\` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit \`remediation.attempted\` / \`remediation.succeeded\` for every fix |
 | Push directly to main | All fixes go through stack branches |
@@ -9091,6 +9107,16 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every \`CHANGES_REQUESTED\` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+\`assess_stack\` is advisory: its \`computeRecommendation\` only forces \`fix-and-resubmit\` on critical/major items, so it can return \`request-approval\` while minor \`comment-reply\` items remain. **Do not treat that as license to skip them** — only request approval once every \`comment-reply\` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -9150,12 +9176,14 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 | Recommendation | Action |
 |----------------|--------|
-| \`request-approval\` | Skip to Step 4 |
+| \`request-approval\` | Skip to Step 4 **only if every \`comment-reply\` item is addressed**. If any inline comment is still unaddressed, treat as \`fix-and-resubmit\` and address it first (see [Default Objective](#default-objective)). |
 | \`fix-and-resubmit\` | Proceed to Step 2 |
 | \`wait\` | Inform user, pause, re-assess after delay |
 | \`escalate\` | See \`references/escalation-criteria.md\` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load \`.exarchos/invariants.md\` (entries marked \`cost-of-load: always-load\`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of \`ideate\`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: \`@skills/brainstorming/references/constraint-anchoring.md\`. **devCatalog-gated:** when \`.exarchos.yml: invariants.devCatalog: enabled\` is unset or \`disabled\`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply \`.exarchos/invariants.md\`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call \`classify_review_items\` on
@@ -9237,6 +9265,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When \`assess_stack\` returns \`recommendation: 'request-approval'\` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining \`comment-reply\` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    \`\`\`
@@ -9334,6 +9364,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use \`assess_stack\` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because \`assess_stack\` said \`request-approval\` | Address every \`comment-reply\` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to \`.exarchos/invariants.md\` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit \`remediation.attempted\` / \`remediation.succeeded\` for every fix |
 | Push directly to main | All fixes go through stack branches |
@@ -14157,6 +14189,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every \`CHANGES_REQUESTED\` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+\`assess_stack\` is advisory: its \`computeRecommendation\` only forces \`fix-and-resubmit\` on critical/major items, so it can return \`request-approval\` while minor \`comment-reply\` items remain. **Do not treat that as license to skip them** — only request approval once every \`comment-reply\` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -14216,12 +14258,14 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 | Recommendation | Action |
 |----------------|--------|
-| \`request-approval\` | Skip to Step 4 |
+| \`request-approval\` | Skip to Step 4 **only if every \`comment-reply\` item is addressed**. If any inline comment is still unaddressed, treat as \`fix-and-resubmit\` and address it first (see [Default Objective](#default-objective)). |
 | \`fix-and-resubmit\` | Proceed to Step 2 |
 | \`wait\` | Inform user, pause, re-assess after delay |
 | \`escalate\` | See \`references/escalation-criteria.md\` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load \`.exarchos/invariants.md\` (entries marked \`cost-of-load: always-load\`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of \`/ideate\`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: \`@skills/brainstorming/references/constraint-anchoring.md\`. **devCatalog-gated:** when \`.exarchos.yml: invariants.devCatalog: enabled\` is unset or \`disabled\`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply \`.exarchos/invariants.md\`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call \`classify_review_items\` on
@@ -14303,6 +14347,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When \`assess_stack\` returns \`recommendation: 'request-approval'\` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining \`comment-reply\` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    \`\`\`
@@ -14400,6 +14446,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use \`assess_stack\` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because \`assess_stack\` said \`request-approval\` | Address every \`comment-reply\` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to \`.exarchos/invariants.md\` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit \`remediation.attempted\` / \`remediation.succeeded\` for every fix |
 | Push directly to main | All fixes go through stack branches |
@@ -19233,6 +19281,16 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every \`CHANGES_REQUESTED\` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+\`assess_stack\` is advisory: its \`computeRecommendation\` only forces \`fix-and-resubmit\` on critical/major items, so it can return \`request-approval\` while minor \`comment-reply\` items remain. **Do not treat that as license to skip them** — only request approval once every \`comment-reply\` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -19292,12 +19350,14 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 | Recommendation | Action |
 |----------------|--------|
-| \`request-approval\` | Skip to Step 4 |
+| \`request-approval\` | Skip to Step 4 **only if every \`comment-reply\` item is addressed**. If any inline comment is still unaddressed, treat as \`fix-and-resubmit\` and address it first (see [Default Objective](#default-objective)). |
 | \`fix-and-resubmit\` | Proceed to Step 2 |
 | \`wait\` | Inform user, pause, re-assess after delay |
 | \`escalate\` | See \`references/escalation-criteria.md\` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load \`.exarchos/invariants.md\` (entries marked \`cost-of-load: always-load\`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of \`ideate\`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: \`@skills/brainstorming/references/constraint-anchoring.md\`. **devCatalog-gated:** when \`.exarchos.yml: invariants.devCatalog: enabled\` is unset or \`disabled\`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply \`.exarchos/invariants.md\`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call \`classify_review_items\` on
@@ -19379,6 +19439,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When \`assess_stack\` returns \`recommendation: 'request-approval'\` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining \`comment-reply\` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    \`\`\`
@@ -19476,6 +19538,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use \`assess_stack\` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because \`assess_stack\` said \`request-approval\` | Address every \`comment-reply\` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to \`.exarchos/invariants.md\` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit \`remediation.attempted\` / \`remediation.succeeded\` for every fix |
 | Push directly to main | All fixes go through stack branches |
@@ -24280,6 +24344,16 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every \`CHANGES_REQUESTED\` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+\`assess_stack\` is advisory: its \`computeRecommendation\` only forces \`fix-and-resubmit\` on critical/major items, so it can return \`request-approval\` while minor \`comment-reply\` items remain. **Do not treat that as license to skip them** — only request approval once every \`comment-reply\` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -24339,12 +24413,14 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 | Recommendation | Action |
 |----------------|--------|
-| \`request-approval\` | Skip to Step 4 |
+| \`request-approval\` | Skip to Step 4 **only if every \`comment-reply\` item is addressed**. If any inline comment is still unaddressed, treat as \`fix-and-resubmit\` and address it first (see [Default Objective](#default-objective)). |
 | \`fix-and-resubmit\` | Proceed to Step 2 |
 | \`wait\` | Inform user, pause, re-assess after delay |
 | \`escalate\` | See \`references/escalation-criteria.md\` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load \`.exarchos/invariants.md\` (entries marked \`cost-of-load: always-load\`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of \`ideate\`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: \`@skills/brainstorming/references/constraint-anchoring.md\`. **devCatalog-gated:** when \`.exarchos.yml: invariants.devCatalog: enabled\` is unset or \`disabled\`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply \`.exarchos/invariants.md\`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call \`classify_review_items\` on
@@ -24426,6 +24502,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When \`assess_stack\` returns \`recommendation: 'request-approval'\` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining \`comment-reply\` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    \`\`\`
@@ -24523,6 +24601,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use \`assess_stack\` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because \`assess_stack\` said \`request-approval\` | Address every \`comment-reply\` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to \`.exarchos/invariants.md\` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit \`remediation.attempted\` / \`remediation.succeeded\` for every fix |
 | Push directly to main | All fixes go through stack branches |
@@ -29354,6 +29434,16 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Default Objective
+
+By default, shepherd seeks to **address every piece of feedback on the PR** — appending "address all feedback" to the invocation is redundant, because it is the default, not an opt-in. Each iteration drives toward zero outstanding items across all three feedback channels:
+
+- **CI / checks** — every failing or pending check is fixed or resolved.
+- **Formal reviews** — every \`CHANGES_REQUESTED\` review is addressed.
+- **Inline comments** — every inline review comment (human, CodeRabbit, Sentry, bots) gets a fix and/or a reply, **regardless of severity**. A minor or nit-level comment is still feedback: address it, or reply explaining why it is intentionally declined. The goal is that a human scanning the PR sees **every** thread has a response.
+
+\`assess_stack\` is advisory: its \`computeRecommendation\` only forces \`fix-and-resubmit\` on critical/major items, so it can return \`request-approval\` while minor \`comment-reply\` items remain. **Do not treat that as license to skip them** — only request approval once every \`comment-reply\` action item is addressed (fix or reply). "Address all feedback" is the standing default.
+
 ## Pipeline Hygiene
 
 When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
@@ -29413,12 +29503,14 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 | Recommendation | Action |
 |----------------|--------|
-| \`request-approval\` | Skip to Step 4 |
+| \`request-approval\` | Skip to Step 4 **only if every \`comment-reply\` item is addressed**. If any inline comment is still unaddressed, treat as \`fix-and-resubmit\` and address it first (see [Default Objective](#default-objective)). |
 | \`fix-and-resubmit\` | Proceed to Step 2 |
 | \`wait\` | Inform user, pause, re-assess after delay |
 | \`escalate\` | See \`references/escalation-criteria.md\` |
 
 ### Step 2 — Fix
+
+**Anchor every change to the invariant catalog (evaluation-time Constraints).** Before composing any code fix, load \`.exarchos/invariants.md\` (entries marked \`cost-of-load: always-load\`) and surface a **Constraints** section naming the invariants the fix must preserve, then probe each proposed change against them. This is the shepherd evaluation-time equivalent of \`/ideate\`'s Phase 0 and uses the **same single shared source of truth** for the selection rules and devCatalog gating: \`@skills/brainstorming/references/constraint-anchoring.md\`. **devCatalog-gated:** when \`.exarchos.yml: invariants.devCatalog: enabled\` is unset or \`disabled\`, surface no Constraints section and fix directly. This makes "when evaluating changes, apply \`.exarchos/invariants.md\`" the default — there is no need to request it per invocation.
 
 Before iterating over individual action items, classify them so the loop
 knows which to fix inline vs. delegate. Call \`classify_review_items\` on
@@ -29500,6 +29592,8 @@ Return to Step 1 for the next iteration. Track iteration count against the limit
 ### Step 4 — Request Approval
 
 When \`assess_stack\` returns \`recommendation: 'request-approval'\` (all checks green, all comments addressed):
+
+> **Guard:** Confirm there are no remaining \`comment-reply\` action items before requesting approval. Per the [Default Objective](#default-objective), every inline comment — including minor/nit-level — must be addressed first. If any remain, return to Step 2 instead of requesting approval.
 
 1. Request review via GitHub MCP:
    \`\`\`
@@ -29597,6 +29691,8 @@ This runbook provides structured criteria for deciding whether to keep iterating
 | Poll CI/reviews directly | Use \`assess_stack\` composite action |
 | Force-merge with failing CI | Fix the failures first |
 | Ignore inline comments | Address every thread with a reply |
+| Skip minor/nit comments because \`assess_stack\` said \`request-approval\` | Address every \`comment-reply\` item first — the recommendation is advisory (see Default Objective) |
+| Compose fixes without checking invariants | Anchor each change to \`.exarchos/invariants.md\` (Step 2, devCatalog-gated) |
 | Loop indefinitely | Respect iteration limits, escalate |
 | Skip remediation events | Emit \`remediation.attempted\` / \`remediation.succeeded\` for every fix |
 | Push directly to main | All fixes go through stack branches |


### PR DESCRIPTION
## Summary

Makes shepherd's two implicit behaviors explicit defaults so that
`/exarchos:shepherd address all feedback; when evaluating changes, apply .exarchos/invariants.md`
is **redundant** with plain `/exarchos:shepherd`:

1. **Address all feedback** — every CI failure, `CHANGES_REQUESTED` review, and inline comment (**regardless of severity**) is fixed and/or replied to before approval is requested.
2. **Apply `.exarchos/invariants.md` when evaluating changes** — fixes are anchored to the invariant catalog at fix time, mirroring `/ideate` Phase 0 (`devCatalog`-gated).

Prompt-level only (the "mirror `/ideate`" reading) — **no behavioral TS changes**; `assess-stack.ts` is untouched. Where the code recommendation is too lax (`computeRecommendation` only forces `fix-and-resubmit` on critical/major), the gap is bridged at the prompt level via Step 1 / Step 4 guards.

## Changes

- **`skills-src/brainstorming/references/constraint-anchoring.md`** — adds `/shepherd` as the 4th consumer of the shared invariant-anchoring source of truth (alongside `/ideate`, `/refactor`, `/debug`); generalizes framing from design-time to **design-time and evaluation-time** (shepherd anchors the changes it composes to address feedback, same selection rules + `devCatalog` gating).
- **`skills-src/shepherd/SKILL.md`** —
  - New `## Default Objective` section (address all feedback, all three channels).
  - New evaluation-time **Constraints** step in Step 2 (Fix), `devCatalog`-gated.
  - Step 1 recommendation table + Step 4 guard: do not request approval while any `comment-reply` item is unaddressed.
  - Two new anti-pattern rows.
- **`commands/shepherd.md`** — `## Default Objective` (with the explicit "this == plain `/exarchos:shepherd`" equivalence), Step 2 Constraints block, Step 1 `request-approval` guard.
- **Generated/test artifacts** — regenerated `skills/<runtime>/{shepherd,brainstorming}/…` (6 runtimes) via `npm run build:skills`; updated `test/migration/__snapshots__/snapshots.test.ts.snap` (`vitest -u`) and the frozen `test/migration/__fixtures__/batch-baselines/shepherd.md` fixture.

## Test Plan

- [x] `npm run build:skills` — idempotent; change scope limited to shepherd + constraint-anchoring
- [x] `npm run typecheck` — clean (no TS changed)
- [x] `npx vitest run migration skills-guard` — **178/178 pass, 114 snapshots matched**
- [x] `skills:guard` drift check — green once source + regenerated `skills/` are committed together (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
