### PR TITLE
fix(agents): structural worktree-isolation boundary — root-fix #1301

### DIFF
--- a/.codex/agents/fixer.toml
+++ b/.codex/agents/fixer.toml
@@ -102,7 +102,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.codex/agents/fixer.toml
+++ b/.codex/agents/fixer.toml
@@ -102,6 +102,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -102,7 +102,7 @@ the worktree.
 {{requirements}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -102,6 +102,7 @@ the worktree.
 {{requirements}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.codex/agents/scaffolder.toml
+++ b/.codex/agents/scaffolder.toml
@@ -99,6 +99,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/.codex/agents/scaffolder.toml
+++ b/.codex/agents/scaffolder.toml
@@ -99,7 +99,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/.cursor/agents/fixer.md
+++ b/.cursor/agents/fixer.md
@@ -81,7 +81,7 @@ NOT rebase or reset to self-heal; the orchestrator owns base correction.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.cursor/agents/fixer.md
+++ b/.cursor/agents/fixer.md
@@ -81,6 +81,7 @@ NOT rebase or reset to self-heal; the orchestrator owns base correction.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -81,6 +81,7 @@ NOT rebase or reset to self-heal; the orchestrator owns base correction.
 {{requirements}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -81,7 +81,7 @@ NOT rebase or reset to self-heal; the orchestrator owns base correction.
 {{requirements}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.cursor/agents/scaffolder.md
+++ b/.cursor/agents/scaffolder.md
@@ -78,6 +78,7 @@ NOT rebase or reset to self-heal; the orchestrator owns base correction.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/.cursor/agents/scaffolder.md
+++ b/.cursor/agents/scaffolder.md
@@ -78,7 +78,7 @@ NOT rebase or reset to self-heal; the orchestrator owns base correction.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/.github/agents/fixer.agent.md
+++ b/.github/agents/fixer.agent.md
@@ -129,6 +129,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.github/agents/fixer.agent.md
+++ b/.github/agents/fixer.agent.md
@@ -129,7 +129,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -129,6 +129,7 @@ the worktree.
 {{requirements}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -129,7 +129,7 @@ the worktree.
 {{requirements}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.github/agents/scaffolder.agent.md
+++ b/.github/agents/scaffolder.agent.md
@@ -127,6 +127,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/.github/agents/scaffolder.agent.md
+++ b/.github/agents/scaffolder.agent.md
@@ -127,7 +127,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -145,6 +145,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -145,7 +145,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/.opencode/agents/implementer.md
+++ b/.opencode/agents/implementer.md
@@ -145,7 +145,7 @@ the worktree.
 {{requirements}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.opencode/agents/implementer.md
+++ b/.opencode/agents/implementer.md
@@ -145,6 +145,7 @@ the worktree.
 {{requirements}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/.opencode/agents/scaffolder.md
+++ b/.opencode/agents/scaffolder.md
@@ -143,6 +143,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/.opencode/agents/scaffolder.md
+++ b/.opencode/agents/scaffolder.md
@@ -143,7 +143,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -141,7 +141,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -28,6 +28,11 @@ mcpServers:
 skills:
   - tdd-patterns
 hooks:
+  PreToolUse:
+    - matcher: Write|Edit|MultiEdit|NotebookEdit
+      hooks:
+        - type: command
+          command: exarchos verify-worktree-boundary
   PostToolUse:
     - matcher: Bash
       hooks:

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -141,6 +141,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -30,6 +30,11 @@ skills:
   - tdd-patterns
   - testing-patterns
 hooks:
+  PreToolUse:
+    - matcher: Write|Edit|MultiEdit|NotebookEdit
+      hooks:
+        - type: command
+          command: exarchos verify-worktree-boundary
   PostToolUse:
     - matcher: Bash
       hooks:

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -143,6 +143,7 @@ the worktree.
 {{requirements}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -143,7 +143,7 @@ the worktree.
 {{requirements}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -25,6 +25,12 @@ disallowedTools:
 isolation: worktree
 mcpServers:
   - exarchos
+hooks:
+  PreToolUse:
+    - matcher: Write|Edit|MultiEdit|NotebookEdit
+      hooks:
+        - type: command
+          command: exarchos verify-worktree-boundary
 ---
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -131,6 +131,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -131,7 +131,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/docs/rca/2026-06-21-worktree-isolation-write-leak.md
+++ b/docs/rca/2026-06-21-worktree-isolation-write-leak.md
@@ -1,0 +1,119 @@
+# RCA: Worktree-isolation write leak — implementer edits land in the main worktree (#1301, root fix)
+
+**Date:** 2026-06-21
+**Issue:** #1301 (mirroring leak) — root-cause + structural fix
+**Workflow:** `debug-worktree-isolation-leak` (thorough track)
+**Invariant:** INV-11 (posture-declared-capabilities — a `task-isolated` agent's write surface is part of its bounded-by-construction contract)
+**Supersedes the disposition of:** `docs/research/2026-05-23-issue-1301-leak-rootcause.md` (verdict ESCALATED-TO-RC2 / "harness-layer, not ownable")
+**Related but distinct:** `docs/rca/2026-05-31-implementer-worktree-base.md` (#1509/#1501 — worktree *base* selection, a different INV-11 gap)
+
+## Symptom
+
+An `exarchos-implementer` subagent dispatched with `isolation: worktree` edits and commits
+cleanly *inside* its worktree, yet after it reports complete the orchestrator's **main**
+worktree shows uncommitted `M` on the same paths — byte-identical to the agent's commit. At
+merge time these phantom modifications FF-block the merge ("mirroring"). Under parallel
+dispatch two agents' leaks overlap and corrupt the main working tree against both branches.
+
+## Why the prior investigation stalled
+
+The 2026-05-23 RCA (T-09) asked exactly one question: *"Does the leak originate in
+MCP-server-owned code (`orchestrate/`)?"* It correctly proved the server never resolves an
+agent's per-file write target (`setup-worktree.ts` provisions strictly inside
+`<repoRoot>/.worktrees/`; nothing in `composite.ts`/`core/dispatch.ts` spawns the agent), and
+concluded "harness-layer, not ownable → escalate; ship the merge-time backstop." That framing
+was too narrow: it never examined the **prompt contract and the agent-hook adapter** — both of
+which exarchos *does* own — and so it foreclosed the structural fix. The merge-time
+`verify-worktree-baseline` `leaked-committed` classifier (`ac2efe72`) has been the only line of
+defense since; it *detects after the fact*, exactly what we want to eliminate.
+
+## Root cause (two facts, both inside exarchos's control)
+
+**1. The dispatch contract feeds the agent absolute *main-repo* file paths.**
+`skills-src/delegation/references/implementer-prompt.md` — "Key Principles" #3 — instructs the
+orchestrator: *"Explicit Paths — **Absolute paths** to working directory and files."* Those
+absolute paths are built from the orchestrator's cwd, which is the **main worktree**. They are
+interpolated verbatim into the agent's `## Files` section
+(`{{filePaths}}`, `servers/exarchos-mcp/src/agents/definitions.ts` `renderImplementerPrompt`).
+
+A git worktree shares the object store but has a **separate working tree**. An `Edit`/`Write`
+to an *absolute* path resolves literally and **ignores the agent's cwd** — so an absolute
+main-repo path writes into main even though the agent has dutifully `cd`-ed into its worktree.
+This matches the 2026-05-17 field diagnosis ("the implementer's Edit/Read/Write calls used the
+main repo's absolute path instead of the worktree's") and explains the byte-identical
+mirroring: same bytes, written through a main-repo path, then also committed in the worktree.
+
+**2. There is no enforcement — only ~90 lines of prose asking the agent to behave.**
+`agents/implementer.md` carries a large "Working Directory Setup / Worktree Verification /
+Worktree Hygiene" block (`cd`, `pwd`-check, `git -C`, `$WORKTREE`-prefix). All of it is
+*advisory*. None of it constrains an absolute-path `Edit`. The agent's only enforced hook is
+`PostToolUse: Bash → exarchos run-tests`. So isolation depends on model compliance — the
+definition of "detected/instructed, not by construction."
+
+**Net:** the contract *hands* the agent a main-repo write address (fact 1) and *nothing
+prevents* its use (fact 2). The leak is a designed-in capability, not a harness accident.
+
+## Evidence
+
+- `skills-src/delegation/references/implementer-prompt.md:456` — "Absolute paths to … files."
+- `servers/exarchos-mcp/src/agents/definitions.ts` — `## Files\n{{filePaths}}` interpolation;
+  IMPLEMENTER `validationRules` has a `pre-write` rule with **no `command`** (guidance only).
+- `servers/exarchos-mcp/src/agents/adapters/claude.ts:51-53` — `TRIGGER_MAP` already maps
+  `pre-write → PreToolUse {matcher:'Write|Edit'}` and `post-test → PostToolUse {Bash}`.
+- `servers/exarchos-mcp/src/agents/adapters/claude.ts:67-91` — `buildHooksFromRules` emits a
+  real hook **iff the rule has a `command`** (line 73 skips command-less rules). This is the
+  exact, proven path `exarchos run-tests` rides today.
+- Claude Code hook contract (verified against current docs): a `PreToolUse` hook **can deny**
+  `Edit|Write|MultiEdit` (exit 2, or `hookSpecificOutput.permissionDecision:"deny"`); it
+  receives `tool_input.file_path` and `cwd` on stdin; under `isolation: worktree` `cwd` **is the
+  worktree path** and agent-scoped frontmatter hooks fire only for that subagent.
+
+## Structural fix (guaranteed by construction)
+
+Two layers — the hook is load-bearing; the contract change removes the source.
+
+**Layer A — Enforcement (the guarantee): a PreToolUse worktree-boundary hook.**
+Add a new CLI subcommand `exarchos verify-worktree-boundary` (mirrors `exarchos run-tests`):
+read the PreToolUse JSON on stdin, resolve `tool_input.file_path` against `cwd`, and **deny
+(exit 2) any write whose realpath escapes the worktree root**. Wire it by adding a `pre-write`
+`validationRule` *with a `command`* to the `task-isolated` agent specs (IMPLEMENTER, FIXER,
+SCAFFOLDER) in `definitions.ts`; the existing `claude.ts` adapter renders it as a `PreToolUse`
+`Write|Edit` hook automatically. Extend the matcher to `Write|Edit|MultiEdit` (+ `NotebookEdit`).
+Result: an absolute main-repo path → realpath outside cwd → **denied**; a correct
+relative/worktree path → inside cwd → allowed. The leak becomes unrepresentable (INV-11).
+
+**Layer B — Prevention (remove the source): relative path contract.**
+Invert "Key Principles" #3 to *"repo-relative paths, resolved against the worktree root — never
+absolute paths into the parent repo,"* and make `renderImplementerPrompt`/the orchestrator emit
+worktree-relative `filePaths`. With cwd = worktree (harness chdir) and only relative paths, the
+common case never even reaches the hook.
+
+**Cross-runtime parity (INV-4).** The guarantee must exist on every runtime's path, not just
+Claude. Map the `pre-write→PreToolUse-equivalent` trigger in the other runtime adapters
+(codex/cursor/copilot/opencode); where a runtime has no pre-write hook surface, **log the gap
+explicitly** rather than silently shipping an unprotected path.
+
+**Backstop demotion.** The merge-time `verify-worktree-baseline` `leaked-committed` classifier
+stays as defense-in-depth, but is no longer the only line — the hook prevents the leak upstream.
+
+## Verification plan (debug → fix, TDD)
+
+- **High tier** — `verify-worktree-boundary` guard: deny absolute-main path; allow
+  worktree-relative path; allow nested worktree path; deny `..`-escape; handle missing/symlink
+  paths. Unit-test the resolver against a temp repo + worktree.
+- **Medium tier** — adapter: a `pre-write` rule *with* command renders a `PreToolUse`
+  `Write|Edit|MultiEdit` hook; command-less `pre-write` still renders nothing (regression).
+- **Snapshot** — `generate-agents.test.ts` byte-pins agent markdown; dual-baseline update
+  (`vitest -u` + regenerate `agents/` + per-runtime trees) is expected and intentional.
+- **Regression guard retained** — the T-09 `ImplementerDispatch_WorktreeEdit_DoesNotAppearInMainWorktree`
+  characterization stays green (server-side isolation invariant).
+
+## Definition of done
+
+- `exarchos verify-worktree-boundary` ships and denies out-of-worktree writes (exit 2).
+- `task-isolated` agents render the PreToolUse boundary hook on Claude; parity mapped or gap
+  logged on every other runtime.
+- Implementer prompt contract uses worktree-relative paths; no absolute main-repo path is
+  emitted by the renderer.
+- Snapshots + `skills:guard`/`hooks:guard` green; the #1301 leak no longer reproduces by
+  construction; merge-time backstop retained as secondary.

--- a/docs/rca/2026-06-21-worktree-isolation-write-leak.md
+++ b/docs/rca/2026-06-21-worktree-isolation-write-leak.md
@@ -68,33 +68,43 @@ prevents* its use (fact 2). The leak is a designed-in capability, not a harness 
   receives `tool_input.file_path` and `cwd` on stdin; under `isolation: worktree` `cwd` **is the
   worktree path** and agent-scoped frontmatter hooks fire only for that subagent.
 
-## Structural fix (guaranteed by construction)
+## Structural fix
 
-Two layers — the hook is load-bearing; the contract change removes the source.
+Defense-in-depth across the dispatch lifecycle. **INV-4 is load-bearing here: the structural
+fix must hold on every runtime's path, so the *platform-agnostic* mechanisms are primary.** A
+Claude-only mechanism cannot *be* the fix — it would leave codex/cursor/copilot/opencode
+unprotected. exarchos has exactly two runtime-agnostic seams (it never spawns the agent and has
+no agnostic during-work interception point), and both are used:
 
-**Layer A — Enforcement (the guarantee): a PreToolUse worktree-boundary hook.**
-Add a new CLI subcommand `exarchos verify-worktree-boundary` (mirrors `exarchos run-tests`):
-read the PreToolUse JSON on stdin, resolve `tool_input.file_path` against `cwd`, and **deny
-(exit 2) any write whose realpath escapes the worktree root**. Wire it by adding a `pre-write`
-`validationRule` *with a `command`* to the `task-isolated` agent specs (IMPLEMENTER, FIXER,
-SCAFFOLDER) in `definitions.ts`; the existing `claude.ts` adapter renders it as a `PreToolUse`
-`Write|Edit` hook automatically. Extend the matcher to `Write|Edit|MultiEdit` (+ `NotebookEdit`).
-Result: an absolute main-repo path → realpath outside cwd → **denied**; a correct
-relative/worktree path → inside cwd → allowed. The leak becomes unrepresentable (INV-11).
+**Primary — agnostic prevention: the relative-path contract.** Remove the leak source. The
+dispatch contract — delegation `SKILL.md`, the IMPLEMENTER/FIXER/SCAFFOLDER system prompts
+(`definitions.ts`), and the `implementer-prompt.md` reference — emits **worktree-relative** file
+paths (absolute only for the `cd` target). With cwd = worktree and only relative paths, no agent
+on *any* runtime is handed a main-repo address. Path construction is the orchestrator's job on
+every runtime, so this is enforced by a *consistent, prominent contract* rather than a code
+rewrite — but it is the one mechanism that reaches all five runtimes, so it is the load-bearing
+line. (It propagates into all 5 rendered agent artifacts + all 8 skill variants.)
 
-**Layer B — Prevention (remove the source): relative path contract.**
-Invert "Key Principles" #3 to *"repo-relative paths, resolved against the worktree root — never
-absolute paths into the parent repo,"* and make `renderImplementerPrompt`/the orchestrator emit
-worktree-relative `filePaths`. With cwd = worktree (harness chdir) and only relative paths, the
-common case never even reaches the hook.
+**Primary — agnostic detection: the merge-time backstop.** `verify-worktree-baseline`'s
+`leaked-committed` classifier runs in exarchos code at merge on **every** runtime, catching any
+leak the contract misses and surfacing a safe `git checkout -- <path>` remediation. By
+construction, runtime-independent — the agnostic safety net.
 
-**Cross-runtime parity (INV-4).** The guarantee must exist on every runtime's path, not just
-Claude. Map the `pre-write→PreToolUse-equivalent` trigger in the other runtime adapters
-(codex/cursor/copilot/opencode); where a runtime has no pre-write hook surface, **log the gap
-explicitly** rather than silently shipping an unprotected path.
+**Per-runtime hardening (NOT the guarantee): the PreToolUse boundary hook.** On Claude — the one
+runtime that exposes a during-work tool-call interception seam — `exarchos
+verify-worktree-boundary` is wired as a `PreToolUse` deny-hook (via a `pre-write` validationRule
+*with a command*; the `claude.ts` adapter renders it automatically; matcher
+`Write|Edit|MultiEdit|NotebookEdit`). It makes an out-of-worktree write impossible *on Claude*.
+This is **belt-and-suspenders on top of the agnostic layers, explicitly not a substitute** for
+them: codex/cursor/copilot/opencode treat `isolation:worktree` as advisory and expose no hook,
+so elevating this to "the fix" would violate INV-4.
 
-**Backstop demotion.** The merge-time `verify-worktree-baseline` `leaked-committed` classifier
-stays as defense-in-depth, but is no longer the only line — the hook prevents the leak upstream.
+**INV-4 parity — extension path, logged gaps.** The correct way to extend *by-construction*
+enforcement beyond Claude is each runtime's **native confinement** primitive, not one Claude
+mechanism: e.g. codex's `sandbox_mode: workspace-write` scoped to the worktree, or each host's
+equivalent sandbox/workspace seam. Where a runtime exposes no confinement seam, the gap is
+**logged** (a regression test pins that the hook renders on Claude only) — never faked. Until
+those land, the agnostic prevention + detection layers above are what hold the line everywhere.
 
 ## Verification plan (debug → fix, TDD)
 
@@ -110,10 +120,16 @@ stays as defense-in-depth, but is no longer the only line — the hook prevents 
 
 ## Definition of done
 
-- `exarchos verify-worktree-boundary` ships and denies out-of-worktree writes (exit 2).
-- `task-isolated` agents render the PreToolUse boundary hook on Claude; parity mapped or gap
-  logged on every other runtime.
-- Implementer prompt contract uses worktree-relative paths; no absolute main-repo path is
-  emitted by the renderer.
-- Snapshots + `skills:guard`/`hooks:guard` green; the #1301 leak no longer reproduces by
-  construction; merge-time backstop retained as secondary.
+- **Agnostic prevention (primary):** the dispatch contract emits worktree-relative paths
+  everywhere it is stated — delegation `SKILL.md`, the IMPLEMENTER/FIXER/SCAFFOLDER system
+  prompts (→ all 5 rendered agent artifacts), and `implementer-prompt.md`. No surface instructs
+  absolute parent-repo paths. (This is the line that holds on every runtime.)
+- **Agnostic detection (primary):** the merge-time `verify-worktree-baseline` `leaked-committed`
+  backstop is retained as the runtime-independent safety net.
+- **Per-runtime hardening (Claude):** `exarchos verify-worktree-boundary` ships, denies
+  out-of-worktree writes (exit 2), and renders as a `PreToolUse` hook on Claude only. The
+  Claude-only scope is **logged** (parity regression test), with native-confinement on other
+  runtimes (e.g. codex `sandbox_mode`) noted as the extension path — not faked as parity.
+- Snapshots + `skills:guard`/`hooks:guard` green. The #1301 leak is prevented by contract +
+  detected by backstop on **every** runtime, and additionally unrepresentable by construction
+  on Claude.

--- a/docs/rca/2026-06-21-worktree-isolation-write-leak.md
+++ b/docs/rca/2026-06-21-worktree-isolation-write-leak.md
@@ -112,7 +112,7 @@ those land, the agnostic prevention + detection layers above are what hold the l
   worktree-relative path; allow nested worktree path; deny `..`-escape; handle missing/symlink
   paths. Unit-test the resolver against a temp repo + worktree.
 - **Medium tier** — adapter: a `pre-write` rule *with* command renders a `PreToolUse`
-  `Write|Edit|MultiEdit` hook; command-less `pre-write` still renders nothing (regression).
+  `Write|Edit|MultiEdit|NotebookEdit` hook; command-less `pre-write` still renders nothing (regression).
 - **Snapshot** — `generate-agents.test.ts` byte-pins agent markdown; dual-baseline update
   (`vitest -u` + regenerate `agents/` + per-runtime trees) is expected and intentional.
 - **Regression guard retained** — the T-09 `ImplementerDispatch_WorktreeEdit_DoesNotAppearInMainWorktree`

--- a/docs/research/2026-06-21-per-runtime-worktree-confinement.md
+++ b/docs/research/2026-06-21-per-runtime-worktree-confinement.md
@@ -1,0 +1,172 @@
+# Per-runtime native worktree write-confinement (#1301 follow-up, INV-4)
+
+**Date:** 2026-06-21
+**Workflow:** `discover-per-runtime-worktree-confinement` (discovery)
+**Predecessor:** `docs/rca/2026-06-21-worktree-isolation-write-leak.md` (#1301) + PR #1568
+**Question:** the #1301 fix shipped an agnostic relative-path contract (prevention) + merge-time
+backstop (detection) on every runtime, plus a Claude-only `PreToolUse` deny-hook (by-construction
+hardening). Can the Claude-only hardening be matched on the other tier-1 runtimes via each one's
+**native** confinement seam — turning the logged INV-4 gap into real per-runtime enforcement?
+
+## Headline verdict
+
+**The gap is closeable on every tier-1 runtime — none needs to stay a pure logged-gap.** But the
+mechanisms differ in *kind* and *strength*, so the honest framing is a **tiered guarantee**, not
+one uniform mechanism (which is exactly what INV-4 asks for: the same guarantee realized through
+each runtime's native seam). Two runtimes (Codex, Cursor) offer **stronger** confinement than
+Claude's hook — OS-kernel sandboxes scopable to the worktree.
+
+## Enforcement-strength tiers
+
+1. **Kernel-enforced OS sandbox (strongest — physical "cannot write outside"):** writes outside
+   the worktree fail at the syscall layer, and this also confines *spawned shell commands* (the
+   universal hole below). Available: **Codex, Cursor**. Preview/partial: Copilot.
+2. **In-process deny-hook (= the Claude class we already shipped):** gates the model's *tool
+   calls* by resolved path; a fail-closed command hook denies an out-of-worktree write. Does
+   **not** confine arbitrary syscalls from a `bash`/shell tool. Available: **Claude (done),
+   Copilot, Codex, OpenCode**.
+3. **Advisory / heuristic (not a guarantee):** approval prompts, additive cwd-allowlists,
+   instruction prose. Present on all; this is the floor, not the target.
+
+**The universal hole:** on every runtime, a `bash`/shell tool can write via redirection
+(`echo > /repo/x`, `cp`, `python -c`) and bypass the *file-tool* permission/hook layer. Only the
+Tier-1 OS sandbox closes it (it confines the spawned subprocess too). In-process hooks must
+additionally gate/deny `bash`, or accept shell-write as residual (as the Claude fix already
+documents).
+
+**The universal lever:** every runtime keys confinement off the **launch cwd / working
+directory**. Spawning the agent with `cwd = <worktree>` is the shared foundation that makes both
+the OS sandbox and the relative-path contract land correctly. exarchos already does this via
+`setup-worktree` + the dispatch contract.
+
+## Per-runtime matrix
+
+| Runtime | Best verdict | Native seam | Worktree-scopable? | Strength | Key caveat |
+|---|---|---|---|---|---|
+| **Claude** | `hook-deny` (shipped) | `PreToolUse` deny-hook → `exarchos verify-worktree-boundary` | Yes (cwd=worktree) | Tier 2 | shell-write residual |
+| **Codex** | `native-scopable` | `--sandbox workspace-write --cd <worktree>` (Seatbelt / bubblewrap+seccomp); `[permissions]` deny-parent/allow-child; TOML pins `sandbox_mode` | **Yes** | **Tier 1** | Linux needs bubblewrap+userns; `apply_patch` ignores `--add-dir` → use `--cd` |
+| **Cursor** | `native-scopable` | `cursor-agent --sandbox enabled --workspace <worktree>` (Seatbelt/Landlock); CLI `Write(glob)` deny/allow; `beforeShellExecution` deny-hook | **Yes** (worktree = workspace root) | **Tier 1** | Linux kernel ≥6.2+Landlock else degrades to prompts; **no `beforeFileEdit` deny hook** |
+| **Copilot CLI** | `hook-deny` (+ preview sandbox) | `preToolUse` fail-closed command hook (root-owned **policy** hook can't be disabled) → reuse our guard; local sandbox (MXC=Seatbelt/bubblewrap) | Yes via hook; sandbox preview/shell-only | Tier 2 (Tier 1 preview) | native cwd-allowlist is heuristic + additive-only (no deny-path); sandbox is public-preview |
+| **OpenCode** | `permission-glob` + `hook-deny` | per-agent `permission.edit` glob→deny/allow + `external_directory`; `tool.execute.before` plugin `throw`s | Yes (in-process) | Tier 2 | **core explicitly is NOT a sandbox** (SECURITY.md); must also deny/scope `bash`; glob deny→allow historically buggy (pin version) |
+
+## Per-runtime detail + wiring approach
+
+### Codex — Tier 1 (OS sandbox), strongest
+- **Mechanism:** `sandbox_mode = "workspace-write"` confines writes to the workspace (= launch
+  cwd) + temp, enforced by Seatbelt (macOS) / bubblewrap+seccomp (Linux, Landlock fallback). The
+  sandbox **also confines spawned commands** (git, test runners). Protected: the worktree's
+  `.git` pointer *and its resolved gitdir* are read-only.
+- **Worktree scoping:** launch `codex exec --sandbox workspace-write --cd /repo/.worktrees/task-1`.
+  The parent `/repo` is read-only by construction. **Do not** keep `--cd /repo` and try
+  `--add-dir <worktree>` — `apply_patch` ignores `--add-dir` (issue #24214); collapse the root
+  with `--cd`. Optional hard floor: `exclude_slash_tmp` / `exclude_tmpdir_env_var`.
+  Most-explicit alternative (Codex ≥0.138, beta): a `[permissions]` profile with `deny` on the
+  parent + `write` on the nested worktree (more-specific-path-wins).
+- **exarchos wiring:** `codex.ts` already emits `sandbox_mode` from capabilities (implementer →
+  `workspace-write`). The **missing piece is the launch**: the orchestrator/`setup-worktree` must
+  spawn `codex exec` with `--cd <worktree>` (cwd=worktree). Custom-agent TOML can *pin*
+  `sandbox_mode` (a hard, non-widenable constraint) but not the writable root — the root is the
+  launch cwd. So: keep the TOML `sandbox_mode`, add `--cd <worktree>` at dispatch.
+- **Defense-in-depth:** Codex also has a Claude-modeled `PreToolUse` deny-hook (apply_patch
+  coverage fixed in 0.123.0) → our `exarchos verify-worktree-boundary` guard could wire here too.
+
+### Cursor — Tier 1 (OS sandbox)
+- **Mechanism:** since Cursor 2.0, agent tool execution runs in a kernel sandbox (Seatbelt /
+  Landlock+seccomp) with write confined to the **workspace root** + `/tmp`.
+- **Worktree scoping:** launch `cursor-agent -p --force --sandbox enabled --workspace
+  /repo/.worktrees/task-1`. The workspace *is* the worktree → kernel-denied writes elsewhere.
+  Defense-in-depth: a `<worktree>/.cursor/cli.json` with `permissions.deny: ["Write(/**)"]` +
+  `allow: ["Write(<worktree>/**)"]` (deny beats allow; absolute globs supported) — but this gates
+  only the `Write` *tool*, not shell. A `beforeShellExecution` deny-hook covers shell (the only
+  hook that can deny; **there is no `beforeFileEdit` deny hook**).
+- **exarchos wiring:** `cursor.ts` currently treats `isolation:worktree` as advisory and renders
+  no confinement. Add: emit `.cursor/cli.json` Write-deny/allow globs scoped to the worktree, and
+  have the orchestrator launch `cursor-agent` with `--sandbox enabled --workspace <worktree>`.
+- **Caveats:** Linux needs kernel ≥6.2 + Landlock (else degrades to approval prompts — verify
+  `CURSOR_SANDBOX_LANDLOCK_STATUS=fully_enforced`); Cursor's own docs call the in-product modes
+  "best-effort." `sandbox.json` path fields only *add* writable roots (can't shrink below the
+  workspace) — so confine by making the worktree the workspace, not by sub-scoping the repo.
+
+### Copilot CLI — Tier 2 (in-process deny-hook), reuses our guard
+- **Mechanism:** `preToolUse` hook fires before each tool with `{ cwd, toolName, toolArgs }`;
+  returns `{ "permissionDecision": "deny", "permissionDecisionReason": "…" }`. **Command hooks
+  are fail-closed** (crash/non-zero → deny). **Root-owned policy hooks**
+  (`/etc/github-copilot/policy.d/*.json`) cannot be disabled by the agent or `disableAllHooks` —
+  the hardening sweet spot.
+- **Worktree scoping:** the `toolArgs` shape is close enough to Claude's that
+  `exarchos verify-worktree-boundary` can be **reused** (resolve path, deny outside cwd). The
+  native cwd-allowlist (`--add-dir`) is heuristic + additive-only (no deny-path), so it is *not*
+  a substitute. Kernel option: the local sandbox (MXC = Seatbelt/bubblewrap) — but public-preview,
+  shell-only, enabled via `settings.json`/slash command (no headless flag documented).
+- **exarchos wiring:** `copilot.ts` renders no hooks today. Add: emit a `preToolUse` hook (ideally
+  a policy hook) wired to `exarchos verify-worktree-boundary`. Launch with cwd=worktree and
+  `--no-ask-user`; pair with `--deny-tool=write` re-allow-nothing-above-worktree if desired.
+- **Caveat:** in-process (respects the deny); shell-escape theoretically possible. GitHub's own
+  issue #892 confirms the native path model doesn't hard-enforce this.
+
+### OpenCode — Tier 2 (permission-glob + plugin hook); core is explicitly not a sandbox
+- **Mechanism:** per-agent `permission.edit` accepts glob→`allow|deny|ask` (the `edit` key covers
+  `edit`/`write`/`apply_patch`), plus `external_directory` for "outside the working dir." And a
+  `tool.execute.before` plugin can resolve `output.args.filePath` and **`throw`** to block.
+- **Worktree scoping:** per-agent block, e.g. `edit: { "*": "deny", "<worktree>/**": "allow" }` +
+  `external_directory` scoped to the worktree + **`bash` denied/allowlisted** (else shell is the
+  hole). Launch `opencode run --dir /repo/.worktrees/task-1 --agent <name>`.
+- **exarchos wiring:** `opencode.ts` renders no permission block today. Add: emit the agent
+  `permission.edit`/`external_directory` globs scoped to the worktree, and optionally ship a
+  `tool.execute.before` plugin that calls the same boundary logic (defense-in-depth, catches bash).
+- **Caveats:** OpenCode `SECURITY.md` states it is **not a sandbox** ("permission system is a UX
+  feature, not security isolation"); true OS confinement is only a third-party plugin
+  (`opencode-sandbox`, Seatbelt/bwrap, **fail-open**, no Windows). Path-scoped `edit` deny→allow
+  was historically mis-evaluated (catch-all won); verified fixed on recent `dev` — **pin a version
+  + add a test**. Last-match-wins, so rule *order* matters (deny `*` first, allow worktree after).
+
+## Cross-cutting design recommendation for exarchos
+
+Model the guarantee as **one runtime-agnostic spec intent, lowered to each runtime's native
+seam** — the same pattern exarchos already uses for `posture` → capabilities → per-adapter tools.
+
+1. **Keep the two agnostic layers as the floor (shipped):** relative-path contract (prevention) +
+   merge-time backstop (detection). These hold even where a runtime offers nothing better.
+2. **Reuse `exarchos verify-worktree-boundary` as the cross-runtime in-process guard.** Its
+   PreToolUse JSON contract already fits **Claude** and **Copilot** (`preToolUse`), and **Codex**
+   (Claude-modeled `PreToolUse`). One binary, three hook wirings — high leverage, low cost.
+3. **Add OS-sandbox lowering where it exists (Tier 1):** `codex.ts` → ensure `--cd <worktree>` at
+   launch (sandbox_mode already emitted); `cursor.ts` → `--sandbox enabled --workspace <worktree>`
+   + `.cursor/cli.json` Write globs.
+4. **Add the in-process seam where that's all there is (Tier 2):** `opencode.ts` → per-agent
+   `permission.edit`/`external_directory` globs (+ optional plugin); `copilot.ts` → `preToolUse`
+   policy hook.
+5. **Make the launch cwd = worktree explicit in `setup-worktree`/dispatch for every runtime** —
+   the universal lever all of the above depend on.
+6. **Per-runtime support-level honesty:** upgrade each adapter's `isolation:worktree` from blanket
+   `advisory` to its real tier (`native`/`hook`/`advisory`) and keep the parity regression test
+   green by asserting each runtime emits its declared seam. Where a strength gap remains
+   (shell-escape on Tier 2; preview-only sandbox on Copilot), **log it** — don't claim Tier 1.
+
+## INV-4 verdict
+
+The original "Claude-only" gap was real but not intrinsic — it reflected effort, not capability.
+Every tier-1 runtime exposes at least an in-process deny seam, and two expose a *stronger*
+kernel sandbox. So the INV-4-correct end state is **achievable**: the worktree boundary can be a
+genuine per-runtime guarantee, tiered by each host's strongest available seam, with residual gaps
+(shell-write on Tier 2; preview status on Copilot's sandbox) explicitly logged rather than faked.
+
+## Risks / things to kill-probe before implementing
+- **Shell-write residual** on Tier-2 runtimes — decide per runtime whether to also deny/scope
+  `bash` (breaks legitimate test/build commands) or accept it + rely on the merge backstop.
+- **Linux sandbox prerequisites** — Codex (bubblewrap+userns) and Cursor (kernel ≥6.2+Landlock)
+  degrade silently to prompts/refuse where unavailable; CI/container envs must verify enforcement
+  at runtime, not assume it.
+- **Version pinning** — OpenCode glob precedence, Codex permission profiles (beta), Copilot
+  sandbox (preview), Cursor CLI (beta) are all fast-moving; each needs a version-pinned probe test.
+- **The worktree `.git` pointer** — every sandbox/permission rule must keep the worktree's own git
+  plumbing (resolved gitdir under `/repo/.git/worktrees/...`) usable while denying the parent
+  working tree. Codex protects it read-only automatically; others need an explicit carve.
+
+## Escalation
+
+This discovery **feeds implementation** (it recommends concrete per-adapter wiring), so per the
+discovery-skill contract the next step is `/exarchos:ideate` (or a `/exarchos:debug` extension of
+#1301) to design + build the per-runtime lowering, referencing this report as input. Suggested
+first slice (highest leverage, lowest risk): **reuse `verify-worktree-boundary` for Copilot's
+`preToolUse`** and **add `--cd <worktree>` for Codex** — two runtimes upgraded with minimal new code.

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -141,7 +141,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -28,6 +28,11 @@ mcpServers:
 skills:
   - tdd-patterns
 hooks:
+  PreToolUse:
+    - matcher: Write|Edit|MultiEdit|NotebookEdit
+      hooks:
+        - type: command
+          command: exarchos verify-worktree-boundary
   PostToolUse:
     - matcher: Bash
       hooks:

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -141,6 +141,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -30,6 +30,11 @@ skills:
   - tdd-patterns
   - testing-patterns
 hooks:
+  PreToolUse:
+    - matcher: Write|Edit|MultiEdit|NotebookEdit
+      hooks:
+        - type: command
+          command: exarchos verify-worktree-boundary
   PostToolUse:
     - matcher: Bash
       hooks:

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -143,6 +143,7 @@ the worktree.
 {{requirements}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -143,7 +143,7 @@ the worktree.
 {{requirements}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Verification (verification ladder)

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
@@ -25,6 +25,12 @@ disallowedTools:
 isolation: worktree
 mcpServers:
   - exarchos
+hooks:
+  PreToolUse:
+    - matcher: Write|Edit|MultiEdit|NotebookEdit
+      hooks:
+        - type: command
+          command: exarchos verify-worktree-boundary
 ---
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
@@ -131,6 +131,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
@@ -131,7 +131,7 @@ the worktree.
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
@@ -204,6 +204,36 @@ describe('ClaudeAdapter_GenerateMarkdown_HandlesYamlSpecialChars', () => {
     expect(hooks.PostToolUse[0].hooks[0].command).toBe(command);
   });
 
+  it('ClaudeAdapter_PreWriteRuleWithCommand_RendersWorktreeBoundaryDenyHook', () => {
+    // #1301 structural fix: a `pre-write` rule carrying a command renders a
+    // PreToolUse hook matching every file-write tool, so an out-of-worktree
+    // write is denied by construction (INV-11).
+    const command = 'exarchos verify-worktree-boundary';
+    const spec = withOverrides(IMPLEMENTER, {
+      validationRules: [{ trigger: 'pre-write', rule: 'Writes must stay in the worktree', command }],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    const hooks = parsed.hooks as Record<string, Array<{
+      matcher: string;
+      hooks: Array<{ type: string; command: string }>;
+    }>>;
+    expect(hooks.PreToolUse).toBeDefined();
+    expect(hooks.PreToolUse[0].matcher).toBe('Write|Edit|MultiEdit|NotebookEdit');
+    expect(hooks.PreToolUse[0].hooks[0].command).toBe(command);
+  });
+
+  it('ClaudeAdapter_PreWriteRuleWithoutCommand_RendersNoHook', () => {
+    // Guidance-only rules (the TDD "test file must exist first" rule) carry no
+    // command and must remain guidance — they must NOT emit an enforced hook.
+    const spec = withOverrides(IMPLEMENTER, {
+      validationRules: [{ trigger: 'pre-write', rule: 'Test file must exist before implementation' }],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect((parsed.hooks as Record<string, unknown> | undefined)?.PreToolUse).toBeUndefined();
+  });
+
   it('DisallowedTool_WithEmbeddedColon_RoundTripsThroughYamlParse', () => {
     // Synthetic case: a tool name with a colon. Not a realistic Claude
     // tool name, but it proves the renderer escapes scalar list entries

--- a/servers/exarchos-mcp/src/agents/adapters/claude.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.ts
@@ -49,7 +49,9 @@ export function deriveClaudeToolsFromCapabilities(spec: AgentSpec): readonly str
 // #1485: `pre-edit` removed — no agent validation rule uses that trigger
 // (verified: only `pre-write` + `post-test` are referenced in definitions.ts).
 const TRIGGER_MAP: Record<string, { hookType: string; matcher: string }> = {
-  'pre-write': { hookType: 'PreToolUse', matcher: 'Write|Edit' },
+  // `pre-write` covers every file-write tool so the worktree-boundary guard
+  // (#1301) cannot be bypassed via MultiEdit/NotebookEdit.
+  'pre-write': { hookType: 'PreToolUse', matcher: 'Write|Edit|MultiEdit|NotebookEdit' },
   'post-test': { hookType: 'PostToolUse', matcher: 'Bash' },
 };
 

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -247,7 +247,7 @@ ${WORKTREE_ENTRY_CONTRACT}
 {{requirements}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 `;
@@ -377,7 +377,7 @@ ${WORKTREE_ENTRY_CONTRACT}
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol
@@ -517,7 +517,7 @@ ${WORKTREE_ENTRY_CONTRACT}
 {{taskDescription}}
 
 ## Files
-Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
+Paths below are **relative to your worktree** (your cwd) and must stay **rooted inside it** — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude both forms are also denied by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -28,6 +28,24 @@ import type { RiskTier } from '../workflow/verification-policy.js';
 // The same string is correct for every runtime and every toolchain.
 export const POST_TEST_COMMAND = 'exarchos run-tests';
 
+// Wired as the `pre-write` PreToolUse hook on every `task-isolated` agent
+// (#1301). Like POST_TEST_COMMAND it is a runtime-resolving exarchos verb, not
+// a baked path: the guard reads the hook JSON on stdin and denies (exit 2) any
+// Write/Edit/MultiEdit/NotebookEdit whose target escapes the agent's worktree.
+// This makes the worktree-isolation write leak unrepresentable by construction
+// (INV-11) rather than detected after the fact by the merge-time backstop.
+export const WORKTREE_BOUNDARY_COMMAND = 'exarchos verify-worktree-boundary';
+
+// The shared `pre-write` boundary rule. Carrying a `command` is what makes the
+// claude adapter emit an enforced PreToolUse hook (a command-less pre-write
+// rule stays guidance-only — see adapters/claude.ts buildHooksFromRules).
+const WORKTREE_BOUNDARY_RULE = {
+  trigger: 'pre-write',
+  rule:
+    'Writes must target the isolated worktree. Out-of-worktree paths (absolute parent-repo paths, `..` escapes) are denied (#1301, INV-11).',
+  command: WORKTREE_BOUNDARY_COMMAND,
+} as const;
+
 // ─── Shared worktree-entry contract ─────────────────────────────────────────
 //
 // Every isolated agent (IMPLEMENTER, FIXER, SCAFFOLDER) must boot into the
@@ -318,6 +336,7 @@ Implementation task requiring test-first development triggers the implementer ag
     { name: 'testing-patterns', content: '' },
   ],
   validationRules: [
+    WORKTREE_BOUNDARY_RULE,
     {
       trigger: 'pre-write',
       rule:
@@ -390,6 +409,7 @@ When done, output a JSON completion report:
     { name: 'tdd-patterns', content: '' },
   ],
   validationRules: [
+    WORKTREE_BOUNDARY_RULE,
     { trigger: 'post-test', rule: 'All tests must pass after fix', command: POST_TEST_COMMAND },
   ],
   resumable: false,
@@ -522,7 +542,7 @@ When done, output a JSON completion report:
   effort: 'low',
   isolation: 'worktree',
   skills: [],
-  validationRules: [],
+  validationRules: [WORKTREE_BOUNDARY_RULE],
   resumable: false,
   mcpServers: ['exarchos'],
 };

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -247,6 +247,7 @@ ${WORKTREE_ENTRY_CONTRACT}
 {{requirements}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 `;
@@ -376,6 +377,7 @@ ${WORKTREE_ENTRY_CONTRACT}
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Adversarial Verification Protocol
@@ -515,6 +517,7 @@ ${WORKTREE_ENTRY_CONTRACT}
 {{taskDescription}}
 
 ## Files
+Paths below are **relative to your worktree** (your cwd). Never read/edit/write an absolute parent-repo path — an absolute path bypasses the worktree cwd and leaks into the main worktree (#1301). This rule is your responsibility on every runtime; on Claude it is also enforced by a PreToolUse boundary hook.
 {{filePaths}}
 
 ## Protocol

--- a/servers/exarchos-mcp/src/agents/generate-agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/generate-agents.test.ts
@@ -47,6 +47,7 @@ import {
   FIXER,
   REVIEWER,
   SCAFFOLDER,
+  WORKTREE_BOUNDARY_COMMAND,
 } from './definitions.js';
 import type { AgentSpec } from './types.js';
 import { claudeAdapter } from './adapters/claude.js';
@@ -390,6 +391,33 @@ describe('generateAgents', () => {
         expect(actual).toBe(expected);
       },
     );
+  });
+
+  // ─── #1301 worktree-boundary parity (INV-4 gap, logged) ───────────────────
+  //
+  // The PreToolUse worktree-boundary deny-hook is the structural guarantee for
+  // the #1301 leak. It exists ONLY on Claude: the other four tier-1 runtimes
+  // treat `isolation:worktree` as advisory (orchestrator-managed) and render no
+  // hooks, so they have no surface to enforce the boundary by construction.
+  // This test pins that asymmetry as a KNOWN, INTENTIONAL gap (per INV-4 we log
+  // it, we do not fake it) — and will start failing the day a non-Claude
+  // adapter grows a pre-write hook surface, prompting us to wire the guard
+  // there too. See docs/rca/2026-06-21-worktree-isolation-write-leak.md §parity.
+  describe('Worktree-boundary cross-runtime parity (#1301 / INV-4)', () => {
+    it('GenerateAgents_WorktreeBoundaryHook_EnforcedOnClaudeOnly', () => {
+      // Enforced on Claude: the implementer artifact carries the guard command.
+      const claudeOut = claudeAdapter.lowerSpec(IMPLEMENTER).contents;
+      expect(claudeOut).toContain(WORKTREE_BOUNDARY_COMMAND);
+
+      // Gap (logged, not faked): advisory-isolation runtimes render no hook,
+      // so the guard command never reaches their artifacts.
+      for (const adapter of [codexAdapter, CursorAdapter, new CopilotAdapter(), OpenCodeAdapter]) {
+        const out = adapter.lowerSpec(IMPLEMENTER).contents;
+        expect(out, `${adapter.runtime} unexpectedly renders the boundary hook`).not.toContain(
+          WORKTREE_BOUNDARY_COMMAND,
+        );
+      }
+    });
   });
 
   it('GenerateAgents_AdvisoryCapability_NotEmittedInTools', () => {

--- a/servers/exarchos-mcp/src/agents/implementer-prompt.test.ts
+++ b/servers/exarchos-mcp/src/agents/implementer-prompt.test.ts
@@ -130,7 +130,11 @@ describe('implementer contract is tier-conditional (CR-1)', () => {
   });
 
   it('ImplementerSpec_PreWriteRule_ScopedToKillProbeTiers', () => {
-    const preWrite = IMPLEMENTER.validationRules?.find((r) => r.trigger === 'pre-write');
+    // There are now two `pre-write` rules (the #1301 worktree-boundary guard is
+    // also pre-write); target the TDD/kill-probe one specifically.
+    const preWrite = IMPLEMENTER.validationRules
+      ?.filter((r) => r.trigger === 'pre-write')
+      .find((r) => /check_test_adequacy|medium\/high/.test(r.rule));
     expect(preWrite).toBeDefined();
     // The rule must self-scope to the stamped verification sequence rather
     // than demanding a test file on every dispatch.

--- a/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  handleVerifyWorktreeBoundary,
+  type VerifyWorktreeBoundaryDeps,
+} from './verify-worktree-boundary.js';
+
+// ─── Test utilities ──────────────────────────────────────────────────────────
+
+interface Recorder {
+  out: string[];
+  err: string[];
+}
+
+const WORKTREE = '/repo/.worktrees/agent-x';
+
+function makeDeps(overrides: Partial<VerifyWorktreeBoundaryDeps> = {}): {
+  deps: VerifyWorktreeBoundaryDeps;
+  rec: Recorder;
+} {
+  const rec: Recorder = { out: [], err: [] };
+  const deps: VerifyWorktreeBoundaryDeps = {
+    // Default: cwd is a real linked worktree whose toplevel is the worktree.
+    gitToplevel: () => WORKTREE,
+    // Identity realpath keeps the unit test free of the filesystem.
+    realpath: (p) => p,
+    stdout: (s) => rec.out.push(s),
+    stderr: (s) => rec.err.push(s),
+    ...overrides,
+  };
+  return { deps, rec };
+}
+
+function preToolUse(
+  toolInput: Record<string, unknown>,
+  toolName = 'Edit',
+  cwd = WORKTREE,
+): string {
+  return JSON.stringify({ cwd, tool_name: toolName, tool_input: toolInput });
+}
+
+// 0 = allow, 2 = deny (PreToolUse block contract).
+describe('handleVerifyWorktreeBoundary', () => {
+  it('VerifyWorktreeBoundary_RelativePathInsideWorktree_Allows', () => {
+    const { deps } = makeDeps();
+    const code = handleVerifyWorktreeBoundary(
+      preToolUse({ file_path: 'servers/exarchos-mcp/src/foo.ts' }),
+      deps,
+    );
+    expect(code).toBe(0);
+  });
+
+  it('VerifyWorktreeBoundary_AbsolutePathInsideWorktree_Allows', () => {
+    const { deps } = makeDeps();
+    const code = handleVerifyWorktreeBoundary(
+      preToolUse({ file_path: `${WORKTREE}/servers/foo.ts` }),
+      deps,
+    );
+    expect(code).toBe(0);
+  });
+
+  it('VerifyWorktreeBoundary_AbsoluteMainRepoPath_Denies', () => {
+    const { deps, rec } = makeDeps();
+    // The #1301 vector: an absolute path into the parent (main) repo.
+    const code = handleVerifyWorktreeBoundary(
+      preToolUse({ file_path: '/repo/servers/exarchos-mcp/src/foo.ts' }),
+      deps,
+    );
+    expect(code).toBe(2);
+    expect(rec.err.join('\n')).toMatch(/worktree|boundary|outside/i);
+  });
+
+  it('VerifyWorktreeBoundary_DotDotEscape_Denies', () => {
+    const { deps } = makeDeps();
+    const code = handleVerifyWorktreeBoundary(
+      preToolUse({ file_path: '../../servers/foo.ts' }),
+      deps,
+    );
+    expect(code).toBe(2);
+  });
+
+  it('VerifyWorktreeBoundary_SiblingWorktreePath_Denies', () => {
+    // Parallel-dispatch protection: another agent's worktree is out of bounds.
+    const { deps } = makeDeps();
+    const code = handleVerifyWorktreeBoundary(
+      preToolUse({ file_path: '/repo/.worktrees/agent-other/foo.ts' }),
+      deps,
+    );
+    expect(code).toBe(2);
+  });
+
+  it('VerifyWorktreeBoundary_NotebookPath_Guarded', () => {
+    const { deps } = makeDeps();
+    const code = handleVerifyWorktreeBoundary(
+      preToolUse({ notebook_path: '/repo/analysis.ipynb' }, 'NotebookEdit'),
+      deps,
+    );
+    expect(code).toBe(2);
+  });
+
+  it('VerifyWorktreeBoundary_NoFilePath_Allows', () => {
+    const { deps } = makeDeps();
+    const code = handleVerifyWorktreeBoundary(preToolUse({ pattern: 'foo' }, 'Grep'), deps);
+    expect(code).toBe(0);
+  });
+
+  it('VerifyWorktreeBoundary_MalformedJson_AllowsWithStderr', () => {
+    // Cannot make a boundary decision on unparseable input — allow, but surface
+    // it (never silent). A format mismatch must not brick every agent write.
+    const { deps, rec } = makeDeps();
+    const code = handleVerifyWorktreeBoundary('not json{', deps);
+    expect(code).toBe(0);
+    expect(rec.err.length).toBeGreaterThan(0);
+  });
+
+  it('VerifyWorktreeBoundary_NoGitToplevel_ConfinesToCwd', () => {
+    // No resolvable worktree toplevel → confine to cwd subtree as the boundary.
+    const insideDeps = makeDeps({ gitToplevel: () => null });
+    expect(
+      handleVerifyWorktreeBoundary(
+        preToolUse({ file_path: 'src/foo.ts' }, 'Write', '/repo/.worktrees/agent-x'),
+        insideDeps.deps,
+      ),
+    ).toBe(0);
+
+    const outsideDeps = makeDeps({ gitToplevel: () => null });
+    expect(
+      handleVerifyWorktreeBoundary(
+        preToolUse({ file_path: '/repo/src/foo.ts' }, 'Write', '/repo/.worktrees/agent-x'),
+        outsideDeps.deps,
+      ),
+    ).toBe(2);
+  });
+});

--- a/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   handleVerifyWorktreeBoundary,
   type VerifyWorktreeBoundaryDeps,
@@ -20,11 +20,15 @@ function makeDeps(overrides: Partial<VerifyWorktreeBoundaryDeps> = {}): {
   const rec: Recorder = { out: [], err: [] };
   const deps: VerifyWorktreeBoundaryDeps = {
     // Default: cwd is a real linked worktree whose toplevel is the worktree.
-    gitToplevel: () => WORKTREE,
+    gitToplevel: vi.fn(() => WORKTREE),
     // Identity realpath keeps the unit test free of the filesystem.
-    realpath: (p) => p,
-    stdout: (s) => rec.out.push(s),
-    stderr: (s) => rec.err.push(s),
+    realpath: vi.fn((p: string) => p),
+    stdout: vi.fn((s: string) => {
+      rec.out.push(s);
+    }),
+    stderr: vi.fn((s: string) => {
+      rec.err.push(s);
+    }),
     ...overrides,
   };
   return { deps, rec };
@@ -101,6 +105,18 @@ describe('handleVerifyWorktreeBoundary', () => {
     const { deps } = makeDeps();
     const code = handleVerifyWorktreeBoundary(preToolUse({ pattern: 'foo' }, 'Grep'), deps);
     expect(code).toBe(0);
+  });
+
+  it('VerifyWorktreeBoundary_NonStringFilePath_AllowsWithoutThrowing', () => {
+    // Valid JSON, wrong-typed path field — must not throw a TypeError from
+    // path.*; treated as a shape mismatch → allow + stderr (fail-open).
+    const { deps, rec } = makeDeps();
+    let code: number | undefined;
+    expect(() => {
+      code = handleVerifyWorktreeBoundary(preToolUse({ file_path: 123 } as never), deps);
+    }).not.toThrow();
+    expect(code).toBe(0);
+    expect(rec.err.length).toBeGreaterThan(0);
   });
 
   it('VerifyWorktreeBoundary_MalformedJson_AllowsWithStderr', () => {

--- a/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.ts
+++ b/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.ts
@@ -1,0 +1,131 @@
+/**
+ * `exarchos verify-worktree-boundary` — PreToolUse boundary guard (#1301).
+ *
+ * The structural fix for the worktree-isolation write leak. A `task-isolated`
+ * agent (implementer/fixer/scaffolder) runs in an isolated git worktree, but
+ * an `Edit`/`Write` to an *absolute* path resolves literally and ignores the
+ * agent's worktree cwd — so an absolute parent-repo path silently writes into
+ * the orchestrator's MAIN worktree (the byte-identical "mirroring" leak).
+ *
+ * Wired as a `PreToolUse` hook (matcher `Write|Edit|MultiEdit|NotebookEdit`)
+ * via the `pre-write` validationRule→hook adapter, this guard reads the hook
+ * JSON on stdin, resolves the target path against the agent's worktree, and
+ * **denies (exit 2) any write whose resolved path escapes the worktree root**.
+ * The leak becomes unrepresentable by construction (INV-11) rather than
+ * detected after the fact by the merge-time backstop.
+ *
+ * Exit contract:
+ *   - target inside the worktree            → exit 0 (allow)
+ *   - target escapes the worktree root      → exit 2 (deny; reason on stderr,
+ *                                              which Claude Code surfaces)
+ *   - no write-target field / non-file tool → exit 0 (nothing to guard)
+ *   - unparseable hook input                → exit 0, reason on stderr. A
+ *     format mismatch must not brick every agent write; the skip is visible,
+ *     never silent (DIM-2).
+ *
+ * The worktree root is `git -C <cwd> rev-parse --show-toplevel` (a linked
+ * worktree reports its OWN toplevel, so the parent main repo is correctly
+ * out of bounds), falling back to `cwd` when no toplevel resolves. Path
+ * comparison goes through `path.relative` so `..`-escapes, sibling-worktree
+ * paths, and absolute parent-repo paths are all rejected cross-platform.
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Allow / deny exit codes per the Claude Code PreToolUse block contract. */
+const ALLOW = 0;
+const DENY = 2;
+
+/** Injectable seams so the unit tests never touch git or the filesystem. */
+export interface VerifyWorktreeBoundaryDeps {
+  /** Resolve the worktree root for `cwd`. Returns null when none resolves. */
+  gitToplevel?: (cwd: string) => string | null;
+  /** Canonicalize a path (resolve symlinks). Defaults to a realpath that
+   *  tolerates not-yet-existing files (a Write creating a new file). */
+  realpath?: (p: string) => string;
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+}
+
+function defaultGitToplevel(cwd: string): string | null {
+  try {
+    return execFileSync('git', ['-C', cwd, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** realpath that resolves the longest existing ancestor, then re-appends the
+ *  non-existent tail — so a brand-new file path still canonicalizes through
+ *  any symlinked parent (defeats symlink-escape) without throwing on ENOENT. */
+function defaultRealpath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    const parent = path.dirname(p);
+    if (parent === p) return p;
+    return path.join(defaultRealpath(parent), path.basename(p));
+  }
+}
+
+/** True when `target` is the root itself or lives strictly within it. */
+function isWithin(root: string, target: string): boolean {
+  const rel = path.relative(root, target);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
+ * Decide whether the PreToolUse write may proceed. Pure over its deps + the
+ * raw stdin string; returns the process exit code (0 allow / 2 deny).
+ */
+export function handleVerifyWorktreeBoundary(
+  stdin: string,
+  deps: VerifyWorktreeBoundaryDeps = {},
+): number {
+  const gitToplevel = deps.gitToplevel ?? defaultGitToplevel;
+  const realpath = deps.realpath ?? defaultRealpath;
+  const stderr = deps.stderr ?? ((s) => process.stderr.write(`${s}\n`));
+
+  let payload: {
+    cwd?: string;
+    tool_input?: { file_path?: string; notebook_path?: string };
+  };
+  try {
+    payload = JSON.parse(stdin);
+  } catch {
+    // Can't make a boundary decision on unparseable input — allow, but surface.
+    stderr('exarchos verify-worktree-boundary: unparseable hook input; skipping boundary check');
+    return ALLOW;
+  }
+
+  const cwd = payload.cwd ?? process.cwd();
+  const targetField = payload.tool_input?.file_path ?? payload.tool_input?.notebook_path;
+  if (!targetField) {
+    // Not a file-write tool call (or no path) — nothing to guard.
+    return ALLOW;
+  }
+
+  const root = realpath(gitToplevel(cwd) ?? cwd);
+  const absTarget = path.isAbsolute(targetField)
+    ? targetField
+    : path.resolve(cwd, targetField);
+  const resolvedTarget = realpath(absTarget);
+
+  if (isWithin(root, resolvedTarget)) {
+    return ALLOW;
+  }
+
+  stderr(
+    `exarchos verify-worktree-boundary: BLOCKED write outside the isolated worktree.\n` +
+      `  worktree root: ${root}\n` +
+      `  attempted path: ${resolvedTarget}\n` +
+      `  Use a path relative to the worktree (your cwd), never an absolute parent-repo path — ` +
+      `absolute paths bypass the worktree and leak into the main worktree (#1301).`,
+  );
+  return DENY;
+}

--- a/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.ts
+++ b/servers/exarchos-mcp/src/cli-commands/verify-worktree-boundary.ts
@@ -33,6 +33,23 @@
 import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { z } from 'zod';
+
+/**
+ * Shape of the PreToolUse hook payload we depend on. Validated with `safeParse`
+ * so a payload that is valid JSON but wrong-typed (e.g. `{file_path: 123}`) is
+ * treated exactly like malformed JSON — allow + stderr — never a thrown
+ * `TypeError` from a non-string reaching `path.*`. Unknown keys are ignored.
+ */
+const preToolUsePayloadSchema = z.object({
+  cwd: z.string().optional(),
+  tool_input: z
+    .object({
+      file_path: z.string().optional(),
+      notebook_path: z.string().optional(),
+    })
+    .optional(),
+});
 
 /** Allow / deny exit codes per the Claude Code PreToolUse block contract. */
 const ALLOW = 0;
@@ -91,17 +108,22 @@ export function handleVerifyWorktreeBoundary(
   const realpath = deps.realpath ?? defaultRealpath;
   const stderr = deps.stderr ?? ((s) => process.stderr.write(`${s}\n`));
 
-  let payload: {
-    cwd?: string;
-    tool_input?: { file_path?: string; notebook_path?: string };
-  };
+  let parsedJson: unknown;
   try {
-    payload = JSON.parse(stdin);
+    parsedJson = JSON.parse(stdin);
   } catch {
     // Can't make a boundary decision on unparseable input — allow, but surface.
     stderr('exarchos verify-worktree-boundary: unparseable hook input; skipping boundary check');
     return ALLOW;
   }
+  const result = preToolUsePayloadSchema.safeParse(parsedJson);
+  if (!result.success) {
+    // Valid JSON but the wrong shape (e.g. a non-string path) — same policy as
+    // malformed JSON: never throw, never brick a write; skip visibly.
+    stderr('exarchos verify-worktree-boundary: unexpected hook payload shape; skipping boundary check');
+    return ALLOW;
+  }
+  const payload = result.data;
 
   const cwd = payload.cwd ?? process.cwd();
   const targetField = payload.tool_input?.file_path ?? payload.tool_input?.notebook_path;

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -352,6 +352,21 @@ async function main() {
     return;
   }
 
+  // ─── verify-worktree-boundary Fast Path ──────────────────────────────────
+  // `exarchos verify-worktree-boundary` is the PreToolUse boundary guard for
+  // task-isolated agents (#1301). The Claude Code hook feeds the tool call as
+  // JSON on stdin; the guard denies (exit 2) any write that escapes the
+  // worktree. Like run-tests it is stateless — it must NOT open the SQLite
+  // backend, and it must stay fast (it runs before every agent file write).
+  if (process.argv[2] === 'verify-worktree-boundary') {
+    const { handleVerifyWorktreeBoundary } = await import(
+      './cli-commands/verify-worktree-boundary.js'
+    );
+    const stdin = fs.readFileSync(0, 'utf8');
+    process.exitCode = handleVerifyWorktreeBoundary(stdin);
+    return;
+  }
+
   const stateDir = await resolveStateDir();
 
   // Ensure state directory exists

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -362,7 +362,10 @@ async function main() {
     const { handleVerifyWorktreeBoundary } = await import(
       './cli-commands/verify-worktree-boundary.js'
     );
-    const stdin = fs.readFileSync(0, 'utf8');
+    // Read the hook payload from stdin. Guard against an interactive TTY (no
+    // piped input): `fs.readFileSync(0)` would block forever waiting on the
+    // terminal. With no payload there is nothing to evaluate — allow.
+    const stdin = process.stdin.isTTY ? '' : fs.readFileSync(0, 'utf8');
     process.exitCode = handleVerifyWorktreeBoundary(stdin);
     return;
   }

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -110,7 +110,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -110,8 +110,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 

--- a/skills-src/delegation/references/implementer-prompt.md
+++ b/skills-src/delegation/references/implementer-prompt.md
@@ -69,6 +69,8 @@ git merge-base --is-ancestor "[integration-tip]" HEAD \
 
 ## Files to Modify
 
+> Paths are **relative to your worktree** (the Working Directory above). Never an absolute parent-repo path — see Key Principle #3 (#1301).
+
 ### Create/Modify:
 - `[path/to/file.ts]` - [Brief description of changes]
 
@@ -453,7 +455,7 @@ describe('validateEmail', () => {
 
 1. **Full Context** - Include everything the implementer needs
 2. **No File References** - Don't say "see plan.md" - paste content
-3. **Explicit Paths** - Absolute paths to working directory and files
+3. **Worktree-relative file paths** - Give an **absolute** path for the *working directory* (the `cd` target) only. Every file to read/edit/write must be a **path relative to that worktree** (e.g. `src/foo.ts`), **never** an absolute path into the parent/main repo. An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into the orchestrator's main worktree (#1301). On Claude this is now enforced by a PreToolUse boundary hook that denies out-of-worktree writes; emitting relative paths keeps every runtime on the safe path.
 4. **Verification scaled to risk** - Include the tier-appropriate verification block (the ladder), not blanket TDD
 5. **Git-First** - Standard git commit + push. PR creation handled by synthesis phase.
 6. **Clear Success Criteria** - Checkboxes for completion

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -109,7 +109,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -109,8 +109,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 

--- a/skills/claude/delegation/references/implementer-prompt.md
+++ b/skills/claude/delegation/references/implementer-prompt.md
@@ -69,6 +69,8 @@ git merge-base --is-ancestor "[integration-tip]" HEAD \
 
 ## Files to Modify
 
+> Paths are **relative to your worktree** (the Working Directory above). Never an absolute parent-repo path — see Key Principle #3 (#1301).
+
 ### Create/Modify:
 - `[path/to/file.ts]` - [Brief description of changes]
 
@@ -458,7 +460,7 @@ describe('validateEmail', () => {
 
 1. **Full Context** - Include everything the implementer needs
 2. **No File References** - Don't say "see plan.md" - paste content
-3. **Explicit Paths** - Absolute paths to working directory and files
+3. **Worktree-relative file paths** - Give an **absolute** path for the *working directory* (the `cd` target) only. Every file to read/edit/write must be a **path relative to that worktree** (e.g. `src/foo.ts`), **never** an absolute path into the parent/main repo. An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into the orchestrator's main worktree (#1301). On Claude this is now enforced by a PreToolUse boundary hook that denies out-of-worktree writes; emitting relative paths keeps every runtime on the safe path.
 4. **Verification scaled to risk** - Include the tier-appropriate verification block (the ladder), not blanket TDD
 5. **Git-First** - Standard git commit + push. PR creation handled by synthesis phase.
 6. **Clear Success Criteria** - Checkboxes for completion

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -100,7 +100,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -100,8 +100,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 

--- a/skills/codex/delegation/references/implementer-prompt.md
+++ b/skills/codex/delegation/references/implementer-prompt.md
@@ -69,6 +69,8 @@ git merge-base --is-ancestor "[integration-tip]" HEAD \
 
 ## Files to Modify
 
+> Paths are **relative to your worktree** (the Working Directory above). Never an absolute parent-repo path — see Key Principle #3 (#1301).
+
 ### Create/Modify:
 - `[path/to/file.ts]` - [Brief description of changes]
 
@@ -430,7 +432,7 @@ describe('validateEmail', () => {
 
 1. **Full Context** - Include everything the implementer needs
 2. **No File References** - Don't say "see plan.md" - paste content
-3. **Explicit Paths** - Absolute paths to working directory and files
+3. **Worktree-relative file paths** - Give an **absolute** path for the *working directory* (the `cd` target) only. Every file to read/edit/write must be a **path relative to that worktree** (e.g. `src/foo.ts`), **never** an absolute path into the parent/main repo. An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into the orchestrator's main worktree (#1301). On Claude this is now enforced by a PreToolUse boundary hook that denies out-of-worktree writes; emitting relative paths keeps every runtime on the safe path.
 4. **Verification scaled to risk** - Include the tier-appropriate verification block (the ladder), not blanket TDD
 5. **Git-First** - Standard git commit + push. PR creation handled by synthesis phase.
 6. **Clear Success Criteria** - Checkboxes for completion

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -100,7 +100,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -100,8 +100,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 

--- a/skills/copilot/delegation/references/implementer-prompt.md
+++ b/skills/copilot/delegation/references/implementer-prompt.md
@@ -69,6 +69,8 @@ git merge-base --is-ancestor "[integration-tip]" HEAD \
 
 ## Files to Modify
 
+> Paths are **relative to your worktree** (the Working Directory above). Never an absolute parent-repo path — see Key Principle #3 (#1301).
+
 ### Create/Modify:
 - `[path/to/file.ts]` - [Brief description of changes]
 
@@ -426,7 +428,7 @@ describe('validateEmail', () => {
 
 1. **Full Context** - Include everything the implementer needs
 2. **No File References** - Don't say "see plan.md" - paste content
-3. **Explicit Paths** - Absolute paths to working directory and files
+3. **Worktree-relative file paths** - Give an **absolute** path for the *working directory* (the `cd` target) only. Every file to read/edit/write must be a **path relative to that worktree** (e.g. `src/foo.ts`), **never** an absolute path into the parent/main repo. An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into the orchestrator's main worktree (#1301). On Claude this is now enforced by a PreToolUse boundary hook that denies out-of-worktree writes; emitting relative paths keeps every runtime on the safe path.
 4. **Verification scaled to risk** - Include the tier-appropriate verification block (the ladder), not blanket TDD
 5. **Git-First** - Standard git commit + push. PR creation handled by synthesis phase.
 6. **Clear Success Criteria** - Checkboxes for completion

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -100,7 +100,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -100,8 +100,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 

--- a/skills/cursor/delegation/references/implementer-prompt.md
+++ b/skills/cursor/delegation/references/implementer-prompt.md
@@ -69,6 +69,8 @@ git merge-base --is-ancestor "[integration-tip]" HEAD \
 
 ## Files to Modify
 
+> Paths are **relative to your worktree** (the Working Directory above). Never an absolute parent-repo path — see Key Principle #3 (#1301).
+
 ### Create/Modify:
 - `[path/to/file.ts]` - [Brief description of changes]
 
@@ -431,7 +433,7 @@ describe('validateEmail', () => {
 
 1. **Full Context** - Include everything the implementer needs
 2. **No File References** - Don't say "see plan.md" - paste content
-3. **Explicit Paths** - Absolute paths to working directory and files
+3. **Worktree-relative file paths** - Give an **absolute** path for the *working directory* (the `cd` target) only. Every file to read/edit/write must be a **path relative to that worktree** (e.g. `src/foo.ts`), **never** an absolute path into the parent/main repo. An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into the orchestrator's main worktree (#1301). On Claude this is now enforced by a PreToolUse boundary hook that denies out-of-worktree writes; emitting relative paths keeps every runtime on the safe path.
 4. **Verification scaled to risk** - Include the tier-appropriate verification block (the ladder), not blanket TDD
 5. **Git-First** - Standard git commit + push. PR creation handled by synthesis phase.
 6. **Clear Success Criteria** - Checkboxes for completion

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -100,7 +100,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -100,8 +100,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 

--- a/skills/generic/delegation/references/implementer-prompt.md
+++ b/skills/generic/delegation/references/implementer-prompt.md
@@ -69,6 +69,8 @@ git merge-base --is-ancestor "[integration-tip]" HEAD \
 
 ## Files to Modify
 
+> Paths are **relative to your worktree** (the Working Directory above). Never an absolute parent-repo path — see Key Principle #3 (#1301).
+
 ### Create/Modify:
 - `[path/to/file.ts]` - [Brief description of changes]
 
@@ -426,7 +428,7 @@ describe('validateEmail', () => {
 
 1. **Full Context** - Include everything the implementer needs
 2. **No File References** - Don't say "see plan.md" - paste content
-3. **Explicit Paths** - Absolute paths to working directory and files
+3. **Worktree-relative file paths** - Give an **absolute** path for the *working directory* (the `cd` target) only. Every file to read/edit/write must be a **path relative to that worktree** (e.g. `src/foo.ts`), **never** an absolute path into the parent/main repo. An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into the orchestrator's main worktree (#1301). On Claude this is now enforced by a PreToolUse boundary hook that denies out-of-worktree writes; emitting relative paths keeps every runtime on the safe path.
 4. **Verification scaled to risk** - Include the tier-appropriate verification block (the ladder), not blanket TDD
 5. **Git-First** - Standard git commit + push. PR creation handled by synthesis phase.
 6. **Clear Success Criteria** - Checkboxes for completion

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -100,7 +100,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -100,8 +100,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 

--- a/skills/opencode/delegation/references/implementer-prompt.md
+++ b/skills/opencode/delegation/references/implementer-prompt.md
@@ -69,6 +69,8 @@ git merge-base --is-ancestor "[integration-tip]" HEAD \
 
 ## Files to Modify
 
+> Paths are **relative to your worktree** (the Working Directory above). Never an absolute parent-repo path — see Key Principle #3 (#1301).
+
 ### Create/Modify:
 - `[path/to/file.ts]` - [Brief description of changes]
 
@@ -430,7 +432,7 @@ describe('validateEmail', () => {
 
 1. **Full Context** - Include everything the implementer needs
 2. **No File References** - Don't say "see plan.md" - paste content
-3. **Explicit Paths** - Absolute paths to working directory and files
+3. **Worktree-relative file paths** - Give an **absolute** path for the *working directory* (the `cd` target) only. Every file to read/edit/write must be a **path relative to that worktree** (e.g. `src/foo.ts`), **never** an absolute path into the parent/main repo. An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into the orchestrator's main worktree (#1301). On Claude this is now enforced by a PreToolUse boundary hook that denies out-of-worktree writes; emitting relative paths keeps every runtime on the safe path.
 4. **Verification scaled to risk** - Include the tier-appropriate verification block (the ladder), not blanket TDD
 5. **Git-First** - Standard git commit + push. PR creation handled by synthesis phase.
 6. **Clear Success Criteria** - Checkboxes for completion

--- a/test/migration/__fixtures__/batch-baselines/delegation.md
+++ b/test/migration/__fixtures__/batch-baselines/delegation.md
@@ -11,7 +11,7 @@ metadata:
 
 # Delegation Skill
 
-Dispatch implementation tasks to Claude Code subagents with proper context, worktree isolation, and TDD requirements. This skill follows a three-step flow: **Prepare, Dispatch, Monitor.**
+Dispatch implementation tasks to subagents with proper context, worktree isolation, and TDD requirements. This skill follows a three-step flow: **Prepare, Dispatch, Monitor.**
 
 ## Triggers
 
@@ -36,9 +36,14 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 ### Delegation Modes
 
+The default `subagent` mode dispatches each task using the runtime's spawn primitive: `Task`.
+
+
+On Claude Code (and any future runtime declaring `team:agent-teams`), an additional `agent-team` mode is available — `Task` invocations bind to a `team_name` for interactive multi-pane coordination.
+
 | Mode | Mechanism | Best for |
 |------|-----------|----------|
-| `subagent` (default) | `Task` with `run_in_background` | 1-3 independent tasks, CI, headless |
+| `subagent` (default) | runtime spawn primitive | 1-3 independent tasks, CI, headless |
 | `agent-team` | `Task` with `team_name` | 3+ interdependent tasks, interactive sessions |
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `/exarchos:delegate --mode subagent|agent-team`.
@@ -58,6 +63,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -73,16 +97,20 @@ The composite action performs:
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
 
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
+
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
 **If `ready: true`:** Extract the `worktrees` paths and `qualityHints` for prompt construction.
+
+**Native isolation — verify worktrees before agents edit (#1542).** Under native isolation (`nativeIsolation: true`), `prepare_delegation` returns `ready: true` even when the host has not yet materialized worktrees (`worktrees.ready: 0`), because isolation is the host's responsibility — readiness cannot be confirmed at prepare-time. When `worktrees.expected > 0` and none are confirmed ready, the response carries a **warning**: *"native isolation requested; N worktree(s) expected but 0 confirmed ready — verify the host materializes worktrees or dispatch may land in the shared checkout."* Do not ignore it. After dispatching, and **before any agent edits files**, confirm each agent's working directory is under `.worktrees/` (e.g. the agent's first reported `pwd`). If an agent is NOT in a worktree it has landed in the shared checkout — stop it, create the worktree manually with `git worktree add -b <task-branch> .worktrees/task-<id> <integration-tip>`, redirect the agent to that path, and only then allow edits. Skipping this check risks silent shared-tree corruption across parallel agents.
 
 ### Task Extraction
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)
 
@@ -96,16 +124,17 @@ Build subagent prompts using `references/implementer-prompt.md` as the template.
 
 ### Prompt Construction
 
-**Claude Code (native agent definitions):**
 
-The `exarchos-implementer` agent spec already includes the system prompt, model, isolation, skills, hooks, and memory. The dispatch prompt should contain ONLY task-specific context:
+**On runtimes with native agent definitions:**
+
+The implementer agent definition already includes the system prompt, model, isolation, skills, hooks, and memory. The dispatch prompt should contain ONLY task-specific context:
 1. Full task description (requirements, acceptance criteria)
 2. Working directory (worktree path from Step 1)
 3. File paths to create/modify and test file paths
 4. Quality hints (if any)
 5. PBT flag when `propertyTests: true`
 
-**Cross-platform (full prompt template):**
+**Full prompt template (default):**
 
 For each task:
 1. Fill the implementer prompt template with task-specific details
@@ -121,9 +150,10 @@ For dispatch strategy decisions, query the decision runbook:
 
 This runbook provides structured criteria for parallel vs sequential dispatch, team sizing, and failure escalation.
 
+
 ### Parallel Dispatch
 
-Dispatch all independent tasks using the runtime's native spawn primitive. On runtimes with subagent support, fan out in a **single message** so the dispatches run in parallel. On runtimes without a subagent primitive, execute each task sequentially against its prepared worktree and emit one operator-visible warning per batch so users know they are not getting parallelism.
+Dispatch all independent tasks using the runtime's native spawn primitive in a **single message** so the dispatches run in parallel.
 
 ```typescript
 Task({
@@ -135,9 +165,10 @@ Task({
 
 ```
 
-> **Note:** On Claude Code, the `exarchos-implementer` agent definition already contains the system prompt, model, isolation, skills, hooks, and memory — the dispatch prompt should carry ONLY task-specific context. On runtimes without native agent definitions, include the full implementer prompt template from `references/implementer-prompt.md` in the `prompt` field so the spawned agent has a self-contained context.
+> **Note:** Include the full implementer prompt template from `references/implementer-prompt.md` in the dispatch payload so the spawned agent has a self-contained context — runtimes that pre-bind the implementer prompt to a named agent will discard the redundant content automatically.
 
 For parallel grouping strategy and model selection, see `references/parallel-strategy.md`.
+
 
 ### Agent Teams Dispatch
 
@@ -151,6 +182,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |
@@ -167,10 +199,10 @@ See `references/agent-teams-saga.md` for full event schemas and emission order.
 
 ### Subagent Monitoring
 
-Poll background tasks and collect results:
+Collect background task results using the runtime's result-collection primitive (this may be a poll/await per task or inline replies, depending on the runtime):
 
-```typescript
-TaskOutput({ task_id: "<id>", block: true })
+```text
+TaskOutput({ task_id, block: true })
 ```
 
 After each subagent reports completion:
@@ -203,7 +235,7 @@ exarchos_orchestrate({
 })
 ```
 
-6. **Update workflow state** — set each passing `tasks[].status` to `"complete"` via `exarchos_workflow set`
+6. **Update workflow state** — set each passing `tasks[].status` to `"complete"` via `exarchos_workflow update`
 7. **Delegation completion gate (D4, advisory)** — after ALL tasks pass, run an operational resilience check on the full branch diff before transitioning to review:
 
 ```typescript
@@ -219,36 +251,40 @@ This is advisory — findings are recorded for the convergence view but do not b
 
 8. **Schema sync** — if any task modified API files (`*Endpoints.cs`, `Models/*.cs`), run `npm run sync:schemas`
 
+
 ### Agent Teams Monitoring
 
 - Teammates visible in tmux split panes
-- `TeammateIdle` hook auto-runs quality gates and emits completion/failure events
+- `TeammateIdle hook` auto-runs quality gates and emits completion/failure events
 - Orchestrator monitors via `exarchos_view delegation_timeline` for bottleneck detection
 - See `references/agent-teams-saga.md` for disbanding and reconciliation
 
 ### Failure Recovery
 
 When a task fails:
-1. Read the failure output from `TaskOutput`
+1. Read the failure output from the runtime's result-collection primitive (`TaskOutput({ task_id, block: true })`)
 2. Diagnose root cause — do NOT trust the implementer's self-assessment (see R3 adversarial posture)
-3. Fix the task using the resume-aware fixer flow below
+3. Fix the task using the fixer flow below
 4. Run the `task-fix` runbook gate chain after the fix completes
 
 For the full recovery flow with a concrete example, see `references/worked-example.md`.
 
 ### Fix Failed Tasks
 
-Dispatch a fix agent with the full failure context and the original task description. On runtimes that support session resume (e.g. Claude Code with an `agentId` in workflow state), prefer resuming the original agent so it retains its implementer context; otherwise dispatch a fresh fixer agent using the runtime's native spawn primitive.
+Dispatch a fresh fixer agent using the runtime's native spawn primitive, carrying the full failure context and the original task description:
 
 ```typescript
 Task({
-  subagent_type: "exarchos-implementer",
+  subagent_type: "exarchos-fixer",
   run_in_background: true,
   description: "Fix failed task-001",
   prompt: "Your implementation failed. [failure context from test output]. Apply adversarial verification: do NOT trust your previous self-assessment, re-read actual test output, identify root cause not symptoms. [Original task context]."
 })
 
 ```
+
+
+**Optimization (opt-in):** On runtimes with native session resume (e.g. Claude Code with an `agentId` in workflow state), you may resume the original agent instead so it retains its implementer context. Fresh dispatch above remains correct and is the canonical default.
 
 After fix completes, run the `task-fix` runbook gate chain:
 `exarchos_orchestrate({ action: "runbook", id: "task-fix" })`
@@ -307,7 +343,15 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 
 **Quick reference:** The `delegate` → `review` transition requires guard `all-tasks-complete` — all `tasks[].status` must be `"complete"` in workflow state.
 
-> **Before transitioning to review:** You MUST first update all task statuses to `"complete"` via `exarchos_workflow set` with the tasks array. The phase transition will be rejected by the guard if any task is still pending/in_progress/failed. Update tasks first, then set the phase in a separate call.
+> **Before transitioning to review:** You MUST first update all task statuses to `"complete"` via `exarchos_workflow update` with the tasks array. The phase transition will be rejected by the guard if any task is still pending/in_progress/failed. Update tasks first, then set the phase in a separate call.
+
+### Worktree-Bearing Tasks: Auto-Detour to `merge-pending`
+
+When a `task.completed` event carries a worktree association (`data.worktree` or `data.worktreePath`), the HSM auto-transitions through `feature/merge-pending` before reaching `review`. The `next_actions` projection surfaces a `merge_orchestrate` verb (idempotency-keyed by `${streamId}:merge_orchestrate:${taskId}`) so a runtime that consumes `next_actions` will dispatch the merge automatically.
+
+The merge lands the subagent's branch on the integration branch via a local `git merge` with a recorded rollback SHA — see `@skills/merge-orchestrator/SKILL.md`. The HSM exits `merge-pending` back to `delegate` once the merge terminates (`completed` / `rolled-back` / `aborted`), at which point `delegate` either re-enters `merge-pending` for the next worktree-bearing task or transitions on to `review` when all delegation is complete.
+
+This detour is invisible to the delegation skill itself — the all-tasks-complete guard still gates the `delegate → review` transition. The merge-pending substate just sits between task completion and the next dispatch decision.
 
 ### Task Status Values
 
@@ -320,18 +364,148 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 
 ### Schema Discovery
 
-Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+Use `exarchos_workflow({ action: "describe", actions: ["update", "init"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
 for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
+
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```text
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+
+> **Prerequisite — pin the worktree base.** Native `isolation: worktree`
+> branches subagent worktrees from the repository's default branch
+> (`origin/HEAD` → `main`), **not** the integration tip, unless
+> `worktree.baseRef: "head"` is set in `.claude/settings.json`. Without the pin,
+> a subagent dispatched onto any stacked / non-`main` integration branch gets a
+> base missing every in-branch prerequisite commit (issues #1509 / #1501).
+> `prepare_delegation` fails loud with this exact remediation when
+> `nativeIsolation` is requested and the pin is absent:
+>
+> ```json
+> { "worktree": { "baseRef": "head" } }
+> ```
+>
+> Worktrees are a clean checkout, so only *committed* HEAD state propagates —
+> commit design / plan / research before dispatching.
+>
+> With the pin in place (and the implementer's own base assert as backstop),
+> operators no longer hand-prepend a `git reset --hard <integration-tip>` STEP 0
+> to each dispatch — base correctness is enforced by configuration + guard.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard "$(cat /tmp/rollback.sha)"
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
 
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):
 
 1. Verify all `tasks[].status === "complete"` in workflow state
-2. Update state: `exarchos_workflow set` with `phase: "review"`
+2. Update state: `exarchos_workflow update` with `phase: "review"`
 3. Invoke: `Skill({ skill: "exarchos:review", args: "<plan-path>" })`
 
 This is NOT a human checkpoint — the workflow continues autonomously.
@@ -346,6 +520,7 @@ This is NOT a human checkpoint — the workflow continues autonomously.
 | `references/fixer-prompt.md` | Fix agent prompt with adversarial verification posture |
 | `references/worked-example.md` | Complete delegation trace with recovery path (R1) |
 | `references/rationalization-refutation.md` | Common rationalizations and counter-arguments (R2) |
+
 | `references/agent-teams-saga.md` | 6-step agent-team saga with event payloads |
 | `references/parallel-strategy.md` | Parallel grouping and model selection |
 | `references/testing-patterns.md` | Arrange/Act/Assert, naming, mocking conventions |

--- a/test/migration/__fixtures__/batch-baselines/delegation.md
+++ b/test/migration/__fixtures__/batch-baselines/delegation.md
@@ -109,7 +109,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. `src/foo.ts`) — NEVER absolute parent-repo paths. An `Edit`/`Write` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (`testingStrategy.propertyTests`)

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -961,7 +961,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
@@ -6109,7 +6109,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
@@ -11199,7 +11199,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
@@ -16281,7 +16281,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
@@ -21373,7 +21373,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
@@ -26436,7 +26436,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -961,8 +961,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
 
@@ -6109,8 +6109,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
 
@@ -11199,8 +11199,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
 
@@ -16281,8 +16281,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
 
@@ -21373,8 +21373,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
 
@@ -26436,8 +26436,8 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
-- Files to create/modify with absolute worktree paths
-- Test file paths and expected test names
+- Files to create/modify as **worktree-relative paths** (e.g. \`src/foo.ts\`) — NEVER absolute parent-repo paths. An \`Edit\`/\`Write\` resolves an absolute path literally and ignores the agent's worktree cwd, so an absolute parent-repo path silently writes into the main worktree (#1301). This is the platform-agnostic line of defense — it must hold on every runtime.
+- Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
 - Property-based testing flag (\`testingStrategy.propertyTests\`)
 


### PR DESCRIPTION
## Summary

Root-causes and structurally fixes the #1301 worktree-isolation write leak — `exarchos-implementer`/`fixer`/`scaffolder` subagent edits leaking into the orchestrator's main worktree as byte-identical uncommitted `M`. The 2026-05-23 RCA framed the question as "is it MCP-server code?" (no), mislabeled it "harness-layer, not ownable," and shipped only a merge-time backstop. This lands the by-construction fix exarchos **does** own.

**Root cause:** exarchos's own dispatch contract instructed *absolute main-repo file paths* (delegation `SKILL.md` said "Files … with absolute worktree paths"; `implementer-prompt.md` Key Principle #3 said "Absolute paths to … files"). An `Edit`/`Write` resolves an absolute path literally and **ignores the agent's worktree cwd**, so an absolute parent-repo path silently writes into main. Nothing enforced the boundary. RCA: `docs/rca/2026-06-21-worktree-isolation-write-leak.md`.

## Changes

Defense-in-depth across the dispatch lifecycle. **INV-4 (platform-agnosticism) is load-bearing: the structural fix must hold on every runtime, so the platform-agnostic mechanisms are primary; the Claude PreToolUse hook is per-runtime hardening, not the guarantee.**

- **Primary — agnostic prevention (every runtime): the relative-path contract.** Flipped the dispatch contract to **worktree-relative** file paths (absolute only for the `cd` target) across delegation `SKILL.md`, the IMPLEMENTER/FIXER/SCAFFOLDER system prompts (→ all 5 rendered agent artifacts), and the `implementer-prompt.md` reference (→ all 8 skill variants). With cwd = worktree and only relative paths, no agent on any runtime is handed a main-repo address.
- **Primary — agnostic detection (every runtime): the merge-time backstop.** `verify-worktree-baseline`'s `leaked-committed` classifier is retained as the runtime-independent safety net.
- **Per-runtime hardening (Claude only): a PreToolUse boundary deny-hook.** New `exarchos verify-worktree-boundary` CLI, wired via the existing `pre-write` validationRule→hook adapter (matcher `Write|Edit|MultiEdit|NotebookEdit`). Denies (exit 2) any write whose resolved path escapes the worktree root. Belt-and-suspenders on top of the agnostic layers — **not** a substitute. codex/cursor/copilot/opencode treat `isolation:worktree` as advisory and expose no hook surface, so this is Claude-only.
- **INV-4 parity, logged not faked.** A regression test pins that the hook renders on Claude only; native confinement (e.g. codex `sandbox_mode: workspace-write` scoped to the worktree) is documented as the extension path for by-construction enforcement on other runtimes.

## Test Plan

- `verify-worktree-boundary.test.ts` — 9 cases (deny: absolute-main, `..`-escape, sibling-worktree, notebook; allow: relative, absolute-inside, no-path, malformed→fail-open, no-toplevel→confine-to-cwd).
- claude adapter — `pre-write` rule *with* a command renders the hook; command-less renders nothing.
- generate-agents parity — boundary hook enforced on Claude only (INV-4 gap pinned).
- Full MCP suite **7874 passed / 0 failed**; root **856 passed / 0 failed**; typecheck clean; `skills:guard` + `hooks:guard` in sync.
- E2E through the bun CLI: absolute outside-worktree path → **exit 2** (blocked); relative inside path → **exit 0**.

Closes #1301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
