### PR TITLE
feat(v2.11.0-preview.3): merge-orchestrator hardening (#1302)

### DIFF
--- a/docs/designs/2026-04-26-autonomous-merge-orchestrator.md
+++ b/docs/designs/2026-04-26-autonomous-merge-orchestrator.md
@@ -8,9 +8,9 @@
 
 ## Overview
 
-Subagent worktrees corrupt during the dispatch -> merge dance, and the team spends substantial cycles untangling failed merges by hand. The pre-existing dispatch guards in `dispatch-guard.ts` (DR-1 ancestry validation, DR-2 worktree assertion) catch some of the upstream causes at delegation time but do nothing about the merge itself: when a subagent's branch lands back on the integration branch, there is no automated preflight, no rollback, and no recovery. This design closes that loop.
+Subagent worktrees corrupt during the dispatch -> merge dance, and the team spends substantial cycles untangling failed merges by hand. The pre-existing dispatch guards in `dispatch-guard.ts` (DR-1 ancestry validation, DR-2 worktree assertion) catch some of the upstream causes at delegation time but do nothing about the merge itself: when a subagent's branch lands back on the integration branch, there is no automated preflight, no recorded recovery point, and no recovery. This design closes that loop.
 
-The orchestrator is two flat handlers in `orchestrate/`. The first composes existing dispatch guards with a worktree drift check and emits a single preflight event. The second records a rollback SHA, delegates the merge to the existing VCS provider, and resets to the recorded SHA on any failure. Triggering is event-sourcing-native: the HSM defines a transition guarded on `task.completed` for tasks with worktree associations, and the existing `next-action@v1` projection surfaces `merge_orchestrate` as the next required action. Per-runtime delegation skills (post #1181) already direct every supported runtime to consume `next_actions`, so auto-dispatch is portable across Claude / Codex / OpenCode / Cursor / Copilot without any platform-specific hook.
+The orchestrator is two flat handlers in `orchestrate/`. The first composes existing dispatch guards with a worktree drift check and emits a single preflight event. The second records a **recovery point** SHA, performs a local `git merge`, and recovers the integration branch back to the recorded point on any failure. The recovery point is durably persisted *before* the merge mutates any ref — a write-ahead-log discipline borrowed from database transactions: the persisted `executing` state is the WAL record, so a crash between recording the point and completing the merge is recoverable from disk. Triggering is event-sourcing-native: the HSM defines a transition guarded on `task.completed` for tasks with worktree associations, and the existing `next-action@v1` projection surfaces `merge_orchestrate` as the next required action. Per-runtime delegation skills (post #1181) already direct every supported runtime to consume `next_actions`, so auto-dispatch is portable across Claude / Codex / OpenCode / Cursor / Copilot without any platform-specific hook.
 
 ## Reuse audit
 
@@ -23,7 +23,7 @@ The most important section of this design. Each row is a piece of infrastructure
 | Main worktree assertion | `dispatch-guard.ts:147` `assertMainWorktree(cwd?)` | Imported and called as-is. |
 | Composition pattern | `prepare-delegation.ts:295-360` (composes all four guards in sequence) | Followed verbatim. |
 | Multi-VCS provider | `vcs/factory.ts:21` `createVcsProvider({ config: ctx.projectConfig })` (GitHub / GitLab / Azure DevOps) | **Not used by `merge_orchestrate`** — its merge is local-git (#1194). VCS provider remains in use by `merge_pr` and other synthesize-phase remote operations. |
-| Local git merge | `execFileSync('git', ['merge', ...])` via `orchestrate/local-git-merge.ts` (#1194) | Production `vcsMerge` adapter. The executor's recorded `rollbackSha` corresponds to a real local ref the rollback `git reset --hard` can undo. |
+| Local git merge | `execFileSync('git', ['merge', ...])` via `orchestrate/local-git-merge.ts` (#1194) | Production `vcsMerge` adapter. The executor's recorded `recoveryPointSha` corresponds to a real local ref the recovery ladder (`git merge --abort` → `git reset --keep`) can rewind to. |
 | Worktree validation pattern | `verify-worktree.ts`, `verify-worktree-baseline.ts` | Drift detection extends this pattern in-place; no parallel module. |
 | Git command exec | `setup-worktree.ts:32` `gitExec(repoRoot, args)` helper using `execFileSync('git', ['-C', repoRoot, ...])` | Same shape, 120s timeout matching `post-merge.ts:48`. |
 | Event emission | `gate-utils.ts:emitGateEvent(store, featureId, gateName, gateType, passed, payload)` | All five orchestrator events emitted through this. |
@@ -44,14 +44,14 @@ Flat, matching every other handler in `orchestrate/`. No sub-directory.
 servers/exarchos-mcp/src/orchestrate/
   merge-orchestrate.ts            # Composer: preflight -> emit; resumes from WorkflowState.mergeOrchestrator
   merge-orchestrate.test.ts
-  execute-merge.ts                # Executor: record rollback SHA -> local git merge -> reset on failure
+  execute-merge.ts                # Executor: record recovery point SHA -> local git merge -> recover on failure
   execute-merge.test.ts
   local-git-merge.ts              # Production vcsMerge adapter: local `git merge` of source into target (#1194)
-  local-git-merge.test.ts         # Integration: real temp git repos, real merges, rollback round-trip
+  local-git-merge.test.ts         # Integration: real temp git repos, real merges, recovery round-trip
   pure/
     merge-preflight.ts            # Pure composer over dispatch-guard fns + drift detection
     merge-preflight.test.ts
-    execute-merge.ts              # Pure rollback logic (SHA recording, reset decision tree)
+    execute-merge.ts              # Pure recovery logic (recovery-point recording, reset decision tree)
     execute-merge.test.ts
   merge-orchestrate.parity.test.ts  # CLI <-> MCP parity assertion
 ```
@@ -83,12 +83,15 @@ export interface MergePreflightResult {
 ```ts
 // orchestrate/merge-orchestrate.ts
 export interface MergeOrchestrateOutput {
+  // `phase: 'rolled-back'` is the recovery-terminal value — intentionally
+  // retained as-is (the phase string is a load-bearing wire/state token, not
+  // renamed in the #1306 recovery reframe).
   readonly phase: 'preflight' | 'executing' | 'completed' | 'rolled-back' | 'aborted';
   readonly preflight: MergePreflightResult;
   readonly mergeSha?: string;
-  readonly rollbackSha?: string;
+  readonly recoveryPointSha?: string;
   readonly abortReason?: 'preflight-failed';
-  readonly rollbackReason?: 'merge-failed' | 'verification-failed' | 'timeout';
+  readonly recoveryReason?: 'merge-failed' | 'verification-failed' | 'timeout';
 }
 ```
 
@@ -118,11 +121,13 @@ exarchos merge-orchestrate (CLI)     exarchos_orchestrate({action:"merge_orchest
   4. IF !preflight.passed: persist WorkflowState.mergeOrchestrator = { phase: 'aborted', ... }; return
                             v
   5. handleExecuteMerge(args, ctx)                            <- orchestrate/execute-merge.ts
-       a. rollbackSha = git rev-parse HEAD
-       b. persist mergeOrchestrator = { phase: 'executing', rollbackSha, ... }
-       c. delegate to vcs/merge-pr.ts (uses VcsProvider — platform-agnostic)
+       a. recoveryPointSha = git rev-parse HEAD            (the WAL recovery point)
+       b. persist mergeOrchestrator = { phase: 'executing', recoveryPointSha, ... }
+       c. local git merge via buildLocalGitMergeAdapter (#1194)
        d. emitGateEvent('merge.executed', success)
-       e. ON FAILURE: git reset --hard <rollbackSha>; emitGateEvent('merge.rollback', { reason })
+       e. ON FAILURE: recovery ladder (git merge --abort → git reset --keep
+          <recoveryPointSha>, never --hard); dual-emit merge.rollback (legacy)
+          + merge.recovered (successor) { reason } during the v2.11.x window
                             v
   6. persist mergeOrchestrator.phase = 'completed' | 'rolled-back'
                             v
@@ -159,24 +164,24 @@ Composes the existing dispatch guards into a single merge-time check.
 4. All git invocations are injectable via `GitExec` (the existing type from `dispatch-guard.ts`). Tests exercise the composer with no live git.
 5. The preflight pure function lives in `pure/merge-preflight.ts` and contains zero direct `execFileSync` calls; the impure handler injects `gitExec`.
 
-### DR-MO-2: Merge execution with rollback
+### DR-MO-2: Merge execution with recovery
 
-The executor records a recovery point before the merge, performs a *local* `git merge` of source into target, and resets to the recovery point on any failure.
+The executor records a **recovery point** before the merge, performs a *local* `git merge` of source into target, and recovers to the recovery point on any failure. The model is a database-transaction one, not a saga: the recovery point is a write-ahead-log marker recorded (and persisted) before the merge mutates any ref, and the recovery itself rewinds the worktree to that point rather than running a compensating action.
 
-> **Revised post-#1194:** earlier drafts of this section delegated the merge to `vcs/merge-pr.ts` (a remote VCS provider call). That made the recorded `rollbackSha` dead code in production — a server-side merge does not move local HEAD, so `git reset --hard <rollbackSha>` is a no-op. The orchestrator's preflight (worktree drift, ancestry, main-worktree assertion) and rollback (`git reset --hard`) are local-git semantics; the executor must use a matching local-git primitive. The remote PR merge is a different concern handled by `merge_pr` in the synthesize-phase shepherd loop.
+> **Revised post-#1194:** earlier drafts of this section delegated the merge to `vcs/merge-pr.ts` (a remote VCS provider call). That made the recorded recovery point dead code in production — a server-side merge does not move local HEAD, so a reset to the recovery point is a no-op. The orchestrator's preflight (worktree drift, ancestry, main-worktree assertion) and recovery (a local `git reset` to the recovery point) are local-git semantics; the executor must use a matching local-git primitive. The remote PR merge is a different concern handled by `merge_pr` in the synthesize-phase shepherd loop.
 
 **Capabilities**
-- Record pre-merge `HEAD` via `git rev-parse HEAD` and persist to `WorkflowState.mergeOrchestrator.rollbackSha` *before* the merge command runs.
+- Record pre-merge `HEAD` via `git rev-parse HEAD` and persist to `WorkflowState.mergeOrchestrator.recoveryPointSha` *before* the merge command runs.
 - Perform the merge via `buildLocalGitMergeAdapter` (`orchestrate/local-git-merge.ts`): checks out `targetBranch`, runs `git merge --no-ff` / `--squash` / rebase + ff-only depending on strategy, captures the new HEAD as `mergeSha`. No `prId`, no remote API call.
-- On merge failure or post-merge verification failure, run `git reset --hard <rollbackSha>` and emit `merge.rollback` with a categorized reason (`merge-failed`, `verification-failed`, `timeout`).
-- Emit distinct events for success (`merge.executed`) and rollback (`merge.rollback`).
+- On merge failure or post-merge verification failure, run the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and dual-emit `merge.rollback` (legacy wire shape) plus `merge.recovered` (the canonical successor, #1306) with a categorized reason (`merge-failed`, `verification-failed`, `timeout`).
+- Emit distinct events for success (`merge.executed`) and recovery (`merge.rollback` / `merge.recovered`).
 
 **Acceptance criteria**
-1. The rollback SHA is persisted to `WorkflowState.mergeOrchestrator` *before* any ref-mutating git command runs. A test asserts ordering by injecting a runner that fails after the persistence step.
-2. After rollback, `git rev-parse HEAD` matches the recorded rollback SHA.
-3. The rollback event payload includes `{ rollbackSha, reason, sourceBranch, targetBranch, taskId }`.
+1. The recovery point SHA is persisted to `WorkflowState.mergeOrchestrator` *before* any ref-mutating git command runs (write-ahead-log ordering). A test asserts ordering by injecting a runner that fails after the persistence step.
+2. After recovery, `git rev-parse HEAD` matches the recorded recovery point SHA.
+3. The recovery event payload includes `{ recoveryPointSha, reason, sourceBranch, targetBranch, taskId }` (the legacy `merge.rollback` event keeps its `rollbackSha` wire field during the v2.11.x deprecation window; `merge.recovered` carries `recoveryPointSha`).
 4. All `execFileSync('git', ...)` calls use the no-shell form and a 120s timeout, matching `post-merge.ts:48`.
-5. Handler returns `ToolResult { success: false, error: { code, message } }` on rollback. The structured error matches existing handler conventions (e.g., `post-merge.ts`).
+5. Handler returns `ToolResult { success: false, error: { code, message } }` on recovery. The structured error matches existing handler conventions (e.g., `post-merge.ts`).
 
 ### DR-MO-4: Worktree drift detection
 
@@ -200,7 +205,7 @@ These were in the original 2026-04-17 design and are deliberately deferred or re
 
 | Original requirement | Disposition |
 |---|---|
-| **DR-MO-3** (semantic conflict resolution, line-level + AST-aware) | Deferred to a follow-up. Rollback covers the failure mode for v2.9.0: any unresolvable conflict triggers a clean rollback rather than a partial-merge state. AST-aware resolution would add a parser dependency and substantial surface area without proportionate value while rollback exists. |
+| **DR-MO-3** (semantic conflict resolution, line-level + AST-aware) | Deferred to a follow-up. Recovery covers the failure mode for v2.9.0: any unresolvable conflict triggers a clean recovery to the recorded recovery point rather than a partial-merge state. AST-aware resolution would add a parser dependency and substantial surface area without proportionate value while recovery exists. |
 | **DR-MO-5** (separate JSON state file at `<stateDir>/merge-orchestrator/<featureId>.json`) | Reframed. State persistence uses the existing `WorkflowState` schema with a new optional `mergeOrchestrator` field. A parallel state file with its own atomic-write semantics, expiry policy, and corruption modes is the divergent-implementations antipattern (DIM-5) the codebase actively cleaned up in #1185. Resume-on-entry comes for free from the existing workflow state loader. |
 
 ## WorkflowState extension
@@ -209,11 +214,14 @@ One new optional field. The schema lives alongside the existing `WorkflowState` 
 
 ```ts
 export interface MergeOrchestratorState {
+  // `'rolled-back'` is the recovery-terminal phase value — intentionally NOT
+  // renamed in the #1306 recovery reframe (the phase string is a load-bearing
+  // wire/state token).
   readonly phase: 'pending' | 'executing' | 'completed' | 'rolled-back' | 'aborted';
   readonly sourceBranch: string;
   readonly targetBranch: string;
   readonly taskId?: string;            // present when auto-dispatched via next_actions
-  readonly rollbackSha?: string;       // populated before merge ref-mutation
+  readonly recoveryPointSha?: string;  // WAL recovery point, recorded before merge ref-mutation
   readonly mergeSha?: string;          // populated after successful merge
   readonly preflight?: MergePreflightResult;
 }
@@ -230,9 +238,12 @@ mergeOrchestrator?: MergeOrchestratorState;
 |---|---|---|
 | `merge.preflight` | `merge-orchestrate.ts` (via `emitGateEvent`) | `{ featureId, sourceBranch, targetBranch, taskId?, ancestry, worktree, currentBranchProtection, drift }` |
 | `merge.executed` | `execute-merge.ts` (via `emitGateEvent`) | `{ featureId, sourceBranch, targetBranch, taskId?, mergeSha, rollbackSha }` |
-| `merge.rollback` | `execute-merge.ts` (via `emitGateEvent`) | `{ featureId, sourceBranch, targetBranch, taskId?, rollbackSha, reason }` |
+| `merge.rollback` | `execute-merge.ts` (via `emitGateEvent`) | `{ featureId, sourceBranch, targetBranch, taskId?, rollbackSha, reason }` — **legacy** wire shape |
+| `merge.recovered` | `execute-merge.ts` (#1306 successor) | `{ sourceBranch, targetBranch, taskId?, recoveryPointSha, reason, recoveryError?, recoveryErrorDetail? }` |
 
 All events flow through the `orchestrate` stream via `ctx.eventStore.append()` and carry `featureId` as the correlation key. The full merge lifecycle is reconstructable from the event log alone (#1109).
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (recorded HEAD SHA) and a **recovery event** (`merge.recovered`), not a "rollback anchor" / "compensation". `merge.recovered` is the additive successor to `merge.rollback` and carries the resolved field names (`recoveryPointSha`, `recoveryErrorDetail`) alongside the unchanged INV-14 `recoveryError` discriminator. During the v2.11.x deprecation window the executor dual-emits both events for the same logical recovery; the legacy `merge.rollback` keeps its `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission. The state-file / `ToolResult.data` carry the renamed `recoveryPointSha` / `recoveryErrorDetail` today. The phase value `'rolled-back'` is intentionally retained.
 
 The two events from the original design (`merge.conflict.detected`, `merge.conflict.resolved`) are out of scope for v2.9.0 along with DR-MO-3.
 
@@ -254,7 +265,7 @@ exarchos merge-orchestrate \
 Exit codes follow the existing `CLI_EXIT_CODES` contract:
 - 0: merge completed successfully (or preflight passed for `--dry-run`)
 - 1: invalid input
-- 2: merge failed (preflight blocked or rollback executed)
+- 2: merge failed (preflight blocked or recovery executed)
 - 3: uncaught exception
 
 `--dry-run` exits after preflight without invoking the executor. This enables CI integration where merge readiness is checked before the merge window opens.
@@ -282,7 +293,7 @@ Return shape: `ToolResult` wrapping `MergeOrchestrateOutput`. CLI and MCP call t
 
 | Constraint | How this design complies | Verification |
 |---|---|---|
-| **Event-sourcing integrity** | Every phase transition emits an event (3 event types covering the full v2.9.0 lifecycle). The trigger itself is derived from state + HSM via the existing `next-action@v1` projection -- not a side effect of a handler call. The merge lifecycle is fully reconstructable from the event log. | A test reconstructs the merge timeline from events alone for a passing run, a rollback run, and an aborted-by-preflight run. |
+| **Event-sourcing integrity** | Every phase transition emits an event (3 event types covering the full v2.9.0 lifecycle). The trigger itself is derived from state + HSM via the existing `next-action@v1` projection -- not a side effect of a handler call. The merge lifecycle is fully reconstructable from the event log. | A test reconstructs the merge timeline from events alone for a passing run, a recovery run, and an aborted-by-preflight run. |
 | **MCP parity** | One handler function (`handleMergeOrchestrate`) called by both the CLI adapter and the MCP composite router. One Zod schema shared by both. No CLI-only code paths. | `merge-orchestrate.parity.test.ts` invokes through both adapters and asserts identical `ToolResult` shape. |
 | **Basileus-forward** | Handler accepts `DispatchContext` (not raw `stateDir`). VCS operations route through `VcsProvider` via `createVcsProvider({ config: ctx.projectConfig })`. State persistence uses the existing JSON `WorkflowState` schema (portable across transports). No `process.stdin` / `process.stdout` assumptions. | Code-review checklist: no raw `gh` / `git push` invocations, no `process.std*`, no module-global EventStore. The CI gate `scripts/check-event-store-composition-root.mjs` enforces the EventStore composition rule structurally. |
 
@@ -293,7 +304,7 @@ Per `axiom:backend-quality` dimensions.
 | Dimension | Risk in original design | How this design addresses it |
 |---|---|---|
 | **DIM-1 Topology** | Original AC "checks are injectable" implied novel -- already enforced by existing `GitExec` injection. | No new injection scaffolding. Handlers receive `EventStore` via `DispatchContext` (post-#1185); pure modules receive `gitExec`. The CI gate at `scripts/check-event-store-composition-root.mjs` blocks regressions. |
-| **DIM-2 Observability** | Catch-all rollback could hide failure causes. | `merge.rollback` payload includes a categorized `reason`. Handler `ToolResult` carries a structured error with `code` + `message`. No silent fallbacks; any caught exception is either re-emitted as a structured error or logged with cause. |
+| **DIM-2 Observability** | Catch-all recovery could hide failure causes. | The recovery event (`merge.rollback` legacy / `merge.recovered` successor) payload includes a categorized `reason`. Handler `ToolResult` carries a structured error with `code` + `message`. No silent fallbacks; any caught exception is either re-emitted as a structured error or logged with cause. |
 | **DIM-3 Contracts** | Original redefined `MergePreflightResultSchema` from scratch. | `MergePreflightResult` composes the existing `AncestryResult` / `WorktreeAssertionResult` / `CurrentBranchProtectionResult` types from `dispatch-guard.ts`. Zod schemas derive from the TS types via `z.infer`. One source of truth per concept. |
 | **DIM-4 Test Fidelity** | Risk of over-mocked tests that pass while production wiring is broken. | Parity test invokes through real composite dispatchers. Integration test reconstructs the merge timeline from a real event store. EventStore is constructed the same way production constructs it (via `DispatchContext`). |
 | **DIM-5 Hygiene** | Original sub-directory `merge-orchestrator/` diverged from the flat `orchestrate/` convention; original separate state file paralleled `WorkflowState`. | Flat layout matching every other handler. One state field on the existing `WorkflowState` schema. No parallel modules, no parallel persistence. |
@@ -313,7 +324,7 @@ Per `axiom:backend-quality` dimensions.
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| Auto-rollback resets a worktree the user expected to keep modifying | High | Drift detection in DR-MO-4 fails preflight whenever uncommitted work is present, *before* the executor records a rollback SHA. The executor only ever resets to the SHA it just recorded -- never to an arbitrary point in history. |
+| Auto-recovery resets a worktree the user expected to keep modifying | High | Drift detection in DR-MO-4 fails preflight whenever uncommitted work is present, *before* the executor records a recovery point. The executor only ever recovers to the SHA it just recorded -- never to an arbitrary point in history. |
 | `WorkflowState.mergeOrchestrator` field corrupts on partial write | Medium | Reuses `workflow/state-store.ts` atomic-write semantics (already battle-tested for the rest of `WorkflowState`). On `VersionConflictError`, the orchestrator re-reads and retries, matching `handleTaskClaim`'s `MAX_CLAIM_RETRIES` pattern in `tasks/tools.ts`. |
 | Auto-dispatch loops on transient failures | Medium | Idempotency key `${streamId}:merge_orchestrate:${taskId}` collapses re-entries. The `next-actions` projection only surfaces `merge_orchestrate` while `mergeOrchestrator.phase` is `pending` or absent; once `phase` becomes `rolled-back` or `aborted`, the projection no longer suggests it (manual re-dispatch required). |
 | Git operations hang on large repos | Low | All `execFileSync('git', ...)` calls use a 120s timeout matching the codebase convention. Preflight has its own 2s soft target enforced by AC. |

--- a/docs/designs/2026-06-21-v2.11.0-preview.2-merge-orchestrator-hardening.md
+++ b/docs/designs/2026-06-21-v2.11.0-preview.2-merge-orchestrator-hardening.md
@@ -1,0 +1,272 @@
+---
+title: "v2.11.0 preview.2 — Merge-Orchestrator Hardening + Token-Capture Proof"
+date: 2026-06-21
+status: draft
+workflow: feature
+featureId: v2-11-preview2-bundle
+milestone: "v2.11.0 — Verification & Reliability"
+closes-epic: 1302
+issues: [1305, 1306, 1308, 1309, 1310, 1311, 1402, 1561]
+supersedes: []
+---
+
+# v2.11.0 preview.2 — Merge-Orchestrator Hardening + Token-Capture Proof
+
+## 1. Context
+
+`v2.11.0-preview.1` shipped the milestone's two **Verification** spines: the risk-proportional
+verification ladder (epic #1515, R1–R10) and the structural-integration-verification foundation
+(SIV-1/2/4), on top of the phase-kind binding (#1546) and the event-sourcing read path
+(#1504/#1554/#1556 — SQLite as sole source of truth). preview.1 was deliberately
+Verification-heavy.
+
+preview.2 rebalances toward the milestone's under-served **Reliability** half by closing the
+merge-orchestrator audit epic **#1302** (audit of the #1119 autonomous merge orchestrator against
+the canonical single-machine frame), and pays down the one explicit preview.1 debt: the live
+end-to-end proof of subagent token capture (#1561, deferred from #1525/W2).
+
+### 1.1 What already shipped (epic #1302 is further along than its checklist shows)
+
+The epic's Wave-A dependencies all landed during the v2.10→preview.1 window — the design below is
+written against the **current** tree, not the epic's original snapshot:
+
+| Dependency | State | Consequence for preview.2 |
+|---|---|---|
+| #1259 durable event-store + capability + HSM contracts | **CLOSED** | C4 (single-path HSM) and C5 (`AgentPosture`) primitives exist. `capabilities/resolver.ts` + `capabilities/posture-mapping.ts` are live → **#1305 is unblocked**. |
+| #1304 (A2) orchestrator state = projection over `merge.*` | **CLOSED** | The orchestrator is already a left-fold projection. #1309's "post-A2 emission site" and #1305's "verify transition exclusivity" apply to a projection-based orchestrator. |
+| #1307 (B2) `git reset --hard` → `--abort` / `--keep` | **CLOSED** | INV-14 native-primitive recovery already holds; #1308's retry path builds on the existing recovery primitive. |
+
+**Remaining open epic children:** #1305 (A3), #1306 (B1), #1308 (B3), #1309 (B4), #1310 (B5),
+#1311 (B6) — six issues. Plus the separate-lineage Windows RCA **#1402** (from #1362), which the
+milestone groups here. Plus the carried-in token-proof **#1561**.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Close epic #1302's remaining handler-author wave with the merge orchestrator's vocabulary,
+  recovery semantics, posture, liveness, and hygiene brought into line with the canonical frame.
+- Land the v2.11 half of #1309's liveness protocol so v2.12 process-lifecycle verbs (`ps`/`wait`)
+  can resolve stuck merges generically — **no per-feature supervisor**.
+- Produce the live token-capture proof (#1561) **as a by-product of this bundle's own
+  worktree-isolated delegation**, not as a synthetic exercise.
+
+**Non-goals**
+- Implementing the v2.12 `ps`/`wait`/`describe` verbs (only the liveness *signal* lands here; the
+  verb-side verification gate folds into v2.12).
+- Reproducing the Windows ancestry bug on Linux CI (#1402 is data-blocked — see §7).
+- Removing the `merge.rollback` legacy emission (that is a v2.12 cleanup obligation — see §8).
+
+## 3. Constraints (invariants, dev catalog enabled)
+
+These load-bearing invariants are the acceptance frame for the bundle. Every work item below cites
+the invariant it must satisfy; the `check_invariant_conformance` gate audits the design against the
+substrate set at review.
+
+| Invariant | Binds on |
+|---|---|
+| **INV-15** single-machine-frame *(load)* | #1306 — "drop saga vocabulary" is literally enforcing this frame. No saga / scheduler-agent-supervisor / compensation-as-remote-command vocabulary survives. |
+| **INV-14** native-primitive-first recovery *(ref)* | #1308 — the bounded-retry path must still fall back to `--abort` / `reset --keep`, never `--hard`; `recoveryError` discriminates indeterminate states. |
+| **INV-13** process-manager two-event split *(ref)* | #1308/#1309 — retry + liveness events must preserve `*.requested`→`*.executed` with idempotent precheck; new events are additive, never replacing the terminal pair. |
+| **INV-10** liveness-event-protocol *(ref)* | #1309 — `merge.executing_started` must follow the generic `<surface>.executing_started` + terminal pairing v2.12 verbs query. |
+| **INV-11** posture-declared-capabilities *(load)* | #1305 — `shared-mutating` posture is unrepresentable-by-construction; a `read-only` caller is rejected at the resolver gate before any git runs. #1561's isolated dispatch is `task-isolated`. |
+| **INV-8** idempotency-at-the-boundary *(load)* | #1308 retry — each retry re-emit must idempotency-collapse on the merge-keys CAS path (see CAS-pin hazard, §6.1). |
+| **INV-5a** input-ergonomics *(load)* | #1310 — "do NOT use for" negative-space guidance on the `merge_orchestrate` description. |
+| **INV-5b / INV-2** output-contract / facade-equivalence *(load)* | #1306 — the `_meta.deprecation` envelope must be byte-equal across CLI and MCP; renamed event shapes preserve the registered outputSchema. |
+| **INV-1** event-sourcing integrity *(load)* | #1561 — `subagent.tokens_used` is the record; folds into views, no side table. All new merge events register in `schemas.ts`. |
+
+## 4. Scope at a glance
+
+```
+epic #1302  (close in preview.2 modulo #1402)
+├─ #1306  B1  vocabulary + recovery rename          ← SPINE (highest blast radius)
+├─ #1308  B3  bounded retry-with-backoff (timeout)  ← depends on #1306 types
+├─ #1309  B4  merge.executing_started liveness        ← uses recoveryPointSha (soft on #1306)
+├─ #1311  B6  dedupe defaultGitExec                  ← touches same files; sequence as foundation
+├─ #1305  A3  posture: shared-mutating + transition  ← independent track (registry + resolver)
+├─ #1310  B5  "do NOT use for" description            ← independent drive-by
+└─ #1402      Windows ancestry RCA                    ← DATA-BLOCKED; split to parallel track (§7)
+
+carried-in:
+   #1561        live token-capture proof              ← falls out of this bundle's isolated dispatch (§6.6)
+```
+
+## 5. Current surface (orientation)
+
+The merge orchestrator is a projection-backed handler chain:
+`merge-orchestrate.ts` (preflight + dispatch) → `execute-merge.ts` (effectful executor) over the
+pure core `pure/execute-merge.ts` (`categorizeFailure`, `RollbackReason`) and
+`pure/merge-preflight.ts` (`GitExec`). Recovery state is a left-fold over `merge.*` events
+registered in `event-store/schemas.ts`; CAS idempotency keys live in `merge-keys.ts`. The vocabulary
+audit (`docs/research/2026-05-08-1119-merge-orchestrator-audit.md`) is the source spec for every
+item below.
+
+**Grounding deltas found against the issue text:**
+- `merge.rollback` / `RollbackReason` / `rollbackSha` span **~13 files** incl. `merge-keys.ts` and
+  9 test files — #1306 is a broad-blast-radius rename, not a local edit.
+- `defaultGitExec` is referenced in **8 files** (preflight, gate-utils, contract-drift,
+  test-adequacy, mock-boundary, …), wider than the 2–3 the issue named. #1311 needs an explicit
+  **definition-site vs. consumer-site** pass before extracting the shared module.
+
+## 6. Design
+
+### 6.1 #1306 — Vocabulary + recovery rename (the spine)
+
+Mechanical, behavior-preserving rename driven by INV-15:
+`RollbackReason → RecoveryReason` (variants `'merge-failed' | 'verification-failed' | 'timeout'`
+unchanged), `rollbackSha → recoveryPointSha`, `rollbackError → recoveryError`, and all
+"rollback"/"compensation" comments → "recovery". Register a new event type **`merge.recovered`**
+in `schemas.ts` carrying the renamed shape.
+
+**Deprecation envelope (one release):** the handler dual-emits `merge.recovered` **and** legacy
+`merge.rollback` for the same logical event throughout v2.11.x; the response surfaces
+`_meta.deprecation = { since: "2.11.0", removeIn: "2.12.0", replacement: "merge.recovered" }`. The
+HSM exit guard `mergePendingExit` recognizes **both** as terminal. v2.12 removal is tracked (§8).
+
+**Hazard — CAS-pin idempotency (memory: `merge-keys.ts`):** the rename touches `merge-keys.ts`.
+Do **not** re-pin the new `merge.recovered` append to a sequence returned by the legacy append; the
+dual-emission must use independent idempotency keys or one shared append boundary, or retries
+conflict forever (INV-8). Add a test asserting a retried recovery is a no-op across **both** event
+types.
+
+### 6.2 #1308 — Bounded retry-with-backoff for `timeout` (depends on §6.1)
+
+`categorizeFailure` stays the discriminator. `'timeout'` no longer routes straight to recovery:
+the executor enters a bounded loop — **max 2 retries** (3 total `vcsMerge` invocations), exponential
+backoff base 1000ms × 2.0 with ±25% jitter, constants at module top. `'verification-failed'` and
+`'merge-failed'` keep immediate recovery (non-transient by definition). Each attempt emits
+**`merge.retry_attempt`** `{ attempt, delayMs, reason: 'timeout' }`. After exhaustion, fall back to
+recovery with `reason: 'timeout'` (current post-exhaustion behavior). INV-14 fallback unchanged;
+INV-13 pairing preserved (retry events are additive between `executing_started` and the terminal
+event).
+
+> **Determinism note for tests:** jitter must be injectable (seam, not `Math.random()` inline) so
+> the timeout-once-then-success and timeout-exhausted fixtures are deterministic.
+
+### 6.3 #1309 — `merge.executing_started` liveness (INV-10)
+
+Immediately after the recovery point is recorded and **before** `vcsMerge`, emit
+**`merge.executing_started`** `{ taskId, sourceBranch, targetBranch, recoveryPointSha, startedAt }`.
+Purely additive observability — no change to terminal emission. This is the v2.11 half of the
+protocol; the v2.12 verification gate (a generic `wait`/`ps` resolving a stuck `executing` by
+reading `executing_started` + absence-of-terminal + cadence) is recorded for traceability and lands
+with the v2.12 verbs. **Do not** bolt a stuck-checker onto `merge_orchestrate` — that would violate
+the generic-not-per-feature rule (INV-10/INV-15).
+
+### 6.4 #1311 — Dedupe `defaultGitExec` (hygiene)
+
+Extract one `defaultGitExec(repoRoot, args)` into a shared module
+(`orchestrate/git-exec-default.ts`), or extend an existing helper if shape-compatible
+(`pure/merge-preflight.ts:GitExec` → `GitExecResult` with `exitCode`; verify the
+`setup-worktree.ts` helper matches before reusing). **Definition-vs-consumer pass first:** of the 8
+referencing files, identify the true byte-identical *definitions* (merge-orchestrate, execute-merge,
+likely post-merge) versus files that merely accept a `GitExec` param — only the definitions
+collapse. No behavior change; existing tests pass unchanged. Sequence this **before** §6.1–6.3 land
+on the same files, or accept it as the first commit of the sequenced sub-batch (§9) to avoid
+rebasing the rename across a moving helper.
+
+### 6.5 #1305 — Posture + transition exclusivity (INV-11), and #1310 — description (INV-5a)
+
+**#1305:** declare `posture: 'shared-mutating'` on the `merge_orchestrate` registration
+(`registry.ts:~981`); add resolver tests asserting (a) it resolves to write capabilities
+(fs-write + shell-exec) and (b) a `read-only` caller is rejected at the resolver gate before
+`handleMergeOrchestrate`. Assert all `merge-pending` HSM transitions emit `workflow.transition`
+(never deprecated `workflow.set({phase})`), and grep-gate that no `orchestrate/` call site uses
+`set({phase})` for merge transitions. Independent of the execute-merge churn → parallel-safe track.
+
+**#1310:** rewrite the `merge_orchestrate` description with Use-for / Do-NOT-use-for negative space
+(do NOT use for remote PR merges → `merge_pr`; worktree validation → `verify_worktree`; synthesis →
+`request_synthesize`). Verify the `describe` action reflects it. ~5-minute drive-by; folds into any
+PR in the bundle.
+
+### 6.6 #1561 — Token-capture proof as a by-product (INV-1, INV-11)
+
+The seam shipped in preview.1 W2 (`subagent.tokens_used` atom + `SubagentStop` handler resolving
+teammate by worktree↔cwd, folding into `team_performance` / `delegation_timeline`). What's missing
+is *live population proof*. **This bundle is the proof workload:** delegating the six code issues
+via **worktree-isolated** sub-agents (required anyway by INV-4 — shared `cwd` produces no atom by
+design) generates exactly the per-teammate token data #1561 needs.
+
+Steps: (1) register the `SubagentStop` hook in the active runtime settings (manifest ships, running
+session must load it); (2) dispatch the §9 waves worktree-isolated; (3) confirm
+`exarchos_view team_performance` / `delegation_timeline` show non-empty per-teammate token metrics;
+(4) confirm session→workflow manifest binding resolves the `v2-11-preview2-bundle` stream. The
+coverage gap (non-isolated / non-Claude runtimes emit no atom) is **logged, never failed** (INV-4
+graceful degradation).
+
+## 7. #1402 (Windows ancestry RCA) — recommended split-out
+
+#1402 is **not a TDD code task** — it is blocked on a real Windows-host `merge.preflight` event
+carrying the 9-field `data.debug` payload (instrumentation already shipped via #1401). Linux
+`outcome-tests` CI **cannot reproduce** the bug (explicit out-of-scope in the issue). Folding it into
+the code bundle would stall the wave on an artifact we cannot produce on demand.
+
+**Recommendation:** keep #1402 in epic #1302 but run it as a **parallel diagnostic track**, not part
+of the preview.2 TDD waves. Action: solicit one Windows-host capture (operator or a Windows-CI
+surface) with `EXARCHOS_PREFLIGHT_DEBUG=1`; once the dump arrives, diagnose (packed-refs lag vs.
+worktree-local ref interaction vs. git-version bug) and fix at `dispatch-guard.ts` /
+`merge-preflight.ts` / `defaultGitExec`. **Consequence:** preview.2 closes epic #1302 *modulo #1402*;
+the epic fully closes when the Windows dump lands. The plan-review checkpoint is the place to confirm
+this split — the alternative (block the bundle on Windows data) is not recommended.
+
+## 8. Forward obligations (tracked, not deferred silently)
+
+- **v2.12 cleanup issue** (required by #1306): open "v2.12 cleanup: remove `merge.rollback`
+  deprecation shim" listing exact removal sites — dual-emission path, `schemas.ts` entry, HSM
+  exit-guard fallback. File it **when #1306 lands**, milestoned v2.12.0.
+- **v2.12 verification gate** (#1309): the generic `wait`/`ps`-resolves-stuck-merge test lands with
+  the v2.12 process-lifecycle verbs, referenced back to `merge.executing_started`.
+- **#1402** epic-close: gated on the Windows capture (§7).
+
+## 9. Delivery plan — conflict topology & waves
+
+Four issues (#1311, #1306, #1308, #1309) touch the same `pure/execute-merge.ts` /
+`execute-merge.ts` / `merge-orchestrate.ts` files → **must not** be dispatched as naive parallel
+sub-agents (guaranteed worktree collisions). Two independent tracks run in parallel.
+
+```
+Wave 1 (foundation, sequenced — same files):
+  T1  #1311  dedupe defaultGitExec          (land first: stabilize the helper)
+  T2  #1306  vocabulary + recovery rename    (spine; rebases cleanly on T1)
+Wave 2 (sequenced on Wave 1):
+  T3  #1308  bounded retry-with-backoff       (needs RecoveryReason from T2)
+  T4  #1309  merge.executing_started          (uses recoveryPointSha from T2; additive)
+Parallel tracks (independent files, dispatch alongside Wave 1):
+  P1  #1305  posture + transition exclusivity  (registry.ts, capabilities/, hsm-definitions tests)
+  P2  #1310  description "do NOT use for"        (registry.ts description string)
+Proof track (consumes the waves' own telemetry):
+  X1  #1561  register SubagentStop hook + verify team_performance/delegation_timeline populate
+Parallel diagnostic (out of TDD waves):
+  W1  #1402  solicit Windows dump → RCA → fix    (data-blocked; epic-close gate)
+```
+
+**Dispatch discipline (CLAUDE.md Workflow Dispatch):** dispatch from the preview.2 feature branch,
+never `main`; verify base-branch topology before each wave; run merges only from the main worktree;
+insert a checkpoint between Wave 1 and Wave 2 (the rename's broad blast radius warrants a full
+`vitest run` + `skills:guard` between merges, per the broad-blast-radius gate guidance). #1306 edits
+`skills-src/merge-orchestrator/**` → run `npm run build:skills` and commit the regenerated tree
+(dual baseline update for any snapshot drift).
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| #1306 rename misses a `merge.rollback` consumer (event log readers, parity snapshots) | Dual-emission window + `_meta.deprecation`; grep-gate for residual `rollback` tokens in live surfaces; parity test byte-equal across CLI/MCP. |
+| CAS-pin idempotency regression on dual-emission (`merge-keys.ts`) | Independent idempotency keys per event type or single shared append; retry-is-no-op test across both types (§6.1). |
+| #1311 over-collapses a consumer that only *accepts* `GitExec` | Definition-vs-consumer pass before extraction; "no behavior change, existing tests pass" gate. |
+| #1308 flaky timeout tests under CI load | Injectable jitter seam; explicit per-test timeout override > child budget (memory: vitest spawn-timeout flake). |
+| Wave collisions on shared files | Sequenced Wave 1→2; only #1305/#1310 run truly parallel. |
+| #1561 proof yields empty metrics (shared cwd, hook not loaded) | Worktree-isolated dispatch is mandatory; verify hook registration in active settings before Wave 1; degradation logged not failed. |
+
+## 11. Acceptance / definition of done (preview.2)
+
+- Epic #1302 children #1305, #1306, #1308, #1309, #1310, #1311 closed; `merge.rollback` survives
+  only as the deprecation shim with a filed v2.12 removal issue.
+- New events `merge.recovered`, `merge.retry_attempt`, `merge.executing_started` registered in
+  `schemas.ts`; timelines assert ordering (`executing_started` → [`retry_attempt`*] → terminal).
+- `merge_orchestrate` resolves `shared-mutating`; `read-only` caller rejected at the resolver;
+  no `set({phase})` merge transitions.
+- `check_invariant_conformance` passes against INV-15/14/13/10/11/8/5a/5b/2/1.
+- #1561: `subagent.tokens_used` events present on the `v2-11-preview2-bundle` stream after isolated
+  dispatch; `team_performance` / `delegation_timeline` non-empty per teammate; coverage gap logged.
+- #1402 carries a recorded decision (split-out) and, if a Windows dump arrives in-window, an RCA.
+- Full `vitest run` + `npm run skills:guard` green; CLI≡MCP parity intact.

--- a/docs/designs/2026-06-21-v2.11.0-preview.3-merge-orchestrator-hardening.md
+++ b/docs/designs/2026-06-21-v2.11.0-preview.3-merge-orchestrator-hardening.md
@@ -1,5 +1,5 @@
 ---
-title: "v2.11.0 preview.2 — Merge-Orchestrator Hardening + Token-Capture Proof"
+title: "v2.11.0 preview.3 — Merge-Orchestrator Hardening + Token-Capture Proof"
 date: 2026-06-21
 status: draft
 workflow: feature
@@ -10,7 +10,7 @@ issues: [1305, 1306, 1308, 1309, 1310, 1311, 1402, 1561]
 supersedes: []
 ---
 
-# v2.11.0 preview.2 — Merge-Orchestrator Hardening + Token-Capture Proof
+# v2.11.0 preview.3 — Merge-Orchestrator Hardening + Token-Capture Proof
 
 ## 1. Context
 
@@ -20,7 +20,7 @@ verification ladder (epic #1515, R1–R10) and the structural-integration-verifi
 (#1504/#1554/#1556 — SQLite as sole source of truth). preview.1 was deliberately
 Verification-heavy.
 
-preview.2 rebalances toward the milestone's under-served **Reliability** half by closing the
+preview.3 rebalances toward the milestone's under-served **Reliability** half by closing the
 merge-orchestrator audit epic **#1302** (audit of the #1119 autonomous merge orchestrator against
 the canonical single-machine frame), and pays down the one explicit preview.1 debt: the live
 end-to-end proof of subagent token capture (#1561, deferred from #1525/W2).
@@ -30,7 +30,7 @@ end-to-end proof of subagent token capture (#1561, deferred from #1525/W2).
 The epic's Wave-A dependencies all landed during the v2.10→preview.1 window — the design below is
 written against the **current** tree, not the epic's original snapshot:
 
-| Dependency | State | Consequence for preview.2 |
+| Dependency | State | Consequence for preview.3 |
 |---|---|---|
 | #1259 durable event-store + capability + HSM contracts | **CLOSED** | C4 (single-path HSM) and C5 (`AgentPosture`) primitives exist. `capabilities/resolver.ts` + `capabilities/posture-mapping.ts` are live → **#1305 is unblocked**. |
 | #1304 (A2) orchestrator state = projection over `merge.*` | **CLOSED** | The orchestrator is already a left-fold projection. #1309's "post-A2 emission site" and #1305's "verify transition exclusivity" apply to a projection-based orchestrator. |
@@ -77,7 +77,7 @@ substrate set at review.
 ## 4. Scope at a glance
 
 ```
-epic #1302  (close in preview.2 modulo #1402)
+epic #1302  (close in preview.3 modulo #1402)
 ├─ #1306  B1  vocabulary + recovery rename          ← SPINE (highest blast radius)
 ├─ #1308  B3  bounded retry-with-backoff (timeout)  ← depends on #1306 types
 ├─ #1309  B4  merge.executing_started liveness        ← uses recoveryPointSha (soft on #1306)
@@ -201,10 +201,10 @@ carrying the 9-field `data.debug` payload (instrumentation already shipped via #
 the code bundle would stall the wave on an artifact we cannot produce on demand.
 
 **Recommendation:** keep #1402 in epic #1302 but run it as a **parallel diagnostic track**, not part
-of the preview.2 TDD waves. Action: solicit one Windows-host capture (operator or a Windows-CI
+of the preview.3 TDD waves. Action: solicit one Windows-host capture (operator or a Windows-CI
 surface) with `EXARCHOS_PREFLIGHT_DEBUG=1`; once the dump arrives, diagnose (packed-refs lag vs.
 worktree-local ref interaction vs. git-version bug) and fix at `dispatch-guard.ts` /
-`merge-preflight.ts` / `defaultGitExec`. **Consequence:** preview.2 closes epic #1302 *modulo #1402*;
+`merge-preflight.ts` / `defaultGitExec`. **Consequence:** preview.3 closes epic #1302 *modulo #1402*;
 the epic fully closes when the Windows dump lands. The plan-review checkpoint is the place to confirm
 this split — the alternative (block the bundle on Windows data) is not recommended.
 
@@ -239,7 +239,7 @@ Parallel diagnostic (out of TDD waves):
   W1  #1402  solicit Windows dump → RCA → fix    (data-blocked; epic-close gate)
 ```
 
-**Dispatch discipline (CLAUDE.md Workflow Dispatch):** dispatch from the preview.2 feature branch,
+**Dispatch discipline (CLAUDE.md Workflow Dispatch):** dispatch from the preview.3 feature branch,
 never `main`; verify base-branch topology before each wave; run merges only from the main worktree;
 insert a checkpoint between Wave 1 and Wave 2 (the rename's broad blast radius warrants a full
 `vitest run` + `skills:guard` between merges, per the broad-blast-radius gate guidance). #1306 edits
@@ -257,7 +257,7 @@ insert a checkpoint between Wave 1 and Wave 2 (the rename's broad blast radius w
 | Wave collisions on shared files | Sequenced Wave 1→2; only #1305/#1310 run truly parallel. |
 | #1561 proof yields empty metrics (shared cwd, hook not loaded) | Worktree-isolated dispatch is mandatory; verify hook registration in active settings before Wave 1; degradation logged not failed. |
 
-## 11. Acceptance / definition of done (preview.2)
+## 11. Acceptance / definition of done (preview.3)
 
 - Epic #1302 children #1305, #1306, #1308, #1309, #1310, #1311 closed; `merge.rollback` survives
   only as the deprecation shim with a filed v2.12 removal issue.

--- a/docs/plans/2026-06-21-v2.11.0-preview.2-merge-orchestrator-hardening.md
+++ b/docs/plans/2026-06-21-v2.11.0-preview.2-merge-orchestrator-hardening.md
@@ -1,0 +1,220 @@
+---
+title: "Plan — v2.11.0 preview.2 — Merge-Orchestrator Hardening + Token-Capture Proof"
+date: 2026-06-21
+design: docs/designs/2026-06-21-v2.11.0-preview.2-merge-orchestrator-hardening.md
+featureId: v2-11-preview2-bundle
+milestone: "v2.11.0 — Verification & Reliability"
+closes-epic: 1302
+---
+
+# Implementation Plan — preview.2
+
+**Verification framing: the risk-proportional ladder (not uniform RED-GREEN-REFACTOR).** Per the
+reframed `implementation-planning` skill (R8 #1523) and the shipped ladder (R1 #1516 / R2 #1517 /
+R3 #1518 / R6 #1521), each task carries a `riskTier` + `boundaryTouching` stamp and gets the
+*cheapest verification that still captures its risk*. RGR is the **high-tier path only**.
+
+| Tier | Obligation | Net |
+|---|---|---|
+| **low** | Static analysis (typecheck + lint) + existing suite | docs/string/config edits — test-first ceremony is pure overhead |
+| **medium** | Scoped tests + the `check_test_adequacy` kill-probe | recaptures "a test can actually fail" without RED-first per commit |
+| **high** | Full red-green-refactor + the integration suite | schema/type/contract/capability surfaces that span the codebase |
+
+Tier counts here: **high ×5** (T3, T4, T9, T10, T14), **medium ×8**, **low ×2**, **n/a ×3**
+(T7 issue-filing, T17 dogfood proof, T18 investigation — not code tasks). Test names follow
+`Method_Scenario_Outcome`. All paths under `servers/exarchos-mcp/src/` unless noted.
+
+> **Note on this plan's lineage:** the `/exarchos:plan` command template still encodes the
+> pre-ladder Iron Law + uniform RGR task format and is stale relative to the reframed skill — a
+> tracked dogfood finding (see §"Tooling follow-up"). This plan is authored in ladder terms.
+
+## Dispatch topology
+
+```
+Wave 1 (sequenced — shared files pure/execute-merge.ts, execute-merge.ts, merge-orchestrate.ts):
+   T1 #1311 → T2 #1306-rename → T3 merge.recovered → {T4 dual-emit, T5 hsm-guard} → T6 docs/skills → T7 file-cleanup-issue
+Wave 2 (sequenced on Wave 1):
+   T8 schema → T9 retry-success → {T10 exhausted, T11 non-transient} ; T12 #1309 liveness
+Parallel track P1 (#1305 — registry/capabilities/hsm, independent files):
+   T13 → T14 ; T15
+Parallel track P2 (#1310 — description string, independent):
+   T16
+Proof track X1 (#1561 — consumes the waves' isolated-dispatch telemetry):
+   T17
+Diagnostic (out of TDD waves — data-blocked, epic-close gate):
+   T18 #1402
+```
+
+**Checkpoint** between Wave 1 and Wave 2: full `vitest run` + `npm run skills:guard` (the #1306
+rename is broad-blast-radius). Merges from main worktree only; dispatch from the feature branch,
+never `main`.
+
+---
+
+## Wave 1 — Foundation
+
+### Task 1: Extract shared `defaultGitExec` (#1311)
+**Tier:** medium · boundaryTouching: false — scoped `DefaultGitExec_*` tests + `check_test_adequacy` kill-probe; existing suite proves no behavior change.
+1. [RED] `orchestrate/git-exec-default.test.ts` — `DefaultGitExec_RunsGitArgs_ReturnsStdoutAndExitCode`, `DefaultGitExec_GitFailure_CapturesStderrAndExitCode`. Expected failure: module does not exist.
+2. [GREEN] Create `orchestrate/git-exec-default.ts` exporting `defaultGitExec(repoRoot, args)` (sync git, 120s timeout, captured stderr, `{stdout, exitCode}`).
+3. [REFACTOR] **Definition-vs-consumer pass** across the 8 referencing files; replace only byte-identical *definitions* (`merge-orchestrate.ts:164-188`, `execute-merge.ts:114-135`, `post-merge.ts:48` if confirmed) with the import. Files that merely accept a `GitExec` param are untouched. No behavior change — existing tests pass.
+**Dependencies:** None. **Parallelizable:** Land first (stabilizes the helper before the rename).
+**Branch:** `refactor/1311-git-exec-dedupe`
+
+### Task 2: Rename recovery vocabulary (#1306 spine)
+**Tier:** medium · boundaryTouching: true — typecheck catches missed renames; renamed scoped tests + adequacy kill-probe (mechanical, behavior-preserving).
+1. [RED] Update `pure/execute-merge.test.ts` + `execute-merge.test.ts` to `RecoveryReason` / `recoveryPointSha` / `recoveryError`. Expected failure: old symbols no longer compile.
+2. [GREEN] Rename `RollbackReason→RecoveryReason` (variants unchanged), `rollbackSha→recoveryPointSha`, `rollbackError→recoveryError` across `pure/execute-merge.ts`, `execute-merge.ts`, `merge-orchestrate.ts`, `merge-keys.ts`, and the `MergeOrchestratorState` schema.
+3. [REFACTOR] Update all "rollback"/"compensation" code comments → "recovery."
+**Dependencies:** Task 1 (same files — rebase clean). **Parallelizable:** No.
+**Branch:** `refactor/1306-recovery-vocab`
+
+### Task 3: Register `merge.recovered` event (#1306)
+**Tier:** **high** · boundaryTouching: true — new event on the shared event-log contract → full red-green-refactor + integration suite.
+1. [RED] `event-store/schemas.test.ts` — `Schemas_MergeRecovered_RegisteredWithRecoveryShape` (asserts `recoveryPointSha`, `recoveryError`).
+2. [GREEN] Register `merge.recovered` in `event-store/schemas.ts` mirroring the legacy `merge.rollback` shape under the renamed fields.
+**Dependencies:** Task 2. **Parallelizable:** No.
+
+### Task 4: Dual-emit + deprecation envelope + CAS safety (#1306)
+**Tier:** **high** · boundaryTouching: true — new dual-emit behavior + CAS idempotency on a contract → full red-green-refactor + integration suite.
+1. [RED] `execute-merge.test.ts` — `ExecuteMerge_RecoveryPath_EmitsBothRecoveredAndLegacyRollback`; `ExecuteMerge_DeprecationEnvelope_ByteEqualAcrossCliMcp`; `ExecuteMerge_RetriedRecovery_IdempotentAcrossBothEventTypes`.
+2. [GREEN] Dual-emit `merge.recovered` + legacy `merge.rollback`; surface `_meta.deprecation = { since:"2.11.0", removeIn:"2.12.0", replacement:"merge.recovered" }`. **CAS hazard:** use independent idempotency keys per event type (or a single shared append boundary) so a retried recovery is a no-op across BOTH types — never re-pin the new append to the legacy append's returned sequence.
+3. [REFACTOR] Parity-harness byte-equality across CLI/MCP for the envelope.
+**Dependencies:** Task 3. **Parallelizable:** No.
+
+### Task 5: HSM exit guard recognizes both terminal events (#1306)
+**Tier:** medium · boundaryTouching: true — scoped HSM-guard test + adequacy kill-probe.
+1. [RED] `workflow/hsm-definitions.test.ts` — `MergePendingExit_RecoveredOrRollback_RecognizedAsTerminal`.
+2. [GREEN] `hsm-definitions.ts:~140` — `mergePendingExit` accepts both `merge.recovered` and `merge.rollback` as terminal.
+**Dependencies:** Task 3. **Parallelizable:** With Task 4 (different file).
+
+### Task 6: Docs + skills + regenerate (#1306)
+**Tier:** low (content) · boundaryTouching: false — gate is `npm run skills:guard`; no test-first ceremony.
+1. Update `docs/designs/2026-04-26-autonomous-merge-orchestrator.md`: saga framing → database-transaction framing (recovery point / recovery event / WAL).
+2. Update `skills-src/merge-orchestrator/**`: drop "compensation"; reference recovery primitives.
+3. `npm run build:skills`; commit regenerated `skills/` tree. Dual-baseline update if snapshots drift (`vitest -u` snapshots.test.ts + `cp` claude render over batch-baselines).
+**Dependencies:** Task 2. **Parallelizable:** No (same branch).
+
+### Task 7: File v2.12 cleanup tracking issue (#1306)
+**Tier:** n/a — tracking action (`gh issue create`), no verification tier.
+1. `gh issue create` — "v2.12 cleanup: remove `merge.rollback` deprecation shim", milestone `v2.12.0 — Process Lifecycle Verbs`, listing exact removal sites: dual-emission path, `schemas.ts` entry, HSM exit-guard fallback.
+**Dependencies:** Task 4. **Parallelizable:** Yes.
+
+---
+
+## Wave 2 — Recovery semantics + liveness
+
+### Task 8: Register `merge.retry_attempt` event (#1308)
+**Tier:** medium · boundaryTouching: true — scoped schema test + adequacy kill-probe (additive registration).
+1. [RED] `event-store/schemas.test.ts` — `Schemas_MergeRetryAttempt_Registered` (`{ attempt, delayMs, reason }`).
+2. [GREEN] Register `merge.retry_attempt` in `schemas.ts`.
+**Dependencies:** Task 3 (schema precedent), Task 2 (`RecoveryReason`). **Parallelizable:** No.
+**Branch:** `feat/1308-timeout-retry-backoff`
+
+### Task 9: Bounded retry — timeout-once-then-success (#1308)
+**Tier:** **high** · boundaryTouching: false — new retry control-flow behavior → full red-green-refactor.
+1. [RED] `pure/execute-merge.test.ts` — `ExecuteMerge_TimeoutOnceThenSuccess_EmitsOneRetryThenExecuted` (one `merge.retry_attempt`, then `merge.executed`, no recovery).
+2. [GREEN] `pure/execute-merge.ts:88-145` — retry loop on `'timeout'`: max 2 retries (3 total `vcsMerge`), exp backoff base 1000ms ×2.0, jitter ±25%, constants at module top. **Injectable jitter seam** (no inline `Math.random()`).
+3. [REFACTOR] Emit `merge.retry_attempt` from `execute-merge.ts` per attempt.
+**Dependencies:** Task 8. **Parallelizable:** No.
+
+### Task 10: Bounded retry — timeout-exhausted → recovery (#1308)
+**Tier:** **high** · boundaryTouching: false — recovery-on-exhaustion behavior → full red-green-refactor.
+1. [RED] `ExecuteMerge_TimeoutExhausted_TwoRetriesThenRecoveryTimeout` (two `merge.retry_attempt`, then recovery `reason:'timeout'`).
+2. [GREEN] Fall back to recovery with `reason:'timeout'` post-exhaustion (matches current behavior).
+**Dependencies:** Task 9. **Parallelizable:** With Task 11.
+
+### Task 11: Non-transient failures keep immediate recovery (#1308)
+**Tier:** medium · boundaryTouching: false — scoped regression test (no-retry on non-transient) + adequacy kill-probe.
+1. [RED] `ExecuteMerge_MergeFailed_NoRetryImmediateRecovery`; `ExecuteMerge_VerificationFailed_NoRetry`.
+2. [GREEN] Ensure `categorizeFailure` routes only `'timeout'` into the retry loop; the other two recover immediately.
+**Dependencies:** Task 9. **Parallelizable:** With Task 10.
+
+### Task 12: `merge.executing_started` liveness (#1309)
+**Tier:** medium · boundaryTouching: true — scoped emission + timeline-ordering test + adequacy kill-probe (additive observability).
+1. [RED] `event-store/schemas.test.ts` — `Schemas_MergeExecutingStarted_Registered`; `execute-merge.test.ts` — `ExecuteMerge_Timeline_ExecutingStartedBeforeTerminal` (order: `executing_started` → [`retry_attempt`*] → terminal).
+2. [GREEN] Register `merge.executing_started`; emit `{taskId, sourceBranch, targetBranch, recoveryPointSha, startedAt}` after the recovery point is recorded, before `vcsMerge`. Purely additive — terminal emission unchanged.
+**Dependencies:** Task 2 (`recoveryPointSha`); orders relative to Task 9 retry events. **Parallelizable:** With Wave-2 retry tasks (different emission site, but assert combined ordering).
+**Branch:** `feat/1309-executing-started-liveness`
+
+---
+
+## Parallel track P1 — Posture + transition exclusivity (#1305)
+
+### Task 13: Declare `posture: 'shared-mutating'` (#1305)
+**Tier:** medium · boundaryTouching: true — scoped resolver test + adequacy kill-probe.
+1. [RED] `capabilities/resolver.test.ts` — `MergeOrchestrate_Posture_ResolvesSharedMutatingWriteCaps` (fs-write + shell-exec).
+2. [GREEN] `registry.ts:~981` — declare `posture: 'shared-mutating'` on the `merge_orchestrate` registration.
+**Dependencies:** None. **Parallelizable:** Yes (dispatch alongside Wave 1).
+**Branch:** `feat/1305-shared-mutating-posture`
+
+### Task 14: Read-only caller rejected at resolver gate (#1305)
+**Tier:** **high** · boundaryTouching: true — capability-boundary enforcement (INV-11 unrepresentable-by-construction) → full red-green-refactor.
+1. [RED] `capabilities/resolver.acceptance.test.ts` — `Resolver_ReadOnlyCaller_RejectedBeforeMergeHandler`.
+2. [GREEN] Confirm the resolver rejects a `read-only` caller before `handleMergeOrchestrate` (fix if it doesn't).
+**Dependencies:** Task 13. **Parallelizable:** No.
+
+### Task 15: Transition exclusivity (#1305)
+**Tier:** medium · boundaryTouching: true — scoped integration + structural test + adequacy kill-probe.
+1. [RED] `merge-orchestrate.integration.test.ts` — `MergePendingTransitions_EmitWorkflowTransition_NotSet`; structural test `Orchestrate_NoSetPhaseCalls_ForMergeTransitions` (scans `orchestrate/` for `set({phase})` on merge transitions).
+2. [GREEN] Verify all `merge-pending` entry/exit transitions emit `workflow.transition`; remove any `set({phase})` merge call site.
+**Dependencies:** None (same branch as T13/T14). **Parallelizable:** With Task 13.
+
+---
+
+## Parallel track P2 — Tool description (#1310)
+
+### Task 16: "Do NOT use for" guidance (#1310)
+**Tier:** low · boundaryTouching: false — static analysis + a scoped assert-contains check; no test-first ceremony.
+1. Rewrite `registry.ts:~981` description with Use-for / Do-NOT-use-for negative space (pointers to `merge_pr`, `verify_worktree`, `request_synthesize`); confirm `exarchos_orchestrate({action:'describe', actions:['merge_orchestrate']})` reflects it.
+2. Scoped check: `registry.test.ts` — `MergeOrchestrateDescription_StatesDoNotUseFor_WithPointers`.
+**Dependencies:** None. **Parallelizable:** Yes. (May fold into the #1305 PR — both edit `registry.ts`.)
+**Branch:** `docs/1310-merge-orchestrate-guidance`
+
+---
+
+## Proof track X1 — Token-capture proof (#1561)
+
+### Task 17: Prove `subagent.tokens_used` end-to-end (#1561)
+**Tier:** n/a — dogfood verification; the seam already carries unit tests, this is live-population proof.
+1. Register the `SubagentStop` hook in the active runtime settings (manifest ships; running session must load it).
+2. Dispatch the Wave 1 / Wave 2 tasks **worktree-isolated** (required by INV-4 — shared `cwd` emits no atom).
+3. Confirm `exarchos_view team_performance` and `exarchos_view delegation_timeline` show non-empty per-teammate token metrics on the `v2-11-preview2-bundle` stream.
+4. Confirm session→workflow manifest binding resolves the correct feature stream.
+5. Log the coverage gap (non-isolated / non-Claude runtimes emit no atom) — never fail (INV-4).
+**Dependencies:** Consumes Wave 1/2 dispatch telemetry — runs concurrently with/after delegation.
+**Branch:** `chore/1561-token-capture-proof`
+
+---
+
+## Diagnostic (out of TDD waves) — Windows ancestry RCA (#1402)
+
+### Task 18: Windows ancestry-preflight RCA (#1402) — DATA-BLOCKED
+**Tier:** n/a — investigation, gated on an external Windows artifact.
+1. Solicit one Windows-host `merge.preflight` event with `data.debug` populated (`EXARCHOS_PREFLIGHT_DEBUG=1`). Linux CI cannot reproduce.
+2. On dump arrival: diagnose (packed-refs lag / worktree-local ref interaction / git-version bug); fix at `dispatch-guard.ts` / `pure/merge-preflight.ts` / `defaultGitExec`.
+3. Keep the phase-1 outcome test green; decide whether to retire or keep the env-gated debug payload.
+**Dependencies:** External Windows capture. **Parallelizable:** Out-of-band — NOT dispatched in the TDD waves. **Epic #1302 closes modulo this task** until the dump lands.
+
+---
+
+## Tooling follow-up (dogfood finding)
+
+While authoring this plan, the `/exarchos:plan` command surfaced a stale surface: **`commands/plan.md`
+still encodes the pre-ladder `Iron Law: NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST` and a uniform
+`[RED]→[GREEN]→[REFACTOR]` task format**, even though the skill it delegates to
+(`skills-src/implementation-planning/SKILL.md`) was reframed around the risk-proportional ladder by
+R8 (#1523). The command and its own skill now disagree. This is not part of the preview.2 feature
+scope; file it separately (a docs/command fix, candidate for `/exarchos:dogfood` triage → code/doc
+bug). Suggested fix: replace the command's Iron Law + RGR task-format sections with the ladder's
+tier-stamp contract (`riskTier` + `boundaryTouching`) so the command matches the skill.
+
+## Definition of done (preview.2)
+- #1305, #1306, #1308, #1309, #1310, #1311 closed; `merge.rollback` survives only as the shim with a filed v2.12 removal issue (Task 7).
+- `merge.recovered`, `merge.retry_attempt`, `merge.executing_started` registered; timeline ordering asserted.
+- `merge_orchestrate` resolves `shared-mutating`; read-only caller rejected; no `set({phase})` merge transitions.
+- `check_invariant_conformance` green against INV-15/14/13/10/11/8/5a/5b/2/1.
+- Verification scaled by tier: `check_tdd_compliance` green on the **high-tier** tasks only (T3, T4, T9, T10, T14); medium tasks pass `check_test_adequacy`; low tasks pass typecheck + lint. No test-first gate on low/medium or the n/a tasks (T7, T17, T18).
+- #1561 metrics non-empty on the feature stream; coverage gap logged.
+- #1402 carries the recorded split-out decision (+ RCA if a dump arrives in-window).
+- Full `vitest run` + `npm run skills:guard` green; CLI≡MCP parity intact.

--- a/docs/plans/2026-06-21-v2.11.0-preview.3-merge-orchestrator-hardening.md
+++ b/docs/plans/2026-06-21-v2.11.0-preview.3-merge-orchestrator-hardening.md
@@ -1,13 +1,20 @@
 ---
-title: "Plan — v2.11.0 preview.2 — Merge-Orchestrator Hardening + Token-Capture Proof"
+title: "Plan — v2.11.0 preview.3 — Merge-Orchestrator Hardening + Token-Capture Proof"
 date: 2026-06-21
-design: docs/designs/2026-06-21-v2.11.0-preview.2-merge-orchestrator-hardening.md
+design: docs/designs/2026-06-21-v2.11.0-preview.3-merge-orchestrator-hardening.md
 featureId: v2-11-preview2-bundle
 milestone: "v2.11.0 — Verification & Reliability"
 closes-epic: 1302
 ---
 
-# Implementation Plan — preview.2
+# Implementation Plan — preview.3
+
+> **Retarget note (2026-06-21):** this work was originally scoped as preview.2. preview.2 was
+> instead cut to ship the #1301 worktree-isolation boundary fix (PR #1568) so dispatched agents
+> consume the parallelization guarantee by construction. This branch
+> (`feat/v2.11-preview3-merge-orch-hardening`) is rebased onto that preview.2 `main` and now ships
+> as **preview.3**. The event-stream `featureId` remains `v2-11-preview2-bundle` (an opaque stream
+> id — kept to preserve the existing workflow history); only the release label moved.
 
 **Verification framing: the risk-proportional ladder (not uniform RED-GREEN-REFACTOR).** Per the
 reframed `implementation-planning` skill (R8 #1523) and the shipped ladder (R1 #1516 / R2 #1517 /
@@ -204,12 +211,12 @@ While authoring this plan, the `/exarchos:plan` command surfaced a stale surface
 still encodes the pre-ladder `Iron Law: NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST` and a uniform
 `[RED]→[GREEN]→[REFACTOR]` task format**, even though the skill it delegates to
 (`skills-src/implementation-planning/SKILL.md`) was reframed around the risk-proportional ladder by
-R8 (#1523). The command and its own skill now disagree. This is not part of the preview.2 feature
+R8 (#1523). The command and its own skill now disagree. This is not part of the preview.3 feature
 scope; file it separately (a docs/command fix, candidate for `/exarchos:dogfood` triage → code/doc
 bug). Suggested fix: replace the command's Iron Law + RGR task-format sections with the ladder's
 tier-stamp contract (`riskTier` + `boundaryTouching`) so the command matches the skill.
 
-## Definition of done (preview.2)
+## Definition of done (preview.3)
 - #1305, #1306, #1308, #1309, #1310, #1311 closed; `merge.rollback` survives only as the shim with a filed v2.12 removal issue (Task 7).
 - `merge.recovered`, `merge.retry_attempt`, `merge.executing_started` registered; timeline ordering asserted.
 - `merge_orchestrate` resolves `shared-mutating`; read-only caller rejected; no `set({phase})` merge transitions.

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -483,7 +483,10 @@ describe('EventTypes', () => {
     // #1525 W2 Half 1 (task H1-C): bumped 125 → 126 to include
     // `subagent.tokens_used`, the per-subagent output-token total emitted by the
     // restored SubagentStop hook (cli-commands/subagent-stop.ts).
-    expect(EventTypes).toHaveLength(126);
+    // #1306: bumped 126 → 127 to include `merge.recovered` (successor to
+    // `merge.rollback`, dual-emitted during the v2.11.x deprecation window).
+    expect(EventTypes).toHaveLength(127);
+    expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('subagent.tokens_used');
     // Explicit membership pin: a future replacement that swaps one event
     // for another would keep the length stable but silently lose the

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -485,8 +485,11 @@ describe('EventTypes', () => {
     // restored SubagentStop hook (cli-commands/subagent-stop.ts).
     // #1306: bumped 126 → 127 to include `merge.recovered` (successor to
     // `merge.rollback`, dual-emitted during the v2.11.x deprecation window).
-    expect(EventTypes).toHaveLength(127);
+    // #1308 T8: bumped 127 → 128 to include `merge.retry_attempt` (bounded
+    // timeout-retry telemetry; registration-only, emission lands in later #1308 tasks).
+    expect(EventTypes).toHaveLength(128);
     expect(EventTypes).toContain('merge.recovered');
+    expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('subagent.tokens_used');
     // Explicit membership pin: a future replacement that swaps one event
     // for another would keep the length stable but silently lose the

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -487,9 +487,13 @@ describe('EventTypes', () => {
     // `merge.rollback`, dual-emitted during the v2.11.x deprecation window).
     // #1308 T8: bumped 127 → 128 to include `merge.retry_attempt` (bounded
     // timeout-retry telemetry; registration-only, emission lands in later #1308 tasks).
-    expect(EventTypes).toHaveLength(128);
+    // #1309 T12: bumped 128 → 129 to include `merge.executing_started` (the
+    // merge-executor liveness event, emitted after the recovery point is recorded
+    // and before the first vcsMerge — INV-10 executing_started + paired terminal).
+    expect(EventTypes).toHaveLength(129);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
+    expect(EventTypes).toContain('merge.executing_started');
     expect(EventTypes).toContain('subagent.tokens_used');
     // Explicit membership pin: a future replacement that swaps one event
     // for another would keep the length stable but silently lose the

--- a/servers/exarchos-mcp/src/capabilities/resolver.acceptance.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.acceptance.test.ts
@@ -11,9 +11,15 @@
 // override-priority case — that is T59's concern. Here we only assert union
 // + posture-derived inclusion.
 
-import { describe, it, expect } from 'vitest';
-import { resolvePosture } from './resolver.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { resolvePosture, createInMemoryResolver } from './resolver.js';
 import type { Capability } from '../agents/capabilities.js';
+import type { DispatchContext } from '../core/dispatch.js';
+import { dispatch, stubCompositeHandler } from '../core/dispatch.js';
+import { EventStore } from '../event-store/store.js';
 
 describe('Capability_PostureSpec_ResolverDerivesEffectiveCapabilities (DR-6)', () => {
   it('derives effective capabilities from posture unioned with handshake declarations', () => {
@@ -34,5 +40,97 @@ describe('Capability_PostureSpec_ResolverDerivesEffectiveCapabilities (DR-6)', (
 
     // Handshake-declared cap is unioned in.
     expect(effective.has('mcp:exarchos')).toBe(true);
+  });
+});
+
+// ─── #1305 T14: read-only caller rejected at the resolver gate ─────────────
+//
+// INV-11 (make the illegal state unrepresentable-by-construction): a caller
+// resolved as `read-only` (effective capability set = {mcp:exarchos:readonly},
+// no mcp:exarchos) that attempts `merge_orchestrate` MUST be rejected at the
+// resolver gate (`enforceReadonlyGate`) BEFORE the merge handler is reached.
+//
+// T13 declared `posture: 'shared-mutating'` on the merge_orchestrate
+// registration; the capability resolver mints fs:write + shell:exec from that
+// posture. This test proves the boundary the other way: the read-only tier is
+// rejected structurally, and `handleMergeOrchestrate` is never entered.
+//
+// The proof exercises the real resolver→dispatch seam (not a unit stub): a
+// genuine `dispatch()` call with a read-only `capabilityResolver`, with the
+// composite handler replaced by a spy. Since `enforceReadonlyGate` runs in
+// `dispatch()` BEFORE `coreHandler` (which routes `merge_orchestrate` to
+// `handleMergeOrchestrate`) is ever constructed/invoked, the spy must never
+// fire. Asserting the spy is uncalled — not merely that the result is an
+// error — is the load-bearing guarantee (a handler that rejected internally
+// would still have been entered).
+describe('Resolver_ReadOnlyCaller_RejectedBeforeMergeHandler (#1305 T14)', () => {
+  let tmpDir: string;
+  let ctx: DispatchContext;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'resolver-gate-test-'));
+    const eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+    ctx = { stateDir: tmpDir, eventStore, enableTelemetry: false };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects a read-only caller at the resolver gate without entering the merge handler', async () => {
+    // Arrange — capability resolver reports ONLY the readonly tier (no
+    // mcp:exarchos), modelling a `read-only` posture's effective capability
+    // set. Confirm the modelling is faithful to the posture mapping.
+    const readOnlyCaps = resolvePosture(
+      { posture: 'read-only' },
+      {},
+    );
+    expect(readOnlyCaps.has('mcp:exarchos:readonly')).toBe(true);
+    expect(readOnlyCaps.has('mcp:exarchos')).toBe(false);
+    expect(readOnlyCaps.has('fs:write')).toBe(false);
+    expect(readOnlyCaps.has('shell:exec')).toBe(false);
+
+    const readonlyCtx: DispatchContext = {
+      ...ctx,
+      capabilityResolver: createInMemoryResolver(['mcp:exarchos:readonly']),
+    };
+
+    // Spy installed on the composite handler that, in production, routes
+    // `merge_orchestrate` through `handleMergeOrchestrate`. If dispatch
+    // reaches the handler, this spy runs — so its call count is the witness
+    // for "handler entered."
+    const compositeSpy = vi.fn(async () => ({ success: true as const, data: {} }));
+    const restore = stubCompositeHandler('exarchos_orchestrate', compositeSpy);
+
+    try {
+      // Act — a valid merge_orchestrate payload (so schema validation passes
+      // and we genuinely exercise the capability gate, not INVALID_INPUT).
+      const result = await dispatch(
+        'exarchos_orchestrate',
+        {
+          action: 'merge_orchestrate',
+          featureId: 'feat-x',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          strategy: 'squash',
+        },
+        readonlyCtx,
+      );
+
+      // Assert (1) — the gate rejected with a structured CAPABILITY_DENIED
+      // identifying the tool/action so the caller can correlate.
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('CAPABILITY_DENIED');
+      expect(result.error?.tool).toBe('exarchos_orchestrate');
+      expect(result.error?.action).toBe('merge_orchestrate');
+
+      // Assert (2) — THE load-bearing guarantee: the merge handler was never
+      // entered. Rejection happens at the resolver gate, before dispatch
+      // constructs/invokes the composite handler.
+      expect(compositeSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
   });
 });

--- a/servers/exarchos-mcp/src/capabilities/resolver.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.test.ts
@@ -12,6 +12,7 @@ import {
 } from './resolver.js';
 import type { Capability } from '../agents/capabilities.js';
 import { KIND_OBLIGATIONS } from '../workflow/phase-kind.js';
+import { findActionInRegistry } from '../registry.js';
 
 describe('CapabilityResolver (T017, DR-14)', () => {
   it('CapabilityResolver_AnthropicNative_ReturnsTrue', () => {
@@ -306,5 +307,35 @@ describe('mintCapabilitiesForKind (POLA bundle, DR-14)', () => {
     // REFACTOR guard (DR-14): IMPLEMENT runs in an isolated worktree (#1512), so
     // its posture must stay task-isolated — never shared-mutating.
     expect(KIND_OBLIGATIONS.IMPLEMENT.posture).toBe('task-isolated');
+  });
+});
+
+// ─── #1305 T13 — merge_orchestrate declares shared-mutating posture ─────────
+//
+// merge_orchestrate mutates shared state (the integration branch, the repo's
+// working tree, the event store) from the main worktree — it has no worktree
+// isolation. Per the posture table (`shared-mutating` → fs:read + fs:write +
+// shell:exec), its registration must declare `posture: 'shared-mutating'` so
+// the resolver mints the fs:write + shell:exec write-capability set. This is
+// the trust-tier source of truth that #1305 T14/T15 (read-only-caller
+// rejection, transition exclusivity) build on.
+
+describe('merge_orchestrate posture (#1305 T13)', () => {
+  it('MergeOrchestrate_Posture_ResolvesSharedMutatingWriteCaps', () => {
+    const action = findActionInRegistry('exarchos_orchestrate', 'merge_orchestrate');
+    expect(action).toBeDefined();
+
+    // The registration declares the shared-mutating trust tier.
+    expect(action!.posture).toBe('shared-mutating');
+
+    // Resolving that posture (empty handshake) yields the shared-mutating
+    // write-capability set: fs:write + shell:exec (plus fs:read). isolation
+    // :worktree is NOT in this tier — shared-mutating runs from the main
+    // worktree without worktree isolation.
+    const effective = resolvePosture({ posture: action!.posture }, {});
+    expect(effective.has('fs:write')).toBe(true);
+    expect(effective.has('shell:exec')).toBe(true);
+    expect(effective.has('fs:read')).toBe(true);
+    expect(effective.has('isolation:worktree')).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -561,9 +561,14 @@ describe('EventTypes', () => {
     //   dual-emitted during the v2.11.x deprecation window; legacy removed v2.12).
     // Bumped 127 → 128: merge.retry_attempt (#1308 — audit record of a
     //   transient-failure retry of the merge attempt; emission lands later).
-    expect(EventTypes).toHaveLength(128);
+    // Bumped 128 → 129: merge.executing_started (#1309 — merge-executor liveness
+    //   event; emitted after the recovery point is recorded, before the first
+    //   vcsMerge, so a long-running merge is observable as started-but-unterminated,
+    //   the INV-10 executing_started + paired terminal pattern).
+    expect(EventTypes).toHaveLength(129);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
+    expect(EventTypes).toContain('merge.executing_started');
     expect(EventTypes).toContain('subagent.tokens_used');
     expect(EventTypes).toContain('onboard.requested');
     expect(EventTypes).toContain('onboard.executed');
@@ -3702,5 +3707,55 @@ describe('merge.retry_attempt (#1308 transient-failure retry)', () => {
       delayMs: 500,
       reason: 'timeout',
     });
+  });
+});
+
+describe('merge.executing_started (#1309 liveness event)', () => {
+  const startedSchema = (
+    EVENT_DATA_SCHEMAS as Record<string, { parse: (v: unknown) => unknown } | undefined>
+  )['merge.executing_started'];
+
+  it('Schemas_MergeExecutingStarted_Registered', () => {
+    // Registered as an event type carrying the liveness payload shape
+    // { taskId, sourceBranch, targetBranch, recoveryPointSha, startedAt }.
+    expect(EventTypes).toContain('merge.executing_started');
+    expect(startedSchema).toBeDefined();
+    const parsed = startedSchema!.parse({
+      taskId: 't-1',
+      sourceBranch: 'feat/x',
+      targetBranch: 'integration',
+      recoveryPointSha: 'abc123',
+      startedAt: '2026-06-21T00:00:00.000Z',
+    });
+    expect(parsed).toMatchObject({
+      sourceBranch: 'feat/x',
+      targetBranch: 'integration',
+      recoveryPointSha: 'abc123',
+      startedAt: '2026-06-21T00:00:00.000Z',
+    });
+  });
+
+  it('MergeExecutingStarted_TaskIdOptional_ParsesWithoutIt', () => {
+    // taskId is optional (CLI direct-invocation has no task context), mirroring
+    // the other merge events.
+    expect(startedSchema).toBeDefined();
+    const parsed = startedSchema!.parse({
+      sourceBranch: 'feat/x',
+      targetBranch: 'integration',
+      recoveryPointSha: 'abc123',
+      startedAt: '2026-06-21T00:00:00.000Z',
+    });
+    expect(parsed).toMatchObject({ recoveryPointSha: 'abc123' });
+  });
+
+  it('MergeExecutingStarted_RejectsMissingRecoveryPointSha', () => {
+    expect(startedSchema).toBeDefined();
+    expect(() =>
+      startedSchema!.parse({
+        sourceBranch: 'feat/x',
+        targetBranch: 'integration',
+        startedAt: '2026-06-21T00:00:00.000Z',
+      }),
+    ).toThrow();
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -559,8 +559,11 @@ describe('EventTypes', () => {
     //   delegation-timeline for the token-reduction acceptance gate).
     // Bumped 126 → 127: merge.recovered (#1306 — successor to merge.rollback,
     //   dual-emitted during the v2.11.x deprecation window; legacy removed v2.12).
-    expect(EventTypes).toHaveLength(127);
+    // Bumped 127 → 128: merge.retry_attempt (#1308 — audit record of a
+    //   transient-failure retry of the merge attempt; emission lands later).
+    expect(EventTypes).toHaveLength(128);
     expect(EventTypes).toContain('merge.recovered');
+    expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('subagent.tokens_used');
     expect(EventTypes).toContain('onboard.requested');
     expect(EventTypes).toContain('onboard.executed');
@@ -3677,5 +3680,27 @@ describe('merge.recovered (#1306 successor to merge.rollback)', () => {
     expect(() =>
       recoveredSchema!.parse({ sourceBranch: 'a', targetBranch: 'b', reason: 'merge-failed' }),
     ).toThrow();
+  });
+});
+
+describe('merge.retry_attempt (#1308 transient-failure retry)', () => {
+  const retrySchema = (
+    EVENT_DATA_SCHEMAS as Record<string, { parse: (v: unknown) => unknown } | undefined>
+  )['merge.retry_attempt'];
+
+  it('Schemas_MergeRetryAttempt_Registered', () => {
+    // Registered as an event type with the expected retry payload shape.
+    expect(EventTypes).toContain('merge.retry_attempt');
+    expect(retrySchema).toBeDefined();
+    const parsed = retrySchema!.parse({
+      attempt: 2,
+      delayMs: 500,
+      reason: 'timeout',
+    });
+    expect(parsed).toMatchObject({
+      attempt: 2,
+      delayMs: 500,
+      reason: 'timeout',
+    });
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -557,7 +557,10 @@ describe('EventTypes', () => {
     //   output-token total emitted by the restored SubagentStop hook
     //   `cli-commands/subagent-stop.ts`, folded by team-performance /
     //   delegation-timeline for the token-reduction acceptance gate).
-    expect(EventTypes).toHaveLength(126);
+    // Bumped 126 → 127: merge.recovered (#1306 — successor to merge.rollback,
+    //   dual-emitted during the v2.11.x deprecation window; legacy removed v2.12).
+    expect(EventTypes).toHaveLength(127);
+    expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('subagent.tokens_used');
     expect(EventTypes).toContain('onboard.requested');
     expect(EventTypes).toContain('onboard.executed');
@@ -3644,5 +3647,35 @@ describe('EventStoreSchemas_ToolActionErrored_HasRegisteredType', () => {
       },
     });
     expect(event.success).toBe(true);
+  });
+});
+
+describe('merge.recovered (#1306 successor to merge.rollback)', () => {
+  const recoveredSchema = (
+    EVENT_DATA_SCHEMAS as Record<string, { parse: (v: unknown) => unknown } | undefined>
+  )['merge.recovered'];
+
+  it('MergeRecovered_RegisteredWithRecoveryShape_ParsesValidPayload', () => {
+    expect(recoveredSchema).toBeDefined();
+    const parsed = recoveredSchema!.parse({
+      taskId: 't-1',
+      sourceBranch: 'feat/x',
+      targetBranch: 'integration',
+      recoveryPointSha: 'abc123',
+      reason: 'timeout',
+      recoveryErrorDetail: 'git reset --keep abc123 exited 1',
+      recoveryError: 'reset-failed',
+    });
+    expect(parsed).toMatchObject({
+      recoveryPointSha: 'abc123',
+      recoveryError: 'reset-failed',
+    });
+  });
+
+  it('MergeRecovered_RejectsMissingRecoveryPointSha', () => {
+    expect(recoveredSchema).toBeDefined();
+    expect(() =>
+      recoveredSchema!.parse({ sourceBranch: 'a', targetBranch: 'b', reason: 'merge-failed' }),
+    ).toThrow();
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -139,6 +139,14 @@ export const EventTypes = [
   // "lifecycle formally terminated" as two states — matching INV-10's
   // executing_started + paired terminal event pattern.
   'merge.completed',
+  // #1309 — merge-executor liveness event. Emitted by `handleExecuteMerge`
+  // after the recovery point sha is recorded and BEFORE the first `vcsMerge`
+  // attempt, so a long-running merge is observable as "started but not yet
+  // terminated" — the INV-10 `<surface>.executing_started` + paired terminal
+  // (`merge.executed` / `merge.recovered`) pattern, mirroring
+  // `mutation.executing_started`. Audit-only: it does NOT transition the
+  // `merge-orchestrator@v1` projection phase.
+  'merge.executing_started',
   'command.resolved',
   // Durable event-store substrate (#1259) — deprecation telemetry + migration
   // pipeline. T02 / T03 / T04 of the substrate plan.
@@ -505,6 +513,10 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // auto — emitted by `handleExecuteMerge` immediately after `merge.executed`
   // succeeds, as the projection's terminal lifecycle marker (#1304 / INV-10).
   'merge.completed': 'auto',
+  // #1309 — emitted by `handleExecuteMerge` (server-deterministic plumbing)
+  // before the first vcsMerge, so it lives in the auto family alongside the
+  // other merge-executor events.
+  'merge.executing_started': 'auto',
 
   // auto — emitted by the test/typecheck/install runtime resolver (#1199 T15).
   // Audit-only: records where each command resolution came from so downstream
@@ -1653,6 +1665,28 @@ export const MergeCompletedData = MergeExecutedData.pick({
     .describe('Feature stream id; useful for cross-stream observability'),
 });
 
+/**
+ * merge.executing_started — #1309 merge-executor liveness event. Emitted by
+ * `handleExecuteMerge` after the recovery point sha is recorded and BEFORE the
+ * first `vcsMerge` attempt, so a long-running merge is observable as "started
+ * but not yet terminated" — the INV-10 `<surface>.executing_started` + paired
+ * terminal (`merge.executed` / `merge.recovered`) pattern, mirroring
+ * `mutation.executing_started`.
+ *
+ * `recoveryPointSha` is the anchor HEAD the merge can be rewound to (the same
+ * sha the terminal events carry as `rollbackSha` / `recoveryPointSha`).
+ * `startedAt` is the ISO timestamp at which the merge attempt began. `taskId`
+ * is optional (CLI direct-invocation has no task context), matching the other
+ * merge events.
+ */
+export const MergeExecutingStartedData = z.object({
+  taskId: z.string().optional(),
+  sourceBranch: z.string().min(1),
+  targetBranch: z.string().min(1),
+  recoveryPointSha: z.string().min(1),
+  startedAt: z.string().min(1),
+});
+
 // ─── Wave B Two-Event Split Schemas (#1342) ──────────────────────────────────
 //
 // Each VCS side-effect handler emits *.requested BEFORE the side effect fires
@@ -2469,6 +2503,7 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'merge.recovered': MergeRecoveredData,
   'merge.retry_attempt': MergeRetryAttemptData,
   'merge.completed': MergeCompletedData,
+  'merge.executing_started': MergeExecutingStartedData,
 
   // Command resolver (#1199 T15) — audit trail for runtime resolver decisions.
   'command.resolved': CommandResolvedEventSchema,
@@ -2603,6 +2638,7 @@ export type MergeRollback = z.infer<typeof MergeRollbackData>;
 export type MergeRecovered = z.infer<typeof MergeRecoveredData>;
 export type MergeRetryAttempt = z.infer<typeof MergeRetryAttemptData>;
 export type MergeCompleted = z.infer<typeof MergeCompletedData>;
+export type MergeExecutingStarted = z.infer<typeof MergeExecutingStartedData>;
 export type HsmDeprecatedActionInvoked = z.infer<typeof HsmDeprecatedActionInvokedData>;
 export type SpecLegacyCapabilitiesArray = z.infer<typeof SpecLegacyCapabilitiesArrayData>;
 export type PhaseContractMissing = z.infer<typeof PhaseContractMissingData>;
@@ -2730,6 +2766,7 @@ export type EventDataMap = {
   'merge.recovered': MergeRecovered;
   'merge.retry_attempt': MergeRetryAttempt;
   'merge.completed': MergeCompleted;
+  'merge.executing_started': MergeExecutingStarted;
   'command.resolved': CommandResolvedEvent;
   'hsm.deprecated_action_invoked': HsmDeprecatedActionInvoked;
   'spec.legacy_capabilities_array': SpecLegacyCapabilitiesArray;

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -123,6 +123,9 @@ export const EventTypes = [
   'merge.requested',
   'merge.executed',
   'merge.rollback',
+  // #1306 — successor to `merge.rollback`; dual-emitted during the v2.11.x
+  // deprecation window. Legacy `merge.rollback` removed in v2.12 (tracked).
+  'merge.recovered',
   // Terminal lifecycle event — emitted by the executor (`handleExecuteMerge`)
   // immediately after a successful `merge.executed` append. Folded by the
   // `merge-orchestrator@v1` projection (#1304) as the transition into the
@@ -489,6 +492,8 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'merge.requested': 'model',
   'merge.executed': 'auto',
   'merge.rollback': 'auto',
+  // #1306 successor — same auto family as the legacy event it replaces.
+  'merge.recovered': 'auto',
   // auto — emitted by `handleExecuteMerge` immediately after `merge.executed`
   // succeeds, as the projection's terminal lifecycle marker (#1304 / INV-10).
   'merge.completed': 'auto',
@@ -1566,6 +1571,32 @@ export const MergeRollbackData = z.object({
 });
 
 /**
+ * merge.recovered — the #1306 successor to `merge.rollback`. Emitted when a
+ * merge is reverted via the INV-14 recovery ladder. Same closed `reason` enum.
+ * `recoveryPointSha` is the anchor the worktree was rewound to (was
+ * `rollbackSha`); `recoveryErrorDetail` is the human-readable recovery-failure
+ * string (was `rollbackError`) paired with the `recoveryError` discriminator.
+ *
+ * During the v2.11.x deprecation window the executor dual-emits this AND the
+ * legacy `merge.rollback` for the same logical event; v2.12 removes the legacy
+ * emission (tracked separately). Vocabulary follows the canonical frame —
+ * recovery point / recovery event, not saga compensation / rollback.
+ */
+export const MergeRecoveredData = z.object({
+  taskId: z.string().optional(),
+  sourceBranch: z.string().min(1),
+  targetBranch: z.string().min(1),
+  recoveryPointSha: z.string().min(1),
+  reason: z.enum(['merge-failed', 'verification-failed', 'timeout']),
+  recoveryErrorDetail: z.string().min(1).optional(),
+  // INV-14 discriminator on the recovery outcome — see MergeRollbackData above
+  // for the full primitive-ordering contract. Kept under the canonical name.
+  recoveryError: z
+    .enum(['reset-keep-blocked', 'reset-failed', 'unexpected-mid-merge-drift'])
+    .optional(),
+});
+
+/**
  * merge.completed — terminal lifecycle event emitted immediately after a
  * successful `merge.executed`. Folded by the `merge-orchestrator@v1`
  * projection (#1304) as the transition into the `completed` phase, which is
@@ -2414,6 +2445,7 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'merge.requested': MergeRequestedData,
   'merge.executed': MergeExecutedData,
   'merge.rollback': MergeRollbackData,
+  'merge.recovered': MergeRecoveredData,
   'merge.completed': MergeCompletedData,
 
   // Command resolver (#1199 T15) — audit trail for runtime resolver decisions.
@@ -2546,6 +2578,7 @@ export type MergePreflight = z.infer<typeof MergePreflightData>;
 export type MergeRequested = z.infer<typeof MergeRequestedData>;
 export type MergeExecuted = z.infer<typeof MergeExecutedData>;
 export type MergeRollback = z.infer<typeof MergeRollbackData>;
+export type MergeRecovered = z.infer<typeof MergeRecoveredData>;
 export type MergeCompleted = z.infer<typeof MergeCompletedData>;
 export type HsmDeprecatedActionInvoked = z.infer<typeof HsmDeprecatedActionInvokedData>;
 export type SpecLegacyCapabilitiesArray = z.infer<typeof SpecLegacyCapabilitiesArrayData>;
@@ -2671,6 +2704,7 @@ export type EventDataMap = {
   'merge.requested': MergeRequested;
   'merge.executed': MergeExecuted;
   'merge.rollback': MergeRollback;
+  'merge.recovered': MergeRecovered;
   'merge.completed': MergeCompleted;
   'command.resolved': CommandResolvedEvent;
   'hsm.deprecated_action_invoked': HsmDeprecatedActionInvoked;

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -126,6 +126,11 @@ export const EventTypes = [
   // #1306 — successor to `merge.rollback`; dual-emitted during the v2.11.x
   // deprecation window. Legacy `merge.rollback` removed in v2.12 (tracked).
   'merge.recovered',
+  // #1308 — audit record of a transient-failure retry of the merge attempt.
+  // Records the retry `attempt` ordinal, the backoff `delayMs` before it, and
+  // the transient-failure `reason` (e.g. 'timeout') that triggered it. The
+  // emission site lands in a later #1308 task; this registration is additive.
+  'merge.retry_attempt',
   // Terminal lifecycle event — emitted by the executor (`handleExecuteMerge`)
   // immediately after a successful `merge.executed` append. Folded by the
   // `merge-orchestrator@v1` projection (#1304) as the transition into the
@@ -494,6 +499,9 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'merge.rollback': 'auto',
   // #1306 successor — same auto family as the legacy event it replaces.
   'merge.recovered': 'auto',
+  // #1308 — emitted by the merge executor's retry loop (server-deterministic
+  // plumbing), so it lives in the auto family alongside the other merge events.
+  'merge.retry_attempt': 'auto',
   // auto — emitted by `handleExecuteMerge` immediately after `merge.executed`
   // succeeds, as the projection's terminal lifecycle marker (#1304 / INV-10).
   'merge.completed': 'auto',
@@ -1597,6 +1605,19 @@ export const MergeRecoveredData = z.object({
 });
 
 /**
+ * merge.retry_attempt — #1308 audit record of a transient-failure retry of the
+ * merge attempt. `attempt` is the retry ordinal, `delayMs` is the backoff
+ * applied before the retry fired, and `reason` is the transient-failure reason
+ * that triggered the retry (e.g. `'timeout'`). The emission site lands in a
+ * later #1308 task; this registration is additive (no behavior change).
+ */
+export const MergeRetryAttemptData = z.object({
+  attempt: z.number().int().nonnegative(),
+  delayMs: z.number().int().nonnegative(),
+  reason: z.string().min(1),
+});
+
+/**
  * merge.completed — terminal lifecycle event emitted immediately after a
  * successful `merge.executed`. Folded by the `merge-orchestrator@v1`
  * projection (#1304) as the transition into the `completed` phase, which is
@@ -2446,6 +2467,7 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'merge.executed': MergeExecutedData,
   'merge.rollback': MergeRollbackData,
   'merge.recovered': MergeRecoveredData,
+  'merge.retry_attempt': MergeRetryAttemptData,
   'merge.completed': MergeCompletedData,
 
   // Command resolver (#1199 T15) — audit trail for runtime resolver decisions.
@@ -2579,6 +2601,7 @@ export type MergeRequested = z.infer<typeof MergeRequestedData>;
 export type MergeExecuted = z.infer<typeof MergeExecutedData>;
 export type MergeRollback = z.infer<typeof MergeRollbackData>;
 export type MergeRecovered = z.infer<typeof MergeRecoveredData>;
+export type MergeRetryAttempt = z.infer<typeof MergeRetryAttemptData>;
 export type MergeCompleted = z.infer<typeof MergeCompletedData>;
 export type HsmDeprecatedActionInvoked = z.infer<typeof HsmDeprecatedActionInvokedData>;
 export type SpecLegacyCapabilitiesArray = z.infer<typeof SpecLegacyCapabilitiesArrayData>;
@@ -2705,6 +2728,7 @@ export type EventDataMap = {
   'merge.executed': MergeExecuted;
   'merge.rollback': MergeRollback;
   'merge.recovered': MergeRecovered;
+  'merge.retry_attempt': MergeRetryAttempt;
   'merge.completed': MergeCompleted;
   'command.resolved': CommandResolvedEvent;
   'hsm.deprecated_action_invoked': HsmDeprecatedActionInvoked;

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.deprecation-parity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.deprecation-parity.test.ts
@@ -1,0 +1,277 @@
+/**
+ * #1306 T4 — deprecation-envelope CLI↔MCP parity (REFACTOR step).
+ *
+ * The legacy `merge.rollback` event dual-emitted on the recovery path carries
+ * a `_meta.deprecation = { since, removeIn, replacement }` envelope. Because
+ * both the CLI (`exarchos orch merge_orchestrate`) and the MCP
+ * (`exarchos_orchestrate`) surfaces funnel the recovery through the SAME
+ * `handleExecuteMerge` code path, that envelope MUST be byte-identical
+ * regardless of which surface drove the merge.
+ *
+ * Strategy (mirrors `merge-orchestrate.parity.test.ts`):
+ *   - Stub the `exarchos_orchestrate` composite so its `merge_orchestrate`
+ *     action forwards to the REAL `handleMergeOrchestrate` with:
+ *       • a passing preflight (DI) — deterministic, no git shell-out,
+ *       • an `executeMerge` adapter that augments the orchestrator-built
+ *         executor input with a REJECTING `vcsMerge` + a deterministic
+ *         `gitExec`, then delegates to the REAL `handleExecuteMerge`. This
+ *         drives the genuine dual-emit (canonical `merge.recovered` + legacy
+ *         `merge.rollback`) into the arm's real `EventStore`.
+ *   - Run two arms (CLI + MCP) against isolated tmp event stores, then read
+ *     each arm's legacy `merge.rollback` event and compare its
+ *     `_meta.deprecation` block byte-for-byte.
+ *
+ * Unlike the success-path parity suite (which stubs the executor and only
+ * compares the projected ToolResult), this suite exercises the real event
+ * emission so the parity assertion pins the EMITTED envelope — the artifact
+ * the deprecation window actually exposes to downstream consumers.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../event-store/store.js';
+import type { DispatchContext, CompositeHandler } from '../core/dispatch.js';
+import { stubCompositeHandler } from '../core/dispatch.js';
+import type { ToolResult } from '../format.js';
+import {
+  callCli as harnessCallCli,
+  callMcp as harnessCallMcp,
+} from '../__tests__/parity-harness.js';
+
+import { handleMergeOrchestrate } from './merge-orchestrate.js';
+import { handleExecuteMerge, type HandleExecuteMergeInput } from './execute-merge.js';
+import type { MergePreflightResult } from './pure/merge-preflight.js';
+import type { GitExec } from './pure/execute-merge.js';
+import '../projections/merge-orchestrator/index.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+const RECOVERY_POINT_SHA = 'b'.repeat(40);
+
+const PASSING_PREFLIGHT: MergePreflightResult = {
+  passed: true,
+  ancestry: { passed: true, checks: ['ancestry'] },
+  currentBranchProtection: { blocked: false, currentBranch: 'feat/x' },
+  worktree: { isMain: true, actual: '/repo', expected: '/repo' },
+  drift: {
+    clean: true,
+    uncommittedFiles: [],
+    indexStale: false,
+    detachedHead: false,
+  },
+};
+
+const PARITY_ARGS = {
+  featureId: 'feat-dep-parity',
+  sourceBranch: 'feat/x',
+  targetBranch: 'main',
+  taskId: 'T44',
+  strategy: 'squash' as const,
+  // repoRoot pins the orchestrator's worktree-topology probe to a fixed dir so
+  // the two arms behave identically and never depend on the runner's cwd.
+  repoRoot: '/repo',
+};
+
+const EXPECTED_DEPRECATION = {
+  since: '2.11.0',
+  removeIn: '2.12.0',
+  replacement: 'merge.recovered',
+};
+
+// ─── Arm helpers ───────────────────────────────────────────────────────────
+
+interface ArmContext {
+  readonly stateDir: string;
+  readonly eventStore: EventStore;
+  readonly ctx: DispatchContext;
+}
+
+async function createArm(prefix: string): Promise<ArmContext> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), prefix));
+  await mkdir(path.join(stateDir, 'workflow-state'), { recursive: true });
+  const eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+  const ctx: DispatchContext = {
+    stateDir,
+    eventStore,
+    enableTelemetry: false,
+  };
+  return { stateDir, eventStore, ctx };
+}
+
+/**
+ * Deterministic gitExec: `git rev-parse HEAD` → the recovery-point sha; the
+ * INV-14 recovery ladder (`merge --abort`, `reset --keep`) succeeds; the
+ * worktree-topology `git worktree list --porcelain` probe reports a single
+ * main worktree on the repoRoot so the orchestrator never aborts early.
+ */
+function makeGitExec(): GitExec {
+  return vi.fn().mockImplementation((_repo: string, args: readonly string[]) => {
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+      return { stdout: `${RECOVERY_POINT_SHA}\n`, exitCode: 0 };
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
+      return { stdout: '/repo\n', exitCode: 0 };
+    }
+    if (args[0] === 'worktree' && args[1] === 'list') {
+      // Single main worktree on the repoRoot, on a branch that is NOT the
+      // merge target — topology is safe, no early abort.
+      return {
+        stdout: 'worktree /repo\nHEAD ' + RECOVERY_POINT_SHA + '\nbranch refs/heads/feat/x\n\n',
+        exitCode: 0,
+      };
+    }
+    return { stdout: '', exitCode: 0 };
+  });
+}
+
+/**
+ * Composite stub forwarding `merge_orchestrate` to the REAL orchestrator with
+ * a passing preflight + an `executeMerge` adapter that drives the REAL
+ * executor down its recovery path (rejecting `vcsMerge`). The executor emits
+ * the genuine dual-emit events into the arm's real EventStore.
+ */
+function buildRecoveryCompositeStub(): CompositeHandler {
+  return async (args, ctx): Promise<ToolResult> => {
+    const { action, ...rest } = args;
+    if (action !== 'merge_orchestrate') {
+      return {
+        success: false,
+        error: {
+          code: 'UNEXPECTED_ACTION',
+          message: `deprecation-parity stub only handles "merge_orchestrate", got "${String(action)}"`,
+        },
+      };
+    }
+
+    const preflight = async (): Promise<MergePreflightResult> => PASSING_PREFLIGHT;
+
+    const executeMerge = async (
+      input: HandleExecuteMergeInput,
+      execCtx: DispatchContext,
+    ): Promise<ToolResult> =>
+      handleExecuteMerge(
+        {
+          ...input,
+          // Force the recovery path: the merge adapter rejects, so the real
+          // executor runs the INV-14 ladder and dual-emits.
+          vcsMerge: vi.fn().mockRejectedValue(new Error('merge conflict')),
+          gitExec: makeGitExec(),
+          // Bypass the state-file write so the arm never touches disk state.
+          persistState: vi.fn().mockResolvedValue(undefined),
+        },
+        execCtx,
+      );
+
+    return handleMergeOrchestrate(
+      {
+        ...(rest as Record<string, unknown>),
+        preflight,
+        executeMerge,
+        gitExec: makeGitExec(),
+        // Orchestrator-level state write is also bypassed.
+        persistState: async (): Promise<void> => {},
+      } as Parameters<typeof handleMergeOrchestrate>[0],
+      ctx,
+    );
+  };
+}
+
+/** Read the `_meta.deprecation` block off the legacy `merge.rollback` event. */
+async function readLegacyDeprecationEnvelope(
+  arm: ArmContext,
+): Promise<unknown> {
+  const events = await arm.eventStore.query(PARITY_ARGS.featureId);
+  const legacy = events.find((e) => e.type === 'merge.rollback');
+  const data = legacy?.data as Record<string, unknown> | undefined;
+  return (data?._meta as Record<string, unknown> | undefined)?.deprecation;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('merge.recovered deprecation envelope CLI↔MCP parity (#1306 T4)', () => {
+  let arms: ArmContext[] = [];
+  let restoreStub: (() => void) | null = null;
+
+  afterEach(async () => {
+    restoreStub?.();
+    restoreStub = null;
+    for (const arm of arms) {
+      await rm(arm.stateDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+    arms = [];
+    vi.restoreAllMocks();
+  });
+
+  it('mergeRecovered_DeprecationEnvelope_ByteEqualAcrossCliAndMcp', async () => {
+    restoreStub = stubCompositeHandler(
+      'exarchos_orchestrate',
+      buildRecoveryCompositeStub(),
+    );
+
+    const cliArm = await createArm('dep-parity-cli-');
+    arms.push(cliArm);
+    const mcpArm = await createArm('dep-parity-mcp-');
+    arms.push(mcpArm);
+
+    // CLI arm — auto-generated `exarchos orch merge_orchestrate`.
+    const { result: cliResult } = await harnessCallCli(
+      cliArm.ctx,
+      'orch',
+      'merge_orchestrate',
+      PARITY_ARGS,
+    );
+    // MCP arm — direct dispatch.
+    const mcpResult = await harnessCallMcp(mcpArm.ctx, 'exarchos_orchestrate', {
+      action: 'merge_orchestrate',
+      ...PARITY_ARGS,
+    });
+
+    // Both surfaces report the recovery failure (MERGE_ROLLED_BACK bubbles up).
+    expect(cliResult.success).toBe(false);
+    expect(mcpResult.success).toBe(false);
+    expect(cliResult.error?.code).toBe('MERGE_ROLLED_BACK');
+    expect(mcpResult.error?.code).toBe('MERGE_ROLLED_BACK');
+
+    // The dual-emit envelope, read off each arm's real event stream.
+    const cliEnvelope = await readLegacyDeprecationEnvelope(cliArm);
+    const mcpEnvelope = await readLegacyDeprecationEnvelope(mcpArm);
+
+    // Each arm carries the exact deprecation contract...
+    expect(cliEnvelope).toEqual(EXPECTED_DEPRECATION);
+    expect(mcpEnvelope).toEqual(EXPECTED_DEPRECATION);
+
+    // ...and the envelopes are byte-identical across surfaces (parity invariant).
+    expect(JSON.stringify(cliEnvelope)).toEqual(JSON.stringify(mcpEnvelope));
+    expect(JSON.stringify(cliEnvelope)).toEqual(JSON.stringify(EXPECTED_DEPRECATION));
+  });
+
+  it('mergeRecovered_BothEventTypesEmitted_OnEachSurface', async () => {
+    // Sanity guard: each surface emits BOTH the canonical and legacy events
+    // (not just the envelope on one of them).
+    restoreStub = stubCompositeHandler(
+      'exarchos_orchestrate',
+      buildRecoveryCompositeStub(),
+    );
+
+    const cliArm = await createArm('dep-parity-both-cli-');
+    arms.push(cliArm);
+    const mcpArm = await createArm('dep-parity-both-mcp-');
+    arms.push(mcpArm);
+
+    await harnessCallCli(cliArm.ctx, 'orch', 'merge_orchestrate', PARITY_ARGS);
+    await harnessCallMcp(mcpArm.ctx, 'exarchos_orchestrate', {
+      action: 'merge_orchestrate',
+      ...PARITY_ARGS,
+    });
+
+    for (const arm of [cliArm, mcpArm]) {
+      const events = await arm.eventStore.query(PARITY_ARGS.featureId);
+      expect(events.filter((e) => e.type === 'merge.recovered')).toHaveLength(1);
+      expect(events.filter((e) => e.type === 'merge.rollback')).toHaveLength(1);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
@@ -135,11 +135,32 @@ describe('handleExecuteMerge (T15)', () => {
     );
 
     expect(result.success).toBe(true);
-    // Two appends: `merge.executed` (side-effect record) and `merge.completed`
+    // Three appends: `merge.executing_started` (#1309 liveness, BEFORE the first
+    // vcsMerge), then `merge.executed` (side-effect record) and `merge.completed`
     // (terminal lifecycle marker). Distinct events per #1304 INV-10 alignment.
-    expect(ctx.eventStore.append).toHaveBeenCalledTimes(2);
+    // The liveness append is leading, so the terminal pair is the 2nd/3rd call;
+    // the terminal payloads themselves are unchanged.
+    expect(ctx.eventStore.append).toHaveBeenCalledTimes(3);
     expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
       1,
+      'feat-x',
+      {
+        type: 'merge.executing_started',
+        data: {
+          taskId: 'T11',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          recoveryPointSha: ROLLBACK_SHA,
+          startedAt: expect.any(String),
+        },
+      },
+      {
+        expectedSequence: 0,
+        idempotencyKey: 'feat-x:merge_orchestrate:T11:merge.executing_started',
+      },
+    );
+    expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
+      2,
       'feat-x',
       {
         type: 'merge.executed',
@@ -159,7 +180,7 @@ describe('handleExecuteMerge (T15)', () => {
       },
     );
     expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
-      2,
+      3,
       'feat-x',
       {
         type: 'merge.completed',
@@ -193,11 +214,13 @@ describe('handleExecuteMerge (T15)', () => {
     // (idempotency-key cache-hit) so the pinned CAS reproduced the conflict
     // forever with no recovery. A live-tail CAS self-heals on retry.
     const ctx = makeMockCtx();
-    // First tail read (before merge.executed) → empty. By the second read
-    // (before merge.completed) a concurrent writer has advanced the tail to
-    // seq 7. merge.executed still returns its own seq 1 from the append mock —
-    // a frozen pin would carry that stale 1 into the merge.completed CAS.
+    // Tail reads, in order: (1) before merge.executing_started (#1309 liveness),
+    // (2) before merge.executed, both empty. By the third read (before
+    // merge.completed) a concurrent writer has advanced the tail to seq 7.
+    // merge.executed still returns its own seq 1 from the append mock — a frozen
+    // pin would carry that stale 1 into the merge.completed CAS.
     (ctx.eventStore.query as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ sequence: 7 }]);
     const vcsMerge = vi.fn().mockResolvedValue({ mergeSha: MERGE_SHA });
@@ -217,10 +240,11 @@ describe('handleExecuteMerge (T15)', () => {
       ctx,
     );
 
-    // merge.completed (2nd append) CAS-pins to the LIVE tail (7), not the
-    // merge.executed append's returned sequence (1).
+    // merge.completed (3rd append, after the liveness + merge.executed appends)
+    // CAS-pins to the LIVE tail (7), not the merge.executed append's returned
+    // sequence (1).
     expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
-      2,
+      3,
       'feat-x',
       expect.objectContaining({ type: 'merge.completed' }),
       expect.objectContaining({ expectedSequence: 7 }),
@@ -346,14 +370,35 @@ describe('handleExecuteMerge rollback (T16)', () => {
     );
 
     expect(result.success).toBe(false);
-    // #1306 T4 dual-emit: the recovery path appends BOTH the canonical
+    // #1309 prepends the `merge.executing_started` liveness append (BEFORE the
+    // first vcsMerge). #1306 T4 dual-emit then appends BOTH the canonical
     // `merge.recovered` event AND the legacy `merge.rollback` event during the
-    // v2.11.x deprecation window. Order is canonical-first, legacy-second.
-    expect(ctx.eventStore.append).toHaveBeenCalledTimes(2);
-    // 1) canonical `merge.recovered` — renamed fields (recoveryPointSha), its
-    //    OWN idempotency key + its OWN fresh-tail CAS read.
+    // v2.11.x deprecation window. Order: liveness → canonical → legacy. The
+    // terminal recovery payloads are unchanged.
+    expect(ctx.eventStore.append).toHaveBeenCalledTimes(3);
+    // 1) #1309 liveness `merge.executing_started`, emitted before the merge.
     expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
       1,
+      'feat-x',
+      {
+        type: 'merge.executing_started',
+        data: {
+          taskId: 'T11',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          recoveryPointSha: ROLLBACK_SHA,
+          startedAt: expect.any(String),
+        },
+      },
+      {
+        expectedSequence: 0,
+        idempotencyKey: 'feat-x:merge_orchestrate:T11:merge.executing_started',
+      },
+    );
+    // 2) canonical `merge.recovered` — renamed fields (recoveryPointSha), its
+    //    OWN idempotency key + its OWN fresh-tail CAS read.
+    expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
+      2,
       'feat-x',
       {
         type: 'merge.recovered',
@@ -370,10 +415,10 @@ describe('handleExecuteMerge rollback (T16)', () => {
         idempotencyKey: 'feat-x:merge_orchestrate:T11:merge.recovered',
       },
     );
-    // 2) legacy `merge.rollback` — kept during the deprecation window, carries
+    // 3) legacy `merge.rollback` — kept during the deprecation window, carries
     //    the `_meta.deprecation` envelope, its OWN independent idempotency key.
     expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
-      2,
+      3,
       'feat-x',
       {
         type: 'merge.rollback',
@@ -536,16 +581,21 @@ describe('handleExecuteMerge rollback (T16)', () => {
     // `merge.recovered` (renamed `recoveryErrorDetail` field) AND the legacy
     // `merge.rollback` (which keeps its `rollbackError` wire field + the
     // `_meta.deprecation` envelope during the deprecation window).
-    expect(ctx.eventStore.append).toHaveBeenCalledTimes(2);
+    // #1309 prepends the liveness append, so the recovery terminal pair is the
+    // 2nd/3rd append. The terminal recovery payloads are unchanged.
+    expect(ctx.eventStore.append).toHaveBeenCalledTimes(3);
     const calls = (ctx.eventStore.append as ReturnType<typeof vi.fn>).mock.calls;
+    // 0) #1309 liveness merge.executing_started — emitted before the merge.
+    const [, startedPayload] = calls[0];
+    expect(startedPayload.type).toBe('merge.executing_started');
     // 1) canonical merge.recovered — carries recoveryError + recoveryErrorDetail.
-    const [, recoveredPayload] = calls[0];
+    const [, recoveredPayload] = calls[1];
     expect(recoveredPayload.type).toBe('merge.recovered');
     expect(recoveredPayload.data.recoveryError).toBe('reset-keep-blocked');
     expect(recoveredPayload.data.recoveryErrorDetail).toContain('reset --keep');
     // 2) legacy merge.rollback — carries recoveryError + the legacy
     //    `rollbackError` detail field, plus the `_meta.deprecation` envelope.
-    const [, rollbackPayload] = calls[1];
+    const [, rollbackPayload] = calls[2];
     expect(rollbackPayload.type).toBe('merge.rollback');
     expect(rollbackPayload.data.recoveryError).toBe('reset-keep-blocked');
     expect(rollbackPayload.data.rollbackError).toContain('reset --keep');
@@ -754,13 +804,16 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
     // fails, replay can still reconstruct from the event stream; if the
     // state write fails after, a reconcile recovers from the events alone.
     //
-    // Order: persist(executing) → vcsMerge → event(merge.executed) →
-    //        event(merge.completed) → persist(completed).
-    // The merge.completed terminal marker (#1304) follows merge.executed and
-    // both precede the state-file write. Ordering is what the projection fold
-    // requires; strict log adjacency is NOT enforced (the CAS reads the live
-    // tail), so an unrelated interleaved event would not break this.
+    // Order: event(merge.executing_started) → persist(executing) → vcsMerge →
+    //        event(merge.executed) → event(merge.completed) → persist(completed).
+    // #1309: the liveness event is emitted inside the persistState wrapper on the
+    // `executing` payload, BEFORE the state write (and thus before the first
+    // vcsMerge). The merge.completed terminal marker (#1304) follows
+    // merge.executed and both precede the state-file write. Ordering is what the
+    // projection fold requires; strict log adjacency is NOT enforced (the CAS
+    // reads the live tail), so an unrelated interleaved event would not break this.
     expect(callOrder).toEqual([
+      'event:merge.executing_started',
       'persist:executing',
       'vcsMerge',
       'event:merge.executed',
@@ -803,10 +856,13 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
       { ...ctx, eventStore },
     );
 
-    // #1306 T4 dual-emit: BOTH the canonical `merge.recovered` and the legacy
+    // #1309: the liveness event leads, emitted inside the persistState wrapper on
+    // the `executing` payload (before the state write / first vcsMerge). #1306 T4
+    // dual-emit: BOTH the canonical `merge.recovered` and the legacy
     // `merge.rollback` are appended (canonical-first) BEFORE the terminal
     // state-file write (event-first commit point, #1109 §1).
     expect(callOrder).toEqual([
+      'event:merge.executing_started',
       'persist:executing',
       'vcsMerge',
       'event:merge.recovered',
@@ -863,9 +919,11 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
 
     expect(result.success).toBe(true);
     expect(vcsMerge).toHaveBeenCalledTimes(2);
-    // Exactly ONE retry attempt event, BEFORE merge.executed, then the
-    // terminal completed marker. NO recovery/rollback events.
+    // #1309 liveness event leads (before the first vcsMerge), then exactly ONE
+    // retry attempt event, then merge.executed, then the terminal completed
+    // marker. NO recovery/rollback events.
     expect(appendedTypes).toEqual([
+      'merge.executing_started',
       'merge.retry_attempt',
       'merge.executed',
       'merge.completed',
@@ -884,6 +942,132 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
       delayMs: 1000,
       reason: 'timeout',
     });
+  });
+
+  // ─── #1309 T12: merge.executing_started liveness event timeline ───────────
+
+  it('ExecuteMerge_Timeline_ExecutingStartedBeforeTerminal', async () => {
+    // The liveness event `merge.executing_started` is emitted EXACTLY ONCE,
+    // after the recovery point is recorded and BEFORE the first vcsMerge — so it
+    // lands before any merge.retry_attempt AND before the terminal event. The
+    // timeout-then-success scenario exercises the full ordering:
+    //   merge.executing_started → merge.retry_attempt → merge.executed →
+    //   merge.completed.
+    const ctx = makeMockCtx();
+    const appendedTypes: string[] = [];
+    (ctx.eventStore.append as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_stream: string, event: { type: string }) => {
+        appendedTypes.push(event.type);
+        return { sequence: 1, type: event.type, timestamp: '' };
+      },
+    );
+
+    let call = 0;
+    const vcsMerge = vi.fn().mockImplementation(async () => {
+      call += 1;
+      if (call === 1) {
+        const err = new Error('operation timed out');
+        (err as Error & { code?: string }).code = 'ETIMEDOUT';
+        throw err;
+      }
+      return { mergeSha: MERGE_SHA };
+    });
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    const result = await handleExecuteMerge(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T11',
+        strategy: 'squash',
+        vcsMerge,
+        persistState,
+        gitExec: makeGitExec(),
+        jitter: () => 0,
+        sleep: async () => {},
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+
+    // Emitted exactly once.
+    const startedCount = appendedTypes.filter(
+      (t) => t === 'merge.executing_started',
+    ).length;
+    expect(startedCount).toBe(1);
+
+    // Position invariants: executing_started precedes EVERY retry_attempt and
+    // the terminal event.
+    const startedIdx = appendedTypes.indexOf('merge.executing_started');
+    const retryIdx = appendedTypes.indexOf('merge.retry_attempt');
+    const executedIdx = appendedTypes.indexOf('merge.executed');
+    expect(startedIdx).toBe(0);
+    expect(retryIdx).toBeGreaterThan(startedIdx);
+    expect(executedIdx).toBeGreaterThan(retryIdx);
+
+    // Full ordering, with the terminal emission path (#1308/#1304) unchanged.
+    expect(appendedTypes).toEqual([
+      'merge.executing_started',
+      'merge.retry_attempt',
+      'merge.executed',
+      'merge.completed',
+    ]);
+
+    // The liveness payload carries the recovery point sha (captured pre-merge)
+    // plus the branch/task context and a startedAt timestamp.
+    const startedCall = (ctx.eventStore.append as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => (c[1] as { type: string }).type === 'merge.executing_started',
+    );
+    expect(startedCall).toBeDefined();
+    const startedData = (startedCall![1] as { data: Record<string, unknown> }).data;
+    expect(startedData).toMatchObject({
+      taskId: 'T11',
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      recoveryPointSha: ROLLBACK_SHA,
+    });
+    expect(typeof startedData.startedAt).toBe('string');
+    expect((startedData.startedAt as string).length).toBeGreaterThan(0);
+  });
+
+  it('ExecuteMerge_Timeline_ExecutingStartedBeforeRecoveryTerminal', async () => {
+    // On the rollback path the liveness event still lands first, before the
+    // recovery terminal pair (merge.recovered → merge.rollback). The terminal
+    // emission path stays byte-for-byte unchanged.
+    const ctx = makeMockCtx();
+    const appendedTypes: string[] = [];
+    (ctx.eventStore.append as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_stream: string, event: { type: string }) => {
+        appendedTypes.push(event.type);
+        return { sequence: 1, type: event.type, timestamp: '' };
+      },
+    );
+
+    const vcsMerge = vi.fn().mockRejectedValue(new Error('merge conflict'));
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    const result = await handleExecuteMerge(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T11',
+        strategy: 'squash',
+        vcsMerge,
+        persistState,
+        gitExec: makeGitExec(),
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(false);
+    expect(appendedTypes).toEqual([
+      'merge.executing_started',
+      'merge.recovered',
+      'merge.rollback',
+    ]);
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
@@ -304,18 +304,18 @@ describe('handleExecuteMerge (T15)', () => {
       ctx,
     );
 
-    // Ordering: persistState({phase:'executing', rollbackSha}) BEFORE vcsMerge.
+    // Ordering: persistState({phase:'executing', recoveryPointSha}) BEFORE vcsMerge.
     expect(callOrder.length).toBeGreaterThanOrEqual(2);
     expect(callOrder[0]).toBe(
       `persistState:${JSON.stringify({
         phase: 'executing',
-        rollbackSha: ROLLBACK_SHA,
+        recoveryPointSha: ROLLBACK_SHA,
       })}`,
     );
     expect(callOrder.indexOf('vcsMerge')).toBeGreaterThan(0);
     expect(persistState).toHaveBeenCalledWith({
       phase: 'executing',
-      rollbackSha: ROLLBACK_SHA,
+      recoveryPointSha: ROLLBACK_SHA,
     });
   });
 });
@@ -439,14 +439,14 @@ describe('handleExecuteMerge rollback (T16)', () => {
     // The handler also surfaces `data` so the caller can introspect.
     expect(result.data).toMatchObject({
       phase: 'rolled-back',
-      rollbackSha: ROLLBACK_SHA,
+      recoveryPointSha: ROLLBACK_SHA,
       reason: 'verification-failed',
     });
   });
 
   // The recovery-failure path is the one that populates `recoveryError` +
-  // `rollbackError` end-to-end — exercising it here keeps the operator recovery
-  // contract (state file + emitted event + ToolResult all carry the
+  // the recovery-error detail end-to-end — exercising it here keeps the operator
+  // recovery contract (state file + emitted event + ToolResult all carry the
   // indeterminate-worktree signal) covered by the test suite.
   it('handleExecuteMerge_ResetKeepRefuses_SurfacesRecoveryErrorOnEventAndToolResult', async () => {
     const ctx = makeMockCtx();
@@ -486,22 +486,23 @@ describe('handleExecuteMerge rollback (T16)', () => {
     expect(result.error?.code).toBe('MERGE_ROLLED_BACK');
     expect(result.data).toMatchObject({
       phase: 'rolled-back',
-      rollbackSha: ROLLBACK_SHA,
+      recoveryPointSha: ROLLBACK_SHA,
       reason: 'merge-failed',
     });
-    // `recoveryError` (discriminator) + `rollbackError` (detail) ride on the
-    // ToolResult `data` so callers detect the indeterminate worktree without
+    // `recoveryError` (discriminator) + `recoveryErrorDetail` (detail) ride on
+    // the ToolResult `data` so callers detect the indeterminate worktree without
     // re-querying the event stream.
     expect((result.data as { recoveryError?: string }).recoveryError).toBe(
       'reset-keep-blocked',
     );
-    expect((result.data as { rollbackError?: string }).rollbackError).toContain(
+    expect((result.data as { recoveryErrorDetail?: string }).recoveryErrorDetail).toContain(
       'reset --keep',
     );
 
     // Same signals must appear on the emitted `merge.rollback` event so
     // event-stream consumers (projections, dashboards, alerting) see them
-    // without reading the state file.
+    // without reading the state file. The legacy event keeps its `rollbackError`
+    // wire field during the #1306 deprecation window.
     expect(ctx.eventStore.append).toHaveBeenCalledTimes(1);
     const [, eventPayload] = (ctx.eventStore.append as ReturnType<typeof vi.fn>)
       .mock.calls[0];
@@ -604,8 +605,8 @@ describe('handleExecuteMerge default persistState retries on VersionConflictErro
 // The pure executor (T09) writes the intermediate `phase: 'executing'` shape
 // before invoking vcsMerge. After T27, the handler is responsible for the
 // terminal-phase write so disk state always reflects the actual outcome:
-//   • completed  → persist {phase, rollbackSha, mergeSha}
-//   • rolled-back → persist {phase, rollbackSha, reason}
+//   • completed  → persist {phase, recoveryPointSha, mergeSha}
+//   • rolled-back → persist {phase, recoveryPointSha, reason}
 // Without this, a successful merge or rollback leaves disk state at
 // 'executing' indefinitely, breaking HSM exit guards and resume semantics.
 
@@ -637,7 +638,7 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
     expect(persistState).toHaveBeenCalledTimes(2);
     expect(persistState).toHaveBeenNthCalledWith(2, {
       phase: 'completed',
-      rollbackSha: ROLLBACK_SHA,
+      recoveryPointSha: ROLLBACK_SHA,
       mergeSha: MERGE_SHA,
     });
   });
@@ -664,7 +665,7 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
     expect(persistState).toHaveBeenCalledTimes(2);
     expect(persistState).toHaveBeenNthCalledWith(2, {
       phase: 'rolled-back',
-      rollbackSha: ROLLBACK_SHA,
+      recoveryPointSha: ROLLBACK_SHA,
       reason: 'merge-failed',
     });
   });

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
@@ -18,7 +18,7 @@
 //   2. rewind to `<rollbackSha>` via the ladder so HEAD matches the captured sha
 //   3. return a structured `ToolResult` failure with code `MERGE_ROLLED_BACK`
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import type { EventStore } from '../event-store/store.js';
 import { SequenceConflictError } from '../event-store/store.js';
 import type { DispatchContext } from '../core/dispatch.js';
@@ -346,10 +346,34 @@ describe('handleExecuteMerge rollback (T16)', () => {
     );
 
     expect(result.success).toBe(false);
-    // Direct stream append to the merge.rollback type — NOT wrapped in
-    // gate.executed and NOT a merge.executed event.
-    expect(ctx.eventStore.append).toHaveBeenCalledTimes(1);
-    expect(ctx.eventStore.append).toHaveBeenCalledWith(
+    // #1306 T4 dual-emit: the recovery path appends BOTH the canonical
+    // `merge.recovered` event AND the legacy `merge.rollback` event during the
+    // v2.11.x deprecation window. Order is canonical-first, legacy-second.
+    expect(ctx.eventStore.append).toHaveBeenCalledTimes(2);
+    // 1) canonical `merge.recovered` — renamed fields (recoveryPointSha), its
+    //    OWN idempotency key + its OWN fresh-tail CAS read.
+    expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
+      1,
+      'feat-x',
+      {
+        type: 'merge.recovered',
+        data: {
+          taskId: 'T11',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          recoveryPointSha: ROLLBACK_SHA,
+          reason: 'merge-failed',
+        },
+      },
+      {
+        expectedSequence: 0,
+        idempotencyKey: 'feat-x:merge_orchestrate:T11:merge.recovered',
+      },
+    );
+    // 2) legacy `merge.rollback` — kept during the deprecation window, carries
+    //    the `_meta.deprecation` envelope, its OWN independent idempotency key.
+    expect(ctx.eventStore.append).toHaveBeenNthCalledWith(
+      2,
       'feat-x',
       {
         type: 'merge.rollback',
@@ -359,6 +383,13 @@ describe('handleExecuteMerge rollback (T16)', () => {
           targetBranch: 'main',
           rollbackSha: ROLLBACK_SHA,
           reason: 'merge-failed',
+          _meta: {
+            deprecation: {
+              since: '2.11.0',
+              removeIn: '2.12.0',
+              replacement: 'merge.recovered',
+            },
+          },
         },
       },
       // #1303 α-05: idempotencyKey + expectedSequence wired on merge.rollback.
@@ -499,16 +530,30 @@ describe('handleExecuteMerge rollback (T16)', () => {
       'reset --keep',
     );
 
-    // Same signals must appear on the emitted `merge.rollback` event so
-    // event-stream consumers (projections, dashboards, alerting) see them
-    // without reading the state file. The legacy event keeps its `rollbackError`
-    // wire field during the #1306 deprecation window.
-    expect(ctx.eventStore.append).toHaveBeenCalledTimes(1);
-    const [, eventPayload] = (ctx.eventStore.append as ReturnType<typeof vi.fn>)
-      .mock.calls[0];
-    expect(eventPayload.type).toBe('merge.rollback');
-    expect(eventPayload.data.recoveryError).toBe('reset-keep-blocked');
-    expect(eventPayload.data.rollbackError).toContain('reset --keep');
+    // Same signals must appear on BOTH dual-emitted events so event-stream
+    // consumers (projections, dashboards, alerting) see them without reading
+    // the state file. #1306 T4: the recovery path appends the canonical
+    // `merge.recovered` (renamed `recoveryErrorDetail` field) AND the legacy
+    // `merge.rollback` (which keeps its `rollbackError` wire field + the
+    // `_meta.deprecation` envelope during the deprecation window).
+    expect(ctx.eventStore.append).toHaveBeenCalledTimes(2);
+    const calls = (ctx.eventStore.append as ReturnType<typeof vi.fn>).mock.calls;
+    // 1) canonical merge.recovered — carries recoveryError + recoveryErrorDetail.
+    const [, recoveredPayload] = calls[0];
+    expect(recoveredPayload.type).toBe('merge.recovered');
+    expect(recoveredPayload.data.recoveryError).toBe('reset-keep-blocked');
+    expect(recoveredPayload.data.recoveryErrorDetail).toContain('reset --keep');
+    // 2) legacy merge.rollback — carries recoveryError + the legacy
+    //    `rollbackError` detail field, plus the `_meta.deprecation` envelope.
+    const [, rollbackPayload] = calls[1];
+    expect(rollbackPayload.type).toBe('merge.rollback');
+    expect(rollbackPayload.data.recoveryError).toBe('reset-keep-blocked');
+    expect(rollbackPayload.data.rollbackError).toContain('reset --keep');
+    expect(rollbackPayload.data._meta.deprecation).toEqual({
+      since: '2.11.0',
+      removeIn: '2.12.0',
+      replacement: 'merge.recovered',
+    });
   });
 });
 
@@ -758,11 +803,209 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
       { ...ctx, eventStore },
     );
 
+    // #1306 T4 dual-emit: BOTH the canonical `merge.recovered` and the legacy
+    // `merge.rollback` are appended (canonical-first) BEFORE the terminal
+    // state-file write (event-first commit point, #1109 §1).
     expect(callOrder).toEqual([
       'persist:executing',
       'vcsMerge',
+      'event:merge.recovered',
       'event:merge.rollback',
       'persist:rolled-back',
     ]);
+  });
+});
+
+// ─── #1306 T4 — dual-emit + deprecation envelope + CAS idempotency ──────────
+//
+// During the v2.11.x deprecation window the recovery path dual-emits the
+// canonical `merge.recovered` AND the legacy `merge.rollback` for the same
+// logical event. The legacy event carries a `_meta.deprecation` envelope. The
+// two appends use INDEPENDENT idempotency keys (one per event type) so a
+// retried recovery is a no-op across BOTH types — and the new
+// `merge.recovered` append is NEVER re-pinned to the legacy append's returned
+// sequence (the CAS-pin trap from PR #1492 / `project_cas_pin_idempotency_trap`).
+//
+// These tests run against a REAL `EventStore` (tmp-dir) so the SQLite
+// idempotency-claims dedup is exercised end-to-end, mirroring
+// `execute-merge.migration.test.ts`.
+
+import { EventStore } from '../event-store/store.js';
+import * as fsp from 'node:fs/promises';
+import * as osMod from 'node:os';
+import * as pathMod from 'node:path';
+import '../projections/merge-orchestrator/index.js';
+
+const realScratchRoots: string[] = [];
+
+async function makeRealScratchEventStore(): Promise<{
+  eventStore: EventStore;
+  stateDir: string;
+}> {
+  const stateDir = await fsp.mkdtemp(
+    pathMod.join(osMod.tmpdir(), '1306-t4-dual-emit-'),
+  );
+  realScratchRoots.push(stateDir);
+  await fsp.mkdir(pathMod.join(stateDir, 'workflow-state'), { recursive: true });
+  const eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+  return { eventStore, stateDir };
+}
+
+function makeRealCtx(eventStore: EventStore, stateDir: string): DispatchContext {
+  return {
+    stateDir,
+    eventStore,
+    enableTelemetry: false,
+  } as unknown as DispatchContext;
+}
+
+describe('handleExecuteMerge #1306 T4 — dual-emit recovery + deprecation envelope + CAS idempotency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await Promise.all(
+      realScratchRoots.map((p) =>
+        fsp.rm(p, { recursive: true, force: true }),
+      ),
+    );
+  });
+
+  it('ExecuteMerge_RecoveryPath_EmitsBothRecoveredAndLegacyRollback', async () => {
+    const { eventStore, stateDir } = await makeRealScratchEventStore();
+    const ctx = makeRealCtx(eventStore, stateDir);
+
+    const vcsMerge = vi.fn().mockRejectedValue(new Error('merge conflict'));
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    const result = await handleExecuteMerge(
+      {
+        featureId: 'feat-dual',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T11',
+        strategy: 'squash',
+        vcsMerge,
+        persistState,
+        gitExec: makeGitExec(),
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('MERGE_ROLLED_BACK');
+
+    const events = await eventStore.query('feat-dual');
+    const recovered = events.filter((e) => e.type === 'merge.recovered');
+    const rollback = events.filter((e) => e.type === 'merge.rollback');
+
+    // Exactly ONE of each — the recovery path dual-emits the canonical event
+    // and the legacy event for the same logical recovery.
+    expect(recovered).toHaveLength(1);
+    expect(rollback).toHaveLength(1);
+
+    // Canonical event uses the renamed field `recoveryPointSha`.
+    const recoveredData = recovered[0].data as Record<string, unknown>;
+    expect(recoveredData.recoveryPointSha).toBe(ROLLBACK_SHA);
+    expect(recoveredData.reason).toBe('merge-failed');
+
+    // Legacy event keeps the `rollbackSha` wire field.
+    const rollbackData = rollback[0].data as Record<string, unknown>;
+    expect(rollbackData.rollbackSha).toBe(ROLLBACK_SHA);
+    expect(rollbackData.reason).toBe('merge-failed');
+
+    // Canonical event is appended BEFORE the legacy event.
+    expect(recovered[0].sequence).toBeLessThan(rollback[0].sequence);
+  });
+
+  it('ExecuteMerge_DeprecationEnvelope_ByteEqualAcrossCliMcp', async () => {
+    // Both surfaces funnel through the SAME `handleExecuteMerge`, so the
+    // deprecation envelope on the legacy `merge.rollback` event MUST be
+    // byte-identical regardless of which surface drove the recovery. We
+    // drive the executor twice against two independent real event stores and
+    // compare the serialized `_meta.deprecation` block byte-for-byte.
+    async function driveRecoveryAndReadEnvelope(): Promise<unknown> {
+      const { eventStore, stateDir } = await makeRealScratchEventStore();
+      const ctx = makeRealCtx(eventStore, stateDir);
+      await handleExecuteMerge(
+        {
+          featureId: 'feat-envelope',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          taskId: 'T11',
+          strategy: 'squash',
+          vcsMerge: vi.fn().mockRejectedValue(new Error('merge conflict')),
+          persistState: vi.fn().mockResolvedValue(undefined),
+          gitExec: makeGitExec(),
+        },
+        ctx,
+      );
+      const events = await eventStore.query('feat-envelope');
+      const legacy = events.find((e) => e.type === 'merge.rollback');
+      const data = legacy?.data as Record<string, unknown> | undefined;
+      return (data?._meta as Record<string, unknown> | undefined)?.deprecation;
+    }
+
+    const cliEnvelope = await driveRecoveryAndReadEnvelope();
+    const mcpEnvelope = await driveRecoveryAndReadEnvelope();
+
+    // The exact deprecation contract: since / removeIn / replacement.
+    const expected = {
+      since: '2.11.0',
+      removeIn: '2.12.0',
+      replacement: 'merge.recovered',
+    };
+    expect(cliEnvelope).toEqual(expected);
+    expect(mcpEnvelope).toEqual(expected);
+
+    // Byte-equality across surfaces (the parity invariant).
+    expect(JSON.stringify(cliEnvelope)).toEqual(JSON.stringify(mcpEnvelope));
+    expect(JSON.stringify(cliEnvelope)).toEqual(JSON.stringify(expected));
+  });
+
+  it('ExecuteMerge_RetriedRecovery_IdempotentAcrossBothEventTypes', async () => {
+    // Re-running the SAME recovery (same featureId + taskId) must be a no-op
+    // across BOTH event types: the SQLite idempotency-claims UNIQUE INDEX
+    // dedups each append by its independent key. A retry must NOT append a
+    // duplicate `merge.recovered` OR a duplicate `merge.rollback`.
+    //
+    // CAS-PIN TRAP GUARD (#1492): if the new `merge.recovered` append were
+    // re-pinned to the legacy `merge.rollback` append's returned sequence,
+    // the cache-hit on the second run would precede the CAS and the retry
+    // would conflict forever. This test fails loudly in that case (the second
+    // run would throw / surface STATE_CONFLICT instead of a clean no-op).
+    const { eventStore, stateDir } = await makeRealScratchEventStore();
+    const ctx = makeRealCtx(eventStore, stateDir);
+
+    const invoke = () =>
+      handleExecuteMerge(
+        {
+          featureId: 'feat-retry',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          taskId: 'T11',
+          strategy: 'squash',
+          vcsMerge: vi.fn().mockRejectedValue(new Error('merge conflict')),
+          persistState: vi.fn().mockResolvedValue(undefined),
+          gitExec: makeGitExec(),
+        },
+        ctx,
+      );
+
+    const first = await invoke();
+    expect(first.success).toBe(false);
+    expect(first.error?.code).toBe('MERGE_ROLLED_BACK');
+
+    // Retry — same operation, same keys. Must be a clean no-op (not a
+    // permanent CAS conflict).
+    const second = await invoke();
+    expect(second.success).toBe(false);
+    expect(second.error?.code).toBe('MERGE_ROLLED_BACK');
+
+    const events = await eventStore.query('feat-retry');
+    expect(events.filter((e) => e.type === 'merge.recovered')).toHaveLength(1);
+    expect(events.filter((e) => e.type === 'merge.rollback')).toHaveLength(1);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
@@ -814,6 +814,77 @@ describe('handleExecuteMerge terminal-phase persistence (T27)', () => {
       'persist:rolled-back',
     ]);
   });
+
+  // ─── T09 (#1308): merge.retry_attempt emission on timeout-then-success ────
+
+  it('handleExecuteMerge_TimeoutOnceThenSuccess_EmitsOneRetryThenExecuted', async () => {
+    // A vcsMerge that times out once then succeeds emits exactly ONE
+    // `merge.retry_attempt` (the retry audit record) followed by the normal
+    // `merge.executed` / `merge.completed` terminal pair — with NO
+    // `merge.recovered` / `merge.rollback` (no recovery ladder runs).
+    const ctx = makeMockCtx();
+    const appendedTypes: string[] = [];
+    (ctx.eventStore.append as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_stream: string, event: { type: string }) => {
+        appendedTypes.push(event.type);
+        return { sequence: 1, type: event.type, timestamp: '' };
+      },
+    );
+
+    let call = 0;
+    const vcsMerge = vi.fn().mockImplementation(async () => {
+      call += 1;
+      if (call === 1) {
+        const err = new Error('operation timed out');
+        (err as Error & { code?: string }).code = 'ETIMEDOUT';
+        throw err;
+      }
+      return { mergeSha: MERGE_SHA };
+    });
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    const result = await handleExecuteMerge(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T11',
+        strategy: 'squash',
+        vcsMerge,
+        persistState,
+        gitExec: makeGitExec(),
+        // Bounded-retry seams (passed through to the pure executor) so the test
+        // is deterministic and instant.
+        jitter: () => 0,
+        sleep: async () => {},
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(vcsMerge).toHaveBeenCalledTimes(2);
+    // Exactly ONE retry attempt event, BEFORE merge.executed, then the
+    // terminal completed marker. NO recovery/rollback events.
+    expect(appendedTypes).toEqual([
+      'merge.retry_attempt',
+      'merge.executed',
+      'merge.completed',
+    ]);
+    expect(appendedTypes).not.toContain('merge.recovered');
+    expect(appendedTypes).not.toContain('merge.rollback');
+
+    // The retry_attempt carries the #1308 audit payload
+    // ({ attempt, delayMs, reason }) for the single retry.
+    const retryCall = (ctx.eventStore.append as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => (c[1] as { type: string }).type === 'merge.retry_attempt',
+    );
+    expect(retryCall).toBeDefined();
+    expect((retryCall![1] as { data: unknown }).data).toMatchObject({
+      attempt: 1,
+      delayMs: 1000,
+      reason: 'timeout',
+    });
+  });
 });
 
 // ─── #1306 T4 — dual-emit + deprecation envelope + CAS idempotency ──────────

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
@@ -235,12 +235,72 @@ export async function handleExecuteMerge(
       ctx.stateDir,
     );
 
+  // #1309 — `merge.executing_started` liveness emission. Appended ONCE, after
+  // the pure executor has recorded the recovery point and BEFORE the first
+  // `vcsMerge` fires (the pure executor calls `persistState({phase:'executing',
+  // recoveryPointSha})` exactly once at that seam). Emitting from inside the
+  // `persistState` wrapper on the `executing` payload pins the liveness event to
+  // that precise lifecycle point so a long-running merge is observable as
+  // "started but not yet terminated" (INV-10), without touching the terminal
+  // emission path. The recovery-point sha rides on the payload, so the audit
+  // record carries the same anchor the terminal events report.
+  //
+  // Best-effort like `onRetryAttempt`: a lost sequence race on this audit append
+  // must NOT abort the merge (the merge attempt is the load-bearing action). The
+  // fresh-tail CAS + own idempotency key (`:merge.executing_started` suffix)
+  // make a crash-replay a clean no-op (project_cas_pin_idempotency_trap).
+  const emitExecutingStarted = async (recoveryPointSha: string): Promise<void> => {
+    const tailEventsStarted = await ctx.eventStore.query(args.featureId);
+    const expectedSequenceStarted =
+      tailEventsStarted.length > 0
+        ? Math.max(...tailEventsStarted.map((e) => e.sequence))
+        : 0;
+    try {
+      await ctx.eventStore.append(
+        args.featureId,
+        {
+          type: 'merge.executing_started',
+          data: {
+            ...(args.taskId !== undefined ? { taskId: args.taskId } : {}),
+            sourceBranch: args.sourceBranch,
+            targetBranch: args.targetBranch,
+            recoveryPointSha,
+            startedAt: new Date().toISOString(),
+          },
+        },
+        {
+          expectedSequence: expectedSequenceStarted,
+          idempotencyKey: buildMergeOrchestrateIdempotencyKey(
+            args.featureId,
+            args.taskId,
+            'merge.executing_started',
+          ),
+        },
+      );
+    } catch (err) {
+      // Swallow a lost sequence race (a concurrent writer advanced the tail) so
+      // the merge proceeds; the liveness record is best-effort observability.
+      if (!(err instanceof SequenceConflictError)) {
+        throw err;
+      }
+    }
+  };
+
   // T29: wrap every state write in `withStateRetry` so concurrent writers
   // (e.g. another orchestrate handler updating the same workflow state file)
   // don't fail this merge permanently on a single CAS conflict. Wraps both
   // injected and default `persistState` so caller-supplied hooks share the
   // same race-tolerance contract.
+  //
+  // #1309 — on the `executing` payload, emit the liveness event BEFORE the
+  // state write (and thus before the first `vcsMerge`). Guarded so it fires at
+  // most once across any `withStateRetry` re-attempts of the `executing` write.
+  let executingStartedEmitted = false;
   const persistState: PersistStateCallback = async (state) => {
+    if (state.phase === 'executing' && !executingStartedEmitted) {
+      executingStartedEmitted = true;
+      await emitExecutingStarted(state.recoveryPointSha);
+    }
     await withStateRetry(async () => {
       await rawPersistState(state);
     });

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
@@ -25,7 +25,7 @@
 // 'verification-failed' | 'timeout') and returns a structured error.
 // ───────────────────────────────────────────────────────────────────────────
 
-import { execFileSync } from 'node:child_process';
+import { defaultGitExec } from './git-exec-default.js';
 import * as path from 'node:path';
 import { z } from 'zod';
 
@@ -120,33 +120,6 @@ export interface HandleExecuteMergeInput extends HandleExecuteMergeArgs {
 
 // ─── Default adapters ──────────────────────────────────────────────────────
 
-/** Default `gitExec`: synchronous shell-out with 120s timeout.
- * Captures stderr so failures (merge conflicts, ref errors) surface in the
- * returned `stdout` channel rather than vanishing — `gitOrThrow` includes
- * this output in the thrown error so categorization and operator diagnostics
- * have the actual git failure message. */
-function defaultGitExec(repoRoot: string, args: readonly string[]): { stdout: string; exitCode: number } {
-  try {
-    const stdout = execFileSync('git', [...args], {
-      cwd: repoRoot,
-      timeout: 120_000,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { stdout, exitCode: 0 };
-  } catch (err) {
-    const status = (err as { status?: number }).status;
-    const stderr = (err as { stderr?: string | Buffer }).stderr;
-    const stdout = (err as { stdout?: string | Buffer }).stdout;
-    const message = [
-      typeof stdout === 'string' ? stdout : stdout?.toString('utf-8') ?? '',
-      typeof stderr === 'string' ? stderr : stderr?.toString('utf-8') ?? '',
-    ]
-      .filter(Boolean)
-      .join('\n');
-    return { stdout: message, exitCode: typeof status === 'number' ? status : 1 };
-  }
-}
 
 /**
  * Build the default `vcsMerge` adapter — a *local* `git merge` of source

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
@@ -3,15 +3,16 @@
 // Wraps the pure `executeMerge` (T08+T09+T10) with:
 //   • a local-git merge adapter via `buildLocalGitMergeAdapter` (#1194 —
 //     replaced the previous remote VcsProvider call so the recorded
-//     rollbackSha actually corresponds to a local ref the executor's
-//     INV-14 rollback (`git reset --keep`) can undo)
+//     recovery point sha actually corresponds to a local ref the executor's
+//     INV-14 recovery (`git reset --keep`) can undo)
 //   • a `gitExec` adapter using `execFileSync` (120s timeout, matches
 //     post-merge.ts:48)
 //   • a `persistState` callback that updates the workflow state's
 //     `mergeOrchestrator` field (T01+T02 schema)
 //   • on `phase: 'completed'`, emits `merge.executed` to the workflow's
 //     event stream (stream id = featureId) carrying both the post-merge
-//     `mergeSha` and the pre-merge `rollbackSha`
+//     `mergeSha` and the pre-merge recovery point sha (the legacy
+//     `rollbackSha` event field — kept during the #1306 deprecation window)
 //
 // The merge adapter is injectable via `args.vcsMerge` so tests bypass real
 // git operations. Same for `gitExec` and `persistState`. In production,
@@ -20,7 +21,7 @@
 //
 // T16 extends this with the `phase: 'rolled-back'` branch: the pure executor
 // has already run the INV-14 recovery ladder (`git merge --abort` →
-// `git reset --keep <rollbackSha>`), so the handler emits a
+// `git reset --keep <recoveryPointSha>`), so the handler emits a
 // `merge.rollback` event (categorized reason: 'merge-failed' |
 // 'verification-failed' | 'timeout') and returns a structured error.
 // ───────────────────────────────────────────────────────────────────────────
@@ -92,16 +93,16 @@ interface VcsMergeAdapter {
  * HSM exit guards and resume semantics.
  */
 export type ExecutorPersistStatePayload =
-  | { phase: 'executing'; rollbackSha: string }
-  | { phase: 'completed'; rollbackSha: string; mergeSha: string }
+  | { phase: 'executing'; recoveryPointSha: string }
+  | { phase: 'completed'; recoveryPointSha: string; mergeSha: string }
   | {
       phase: 'rolled-back';
-      rollbackSha: string;
+      recoveryPointSha: string;
       reason: 'merge-failed' | 'verification-failed' | 'timeout';
-      /** INV-14 recovery-outcome discriminator; absent on a clean rollback. */
+      /** INV-14 recovery-outcome discriminator; absent on a clean recovery. */
       recoveryError?: 'reset-keep-blocked' | 'reset-failed' | 'unexpected-mid-merge-drift';
-      /** Human-readable detail for `recoveryError`; absent on clean rollback. */
-      rollbackError?: string;
+      /** Human-readable detail for `recoveryError`; absent on clean recovery. */
+      recoveryErrorDetail?: string;
     };
 
 interface PersistStateCallback {
@@ -124,8 +125,8 @@ export interface HandleExecuteMergeInput extends HandleExecuteMergeArgs {
 /**
  * Build the default `vcsMerge` adapter — a *local* `git merge` of source
  * into target. See `local-git-merge.ts` for the full contract; the executor
- * uses this adapter so the recorded `rollbackSha` actually corresponds to
- * a local ref the rollback `git reset --keep` can undo (#1194).
+ * uses this adapter so the recorded `recoveryPointSha` actually corresponds to
+ * a local ref the recovery `git reset --keep` can undo (#1194).
  */
 function buildDefaultVcsMerge(
   input: HandleExecuteMergeInput,
@@ -141,7 +142,7 @@ function buildDefaultVcsMerge(
  *
  * Shallow-merges (rather than replacing) the existing `mergeOrchestrator`
  * block so terminal-phase fields like `mergeSha` and `reason` ride alongside
- * the always-present `phase` + `rollbackSha`. This is intentionally
+ * the always-present `phase` + `recoveryPointSha`. This is intentionally
  * different from `merge-orchestrate.ts`'s `buildDefaultPersistState`, which
  * REPLACES the block on `aborted`: the executor progresses through
  * `executing` → `completed`/`rolled-back`, so merging preserves
@@ -422,7 +423,7 @@ export async function handleExecuteMerge(
             targetBranch: args.targetBranch,
             strategy: args.strategy,
             mergeSha: result.mergeSha,
-            rollbackSha: result.rollbackSha,
+            rollbackSha: result.recoveryPointSha,
           },
         },
         appendOptionsExecuted,
@@ -562,7 +563,7 @@ export async function handleExecuteMerge(
             ...(args.taskId !== undefined ? { taskId: args.taskId } : {}),
             sourceBranch: args.sourceBranch,
             targetBranch: args.targetBranch,
-            rollbackSha: result.rollbackSha,
+            rollbackSha: result.recoveryPointSha,
             reason: result.reason,
             // INV-14 discriminator — the pure executor's recovery ladder
             // (`git merge --abort` → `git reset --keep`, never `--hard`)
@@ -572,8 +573,8 @@ export async function handleExecuteMerge(
             ...(result.recoveryError !== undefined
               ? {
                   recoveryError: result.recoveryError,
-                  ...(result.rollbackError !== undefined
-                    ? { rollbackError: result.rollbackError }
+                  ...(result.recoveryErrorDetail !== undefined
+                    ? { rollbackError: result.recoveryErrorDetail }
                     : {}),
                 }
               : {}),
@@ -605,16 +606,16 @@ export async function handleExecuteMerge(
     if (result.phase === 'completed') {
       await persistState({
         phase: 'completed',
-        rollbackSha: result.rollbackSha,
+        recoveryPointSha: result.recoveryPointSha,
         mergeSha: result.mergeSha,
       });
     } else {
       await persistState({
         phase: 'rolled-back',
-        rollbackSha: result.rollbackSha,
+        recoveryPointSha: result.recoveryPointSha,
         reason: result.reason,
         ...(result.recoveryError !== undefined ? { recoveryError: result.recoveryError } : {}),
-        ...(result.rollbackError !== undefined ? { rollbackError: result.rollbackError } : {}),
+        ...(result.recoveryErrorDetail !== undefined ? { recoveryErrorDetail: result.recoveryErrorDetail } : {}),
       });
     }
   } catch (err) {
@@ -650,7 +651,7 @@ export async function handleExecuteMerge(
       data: {
         phase: 'completed' as const,
         mergeSha: result.mergeSha,
-        rollbackSha: result.rollbackSha,
+        recoveryPointSha: result.recoveryPointSha,
       },
     };
   }
@@ -663,10 +664,10 @@ export async function handleExecuteMerge(
     },
     data: {
       phase: 'rolled-back' as const,
-      rollbackSha: result.rollbackSha,
+      recoveryPointSha: result.recoveryPointSha,
       reason: result.reason,
       ...(result.recoveryError !== undefined ? { recoveryError: result.recoveryError } : {}),
-      ...(result.rollbackError !== undefined ? { rollbackError: result.rollbackError } : {}),
+      ...(result.recoveryErrorDetail !== undefined ? { recoveryErrorDetail: result.recoveryErrorDetail } : {}),
     },
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
@@ -117,6 +117,15 @@ export interface HandleExecuteMergeInput extends HandleExecuteMergeArgs {
   readonly vcsMerge?: VcsMergeAdapter;
   readonly gitExec?: GitExec;
   readonly persistState?: PersistStateCallback;
+  /**
+   * #1308 T09 — bounded timeout-retry seams forwarded verbatim to the pure
+   * `executeMerge`. Both are test-only DI hooks (never supplied over the wire):
+   * `jitter` pins the backoff jitter for determinism, `sleep` skips the real
+   * wall-clock backoff. Production leaves them undefined → real Math.random
+   * jitter + real setTimeout sleep.
+   */
+  readonly jitter?: () => number;
+  readonly sleep?: (ms: number) => Promise<void>;
 }
 
 // ─── Default adapters ──────────────────────────────────────────────────────
@@ -323,6 +332,55 @@ export async function handleExecuteMerge(
     throw err;
   }
 
+  // #1308 T09 — `merge.retry_attempt` audit emission. The pure executor invokes
+  // this once per bounded timeout-retry, BEFORE the re-attempt fires, so each
+  // retry leaves a durable audit record on the stream ahead of the terminal
+  // `merge.executed`/`merge.recovered` events. Each append reads the LIVE stream
+  // tail FRESH for its own `expectedSequence` and carries its OWN idempotency
+  // key (the `:${attempt}` suffix disambiguates the per-attempt rows so a
+  // crash-replay of a given retry dedups rather than colliding with sibling
+  // attempts — `project_cas_pin_idempotency_trap`).
+  const onRetryAttempt = async (info: {
+    attempt: number;
+    delayMs: number;
+    reason: 'timeout';
+  }): Promise<void> => {
+    const tailEventsRetry = await ctx.eventStore.query(args.featureId);
+    const expectedSequenceRetry =
+      tailEventsRetry.length > 0
+        ? Math.max(...tailEventsRetry.map((e) => e.sequence))
+        : 0;
+    try {
+      await ctx.eventStore.append(
+        args.featureId,
+        {
+          type: 'merge.retry_attempt',
+          data: {
+            attempt: info.attempt,
+            delayMs: info.delayMs,
+            reason: info.reason,
+          },
+        },
+        {
+          expectedSequence: expectedSequenceRetry,
+          idempotencyKey: buildMergeOrchestrateIdempotencyKey(
+            args.featureId,
+            args.taskId,
+            `merge.retry_attempt:${info.attempt}`,
+          ),
+        },
+      );
+    } catch (err) {
+      // A lost sequence race on the audit append must NOT abort the merge — the
+      // retry itself is the load-bearing action; the audit record is
+      // best-effort. Swallow the SequenceConflict (a concurrent writer advanced
+      // the tail) so the bounded-retry loop proceeds to its re-attempt.
+      if (!(err instanceof SequenceConflictError)) {
+        throw err;
+      }
+    }
+  };
+
   let result;
   try {
     result = await executeMerge({
@@ -332,6 +390,9 @@ export async function handleExecuteMerge(
       gitExec,
       vcsMerge,
       persistState,
+      onRetryAttempt,
+      ...(input.jitter !== undefined ? { jitter: input.jitter } : {}),
+      ...(input.sleep !== undefined ? { sleep: input.sleep } : {}),
       ...(args.repoRoot !== undefined ? { repoRoot: args.repoRoot } : {}),
     });
   } catch (err) {

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
@@ -531,13 +531,86 @@ export async function handleExecuteMerge(
     // `--hard`). Surface `recoveryError` + detail (when recovery was not clean)
     // so consumers can detect an indeterminate worktree.
     //
-    // #1303 (α-05): pass `idempotencyKey` (when `taskId` is present) and
-    // `expectedSequence` (CAS on stream high-water mark) so the substrate
-    // guarantees from #1259 / #1323 reach this append site too. Symmetric
-    // with α-02 (merge.executed) and α-04 (merge.preflight). The three
-    // append sites in this orchestrator surface — preflight, executed,
-    // rollback — each carry a distinct dedup key via the trailing
-    // `:${eventType}` segment.
+    // #1306 T4 — DUAL-EMIT during the v2.11.x deprecation window. The recovery
+    // path appends TWO events for the same logical recovery:
+    //
+    //   1) the canonical `merge.recovered` (successor; renamed fields
+    //      `recoveryPointSha` / `recoveryErrorDetail`), then
+    //   2) the legacy `merge.rollback` (kept until v2.12; carries the
+    //      `_meta.deprecation` envelope on its `data`).
+    //
+    // CAS HAZARD (project_cas_pin_idempotency_trap / PR #1492): each append
+    // reads the LIVE stream tail FRESH to compute its own `expectedSequence`
+    // and carries its OWN independent idempotency key (the trailing
+    // `:${eventType}` segment disambiguates). The `merge.recovered` append is
+    // NEVER re-pinned to the `merge.rollback` append's returned sequence — a
+    // cache-hit precedes the CAS, so a static cross-pin would make a retried
+    // recovery conflict FOREVER. Independent keys + independent fresh-tail CAS
+    // make a retried recovery a clean no-op across BOTH event types.
+    //
+    // #1303 (α-05): each append carries `idempotencyKey` + `expectedSequence`
+    // so the substrate guarantees from #1259 / #1323 reach both sites.
+    //
+    // The legacy event still drives the `merge-orchestrator@v1` projection's
+    // `recovering` phase (the reducer folds `merge.rollback`, NOT
+    // `merge.recovered`, during the deprecation window); emitting both does
+    // NOT double-advance the projection. The v2.12 swap is tracked separately.
+
+    // ── 1) Canonical `merge.recovered` (fresh-tail CAS, own idempotency key) ──
+    const tailEventsRecovered = await ctx.eventStore.query(args.featureId);
+    const expectedSequenceRecovered =
+      tailEventsRecovered.length > 0
+        ? Math.max(...tailEventsRecovered.map((e) => e.sequence))
+        : 0;
+    const appendOptionsRecovered: { idempotencyKey: string; expectedSequence: number } = {
+      expectedSequence: expectedSequenceRecovered,
+      idempotencyKey: buildMergeOrchestrateIdempotencyKey(
+        args.featureId,
+        args.taskId,
+        'merge.recovered',
+      ),
+    };
+    try {
+      await ctx.eventStore.append(
+        args.featureId,
+        {
+          type: 'merge.recovered',
+          data: {
+            ...(args.taskId !== undefined ? { taskId: args.taskId } : {}),
+            sourceBranch: args.sourceBranch,
+            targetBranch: args.targetBranch,
+            recoveryPointSha: result.recoveryPointSha,
+            reason: result.reason,
+            // INV-14 discriminator under the CANONICAL field names
+            // (`recoveryError` enum + `recoveryErrorDetail` detail). Both
+            // absent on a clean recovery.
+            ...(result.recoveryError !== undefined
+              ? {
+                  recoveryError: result.recoveryError,
+                  ...(result.recoveryErrorDetail !== undefined
+                    ? { recoveryErrorDetail: result.recoveryErrorDetail }
+                    : {}),
+                }
+              : {}),
+          },
+        },
+        appendOptionsRecovered,
+      );
+    } catch (err) {
+      if (err instanceof SequenceConflictError) {
+        return {
+          success: false,
+          error: {
+            code: 'STATE_CONFLICT',
+            message: `merge.recovered append lost sequence race: expected=${err.expected} actual=${err.actual}`,
+          },
+        };
+      }
+      throw err;
+    }
+
+    // ── 2) Legacy `merge.rollback` (own FRESH-tail CAS — re-read so it sees
+    //       the `merge.recovered` we just appended; own idempotency key) ──────
     const tailEventsRollback = await ctx.eventStore.query(args.featureId);
     const expectedSequenceRollback =
       tailEventsRollback.length > 0
@@ -565,11 +638,25 @@ export async function handleExecuteMerge(
             targetBranch: args.targetBranch,
             rollbackSha: result.recoveryPointSha,
             reason: result.reason,
+            // #1306 deprecation envelope — surfaced on the legacy event's
+            // `data` so consumers reading the legacy stream see the migration
+            // window and the canonical replacement. Lives under `data._meta`
+            // (the top-level event shape strips unknown keys); byte-identical
+            // across every emission surface because both CLI and MCP funnel
+            // through this single code path.
+            _meta: {
+              deprecation: {
+                since: '2.11.0',
+                removeIn: '2.12.0',
+                replacement: 'merge.recovered',
+              },
+            },
             // INV-14 discriminator — the pure executor's recovery ladder
             // (`git merge --abort` → `git reset --keep`, never `--hard`)
             // classifies any indeterminate outcome so observability distinguishes
             // a stranded worktree from a clean rollback. Forward the enum + detail
-            // verbatim; both absent on a clean recovery.
+            // verbatim under the LEGACY `rollbackError` wire field; both absent
+            // on a clean recovery.
             ...(result.recoveryError !== undefined
               ? {
                   recoveryError: result.recoveryError,

--- a/servers/exarchos-mcp/src/orchestrate/git-exec-default.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/git-exec-default.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { defaultGitExec } from './git-exec-default.js';
+
+// #1311 — scoped coverage for the shared merge-orchestrator git executor.
+// The canonical (120s, stderr-capturing) `defaultGitExec` extracted from the
+// two byte-equivalent copies in merge-orchestrate.ts and execute-merge.ts.
+// The 30s gate-utils variant is intentionally separate (different workload).
+describe('git-exec-default', () => {
+  const repoRoot = process.cwd();
+
+  it('DefaultGitExec_RunsGitArgs_ReturnsStdoutAndExitCode', () => {
+    const result = defaultGitExec(repoRoot, ['--version']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/git version/i);
+    // success path captures empty stderr separately (richer #1401 body)
+    expect(result.stderr).toBe('');
+  });
+
+  it('DefaultGitExec_GitFailure_CapturesStderrAndExitCode', () => {
+    const result = defaultGitExec(repoRoot, ['this-is-not-a-git-command']);
+    expect(result.exitCode).not.toBe(0);
+    // stderr is captured separately (the behavior #1401 added) ...
+    expect(result.stderr.length).toBeGreaterThan(0);
+    // ... and also folded into the stdout channel for backwards-compat with
+    // callers that read `stdout` as the failure-message channel.
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/git-exec-default.ts
+++ b/servers/exarchos-mcp/src/orchestrate/git-exec-default.ts
@@ -1,0 +1,44 @@
+import { execFileSync } from 'node:child_process';
+import type { GitExecResult } from './pure/merge-preflight.js';
+
+/**
+ * Canonical default git executor for the merge orchestrator (#1311 dedupe).
+ *
+ * Synchronous shell-out from `repoRoot` with a 120s ceiling. NEVER throws on a
+ * non-zero exit — failures surface via `exitCode`. git's stderr is captured
+ * *separately* (so #1362 phase-1 diagnostics can distinguish git's error output
+ * from any partial stdout) AND folded into `stdout` with a newline for
+ * backwards-compat with callers that read `stdout` as the failure-message
+ * channel.
+ *
+ * Extracted from the two byte-equivalent 120s copies previously inlined in
+ * `merge-orchestrate.ts` and `execute-merge.ts`. NOTE: the per-task gate
+ * handlers use a deliberately *separate* `defaultGitExec` in `gate-utils.ts`
+ * with a 30s ceiling tuned for quick gate git ops — the two are different
+ * workloads and must NOT be collapsed.
+ */
+export function defaultGitExec(repoRoot: string, args: readonly string[]): GitExecResult {
+  try {
+    const stdout = execFileSync('git', [...args], {
+      cwd: repoRoot,
+      timeout: 120_000,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    const rawStderr = (err as { stderr?: string | Buffer }).stderr;
+    const rawStdout = (err as { stdout?: string | Buffer }).stdout;
+    const stderr =
+      typeof rawStderr === 'string' ? rawStderr : rawStderr?.toString('utf-8') ?? '';
+    const stdoutOnly =
+      typeof rawStdout === 'string' ? rawStdout : rawStdout?.toString('utf-8') ?? '';
+    const message = [stdoutOnly, stderr].filter(Boolean).join('\n');
+    return {
+      stdout: message,
+      stderr,
+      exitCode: typeof status === 'number' ? status : 1,
+    };
+  }
+}

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.integration.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.integration.test.ts
@@ -58,6 +58,7 @@ import {
   executeTransition,
 } from '../workflow/state-machine.js';
 import { createFeatureHSM } from '../workflow/hsm-definitions.js';
+import { handleWorkflow } from '../workflow/composite.js';
 
 // ─── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -728,5 +729,221 @@ describe('handleMergeOrchestrate integration — idempotency & concurrency (#130
     expect(mergeExecuted).toHaveLength(1);
   });
 
+});
+
+// ─── #1305 T15 — merge-pending transitions emit workflow.transition ─────────
+//
+// INVARIANT: the `merge-pending` entry (`delegate → merge-pending`) and exit
+// (`merge-pending → delegate`) phase transitions MUST go through the
+// canonical HSM transition primitive — `handleWorkflow({ action: 'transition' })`
+// → `handleTransition` → `hsmTransitionGuard.attempt` — which emits exactly
+// one `workflow.transition` event per call and NEVER a bare top-level
+// phase-set that would bypass the event log and desync the projection.
+//
+// v2.11 (composite.ts T5a.1) hard-cut the prior `set({phase})` rerouting
+// path; `transition` is now the single phase-mutation entry point. These
+// tests pin that the merge-pending edges resolve through it and produce the
+// canonical event — `workflow.transition`, not `workflow.set` / a bare
+// phase-set.
+//
+// Coverage split:
+//   • The EXIT edge (`merge-pending → delegate`) is driven END-TO-END through
+//     the real store + canonical primitive: its guard (`mergePendingExit`)
+//     inspects only `_events[].type` for terminal events, so it evaluates
+//     correctly against the store-hydrated `_events` shape.
+//   • The ENTRY edge (`delegate → merge-pending`) is asserted reachable
+//     through the HSM evaluator (the production projection path consumes the
+//     same evaluator) and confirmed to route through the canonical primitive.
+//     The entry guard reads `task.completed.data.worktree`; the store
+//     hydration helper flattens event `data` to the top level (worktree lands
+//     under `metadata`, not `.data`), so an entry transition cannot be driven
+//     through `handleTransition` against a live store today. That `.data`-vs-
+//     `metadata` impedance is a pre-existing hydration concern (out of scope
+//     for T15 — the resolver/projection work is #1305 T13/T14), so the entry
+//     edge is exercised at the HSM-evaluator seam the projection uses.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Seed a minimal feature workflow state file at the given phase. Same minimal
+ * shape as the rollback seed helper, with a fresh `mergeOrchestrator` block
+ * (`phase: 'pending'`) so the entry guard's "not in a terminal phase" check
+ * passes.
+ */
+async function seedFeatureStateAtPhase(
+  stateDir: string,
+  featureId: string,
+  phase: 'delegate' | 'merge-pending',
+): Promise<string> {
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+  const now = new Date().toISOString();
+  const state = {
+    version: '1.1',
+    workflowType: 'feature' as const,
+    featureId,
+    phase,
+    createdAt: now,
+    updatedAt: now,
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    integration: null,
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+    mergeOrchestrator: {
+      phase: 'pending' as const,
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      taskId: 'T15',
+    },
+  };
+  await writeStateFile(stateFile, state as never);
+  return stateFile;
+}
+
+describe('MergePendingTransitions_EmitWorkflowTransition_NotSet (#1305 T15)', () => {
+  let stateDir: string;
+  let eventStore: EventStore;
+  let ctx: DispatchContext;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(path.join(tmpdir(), 'merge-orch-transition-'));
+    eventStore = new EventStore(stateDir);
+    await eventStore.initialize();
+    ctx = {
+      stateDir,
+      eventStore,
+      enableTelemetry: false,
+    };
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(stateDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
+  });
+
+  it('MergePendingExit_DrivenThroughCanonicalPrimitive_EmitsWorkflowTransitionNotBarePhaseSet', async () => {
+    const featureId = 'feat-t15-exit';
+    await seedFeatureStateAtPhase(stateDir, featureId, 'merge-pending');
+
+    // Terminal events that authorize the `merge-pending → delegate` edge
+    // (mergePendingExit guard): a worktree-bearing task.completed followed by
+    // a merge.executed. Both land on the real stream so the guard evaluates
+    // against production-shaped (store-hydrated) `_events`.
+    await eventStore.append(featureId, {
+      type: 'task.completed',
+      data: { taskId: 'T15', worktree: WORKTREE_PATH },
+    });
+    await eventStore.append(featureId, {
+      type: 'merge.executed',
+      data: {
+        taskId: 'T15',
+        sourceBranch: SOURCE_BRANCH,
+        targetBranch: TARGET_BRANCH,
+        mergeSha: MERGE_SHA,
+        rollbackSha: ROLLBACK_SHA,
+      },
+    });
+
+    // No transition events before the exit call.
+    const before = await eventStore.query(featureId);
+    expect(
+      before.filter((e) => e.type === 'workflow.transition'),
+    ).toHaveLength(0);
+
+    // ─── EXIT transition through the canonical primitive ────────────────────
+    const exitResult = await handleWorkflow(
+      { action: 'transition', featureId, target: 'delegate' },
+      ctx,
+    );
+    expect(exitResult.success).toBe(true);
+
+    // Exactly one workflow.transition event, from merge-pending → delegate.
+    const after = await eventStore.query(featureId);
+    const transitions = after.filter((e) => e.type === 'workflow.transition');
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0]!.data).toMatchObject({
+      from: 'merge-pending',
+      to: 'delegate',
+      featureId,
+    });
+
+    // ─── No bare phase-set bypass ───────────────────────────────────────────
+    // The event log is the ONLY phase-mutation seam: the phase change is
+    // carried by a `workflow.transition` event. No separate `workflow.set` /
+    // phase-mutation event exists that would indicate a `set({phase})` bypass.
+    const phaseMutationEvents = after.filter(
+      (e) =>
+        e.type === 'workflow.transition' ||
+        // Defensive: catch a hypothetical future `workflow.set` phase event.
+        e.type === ('workflow.set' as typeof e.type),
+    );
+    expect(
+      phaseMutationEvents.every((e) => e.type === 'workflow.transition'),
+    ).toBe(true);
+    expect(phaseMutationEvents).toHaveLength(1);
+
+    // Final on-disk phase reflects the exit transition (delegate), proving the
+    // CAS write that accompanies the transition primitive landed.
+    const finalRaw = await fs.readFile(
+      path.join(stateDir, `${featureId}.state.json`),
+      'utf-8',
+    );
+    const finalState = JSON.parse(finalRaw) as { phase: string };
+    expect(finalState.phase).toBe('delegate');
+  });
+
+  it('MergePendingEntry_IsReachableThroughHsmEvaluatorAndCanonicalPrimitive', async () => {
+    // The entry edge (`delegate → merge-pending`) is the same edge the
+    // production rehydration projection consults. Assert it is reachable
+    // through the HSM evaluator with a worktree-bearing task.completed, and
+    // that the only declared edge into `merge-pending` from `delegate` is the
+    // guarded transition (so the sole phase-mutation seam is the canonical
+    // `workflow.transition` primitive, never a bare set).
+    const hsm = getHSMDefinition('feature');
+
+    // (1) HSM evaluator — the entry edge fires with a worktree association.
+    const stateForEntry = {
+      phase: 'delegate',
+      featureId: 'feat-t15-entry',
+      mergeOrchestrator: { taskId: 'T15', phase: 'pending' },
+      _events: [
+        { type: 'task.completed', data: { taskId: 'T15', worktree: WORKTREE_PATH } },
+      ],
+    };
+    const entryEval = executeTransition(hsm, stateForEntry, 'merge-pending');
+    expect(entryEval.success).toBe(true);
+    expect(entryEval.newPhase).toBe('merge-pending');
+
+    // (2) Topology — `delegate → merge-pending` is a declared, guarded edge.
+    //     A declared HSM edge is mutated ONLY by the canonical transition
+    //     primitive (which emits `workflow.transition`); there is no separate
+    //     phase-set code path for it.
+    const entryEdges = hsm.transitions.filter(
+      (t) => t.from === 'delegate' && t.to === 'merge-pending',
+    );
+    expect(entryEdges).toHaveLength(1);
+    expect(entryEdges[0]!.guard).toBeDefined();
+
+    // (3) Without a worktree association the entry edge does NOT fire — the
+    //     guard, not a bare phase-set, gates entry.
+    const stateNoWorktree = {
+      phase: 'delegate',
+      featureId: 'feat-t15-entry',
+      _events: [{ type: 'task.completed', data: { taskId: 'T15' } }],
+    };
+    const blockedEval = executeTransition(hsm, stateNoWorktree, 'merge-pending');
+    expect(blockedEval.success).toBe(false);
+  });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.integration.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.integration.test.ts
@@ -276,12 +276,15 @@ describe('Merge orchestrator happy timeline (T23, DR-MO-1, DR-MO-2)', () => {
     // The expected order is the production contract (post Wave 4 / audit
     // §F1.2 two-event split):
     //
-    //   sequence 1: task.completed  (the T17 trigger, from step 2)
-    //   sequence 2: merge.preflight (T11 emits before delegating)
-    //   sequence 3: merge.requested (Wave 4 Phase A — durable intent
-    //                                emitted via `decide` BEFORE the
-    //                                executor's local git merge side effect)
-    //   sequence 4: merge.executed  (T15 emits on phase: 'completed')
+    //   sequence 1: task.completed          (the T17 trigger, from step 2)
+    //   sequence 2: merge.preflight          (T11 emits before delegating)
+    //   sequence 3: merge.requested          (Wave 4 Phase A — durable intent
+    //                                          emitted via `decide` BEFORE the
+    //                                          executor's local git merge side effect)
+    //   sequence 4: merge.executing_started  (#1309 liveness — emitted after the
+    //                                          recovery point is recorded, before
+    //                                          the first vcsMerge)
+    //   sequence 5: merge.executed           (T15 emits on phase: 'completed')
     //
     // No other events are expected on the happy path (no merge.rollback,
     // no merge.aborted).
@@ -291,6 +294,9 @@ describe('Merge orchestrator happy timeline (T23, DR-MO-1, DR-MO-2)', () => {
       'task.completed',
       'merge.preflight',
       'merge.requested',
+      // #1309 INV-10 liveness — emitted before the merge so a long-running merge
+      // is observable as started-but-unterminated.
+      'merge.executing_started',
       'merge.executed',
       // #1304 INV-10 terminal marker — emitted adjacent to merge.executed
       // by `handleExecuteMerge` once `merge.executed` lands successfully.
@@ -304,7 +310,7 @@ describe('Merge orchestrator happy timeline (T23, DR-MO-1, DR-MO-2)', () => {
     // racing the sequence counter, sidecar mode leaking into the happy path)
     // shows up in this integration suite, not just in store-level unit tests.
     const sequences = finalEvents.map((e) => e.sequence);
-    expect(sequences).toEqual([1, 2, 3, 4, 5]);
+    expect(sequences).toEqual([1, 2, 3, 4, 5, 6]);
     for (let i = 1; i < sequences.length; i += 1) {
       const prev = sequences[i - 1];
       const curr = sequences[i];

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.integration.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.integration.test.ts
@@ -254,14 +254,14 @@ describe('Merge orchestrator happy timeline (T23, DR-MO-1, DR-MO-2)', () => {
     const data = dispatchResult.data as {
       phase: string;
       mergeSha: string;
-      rollbackSha: string;
+      recoveryPointSha: string;
       preflight: MergePreflightResult;
       // Composite envelope wrapping (T038) may add `next_actions`, `_meta`,
       // `_perf` here — we only assert the shape we contracted on.
     };
     expect(data.phase).toBe('completed');
     expect(data.mergeSha).toBe(MERGE_SHA);
-    expect(data.rollbackSha).toBe(ROLLBACK_SHA);
+    expect(data.recoveryPointSha).toBe(ROLLBACK_SHA);
     expect(stubVcsMerge).toHaveBeenCalledTimes(1);
     expect(stubVcsMerge).toHaveBeenCalledWith({
       sourceBranch: SOURCE_BRANCH,
@@ -522,7 +522,7 @@ describe('handleMergeOrchestrate integration — rollback timeline (T24)', () =>
     const raw = await fs.readFile(stateFile, 'utf-8');
     const state = JSON.parse(raw) as {
       phase: string;
-      mergeOrchestrator?: { phase?: string; taskId?: string; reason?: string; rollbackSha?: string };
+      mergeOrchestrator?: { phase?: string; taskId?: string; reason?: string; recoveryPointSha?: string };
       featureId: string;
       workflowType: string;
     };
@@ -533,7 +533,7 @@ describe('handleMergeOrchestrate integration — rollback timeline (T24)', () =>
     //  gap; now strict per the design.)
     expect(state.mergeOrchestrator?.phase).toBe('rolled-back');
     expect(state.mergeOrchestrator?.reason).toBe('merge-failed');
-    expect(typeof state.mergeOrchestrator?.rollbackSha).toBe('string');
+    expect(typeof state.mergeOrchestrator?.recoveryPointSha).toBe('string');
 
     // T19 contract: when state carries `mergeOrchestrator.phase ===
     // 'rolled-back'`, `merge_orchestrate` is omitted from next-actions.

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.parity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.parity.test.ts
@@ -131,7 +131,7 @@ function buildMergeOrchestrateCompositeStub(
           data: {
             phase: 'completed' as const,
             mergeSha: MERGE_SHA,
-            rollbackSha: ROLLBACK_SHA,
+            recoveryPointSha: ROLLBACK_SHA,
           },
         };
       }
@@ -145,7 +145,7 @@ function buildMergeOrchestrateCompositeStub(
         data: {
           phase: 'rolled-back' as const,
           mergeSha: MERGE_SHA,
-          rollbackSha: ROLLBACK_SHA,
+          recoveryPointSha: ROLLBACK_SHA,
         },
       };
     };
@@ -242,12 +242,12 @@ describe('exarchos merge-orchestrate CLI↔MCP parity (T22, DR-MO-1)', () => {
     const cliData = cliResult.data as {
       phase: string;
       mergeSha: string;
-      rollbackSha: string;
+      recoveryPointSha: string;
       preflight: MergePreflightResult;
     };
     expect(cliData.phase).toBe('completed');
     expect(cliData.mergeSha).toBe(MERGE_SHA);
-    expect(cliData.rollbackSha).toBe(ROLLBACK_SHA);
+    expect(cliData.recoveryPointSha).toBe(ROLLBACK_SHA);
     expect(cliData.preflight).toEqual(PASSING_PREFLIGHT);
 
     // Assert — both surfaces project byte-equal ToolResult after stripping

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
@@ -4,7 +4,7 @@
 // (T06/T07) with executor (T15) and emits the `merge.preflight` event for
 // observability. Asserts:
 //   1. on preflight pass + execute success returns
-//      { success: true, data: { phase: 'completed', mergeSha, rollbackSha,
+//      { success: true, data: { phase: 'completed', mergeSha, recoveryPointSha,
 //        preflight } }.
 //   2. emits `merge.preflight` exactly once (direct stream append, NOT
 //      wrapped in `gate.executed` — the dedicated schema (T03) is top-level).
@@ -138,7 +138,7 @@ describe('handleMergeOrchestrate (T11)', () => {
       data: {
         phase: 'completed' as const,
         mergeSha: MERGE_SHA,
-        rollbackSha: ROLLBACK_SHA,
+        recoveryPointSha: ROLLBACK_SHA,
       },
     });
 
@@ -160,7 +160,7 @@ describe('handleMergeOrchestrate (T11)', () => {
     expect(result.data).toEqual({
       phase: 'completed',
       mergeSha: MERGE_SHA,
-      rollbackSha: ROLLBACK_SHA,
+      recoveryPointSha: ROLLBACK_SHA,
       preflight: PASSING_PREFLIGHT,
     });
     expect(preflight).toHaveBeenCalledTimes(1);
@@ -175,7 +175,7 @@ describe('handleMergeOrchestrate (T11)', () => {
       data: {
         phase: 'completed' as const,
         mergeSha: MERGE_SHA,
-        rollbackSha: ROLLBACK_SHA,
+        recoveryPointSha: ROLLBACK_SHA,
       },
     });
 
@@ -492,7 +492,7 @@ describe('handleMergeOrchestrate (#1362 — preflight.debug event-wire)', () => 
       data: {
         phase: 'completed' as const,
         mergeSha: MERGE_SHA,
-        rollbackSha: ROLLBACK_SHA,
+        recoveryPointSha: ROLLBACK_SHA,
       },
     });
     const persistState = vi.fn().mockResolvedValue(undefined);
@@ -603,7 +603,7 @@ describe('handleMergeOrchestrate (T14 — resume path)', () => {
       data: {
         phase: 'completed' as const,
         mergeSha: MERGE_SHA,
-        rollbackSha: ROLLBACK_SHA,
+        recoveryPointSha: ROLLBACK_SHA,
       },
     });
     const persistState = vi.fn().mockResolvedValue(undefined);
@@ -653,7 +653,7 @@ describe('handleMergeOrchestrate (T14 — resume path)', () => {
         targetBranch: 'main',
         taskId: 'T14',
         mergeSha: MERGE_SHA,
-        rollbackSha: ROLLBACK_SHA,
+        recoveryPointSha: ROLLBACK_SHA,
       },
     });
 
@@ -685,7 +685,7 @@ describe('handleMergeOrchestrate (T14 — resume path)', () => {
     expect(result.data).toMatchObject({
       phase: 'completed',
       mergeSha: MERGE_SHA,
-      rollbackSha: ROLLBACK_SHA,
+      recoveryPointSha: ROLLBACK_SHA,
     });
   });
 
@@ -697,7 +697,7 @@ describe('handleMergeOrchestrate (T14 — resume path)', () => {
       data: {
         phase: 'completed' as const,
         mergeSha: MERGE_SHA,
-        rollbackSha: ROLLBACK_SHA,
+        recoveryPointSha: ROLLBACK_SHA,
       },
     });
     const persistState = vi.fn().mockResolvedValue(undefined);
@@ -706,7 +706,7 @@ describe('handleMergeOrchestrate (T14 — resume path)', () => {
       mergeOrchestrator: {
         phase: 'completed',
         mergeSha: 'old-merge-sha',
-        rollbackSha: 'old-rollback-sha',
+        recoveryPointSha: 'old-rollback-sha',
       },
     });
 

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -34,7 +34,7 @@
 // `ctx.projectConfig` + `ctx.stateDir`.
 // ───────────────────────────────────────────────────────────────────────────
 
-import { execFileSync } from 'node:child_process';
+import { defaultGitExec } from './git-exec-default.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
@@ -187,42 +187,6 @@ function normalizePath(p: string): string {
 }
 
 // ─── Default gitExec ───────────────────────────────────────────────────────
-
-/**
- * Default `gitExec` for the preflight composer. Mirrors the convention used
- * by `handleExecuteMerge`: synchronous shell-out with a 120s ceiling, never
- * throws (we surface failures via `exitCode`).
- */
-function defaultGitExec(repoRoot: string, args: readonly string[]): GitExecResult {
-  try {
-    const stdout = execFileSync('git', [...args], {
-      cwd: repoRoot,
-      timeout: 120_000,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { stdout, stderr: '', exitCode: 0 };
-  } catch (err) {
-    // Capture stderr separately so #1362 phase-1 diagnostics can read the
-    // actual git error output (e.g., for `merge-base --is-ancestor` exit
-    // codes != 0/1 indicating a real failure vs the documented "non-ancestor"
-    // signal). Also fold stderr into stdout for backwards-compat with
-    // existing callers that read `stdout` as the failure-message channel.
-    const status = (err as { status?: number }).status;
-    const rawStderr = (err as { stderr?: string | Buffer }).stderr;
-    const rawStdout = (err as { stdout?: string | Buffer }).stdout;
-    const stderr =
-      typeof rawStderr === 'string' ? rawStderr : rawStderr?.toString('utf-8') ?? '';
-    const stdoutOnly =
-      typeof rawStdout === 'string' ? rawStdout : rawStdout?.toString('utf-8') ?? '';
-    const message = [stdoutOnly, stderr].filter(Boolean).join('\n');
-    return {
-      stdout: message,
-      stderr,
-      exitCode: typeof status === 'number' ? status : 1,
-    };
-  }
-}
 
 /**
  * Default `persistState` for the orchestrator. Reads the workflow state

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -802,7 +802,7 @@ export async function handleMergeOrchestrate(
   const execData = execResult.data as {
     phase: 'completed';
     mergeSha: string;
-    rollbackSha: string;
+    recoveryPointSha: string;
   };
 
   return {
@@ -810,7 +810,7 @@ export async function handleMergeOrchestrate(
     data: {
       phase: 'completed' as const,
       mergeSha: execData.mergeSha,
-      rollbackSha: execData.rollbackSha,
+      recoveryPointSha: execData.recoveryPointSha,
       preflight,
     },
   };

--- a/servers/exarchos-mcp/src/orchestrate/merge-transition-exclusivity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-transition-exclusivity.test.ts
@@ -1,0 +1,123 @@
+// ─── Merge-transition exclusivity shield (#1305 T15) ───────────────────────
+//
+// INVARIANT: the merge-orchestrator's `merge-pending` entry/exit phase
+// transitions MUST go through the canonical HSM transition primitive
+// (`handleSet({ phase })` → `hsmTransitionGuard.attempt` → a single
+// `workflow.transition` event). They MUST NOT bypass the event log with a
+// direct top-level-phase mutation (`set({ phase: 'merge-pending' })` or
+// `set({ phase: 'delegate' })`), which would desync the projection from the
+// event store (the SQLite event store is the authoritative existence/phase
+// record — see CLAUDE.md "State surfaces").
+//
+// This is a structural guard: it scans every `.ts` source file under
+// `src/orchestrate/` and asserts no merge-transition code path applies a
+// bare top-level phase-set for a merge-pending entry/exit. The merge
+// orchestrator is permitted to write its OWN sub-state (`mergeOrchestrator.
+// phase`, an internal pending/executing/completed/rolled-back/aborted
+// marker) — that is NOT the top-level workflow HSM phase and does NOT bypass
+// the transition primitive.
+//
+// NOTE: the forbidden substrings are assembled from fragments at runtime
+// (see `setCall` / `mp` / `dlg` below) so they never appear verbatim in THIS
+// source — otherwise the scan would flag the shield itself.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// Fragments assembled at runtime so the forbidden literals never appear
+// verbatim in THIS file (otherwise this shield would flag itself, and the
+// repo-wide scan would have a false positive on its own guard).
+const setCall = 'set' + '({ ';
+const setCallTight = 'set' + '({';
+const phaseKey = 'phase';
+const mp = 'merge' + '-pending';
+const dlg = 'delegate';
+
+/**
+ * Forbidden patterns: a direct top-level workflow-phase mutation routing a
+ * merge-pending entry or exit transition. Each entry is the source substring
+ * that, if present in any orchestrate source file, indicates a transition
+ * that bypassed the `workflow.transition` primitive.
+ *
+ * We cover both spacings (`set({ phase` and `set({phase`) and both the
+ * entry (`-> merge-pending`) and exit (`-> delegate`) targets a merge
+ * transition would set.
+ */
+const FORBIDDEN_PATTERNS: readonly string[] = [
+  `${setCall}${phaseKey}: '${mp}'`,
+  `${setCallTight}${phaseKey}: '${mp}'`,
+  `${setCall}${phaseKey}: "${mp}"`,
+  `${setCall}${phaseKey}: \`${mp}\``,
+  // The exit target — a merge transition driving `merge-pending -> delegate`
+  // via a bare phase-set rather than the transition primitive.
+  `${setCall}${phaseKey}: '${dlg}', // merge`,
+];
+
+/** Collect every `.ts` source file under `dir`, recursively. */
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectTsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('Orchestrate_NoSetPhaseCalls_ForMergeTransitions (#1305 T15)', () => {
+  it('no orchestrate source applies a bare set({ phase }) for a merge-pending entry/exit transition', () => {
+    const files = collectTsFiles(here);
+    // The shield must not flag itself — FORBIDDEN_PATTERNS appears here as
+    // data (assembled at runtime), and test files are not production paths.
+    const candidates = files.filter(
+      (f) => !f.endsWith('.test.ts') && !f.endsWith('.characterization.test.ts'),
+    );
+
+    const offenders: string[] = [];
+    for (const file of candidates) {
+      const contents = readFileSync(file, 'utf-8');
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        if (contents.includes(pattern)) {
+          offenders.push(`${file} contains forbidden bare phase-set "${pattern}"`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('the merge orchestrator source contains no top-level workflow phase-set call at all', () => {
+    // Stronger statement scoped to the two merge-transition-emitting source
+    // files: neither may contain a `set({ phase` token (any spacing). They
+    // legitimately write `mergeOrchestrator: { phase: ... }` sub-state, which
+    // is a DIFFERENT token (object-literal key, not a `set({ phase` call) and
+    // does not match. If a future change introduces a bare top-level phase
+    // mutation on the merge path, this fails before it can desync the
+    // projection.
+    const mergeFiles = [
+      join(here, 'merge-orchestrate.ts'),
+      join(here, 'execute-merge.ts'),
+    ];
+    const bareSetTokens = [`${setCall}${phaseKey}`, `${setCallTight}${phaseKey}`];
+
+    const offenders: string[] = [];
+    for (const file of mergeFiles) {
+      const contents = readFileSync(file, 'utf-8');
+      for (const token of bareSetTokens) {
+        if (contents.includes(token)) {
+          offenders.push(`${file} contains "${token}"`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.test.ts
@@ -1,4 +1,4 @@
-// ─── execute-merge: recordRollbackPoint tests ──────────────────────────────
+// ─── execute-merge: recordRecoveryPoint tests ──────────────────────────────
 //
 // T08 — pure helper that captures HEAD sha as a rollback point before merge
 // execution (T09/T10 compose executeMerge on top). Must NEVER throw — all
@@ -6,25 +6,25 @@
 // ───────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { recordRollbackPoint, executeMerge, type GitExec } from './execute-merge.js';
+import { recordRecoveryPoint, executeMerge, type GitExec } from './execute-merge.js';
 
-describe('recordRollbackPoint', () => {
-  it('recordRollbackPoint_HappyPath_ReturnsHeadSha', () => {
+describe('recordRecoveryPoint', () => {
+  it('recordRecoveryPoint_HappyPath_ReturnsHeadSha', () => {
     const gitExec: GitExec = vi.fn((_repoRoot: string, args: readonly string[]) => {
       expect(args).toEqual(['rev-parse', 'HEAD']);
       return { stdout: 'abc1234567890\n', exitCode: 0 };
     });
 
-    const result = recordRollbackPoint(gitExec, '/some/repo');
+    const result = recordRecoveryPoint(gitExec, '/some/repo');
 
     expect(result).toEqual({ sha: 'abc1234567890' });
     expect(gitExec).toHaveBeenCalledTimes(1);
   });
 
-  it('recordRollbackPoint_GitFails_ReturnsStructuredError', () => {
+  it('recordRecoveryPoint_GitFails_ReturnsStructuredError', () => {
     const gitExec: GitExec = vi.fn(() => ({ stdout: '', exitCode: 128 }));
 
-    const result = recordRollbackPoint(gitExec, '/some/repo');
+    const result = recordRecoveryPoint(gitExec, '/some/repo');
 
     expect('error' in result).toBe(true);
     if ('error' in result) {
@@ -33,23 +33,23 @@ describe('recordRollbackPoint', () => {
     }
   });
 
-  it('recordRollbackPoint_GitThrows_ReturnsStructuredError_DoesNotThrow', () => {
+  it('recordRecoveryPoint_GitThrows_ReturnsStructuredError_DoesNotThrow', () => {
     const gitExec: GitExec = vi.fn(() => {
       throw new Error('spawn ENOENT');
     });
 
-    expect(() => recordRollbackPoint(gitExec, '/some/repo')).not.toThrow();
-    const result = recordRollbackPoint(gitExec, '/some/repo');
+    expect(() => recordRecoveryPoint(gitExec, '/some/repo')).not.toThrow();
+    const result = recordRecoveryPoint(gitExec, '/some/repo');
     expect('error' in result).toBe(true);
     if ('error' in result) {
       expect(result.error).toContain('spawn ENOENT');
     }
   });
 
-  it('recordRollbackPoint_EmptyStdout_ReturnsStructuredError', () => {
+  it('recordRecoveryPoint_EmptyStdout_ReturnsStructuredError', () => {
     const gitExec: GitExec = vi.fn(() => ({ stdout: '   \n', exitCode: 0 }));
 
-    const result = recordRollbackPoint(gitExec, '/some/repo');
+    const result = recordRecoveryPoint(gitExec, '/some/repo');
 
     expect('error' in result).toBe(true);
   });
@@ -76,7 +76,7 @@ describe('executeMerge', () => {
     expect(result).toEqual({
       phase: 'completed',
       mergeSha: 'merge-sha-xyz',
-      rollbackSha: 'rollback-sha-abc',
+      recoveryPointSha: 'rollback-sha-abc',
     });
     expect(vcsMerge).toHaveBeenCalledWith({
       sourceBranch: 'feat/x',
@@ -96,8 +96,8 @@ describe('executeMerge', () => {
       throw new Error(`unexpected git args: ${args.join(' ')}`);
     });
 
-    const persistState = vi.fn(async (state: { phase: 'executing'; rollbackSha: string }) => {
-      calls.push(`persistState({phase:${state.phase},rollbackSha:${state.rollbackSha}})`);
+    const persistState = vi.fn(async (state: { phase: 'executing'; recoveryPointSha: string }) => {
+      calls.push(`persistState({phase:${state.phase},recoveryPointSha:${state.recoveryPointSha}})`);
     });
 
     const vcsMerge = vi.fn(async () => {
@@ -116,7 +116,7 @@ describe('executeMerge', () => {
 
     expect(calls).toEqual([
       'rev-parse-HEAD',
-      'persistState({phase:executing,rollbackSha:rollback-sha-abc})',
+      'persistState({phase:executing,recoveryPointSha:rollback-sha-abc})',
       'vcsMerge',
     ]);
     expect(result.phase).toBe('completed');
@@ -156,7 +156,7 @@ describe('executeMerge', () => {
 
     expect(result).toEqual({
       phase: 'rolled-back',
-      rollbackSha: 'abc',
+      recoveryPointSha: 'abc',
       reason: 'merge-failed',
     });
     // INV-14: native primitive first (`git merge --abort`), then refuse-to-discard
@@ -197,7 +197,7 @@ describe('executeMerge', () => {
 
     expect(result).toEqual({
       phase: 'rolled-back',
-      rollbackSha: 'abc',
+      recoveryPointSha: 'abc',
       reason: 'verification-failed',
     });
   });
@@ -235,7 +235,7 @@ describe('executeMerge', () => {
 
     expect(result).toEqual({
       phase: 'rolled-back',
-      rollbackSha: 'abc',
+      recoveryPointSha: 'abc',
       reason: 'timeout',
     });
   });
@@ -264,7 +264,7 @@ describe('executeMerge', () => {
       calls.push('vcsMerge-rejects');
       throw new Error('boom');
     });
-    const persistState = vi.fn(async (state: { phase: 'executing'; rollbackSha: string }) => {
+    const persistState = vi.fn(async (state: { phase: 'executing'; recoveryPointSha: string }) => {
       calls.push(`persistState({phase:${state.phase}})`);
     });
 
@@ -287,7 +287,7 @@ describe('executeMerge', () => {
     expect(resetIdx).toBeGreaterThan(abortIdx);
     expect(result.phase).toBe('rolled-back');
     if (result.phase === 'rolled-back') {
-      expect(result.rollbackSha).toBe('abc');
+      expect(result.recoveryPointSha).toBe('abc');
     }
   });
 
@@ -325,10 +325,10 @@ describe('executeMerge', () => {
 
     expect(result.phase).toBe('rolled-back');
     if (result.phase === 'rolled-back') {
-      expect(result.rollbackSha).toBe('abc');
+      expect(result.recoveryPointSha).toBe('abc');
       expect(result.reason).toBe('merge-failed');
       expect(result.recoveryError).toBe('reset-keep-blocked');
-      expect(result.rollbackError).toMatch(/exited 128/);
+      expect(result.recoveryErrorDetail).toMatch(/exited 128/);
     }
   });
 
@@ -365,7 +365,7 @@ describe('executeMerge', () => {
     expect(result.phase).toBe('rolled-back');
     if (result.phase === 'rolled-back') {
       expect(result.recoveryError).toBe('reset-failed');
-      expect(result.rollbackError).toMatch(/git binary missing/);
+      expect(result.recoveryErrorDetail).toMatch(/git binary missing/);
     }
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.test.ts
@@ -231,8 +231,19 @@ describe('executeMerge', () => {
       vcsMerge,
       persistState,
       repoRoot: '/some/repo',
+      // T09 (#1308): a timeout now triggers the bounded retry loop before
+      // recovery. Inject a no-op sleep + zero jitter so this assertion still
+      // exercises the timeout→exhaustion→recovery path without paying the
+      // real backoff wall time. The retry mechanics themselves are covered by
+      // the dedicated `ExecuteMerge_Timeout*` tests below.
+      sleep: async () => {},
+      jitter: () => 0,
     });
 
+    // After exhausting the timeout retries, vcsMerge was called 3 times
+    // (1 initial + MAX_MERGE_RETRIES) and the executor recovers with reason
+    // 'timeout'.
+    expect(vcsMerge).toHaveBeenCalledTimes(3);
     expect(result).toEqual({
       phase: 'rolled-back',
       recoveryPointSha: 'abc',
@@ -407,5 +418,188 @@ describe('executeMerge', () => {
     if (result.phase === 'rolled-back') {
       expect(result.recoveryError).toBe('unexpected-mid-merge-drift');
     }
+  });
+
+  // ─── T09 (#1308): bounded timeout-retry with backoff + jitter ────────────
+  //
+  // ONLY a `'timeout'`-categorized failure enters the retry loop (max 2 retries
+  // → 3 total vcsMerge calls). Each retry reports its attempt/delay via the
+  // injected `onRetryAttempt` seam (the handler emits `merge.retry_attempt`).
+  // The jitter source is INJECTED (workflow-determinism invariant) so tests
+  // pin a deterministic value rather than relying on Math.random(). `sleep` is
+  // injected too so tests don't actually wait out the backoff.
+
+  // A signed jitter source pinned to 0 → no jitter (delay == base * factor^n).
+  const zeroJitter = () => 0;
+  // No-op sleep so tests don't pay the real backoff wall time.
+  const noSleep = async () => {};
+
+  function makeTimeoutError(message = 'operation timed out'): Error {
+    const err = new Error(message);
+    (err as Error & { code?: string }).code = 'ETIMEDOUT';
+    return err;
+  }
+
+  function happyGitExec(): GitExec {
+    return vi.fn((_repoRoot: string, args: readonly string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+        return { stdout: 'abc\n', exitCode: 0 };
+      }
+      // merge --abort / reset --keep both succeed via this catch-all.
+      return { stdout: '', exitCode: 0 };
+    });
+  }
+
+  it('ExecuteMerge_TimeoutOnceThenSuccess_EmitsOneRetryThenExecuted', async () => {
+    // vcsMerge times out on the first call, then succeeds. The executor retries
+    // exactly ONCE, reports exactly ONE retry attempt, and returns
+    // `phase: 'completed'` — NO recovery/rollback ladder runs.
+    let call = 0;
+    const vcsMerge = vi.fn(async () => {
+      call += 1;
+      if (call === 1) throw makeTimeoutError();
+      return { mergeSha: 'merge-sha-xyz' };
+    });
+    const persistState = vi.fn(async () => {});
+    const retries: Array<{ attempt: number; delayMs: number; reason: string }> = [];
+    const onRetryAttempt = vi.fn((info: { attempt: number; delayMs: number; reason: string }) => {
+      retries.push(info);
+    });
+    const gitExec = happyGitExec();
+
+    const result = await executeMerge({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      strategy: 'squash',
+      gitExec,
+      vcsMerge,
+      persistState,
+      repoRoot: '/some/repo',
+      jitter: zeroJitter,
+      sleep: noSleep,
+      onRetryAttempt,
+    });
+
+    // Completed — no rollback.
+    expect(result).toEqual({
+      phase: 'completed',
+      mergeSha: 'merge-sha-xyz',
+      recoveryPointSha: 'abc',
+    });
+    // Exactly two vcsMerge calls: the timeout + the successful retry.
+    expect(vcsMerge).toHaveBeenCalledTimes(2);
+    // Exactly ONE retry attempt reported, ordinal 1, reason 'timeout',
+    // delay = base (1000) * factor^0 with zero jitter.
+    expect(onRetryAttempt).toHaveBeenCalledTimes(1);
+    expect(retries).toEqual([{ attempt: 1, delayMs: 1000, reason: 'timeout' }]);
+    // No recovery ladder — `git merge --abort` / `git reset --keep` never ran.
+    const gitCalls = (gitExec as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[1] as readonly string[],
+    );
+    expect(gitCalls.some((a) => a[0] === 'merge' && a[1] === '--abort')).toBe(false);
+    expect(gitCalls.some((a) => a[0] === 'reset')).toBe(false);
+  });
+
+  it('ExecuteMerge_NonTimeoutFailure_DoesNotRetry_RecoversImmediately', async () => {
+    // A non-timeout failure (default 'merge-failed' bucket) must NOT enter the
+    // retry loop — it recovers immediately on the first failure. This guards
+    // the T10/T11 exhaustion behavior from being implemented here while
+    // confirming the existing immediate-recovery path still fires.
+    const vcsMerge = vi.fn(async () => {
+      throw new Error('merge conflict in foo.ts');
+    });
+    const persistState = vi.fn(async () => {});
+    const onRetryAttempt = vi.fn();
+
+    const result = await executeMerge({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      strategy: 'squash',
+      gitExec: happyGitExec(),
+      vcsMerge,
+      persistState,
+      repoRoot: '/some/repo',
+      jitter: zeroJitter,
+      sleep: noSleep,
+      onRetryAttempt,
+    });
+
+    expect(vcsMerge).toHaveBeenCalledTimes(1);
+    expect(onRetryAttempt).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      phase: 'rolled-back',
+      recoveryPointSha: 'abc',
+      reason: 'merge-failed',
+    });
+  });
+
+  it('ExecuteMerge_TimeoutExhaustsRetries_RecoversWithTimeoutReason', async () => {
+    // Persistent timeout: 3 total vcsMerge calls (initial + 2 retries), 2 retry
+    // attempts reported, then recovery with reason 'timeout'. Backoff grows by
+    // the configured factor (1000 → 2000 with zero jitter).
+    const vcsMerge = vi.fn(async () => {
+      throw makeTimeoutError();
+    });
+    const persistState = vi.fn(async () => {});
+    const retries: Array<{ attempt: number; delayMs: number; reason: string }> = [];
+    const onRetryAttempt = vi.fn((info: { attempt: number; delayMs: number; reason: string }) => {
+      retries.push(info);
+    });
+
+    const result = await executeMerge({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      strategy: 'squash',
+      gitExec: happyGitExec(),
+      vcsMerge,
+      persistState,
+      repoRoot: '/some/repo',
+      jitter: zeroJitter,
+      sleep: noSleep,
+      onRetryAttempt,
+    });
+
+    // 1 initial + 2 retries = 3 total attempts.
+    expect(vcsMerge).toHaveBeenCalledTimes(3);
+    expect(onRetryAttempt).toHaveBeenCalledTimes(2);
+    expect(retries).toEqual([
+      { attempt: 1, delayMs: 1000, reason: 'timeout' },
+      { attempt: 2, delayMs: 2000, reason: 'timeout' },
+    ]);
+    expect(result.phase).toBe('rolled-back');
+    if (result.phase === 'rolled-back') {
+      expect(result.reason).toBe('timeout');
+    }
+  });
+
+  it('ExecuteMerge_JitterApplied_WidensDelayWithinBand', async () => {
+    // The injected jitter source perturbs the delay by ±25%. A pinned +1
+    // signed-jitter value yields base * (1 + 0.25) = 1250 on the first retry;
+    // -1 yields base * (1 - 0.25) = 750. Proves the jitter seam is wired and
+    // applied to the computed backoff (not a hard-coded inline Math.random).
+    const vcsMerge = vi.fn(async () => {
+      throw makeTimeoutError();
+    });
+    const persistState = vi.fn(async () => {});
+    const retries: number[] = [];
+    const onRetryAttempt = vi.fn((info: { attempt: number; delayMs: number; reason: string }) => {
+      retries.push(info.delayMs);
+    });
+
+    await executeMerge({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      strategy: 'squash',
+      gitExec: happyGitExec(),
+      vcsMerge,
+      persistState,
+      repoRoot: '/some/repo',
+      jitter: () => 1, // max positive jitter
+      sleep: noSleep,
+      onRetryAttempt,
+    });
+
+    // attempt 1: 1000 * (1 + 0.25) = 1250; attempt 2: 2000 * 1.25 = 2500.
+    expect(retries).toEqual([1250, 2500]);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.test.ts
@@ -533,6 +533,38 @@ describe('executeMerge', () => {
     });
   });
 
+  it('ExecuteMerge_VerificationFailed_NoRetry', async () => {
+    // T11: a verification-failed (non-transient) outcome must NOT enter the
+    // retry loop — exactly one vcsMerge attempt, zero retries reported, then
+    // immediate recovery with reason 'verification-failed'. Only 'timeout' retries.
+    const vcsMerge = vi.fn(async () => {
+      throw new Error('post-merge verification failed: tests red');
+    });
+    const persistState = vi.fn(async () => {});
+    const onRetryAttempt = vi.fn();
+
+    const result = await executeMerge({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      strategy: 'squash',
+      gitExec: happyGitExec(),
+      vcsMerge,
+      persistState,
+      repoRoot: '/some/repo',
+      jitter: zeroJitter,
+      sleep: noSleep,
+      onRetryAttempt,
+    });
+
+    expect(vcsMerge).toHaveBeenCalledTimes(1);
+    expect(onRetryAttempt).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      phase: 'rolled-back',
+      recoveryPointSha: 'abc',
+      reason: 'verification-failed',
+    });
+  });
+
   it('ExecuteMerge_TimeoutExhaustsRetries_RecoversWithTimeoutReason', async () => {
     // Persistent timeout: 3 total vcsMerge calls (initial + 2 retries), 2 retry
     // attempts reported, then recovery with reason 'timeout'. Backoff grows by

--- a/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.ts
@@ -23,6 +23,23 @@ export type GitExec = (
   args: readonly string[],
 ) => { stdout: string; exitCode: number };
 
+// ─── Bounded timeout-retry tuning (T09 #1308) ──────────────────────────────
+//
+// ONLY a `'timeout'`-categorized `vcsMerge` failure is retried — non-transient
+// failures fall straight through to the INV-14 recovery ladder. Backoff is
+// exponential with bounded jitter; the jitter source is INJECTED (not an inline
+// `Math.random()`) to preserve the workflow-determinism invariant, so tests
+// pin a deterministic value.
+
+/** Max retries after the initial attempt → `MAX_MERGE_RETRIES + 1` total `vcsMerge` calls. */
+export const MAX_MERGE_RETRIES = 2;
+/** Base backoff delay (ms) before the first retry. */
+export const RETRY_BASE_DELAY_MS = 1000;
+/** Exponential growth factor applied per retry: `base * factor^(attempt-1)`. */
+export const RETRY_BACKOFF_FACTOR = 2.0;
+/** Symmetric jitter band as a fraction of the computed delay (±25%). */
+export const RETRY_JITTER_FRACTION = 0.25;
+
 export type RecoveryPoint = { sha: string } | { error: string };
 
 /**
@@ -67,6 +84,33 @@ export interface ExecuteMergeArgs {
     recoveryPointSha: string;
   }) => Promise<void> | void;
   repoRoot?: string;
+  /**
+   * Injected jitter source for the bounded timeout-retry backoff (T09 #1308).
+   * Returns a signed fraction in `[-1, 1]`; the effective delay is
+   * `base * (1 + RETRY_JITTER_FRACTION * jitter())`. INJECTED rather than an
+   * inline `Math.random()` so the retry path stays deterministic under test
+   * (workflow-determinism invariant). Defaults to a uniform signed
+   * `Math.random()`-derived value.
+   */
+  jitter?: () => number;
+  /**
+   * Injected delay seam — invoked with the computed backoff (ms) before each
+   * retry. Injected so tests skip the real wall-clock wait. Defaults to a real
+   * `setTimeout`-based sleep.
+   */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Invoked once per retry attempt, BEFORE the re-attempt's `vcsMerge` call, so
+   * the handler can emit a `merge.retry_attempt` audit event. `attempt` is the
+   * 1-based retry ordinal; `delayMs` is the backoff already applied; `reason`
+   * is the transient-failure category that triggered the retry (always
+   * `'timeout'` today). Awaited so emission ordering is observable.
+   */
+  onRetryAttempt?: (info: {
+    attempt: number;
+    delayMs: number;
+    reason: 'timeout';
+  }) => Promise<void> | void;
 }
 
 export type RecoveryReason = 'merge-failed' | 'verification-failed' | 'timeout';
@@ -129,15 +173,50 @@ export async function executeMerge(
   // 2) persist intermediate state so a crash here is recoverable
   await args.persistState({ phase: 'executing', recoveryPointSha });
 
-  // 3) call vcs merge — on rejection, reset to recovery point sha and categorize.
-  try {
-    const { mergeSha } = await args.vcsMerge({
-      sourceBranch: args.sourceBranch,
-      targetBranch: args.targetBranch,
-      strategy: args.strategy,
-    });
-    return { phase: 'completed', mergeSha, recoveryPointSha };
-  } catch (err) {
+  // 3) call vcs merge with a bounded timeout-retry loop (T09 #1308). Only a
+  //    `'timeout'`-categorized failure is retried (max MAX_MERGE_RETRIES, so
+  //    MAX_MERGE_RETRIES + 1 total attempts); any other failure — or a timeout
+  //    after exhausting retries — falls through to the INV-14 recovery ladder.
+  //    The jitter source and sleep are injected so the retry path is
+  //    deterministic and instant under test.
+  const jitter = args.jitter ?? (() => Math.random() * 2 - 1);
+  const sleep =
+    args.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let lastErr: unknown;
+  // attempt index: 0 = initial, 1..MAX_MERGE_RETRIES = retries.
+  for (let attempt = 0; attempt <= MAX_MERGE_RETRIES; attempt += 1) {
+    try {
+      const { mergeSha } = await args.vcsMerge({
+        sourceBranch: args.sourceBranch,
+        targetBranch: args.targetBranch,
+        strategy: args.strategy,
+      });
+      return { phase: 'completed', mergeSha, recoveryPointSha };
+    } catch (err) {
+      lastErr = err;
+      const isTimeout = categorizeFailure(err) === 'timeout';
+      const retriesRemain = attempt < MAX_MERGE_RETRIES;
+      if (!isTimeout || !retriesRemain) {
+        // Non-transient, or out of retry budget → exit the loop and recover.
+        break;
+      }
+      // Exponential backoff with bounded symmetric jitter. The next retry's
+      // 1-based ordinal is `attempt + 1`; its base delay is
+      // `RETRY_BASE_DELAY_MS * RETRY_BACKOFF_FACTOR^attempt`.
+      const baseDelay = RETRY_BASE_DELAY_MS * RETRY_BACKOFF_FACTOR ** attempt;
+      const delayMs = Math.round(baseDelay * (1 + RETRY_JITTER_FRACTION * jitter()));
+      if (args.onRetryAttempt) {
+        await args.onRetryAttempt({ attempt: attempt + 1, delayMs, reason: 'timeout' });
+      }
+      await sleep(delayMs);
+    }
+  }
+
+  // Retries exhausted (or non-timeout failure): recover to the anchor and
+  // categorize the *last* observed failure.
+  {
+    const err = lastErr;
     const reason = categorizeFailure(err);
     // INV-14: reverse via the operation's own recovery primitive first, then a
     // refuse-to-discard substrate undo — never a destructive `git reset --hard`.

--- a/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/execute-merge.ts
@@ -1,21 +1,21 @@
 // ─── execute-merge: pure helpers for autonomous merge orchestrator ─────────
 //
-// T08 — `recordRollbackPoint`: capture HEAD sha as a rollback anchor *before*
+// T08 — `recordRecoveryPoint`: capture HEAD sha as a recovery point *before*
 // merge execution. Pure (DI'd `gitExec`), total (never throws), structured
 // error returns.
 //
-// T09 — `executeMerge` happy path: composes `recordRollbackPoint` with a
-// DI'd `vcsMerge` adapter and `persistState` callback. Records the rollback
-// sha, persists the `executing` intermediate state, then invokes the merge
-// adapter and returns `{ phase: 'completed', mergeSha, rollbackSha }`.
+// T09 — `executeMerge` happy path: composes `recordRecoveryPoint` with a
+// DI'd `vcsMerge` adapter and `persistState` callback. Records the recovery
+// point sha, persists the `executing` intermediate state, then invokes the merge
+// adapter and returns `{ phase: 'completed', mergeSha, recoveryPointSha }`.
 //
-// T10 — rollback paths: on `vcsMerge` rejection, run the INV-14 recovery ladder
-// (`git merge --abort` → `git reset --keep <rollbackSha>`, never `--hard`) and
-// return `{ phase: 'rolled-back', rollbackSha, reason, recoveryError? }`. The
+// T10 — recovery paths: on `vcsMerge` rejection, run the INV-14 recovery ladder
+// (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and
+// return `{ phase: 'rolled-back', recoveryPointSha, reason, recoveryError? }`. The
 // reason is categorized as 'timeout' | 'verification-failed' | 'merge-failed';
 // `recoveryError` discriminates a non-clean recovery (INV-14).
 //
-// Implements: DR-MO-2 (merge execution with rollback).
+// Implements: DR-MO-2 (merge execution with recovery).
 // ───────────────────────────────────────────────────────────────────────────
 
 export type GitExec = (
@@ -23,16 +23,16 @@ export type GitExec = (
   args: readonly string[],
 ) => { stdout: string; exitCode: number };
 
-export type RollbackPoint = { sha: string } | { error: string };
+export type RecoveryPoint = { sha: string } | { error: string };
 
 /**
- * Capture the current HEAD sha so a downstream merge step can roll back.
+ * Capture the current HEAD sha so a downstream merge step can recover to it.
  * Never throws — all failure modes return `{ error }`.
  */
-export function recordRollbackPoint(
+export function recordRecoveryPoint(
   gitExec: GitExec,
   repoRoot: string = process.cwd(),
-): RollbackPoint {
+): RecoveryPoint {
   try {
     const result = gitExec(repoRoot, ['rev-parse', 'HEAD']);
     if (result.exitCode !== 0) {
@@ -64,12 +64,12 @@ export interface ExecuteMergeArgs {
   }) => Promise<{ mergeSha: string }>;
   persistState: (state: {
     phase: 'executing';
-    rollbackSha: string;
+    recoveryPointSha: string;
   }) => Promise<void> | void;
   repoRoot?: string;
 }
 
-export type RollbackReason = 'merge-failed' | 'verification-failed' | 'timeout';
+export type RecoveryReason = 'merge-failed' | 'verification-failed' | 'timeout';
 
 /**
  * INV-14 recovery-outcome discriminator: the three indeterminate cases the
@@ -82,25 +82,25 @@ export type RecoveryError =
   | 'unexpected-mid-merge-drift';
 
 export type ExecuteMergeResult =
-  | { phase: 'completed'; mergeSha: string; rollbackSha: string }
+  | { phase: 'completed'; mergeSha: string; recoveryPointSha: string }
   | {
       phase: 'rolled-back';
-      rollbackSha: string;
-      reason: RollbackReason;
+      recoveryPointSha: string;
+      reason: RecoveryReason;
       /**
        * INV-14 recovery-outcome discriminator. Absent when recovery landed the
-       * worktree cleanly on `rollbackSha`. Otherwise classifies the
+       * worktree cleanly on `recoveryPointSha`. Otherwise classifies the
        * indeterminate outcome so callers escalate instead of treating a
-       * stranded tree as a clean rollback.
+       * stranded tree as a clean recovery.
        */
       recoveryError?: RecoveryError;
       /** Human-readable detail for `recoveryError`; absent on clean recovery. */
-      rollbackError?: string;
+      recoveryErrorDetail?: string;
     };
 
 // Categorization convention: timeout = err.name === 'TimeoutError' OR (err as any).code === 'ETIMEDOUT';
 // verification-failed = err.message matches /verification/i; otherwise merge-failed.
-function categorizeFailure(err: unknown): RollbackReason {
+function categorizeFailure(err: unknown): RecoveryReason {
   if (err instanceof Error) {
     const code = (err as Error & { code?: string }).code;
     if (err.name === 'TimeoutError' || code === 'ETIMEDOUT') return 'timeout';
@@ -110,57 +110,57 @@ function categorizeFailure(err: unknown): RollbackReason {
 }
 
 /**
- * Execute a merge with a recorded rollback anchor.
+ * Execute a merge with a recorded recovery point.
  *
- * Happy path only (T09): records rollback sha, persists `executing` state,
- * invokes the VCS merge adapter, returns `phase: 'completed'`. Rollback /
+ * Happy path only (T09): records recovery point sha, persists `executing` state,
+ * invokes the VCS merge adapter, returns `phase: 'completed'`. Recovery /
  * failure handling lands in T10.
  */
 export async function executeMerge(
   args: ExecuteMergeArgs,
 ): Promise<ExecuteMergeResult> {
-  // 1) record rollback point
-  const rollback = recordRollbackPoint(args.gitExec, args.repoRoot);
-  if ('error' in rollback) {
-    throw new Error(`rollback record failed: ${rollback.error}`);
+  // 1) record recovery point
+  const recoveryPoint = recordRecoveryPoint(args.gitExec, args.repoRoot);
+  if ('error' in recoveryPoint) {
+    throw new Error(`recovery point record failed: ${recoveryPoint.error}`);
   }
-  const rollbackSha = rollback.sha;
+  const recoveryPointSha = recoveryPoint.sha;
 
   // 2) persist intermediate state so a crash here is recoverable
-  await args.persistState({ phase: 'executing', rollbackSha });
+  await args.persistState({ phase: 'executing', recoveryPointSha });
 
-  // 3) call vcs merge — on rejection, reset to rollback sha and categorize.
+  // 3) call vcs merge — on rejection, reset to recovery point sha and categorize.
   try {
     const { mergeSha } = await args.vcsMerge({
       sourceBranch: args.sourceBranch,
       targetBranch: args.targetBranch,
       strategy: args.strategy,
     });
-    return { phase: 'completed', mergeSha, rollbackSha };
+    return { phase: 'completed', mergeSha, recoveryPointSha };
   } catch (err) {
     const reason = categorizeFailure(err);
     // INV-14: reverse via the operation's own recovery primitive first, then a
     // refuse-to-discard substrate undo — never a destructive `git reset --hard`.
     // A non-clean outcome is surfaced (recoveryError + detail) rather than
     // silently masked under `phase: 'rolled-back'`.
-    const recovery = recoverToAnchor(args.gitExec, args.repoRoot ?? process.cwd(), rollbackSha);
+    const recovery = recoverToAnchor(args.gitExec, args.repoRoot ?? process.cwd(), recoveryPointSha);
     return recovery === undefined
-      ? { phase: 'rolled-back', rollbackSha, reason }
+      ? { phase: 'rolled-back', recoveryPointSha, reason }
       : {
           phase: 'rolled-back',
-          rollbackSha,
+          recoveryPointSha,
           reason,
           recoveryError: recovery.code,
-          rollbackError: recovery.detail,
+          recoveryErrorDetail: recovery.detail,
         };
   }
 }
 
 /**
- * INV-14 recovery ladder for a failed merge. Reverses to `rollbackSha` using,
+ * INV-14 recovery ladder for a failed merge. Reverses to `recoveryPointSha` using,
  * in order: (1) `git merge --abort` — the operation's own recovery primitive,
  * best-effort (a no-op exit when no merge is in progress is expected and
- * ignored); (2) `git reset --keep <rollbackSha>` — a refuse-to-discard substrate
+ * ignored); (2) `git reset --keep <recoveryPointSha>` — a refuse-to-discard substrate
  * undo (NEVER `--hard`, which would silently destroy uncommitted work). Returns
  * `undefined` when the worktree lands cleanly on the anchor, or a discriminated
  * `recoveryError` + human-readable `detail` when the outcome is indeterminate.
@@ -168,7 +168,7 @@ export async function executeMerge(
 function recoverToAnchor(
   gitExec: GitExec,
   repoRoot: string,
-  rollbackSha: string,
+  recoveryPointSha: string,
 ): { code: RecoveryError; detail: string } | undefined {
   // 1) Native primitive first. Best-effort: a non-zero exit means "no merge in
   //    progress", which the authoritative reset below handles.
@@ -182,7 +182,7 @@ function recoverToAnchor(
   // 2) Substrate undo, refuse-to-discard. NEVER `--hard`.
   let reset: { stdout: string; exitCode: number };
   try {
-    reset = gitExec(repoRoot, ['reset', '--keep', rollbackSha]);
+    reset = gitExec(repoRoot, ['reset', '--keep', recoveryPointSha]);
   } catch (resetErr) {
     return {
       code: 'reset-failed',
@@ -194,7 +194,7 @@ function recoverToAnchor(
     // indeterminate. Distinct from a hard failure so callers can page operators.
     return {
       code: 'reset-keep-blocked',
-      detail: `git reset --keep ${rollbackSha} exited ${reset.exitCode}${reset.stdout ? `: ${reset.stdout.trim()}` : ''}`,
+      detail: `git reset --keep ${recoveryPointSha} exited ${reset.exitCode}${reset.stdout ? `: ${reset.stdout.trim()}` : ''}`,
     };
   }
 
@@ -208,10 +208,10 @@ function recoverToAnchor(
       detail: `post-recovery rev-parse HEAD failed: ${headErr instanceof Error ? headErr.message : String(headErr)}`,
     };
   }
-  if (head.exitCode !== 0 || head.stdout.trim() !== rollbackSha) {
+  if (head.exitCode !== 0 || head.stdout.trim() !== recoveryPointSha) {
     return {
       code: 'unexpected-mid-merge-drift',
-      detail: `worktree HEAD ${head.stdout.trim() || '(unknown)'} != rollback anchor ${rollbackSha} after merge --abort + reset --keep`,
+      detail: `worktree HEAD ${head.stdout.trim() || '(unknown)'} != recovery anchor ${recoveryPointSha} after merge --abort + reset --keep`,
     };
   }
 

--- a/servers/exarchos-mcp/src/projections/merge-orchestrator/reducer.test.ts
+++ b/servers/exarchos-mcp/src/projections/merge-orchestrator/reducer.test.ts
@@ -238,6 +238,45 @@ describe('mergeOrchestratorReducer.apply — phase transitions (Wave 2B.2)', () 
     expect(next.projectionSequence).toBe(2);
   });
 
+  it('Apply_MergeRecovered_AdvancesToRecovering_WithoutLegacyRollback', () => {
+    // #1306 dual-emit robustness (Sentry #1571 review): the canonical
+    // `merge.recovered` is emitted FIRST; if the second legacy `merge.rollback`
+    // append loses a sequence race (the two appends are not atomic), the stream
+    // carries `merge.recovered` alone. The projection MUST still advance to
+    // `recovering` off the canonical event so it never strands at `executing`.
+    const state: MergeOrchestratorState = mergeOrchestratorReducer.apply(
+      mergeOrchestratorReducer.initial,
+      makeEvent(
+        'merge.executed',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          mergeSha: 'abc1234',
+          recoveryPointSha: 'def5678',
+        },
+        1,
+      ),
+    );
+    // WHEN we fold a merge.recovered event ALONE (no merge.rollback follows).
+    const event = makeEvent(
+      'merge.recovered',
+      {
+        taskId: 'task-1',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        recoveryPointSha: 'def5678',
+        reason: 'verification-failed',
+      },
+      2,
+    );
+    const next = mergeOrchestratorReducer.apply(state, event);
+    // THEN phase advances to 'recovering' off the canonical event.
+    expect(next.phase).toBe('recovering');
+    expect(next.recovery?.reason).toBe('verification-failed');
+    expect(next.projectionSequence).toBe(2);
+  });
+
   it('Apply_MergeRollback_FoldsRecoveryErrorDiscriminator', () => {
     // INV-14: indeterminate worktree must surface explicitly via the closed
     // `recoveryError` enum, not as a silent success.

--- a/servers/exarchos-mcp/src/projections/merge-orchestrator/reducer.ts
+++ b/servers/exarchos-mcp/src/projections/merge-orchestrator/reducer.ts
@@ -305,10 +305,17 @@ export const mergeOrchestratorReducer: ProjectionReducer<
         return applyMergeRequested(state, event);
       case 'merge.executed':
         return applyMergeExecuted(state, event);
-      // #1306 rename tracker: when `merge.rollback` is renamed to
-      // `merge.recovered`, swap the case label here alongside the schema
-      // change. The recovery-context shape and `recovering` phase do not
-      // change with the rename.
+      // #1306 deprecation window — the recovery path DUAL-EMITS the canonical
+      // `merge.recovered` (emitted first) + the legacy `merge.rollback`. Fold
+      // BOTH into the `any → recovering` transition so the projection advances
+      // on whichever event lands. The two appends are NOT atomic: a concurrent
+      // writer between them (or a lost sequence race on the second) can leave a
+      // `merge.recovered`-only stream; keying the projection on the legacy
+      // second event alone would strand it at `executing` (Sentry review,
+      // #1571). Folding both is safe — `applyMergeRollback` sets
+      // `phase: 'recovering'` from any prior phase and the recovery context is
+      // identical across the pair. v2.12 (#1570) drops the `merge.rollback` case.
+      case 'merge.recovered':
       case 'merge.rollback':
         return applyMergeRollback(state, event);
       case 'merge.completed':

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -307,6 +307,24 @@ describe('buildRegistrationSchema', () => {
   });
 });
 
+// ─── merge_orchestrate description guidance (#1310 T16) ──────────────────────
+
+describe('merge_orchestrate description', () => {
+  it('MergeOrchestrateDescription_StatesDoNotUseFor_WithPointers', () => {
+    const action = findActionInRegistry('exarchos_orchestrate', 'merge_orchestrate');
+    expect(action).toBeDefined();
+    const description = action!.description;
+
+    // Negative-space guidance must be explicit.
+    expect(description).toContain('Do NOT use for');
+
+    // Each misuse must point at the right alternative action.
+    expect(description).toContain('merge_pr');
+    expect(description).toContain('verify_worktree');
+    expect(description).toContain('request_synthesize');
+  });
+});
+
 // ─── Type Coercion Tests ─────────────────────────────────────────────────────
 
 describe('coercedRecord', () => {

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1872,7 +1872,7 @@ const orchestrateActions: readonly ToolAction[] = [
   // ─── Merge Orchestrator (DR-MO-1) ─────────────────────────────────────────
   {
     name: 'merge_orchestrate',
-    description: 'Top-level merge orchestrator: runs preflight, emits merge.preflight, then delegates to the executor on pass. Handles abort/dryRun/resume per DR-MO-1.',
+    description: 'Top-level merge orchestrator (DR-MO-1): runs preflight, emits merge.preflight, then delegates to the executor on pass; handles abort/dryRun/resume. Use for: merging a task/feature source branch into the integration target with full preflight + compensating recovery from the main worktree. Do NOT use for: a raw provider PR/MR merge (use merge_pr); verifying a directory is a git worktree (use verify_worktree); or requesting synthesis/PR creation on a oneshot workflow (use request_synthesize).',
     schema: z.object({
       featureId: z.string().min(1),
       sourceBranch: z.string().min(1),

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { AsOfSchema, CheckpointHandoffSchema, WorkflowTypeSchema } from './workflow/schemas.js';
 import { agentSpecSchema as agentSpecSchemaForRegistry } from './agents/handler.js';
 import { EnvelopeSchema } from './schemas/envelope.js';
+import type { AgentPosture } from './agents/spec.js';
 export { coercedRecord, coercedPositiveInt, coercedNonnegativeInt, coercedStringArray } from './coerce.js';
 import { coercedRecord, coercedPositiveInt, coercedNonnegativeInt, coercedStringArray } from './coerce.js';
 
@@ -337,6 +338,19 @@ export interface ToolAction {
    * human prompting.
    */
   readonly deprecated?: boolean;
+  /**
+   * #1305 — Trust-tier posture for this action's handler. When declared, the
+   * capability resolver mints this action's write capabilities from the
+   * posture table (`capabilities/posture-mapping.ts`) rather than inferring
+   * them from the (advisory, MCP-untrusted) annotation hints. Today only
+   * `merge_orchestrate` declares a posture: `shared-mutating`, because it
+   * mutates shared state (the integration branch, the working tree, the
+   * event store) from the main worktree with no worktree isolation. Most
+   * actions leave this undefined and rely on annotations alone; #1305 T14/T15
+   * (read-only-caller rejection, transition exclusivity) build on this
+   * declaration being the trust-tier source of truth.
+   */
+  readonly posture?: AgentPosture;
   /**
    * Typed Zod schema describing the action's response envelope (Wave 0
    * task E.1-E.5, DR-11, design §2.1). All actions in the built-in
@@ -1885,6 +1899,11 @@ const orchestrateActions: readonly ToolAction[] = [
     // dispatch. Advisory — the binding opt-in gate stays at
     // `core/dispatch.ts:927-954`.
     dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 },
+    // #1305 T13: merge_orchestrate mutates shared state (the integration
+    // branch, the working tree, the event store) from the main worktree with
+    // no worktree isolation — the strictest mutating trust tier. The resolver
+    // mints fs:write + shell:exec from this posture.
+    posture: 'shared-mutating',
     outputSchema: EnvelopeSchema(z.unknown()),
     annotations: COMPENSABLE_REMOTE,
   },

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -658,6 +658,11 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
       // mergeOrchestrator phase (the retry sits between attempts), so the
       // projection treats it as an observation and folds to identity.
       case 'merge.retry_attempt':
+      // #1309 — audit-only liveness marker emitted before the first vcsMerge;
+      // it does not transition the mergeOrchestrator phase (the terminal
+      // merge.executed / merge.recovered events drive the phase), so the
+      // projection treats it as an observation and folds to identity.
+      case 'merge.executing_started':
       case 'command.resolved':
       case 'hsm.deprecated_action_invoked':
       case 'spec.legacy_capabilities_array':

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -469,6 +469,29 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
         };
       }
 
+      case 'merge.recovered': {
+        // #1306 successor to merge.rollback — same logical fold, reading the
+        // renamed event fields (recoveryPointSha / recoveryErrorDetail) onto the
+        // existing view fields. Dual-emitted alongside merge.rollback during the
+        // v2.11.x deprecation window; folding both is idempotent (same view).
+        const data = event.data as Record<string, unknown> | undefined;
+        if (!data) return view;
+        return {
+          ...view,
+          updatedAt: event.timestamp,
+          mergeOrchestrator: {
+            phase: 'rolled-back',
+            ...(data.taskId !== undefined ? { taskId: data.taskId as string } : {}),
+            ...(data.sourceBranch !== undefined ? { sourceBranch: data.sourceBranch as string } : {}),
+            ...(data.targetBranch !== undefined ? { targetBranch: data.targetBranch as string } : {}),
+            ...(data.recoveryPointSha !== undefined ? { rollbackSha: data.recoveryPointSha as string } : {}),
+            ...(data.reason !== undefined ? { reason: data.reason as MergeOrchestratorView['reason'] } : {}),
+            ...(data.recoveryError !== undefined ? { recoveryError: data.recoveryError as MergeOrchestratorView['recoveryError'] } : {}),
+            ...(data.recoveryErrorDetail !== undefined ? { rollbackError: data.recoveryErrorDetail as string } : {}),
+          },
+        };
+      }
+
       // ── State Patch (generic field updates) ────────────────────────────
 
       case 'state.patched': {

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -654,6 +654,10 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
       case 'dispatch.preflight':
       case 'merge.requested':
       case 'merge.completed':
+      // #1308 — audit-only retry record; it does not transition the
+      // mergeOrchestrator phase (the retry sits between attempts), so the
+      // projection treats it as an observation and folds to identity.
+      case 'merge.retry_attempt':
       case 'command.resolved':
       case 'hsm.deprecated_action_invoked':
       case 'spec.legacy_capabilities_array':

--- a/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
@@ -114,13 +114,13 @@ const mergePendingEntry: Guard = {
 
 /**
  * Guard for `merge-pending → delegate`: fires when the event stream contains
- * a `merge.executed`, `merge.rollback`, or any explicit abort signal
- * (`merge.aborted`, or `mergeOrchestrator.phase === 'aborted'`).
+ * a `merge.executed`, `merge.rollback`/`merge.recovered`, or any explicit abort
+ * signal (`merge.aborted`, or `mergeOrchestrator.phase === 'aborted'`).
  */
 const mergePendingExit: Guard = {
   id: 'merge-pending-exit',
   description:
-    'A merge.executed/merge.rollback/merge.aborted must follow the latest task.completed (or mergeOrchestrator.phase must be terminal)',
+    'A merge.executed/merge.rollback/merge.recovered/merge.aborted must follow the latest task.completed (or mergeOrchestrator.phase must be terminal)',
   evaluate: (state: Record<string, unknown>): GuardResult => {
     const events = (state._events as readonly Record<string, unknown>[]) ?? [];
     // Cycle-scoped: only terminal events that follow the latest task.completed
@@ -141,6 +141,9 @@ const mergePendingExit: Guard = {
       (e) =>
         e.type === 'merge.executed' ||
         e.type === 'merge.rollback' ||
+        // #1306 — merge.recovered is the successor to merge.rollback; both are
+        // terminal during the v2.11.x dual-emit deprecation window.
+        e.type === 'merge.recovered' ||
         e.type === 'merge.aborted',
     );
     if (hasTerminalEvent) return true;
@@ -150,7 +153,7 @@ const mergePendingExit: Guard = {
     return {
       passed: false,
       reason:
-        'merge-pending-exit not satisfied: no merge.executed/merge.rollback/merge.aborted event found after the latest task.completed and mergeOrchestrator.phase is not terminal',
+        'merge-pending-exit not satisfied: no merge.executed/merge.rollback/merge.recovered/merge.aborted event found after the latest task.completed and mergeOrchestrator.phase is not terminal',
     };
   },
 };

--- a/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -246,14 +246,14 @@ export const MergeOrchestratorStateSchema = z.object({
   // Operator-selected merge strategy — set on `executing`/`completed`/
   // `rolled-back` writes via the executor.
   strategy: z.enum(['squash', 'rebase', 'merge']).optional(),
-  rollbackSha: z.string().optional(),
+  recoveryPointSha: z.string().optional(),
   mergeSha: z.string().optional(),
-  // Terminal-failure descriptors. `reason` and `rollbackError` come from
+  // Terminal-failure descriptors. `reason` and `recoveryErrorDetail` come from
   // the executor's rolled-back write; `abortReason` from the orchestrator's
   // preflight-fail abort write. Modeling them explicitly gives downstream
   // consumers strong typing instead of leaning on `.passthrough()`.
   reason: z.enum(['merge-failed', 'verification-failed', 'timeout']).optional(),
-  rollbackError: z.string().min(1).optional(),
+  recoveryErrorDetail: z.string().min(1).optional(),
   // INV-14 recovery-outcome discriminator on the executor's rolled-back write
   // (mirrors `MergeRollbackData.recoveryError`). Modeled explicitly rather than
   // leaning on `.passthrough()` so consumers get strong typing.

--- a/servers/exarchos-mcp/src/workflow/state-machine.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.test.ts
@@ -448,6 +448,30 @@ describe('Feature workflow merge-pending substate', () => {
     expect(result.newPhase).toBe('delegate');
   });
 
+  it('featureHsm_MergeRecoveredEvent_LeavesMergePendingState', () => {
+    // #1306 — merge.recovered (successor to merge.rollback) is a terminal exit
+    // event for merge-pending during the dual-emit window. No terminal
+    // mergeOrchestrator.phase is set, so this exercises the EVENT-recognition
+    // path specifically (not the EXCLUDED_MERGE_PHASES fallback).
+    const hsm = getHSMDefinition('feature');
+    const state = {
+      phase: 'merge-pending',
+      _events: [
+        {
+          type: 'task.completed',
+          data: { taskId: 'T01', worktree: '/path/to/worktree' },
+        },
+        {
+          type: 'merge.recovered',
+          data: { taskId: 'T01', recoveryPointSha: 'abc123', reason: 'timeout' },
+        },
+      ],
+    };
+    const result = executeTransition(hsm, state, 'delegate');
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('delegate');
+  });
+
   it('featureHsm_TaskCompletedWithWorktree_DoesNotTransitionWhenMergeCompleted', () => {
     // Excluded phase guard: even with a worktree-bearing task.completed, do
     // not re-enter merge-pending if the merge already terminated.

--- a/skills-src/merge-orchestrator/SKILL.md
+++ b/skills-src/merge-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12,7 +12,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (`git merge --abort` → `git reset --keep`, never `--hard`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
@@ -22,9 +22,9 @@ This skill activates whenever an operator (or an automated `next_actions` dispat
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+3. Records pre-merge `HEAD` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local `git merge` of the source branch into the target branch.
-5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
@@ -51,7 +51,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | `merge`  | `git merge --no-ff --no-edit <source>` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | `squash` | `git merge --squash <source>` then `git commit` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -84,7 +84,7 @@ exarchos merge-orchestrate \
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -94,7 +94,7 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 |---------|---------|-----------------|
 | `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`) ran. The target branch is rewound to the recovery point. (The phase value stays `rolled-back` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect `data.reason`. If `data.recoveryError` / `data.recoveryErrorDetail` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -105,24 +105,27 @@ When `phase === 'aborted'`, the data payload discriminates the cause:
 | `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
-| `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.rollback`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.recovered` | On post-merge failure followed by recovery — the canonical **successor** to `merge.rollback` (#1306); dual-emitted alongside it during the deprecation window | `recoveryPointSha`, `reason`, `recoveryError?`, `recoveryErrorDetail?`, `taskId`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (`merge.recovered`). `merge.recovered` is the additive successor to `merge.rollback`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy `merge.rollback` / `merge.executed` events keep their `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission; `merge.recovered` carries the resolved `recoveryPointSha` / `recoveryErrorDetail` names alongside the unchanged INV-14 `recoveryError` discriminator. The phase value `'rolled-back'` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via `{{MCP_PREFIX}}exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 
@@ -134,8 +137,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
-| **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Recovery** | INV-14 recovery ladder: `git merge --abort` → `git reset --keep <recoveryPointSha>` (real, rewinds the merge; never `--hard`) | None — the VCS provider owns merge state |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` (legacy) / `merge.recovered` (successor) | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,9 +159,9 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` / `merge.recovered` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.recoveryErrorDetail` (with the `data.recoveryError` discriminator); address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -192,7 +195,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 `mergeOrchestrator.*` fields on workflow state are written by this skill and `mergeOrchestrator.phase` is read by gates; the underlying `phase` workflow field is immutable and must be changed via `transition`, not `update`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the `workflow-state` skill for the full immutable-key list and the typed `RESERVED_FIELD` error envelope.
 
@@ -200,7 +203,7 @@ For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "des
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
-- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
+- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills-src/merge-orchestrator/references/local-git-semantics.md
+++ b/skills-src/merge-orchestrator/references/local-git-semantics.md
@@ -1,15 +1,17 @@
 # Local-Git Semantics
 
-This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the rollback contract.
+This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the recovery contract.
+
+> **Recovery vocabulary (#1306).** The orchestrator's failure handling is modeled as a database transaction, not a saga: it records a **recovery point** (the integration branch's pre-merge HEAD) and, on failure, runs the INV-14 **recovery ladder** (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) to rewind to that point. "Recovery point" and "recovery" replace the older "rollback anchor" / "rollback" / "compensation" framing throughout. The legacy `merge.rollback` event name and its `rollbackSha` wire field are retained during the v2.11.x deprecation window; the canonical successor event is `merge.recovered`.
 
 ## The model
 
 `merge_orchestrate` is the SDLC handoff for landing a subagent's worktree branch onto the integration branch in the **main worktree**. Every operation in the orchestrator is a local-git operation:
 
 - **Preflight** — `git status --porcelain`, `git diff --cached --quiet`, `git rev-parse --abbrev-ref HEAD`, `git merge-base --is-ancestor`, `git rev-parse --git-dir`. All run against local refs.
-- **Rollback anchor** — `git rev-parse HEAD` captures the integration branch's tip before the merge.
+- **Recovery point** — `git rev-parse HEAD` captures the integration branch's tip before the merge, persisted as a write-ahead-log marker before any ref mutation.
 - **Merge** — `git merge --no-ff` / `--squash` / rebase + ff-only against local branches, in the main worktree's working directory.
-- **Rollback execution** — `git reset --hard <rollbackSha>` restores the integration branch's tip if the merge or post-merge verification fails.
+- **Recovery execution** — the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) rewinds the integration branch's tip to the recovery point if the merge or post-merge verification fails.
 
 The integration branch may eventually be pushed to a remote and merged into `main` via a PR — that is a separate concern handled by `merge_pr` in the synthesize phase, when the full feature is ready for human review.
 
@@ -20,13 +22,13 @@ An earlier implementation of this orchestrator routed the merge through `provide
 | What runs locally | What runs remotely |
 |-------------------|--------------------|
 | Preflight (drift, ancestry, branch protection, worktree assertion) | (nothing) |
-| Rollback anchor `git rev-parse HEAD` | (nothing) |
-| Rollback `git reset --hard` | (nothing) |
+| Recovery point `git rev-parse HEAD` | (nothing) |
+| Recovery `git reset --keep` | (nothing) |
 | ❌ Merge | ✅ Merge (server-side via VCS API) |
 
-A server-side merge does not move local `HEAD`. So the recorded `rollbackSha` corresponded to a local ref the merge never touched, and `git reset --hard <rollbackSha>` was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
+A server-side merge does not move local `HEAD`. So the recorded recovery point corresponded to a local ref the merge never touched, and the reset back to it was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
 
-The fix was structural: align the merge primitive with the rollback primitive. Both are now local-git, and the rollback is a real undo operation.
+The fix was structural: align the merge primitive with the recovery primitive. Both are now local-git, and the recovery is a real undo operation that rewinds the integration branch to the recorded recovery point.
 
 ## Why the integration branch and not main?
 
@@ -50,14 +52,16 @@ The preflight composer separately asserts main-worktree (`git rev-parse --git-di
 
 `rebase` rewrites the source branch's history. For ephemeral subagent branches (created by `delegate`, deleted after merge), this is fine — the branch has no consumers other than the orchestrator. Don't pick `rebase` for source branches that are pushed and shared.
 
-## What the rollback actually undoes
+## What the recovery actually undoes
 
-`git reset --hard <rollbackSha>` on the integration branch restores `HEAD` to the recorded SHA. This **does** undo:
+The recovery ladder — `git merge --abort` (the operation's own recovery primitive, best-effort) followed by `git reset --keep <recoveryPointSha>` (a refuse-to-discard substrate undo, never `--hard`) — restores the integration branch's `HEAD` to the recorded recovery point. This **does** undo:
 
 - A merge commit created by `--no-ff`
 - A squash commit created by `--squash` + `git commit`
 - A fast-forward advance from a `rebase` strategy (target moves back to its pre-rebase tip)
 
-The reset **does not** undo:
+`--keep` refuses to clobber uncommitted local changes (where `--hard` would silently destroy them); the executor surfaces an indeterminate outcome (`recoveryError` + `recoveryErrorDetail`) rather than masking a stranded worktree as a clean recovery.
+
+The recovery **does not** undo:
 
 - The source branch's history rewrite from a `rebase` strategy. The source branch keeps the rebased commits; only the integration branch's reference returns to its prior state. This is acceptable in the SDLC model because the source branch is ephemeral — it gets deleted after the merge cycle either way. If you need to inspect the original source commits, the reflog still has them until expiry.

--- a/skills-src/merge-orchestrator/references/recovery-runbook.md
+++ b/skills-src/merge-orchestrator/references/recovery-runbook.md
@@ -35,9 +35,11 @@ Inspect each guard field in order (the orchestrator evaluates them in this prece
 
 After resolving the underlying condition, re-invoke `merge_orchestrate` with the same arguments. The fresh dispatch re-runs preflight; if all guards now pass, the executor proceeds.
 
-## `phase: 'rolled-back'` — merge attempted, reverted
+## `phase: 'rolled-back'` — merge attempted, recovered
 
-The executor recorded the rollback SHA, attempted the merge, the merge or post-merge verification failed, and `git reset --hard <rollbackSha>` ran. The integration branch is restored to its pre-merge state.
+> The phase value is still `rolled-back` — a load-bearing state token intentionally unchanged by the #1306 recovery reframe. The *behavior* it describes is recovery to the recorded recovery point.
+
+The executor recorded the recovery point, attempted the merge, the merge or post-merge verification failed, and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) ran. The integration branch is rewound to its pre-merge state.
 
 ### Diagnose
 
@@ -49,28 +51,32 @@ Check `data.reason`:
 | `verification-failed` | Post-merge verification step rejected the merge | Custom verification adapter detected a problem (rare in default config) |
 | `timeout` | Underlying operation exceeded the 120s timeout | Repo size, slow disk, lock contention |
 
-### Then check `data.rollbackError`
+### Then check `data.recoveryError` / `data.recoveryErrorDetail`
 
-If present, the reset itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded `rollbackSha`. This is a critical condition requiring manual intervention:
+If present, the recovery itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded recovery point. `data.recoveryError` is the INV-14 discriminator (`reset-keep-blocked` / `reset-failed` / `unexpected-mid-merge-drift`) and `data.recoveryErrorDetail` is the human-readable detail. This is a critical condition requiring manual intervention:
 
 ```bash
 # Verify current state
 git status
 git log --oneline -5
 
-# If the integration branch is in an unexpected state:
+# If the integration branch is in an unexpected state, rewind it to the
+# recovery point. Prefer --keep (refuse-to-discard); use --hard only if you
+# have already confirmed there is no uncommitted work you need to preserve.
 git checkout <integration-branch>
-git reset --hard <rollbackSha-from-the-event-log>
+git reset --keep <recoveryPointSha-from-the-event-log>
 
-# Where <rollbackSha-from-the-event-log> can be retrieved from the most recent
-# merge.executed (completed run) or merge.rollback (rolled-back run) event:
-exarchos_event query stream=<featureId> filter='{"type":"merge.rollback"}'
-# fall back to merge.executed if no rollback was emitted.
-# (merge.preflight does NOT carry rollbackSha — it runs before the rollback
-# anchor is captured.)
+# Where <recoveryPointSha-from-the-event-log> can be retrieved from the most
+# recent recovery event. Prefer the canonical merge.recovered (#1306), which
+# carries recoveryPointSha; fall back to the legacy merge.rollback, whose
+# rollbackSha wire field holds the same value during the deprecation window:
+exarchos_event query stream=<featureId> filter='{"type":"merge.recovered"}'
+# fall back to merge.rollback, then merge.executed, if no recovery event exists.
+# (merge.preflight does NOT carry the recovery point — it runs before the
+# recovery point is captured.)
 ```
 
-If `rollbackError` is absent, the reset succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
+If neither `recoveryError` nor `recoveryErrorDetail` is present, the recovery succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
 
 ### Resolve a `merge-failed` outcome
 
@@ -87,6 +93,8 @@ For merge conflicts (most common cause of `merge-failed`):
 // Event first — the repository treats event append as the commit point.
 // Use the same `strategy` the original dispatch was invoked with so the
 // projected state matches what the auto-emit path would have produced.
+// NOTE: the merge.executed EVENT keeps the legacy `rollbackSha` wire field
+// during the v2.11.x deprecation window — supply the recovery-point SHA there.
 {{MCP_PREFIX}}exarchos_event({ action: "append", stream: "<featureId>", event: {
   type: "merge.executed",
   data: {
@@ -95,11 +103,14 @@ For merge conflicts (most common cause of `merge-failed`):
     targetBranch: "<target>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    rollbackSha: "<recovery-point-sha-from-prior-event>",
   },
 }});
 
 // Then update workflow state to reflect the terminal phase.
+// The mergeOrchestrator STATE field is `recoveryPointSha` (renamed from
+// `rollbackSha` in #1306 — the state file follows the canonical recovery frame
+// even while the legacy event wire field above does not yet).
 {{MCP_PREFIX}}exarchos_workflow({ action: "update", featureId: "<featureId>",
   updates: { mergeOrchestrator: {
     phase: "completed",
@@ -107,7 +118,7 @@ For merge conflicts (most common cause of `merge-failed`):
     taskId: "<task-id>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    recoveryPointSha: "<recovery-point-sha-from-prior-event>",
   } } });
 ```
 

--- a/skills/claude/merge-orchestrator/SKILL.md
+++ b/skills/claude/merge-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12,7 +12,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (`git merge --abort` → `git reset --keep`, never `--hard`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
@@ -22,9 +22,9 @@ This skill activates whenever an operator (or an automated `next_actions` dispat
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+3. Records pre-merge `HEAD` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local `git merge` of the source branch into the target branch.
-5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
@@ -51,7 +51,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | `merge`  | `git merge --no-ff --no-edit <source>` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | `squash` | `git merge --squash <source>` then `git commit` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -84,7 +84,7 @@ exarchos merge-orchestrate \
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -94,7 +94,7 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 |---------|---------|-----------------|
 | `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`) ran. The target branch is rewound to the recovery point. (The phase value stays `rolled-back` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect `data.reason`. If `data.recoveryError` / `data.recoveryErrorDetail` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -105,24 +105,27 @@ When `phase === 'aborted'`, the data payload discriminates the cause:
 | `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
-| `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.rollback`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.recovered` | On post-merge failure followed by recovery — the canonical **successor** to `merge.rollback` (#1306); dual-emitted alongside it during the deprecation window | `recoveryPointSha`, `reason`, `recoveryError?`, `recoveryErrorDetail?`, `taskId`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (`merge.recovered`). `merge.recovered` is the additive successor to `merge.rollback`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy `merge.rollback` / `merge.executed` events keep their `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission; `merge.recovered` carries the resolved `recoveryPointSha` / `recoveryErrorDetail` names alongside the unchanged INV-14 `recoveryError` discriminator. The phase value `'rolled-back'` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__plugin_exarchos_exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 
@@ -134,8 +137,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
-| **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Recovery** | INV-14 recovery ladder: `git merge --abort` → `git reset --keep <recoveryPointSha>` (real, rewinds the merge; never `--hard`) | None — the VCS provider owns merge state |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` (legacy) / `merge.recovered` (successor) | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,9 +159,9 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` / `merge.recovered` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.recoveryErrorDetail` (with the `data.recoveryError` discriminator); address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -192,7 +195,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 `mergeOrchestrator.*` fields on workflow state are written by this skill and `mergeOrchestrator.phase` is read by gates; the underlying `phase` workflow field is immutable and must be changed via `transition`, not `update`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the `workflow-state` skill for the full immutable-key list and the typed `RESERVED_FIELD` error envelope.
 
@@ -200,7 +203,7 @@ For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestra
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
-- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
+- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/claude/merge-orchestrator/references/local-git-semantics.md
+++ b/skills/claude/merge-orchestrator/references/local-git-semantics.md
@@ -1,15 +1,17 @@
 # Local-Git Semantics
 
-This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the rollback contract.
+This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the recovery contract.
+
+> **Recovery vocabulary (#1306).** The orchestrator's failure handling is modeled as a database transaction, not a saga: it records a **recovery point** (the integration branch's pre-merge HEAD) and, on failure, runs the INV-14 **recovery ladder** (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) to rewind to that point. "Recovery point" and "recovery" replace the older "rollback anchor" / "rollback" / "compensation" framing throughout. The legacy `merge.rollback` event name and its `rollbackSha` wire field are retained during the v2.11.x deprecation window; the canonical successor event is `merge.recovered`.
 
 ## The model
 
 `merge_orchestrate` is the SDLC handoff for landing a subagent's worktree branch onto the integration branch in the **main worktree**. Every operation in the orchestrator is a local-git operation:
 
 - **Preflight** — `git status --porcelain`, `git diff --cached --quiet`, `git rev-parse --abbrev-ref HEAD`, `git merge-base --is-ancestor`, `git rev-parse --git-dir`. All run against local refs.
-- **Rollback anchor** — `git rev-parse HEAD` captures the integration branch's tip before the merge.
+- **Recovery point** — `git rev-parse HEAD` captures the integration branch's tip before the merge, persisted as a write-ahead-log marker before any ref mutation.
 - **Merge** — `git merge --no-ff` / `--squash` / rebase + ff-only against local branches, in the main worktree's working directory.
-- **Rollback execution** — `git reset --hard <rollbackSha>` restores the integration branch's tip if the merge or post-merge verification fails.
+- **Recovery execution** — the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) rewinds the integration branch's tip to the recovery point if the merge or post-merge verification fails.
 
 The integration branch may eventually be pushed to a remote and merged into `main` via a PR — that is a separate concern handled by `merge_pr` in the synthesize phase, when the full feature is ready for human review.
 
@@ -20,13 +22,13 @@ An earlier implementation of this orchestrator routed the merge through `provide
 | What runs locally | What runs remotely |
 |-------------------|--------------------|
 | Preflight (drift, ancestry, branch protection, worktree assertion) | (nothing) |
-| Rollback anchor `git rev-parse HEAD` | (nothing) |
-| Rollback `git reset --hard` | (nothing) |
+| Recovery point `git rev-parse HEAD` | (nothing) |
+| Recovery `git reset --keep` | (nothing) |
 | ❌ Merge | ✅ Merge (server-side via VCS API) |
 
-A server-side merge does not move local `HEAD`. So the recorded `rollbackSha` corresponded to a local ref the merge never touched, and `git reset --hard <rollbackSha>` was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
+A server-side merge does not move local `HEAD`. So the recorded recovery point corresponded to a local ref the merge never touched, and the reset back to it was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
 
-The fix was structural: align the merge primitive with the rollback primitive. Both are now local-git, and the rollback is a real undo operation.
+The fix was structural: align the merge primitive with the recovery primitive. Both are now local-git, and the recovery is a real undo operation that rewinds the integration branch to the recorded recovery point.
 
 ## Why the integration branch and not main?
 
@@ -50,14 +52,16 @@ The preflight composer separately asserts main-worktree (`git rev-parse --git-di
 
 `rebase` rewrites the source branch's history. For ephemeral subagent branches (created by `delegate`, deleted after merge), this is fine — the branch has no consumers other than the orchestrator. Don't pick `rebase` for source branches that are pushed and shared.
 
-## What the rollback actually undoes
+## What the recovery actually undoes
 
-`git reset --hard <rollbackSha>` on the integration branch restores `HEAD` to the recorded SHA. This **does** undo:
+The recovery ladder — `git merge --abort` (the operation's own recovery primitive, best-effort) followed by `git reset --keep <recoveryPointSha>` (a refuse-to-discard substrate undo, never `--hard`) — restores the integration branch's `HEAD` to the recorded recovery point. This **does** undo:
 
 - A merge commit created by `--no-ff`
 - A squash commit created by `--squash` + `git commit`
 - A fast-forward advance from a `rebase` strategy (target moves back to its pre-rebase tip)
 
-The reset **does not** undo:
+`--keep` refuses to clobber uncommitted local changes (where `--hard` would silently destroy them); the executor surfaces an indeterminate outcome (`recoveryError` + `recoveryErrorDetail`) rather than masking a stranded worktree as a clean recovery.
+
+The recovery **does not** undo:
 
 - The source branch's history rewrite from a `rebase` strategy. The source branch keeps the rebased commits; only the integration branch's reference returns to its prior state. This is acceptable in the SDLC model because the source branch is ephemeral — it gets deleted after the merge cycle either way. If you need to inspect the original source commits, the reflog still has them until expiry.

--- a/skills/claude/merge-orchestrator/references/recovery-runbook.md
+++ b/skills/claude/merge-orchestrator/references/recovery-runbook.md
@@ -35,9 +35,11 @@ Inspect each guard field in order (the orchestrator evaluates them in this prece
 
 After resolving the underlying condition, re-invoke `merge_orchestrate` with the same arguments. The fresh dispatch re-runs preflight; if all guards now pass, the executor proceeds.
 
-## `phase: 'rolled-back'` — merge attempted, reverted
+## `phase: 'rolled-back'` — merge attempted, recovered
 
-The executor recorded the rollback SHA, attempted the merge, the merge or post-merge verification failed, and `git reset --hard <rollbackSha>` ran. The integration branch is restored to its pre-merge state.
+> The phase value is still `rolled-back` — a load-bearing state token intentionally unchanged by the #1306 recovery reframe. The *behavior* it describes is recovery to the recorded recovery point.
+
+The executor recorded the recovery point, attempted the merge, the merge or post-merge verification failed, and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) ran. The integration branch is rewound to its pre-merge state.
 
 ### Diagnose
 
@@ -49,28 +51,32 @@ Check `data.reason`:
 | `verification-failed` | Post-merge verification step rejected the merge | Custom verification adapter detected a problem (rare in default config) |
 | `timeout` | Underlying operation exceeded the 120s timeout | Repo size, slow disk, lock contention |
 
-### Then check `data.rollbackError`
+### Then check `data.recoveryError` / `data.recoveryErrorDetail`
 
-If present, the reset itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded `rollbackSha`. This is a critical condition requiring manual intervention:
+If present, the recovery itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded recovery point. `data.recoveryError` is the INV-14 discriminator (`reset-keep-blocked` / `reset-failed` / `unexpected-mid-merge-drift`) and `data.recoveryErrorDetail` is the human-readable detail. This is a critical condition requiring manual intervention:
 
 ```bash
 # Verify current state
 git status
 git log --oneline -5
 
-# If the integration branch is in an unexpected state:
+# If the integration branch is in an unexpected state, rewind it to the
+# recovery point. Prefer --keep (refuse-to-discard); use --hard only if you
+# have already confirmed there is no uncommitted work you need to preserve.
 git checkout <integration-branch>
-git reset --hard <rollbackSha-from-the-event-log>
+git reset --keep <recoveryPointSha-from-the-event-log>
 
-# Where <rollbackSha-from-the-event-log> can be retrieved from the most recent
-# merge.executed (completed run) or merge.rollback (rolled-back run) event:
-exarchos_event query stream=<featureId> filter='{"type":"merge.rollback"}'
-# fall back to merge.executed if no rollback was emitted.
-# (merge.preflight does NOT carry rollbackSha — it runs before the rollback
-# anchor is captured.)
+# Where <recoveryPointSha-from-the-event-log> can be retrieved from the most
+# recent recovery event. Prefer the canonical merge.recovered (#1306), which
+# carries recoveryPointSha; fall back to the legacy merge.rollback, whose
+# rollbackSha wire field holds the same value during the deprecation window:
+exarchos_event query stream=<featureId> filter='{"type":"merge.recovered"}'
+# fall back to merge.rollback, then merge.executed, if no recovery event exists.
+# (merge.preflight does NOT carry the recovery point — it runs before the
+# recovery point is captured.)
 ```
 
-If `rollbackError` is absent, the reset succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
+If neither `recoveryError` nor `recoveryErrorDetail` is present, the recovery succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
 
 ### Resolve a `merge-failed` outcome
 
@@ -87,6 +93,8 @@ For merge conflicts (most common cause of `merge-failed`):
 // Event first — the repository treats event append as the commit point.
 // Use the same `strategy` the original dispatch was invoked with so the
 // projected state matches what the auto-emit path would have produced.
+// NOTE: the merge.executed EVENT keeps the legacy `rollbackSha` wire field
+// during the v2.11.x deprecation window — supply the recovery-point SHA there.
 mcp__plugin_exarchos_exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: {
   type: "merge.executed",
   data: {
@@ -95,11 +103,14 @@ mcp__plugin_exarchos_exarchos__exarchos_event({ action: "append", stream: "<feat
     targetBranch: "<target>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    rollbackSha: "<recovery-point-sha-from-prior-event>",
   },
 }});
 
 // Then update workflow state to reflect the terminal phase.
+// The mergeOrchestrator STATE field is `recoveryPointSha` (renamed from
+// `rollbackSha` in #1306 — the state file follows the canonical recovery frame
+// even while the legacy event wire field above does not yet).
 mcp__plugin_exarchos_exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
   updates: { mergeOrchestrator: {
     phase: "completed",
@@ -107,7 +118,7 @@ mcp__plugin_exarchos_exarchos__exarchos_workflow({ action: "update", featureId: 
     taskId: "<task-id>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    recoveryPointSha: "<recovery-point-sha-from-prior-event>",
   } } });
 ```
 

--- a/skills/codex/merge-orchestrator/SKILL.md
+++ b/skills/codex/merge-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12,7 +12,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (`git merge --abort` → `git reset --keep`, never `--hard`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
@@ -22,9 +22,9 @@ This skill activates whenever an operator (or an automated `next_actions` dispat
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+3. Records pre-merge `HEAD` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local `git merge` of the source branch into the target branch.
-5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
@@ -51,7 +51,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | `merge`  | `git merge --no-ff --no-edit <source>` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | `squash` | `git merge --squash <source>` then `git commit` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -84,7 +84,7 @@ exarchos merge-orchestrate \
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -94,7 +94,7 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 |---------|---------|-----------------|
 | `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`) ran. The target branch is rewound to the recovery point. (The phase value stays `rolled-back` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect `data.reason`. If `data.recoveryError` / `data.recoveryErrorDetail` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -105,24 +105,27 @@ When `phase === 'aborted'`, the data payload discriminates the cause:
 | `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
-| `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.rollback`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.recovered` | On post-merge failure followed by recovery — the canonical **successor** to `merge.rollback` (#1306); dual-emitted alongside it during the deprecation window | `recoveryPointSha`, `reason`, `recoveryError?`, `recoveryErrorDetail?`, `taskId`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (`merge.recovered`). `merge.recovered` is the additive successor to `merge.rollback`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy `merge.rollback` / `merge.executed` events keep their `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission; `merge.recovered` carries the resolved `recoveryPointSha` / `recoveryErrorDetail` names alongside the unchanged INV-14 `recoveryError` discriminator. The phase value `'rolled-back'` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 
@@ -134,8 +137,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
-| **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Recovery** | INV-14 recovery ladder: `git merge --abort` → `git reset --keep <recoveryPointSha>` (real, rewinds the merge; never `--hard`) | None — the VCS provider owns merge state |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` (legacy) / `merge.recovered` (successor) | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,9 +159,9 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` / `merge.recovered` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.recoveryErrorDetail` (with the `data.recoveryError` discriminator); address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -192,7 +195,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 `mergeOrchestrator.*` fields on workflow state are written by this skill and `mergeOrchestrator.phase` is read by gates; the underlying `phase` workflow field is immutable and must be changed via `transition`, not `update`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the `workflow-state` skill for the full immutable-key list and the typed `RESERVED_FIELD` error envelope.
 
@@ -200,7 +203,7 @@ For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "de
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
-- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
+- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/codex/merge-orchestrator/references/local-git-semantics.md
+++ b/skills/codex/merge-orchestrator/references/local-git-semantics.md
@@ -1,15 +1,17 @@
 # Local-Git Semantics
 
-This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the rollback contract.
+This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the recovery contract.
+
+> **Recovery vocabulary (#1306).** The orchestrator's failure handling is modeled as a database transaction, not a saga: it records a **recovery point** (the integration branch's pre-merge HEAD) and, on failure, runs the INV-14 **recovery ladder** (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) to rewind to that point. "Recovery point" and "recovery" replace the older "rollback anchor" / "rollback" / "compensation" framing throughout. The legacy `merge.rollback` event name and its `rollbackSha` wire field are retained during the v2.11.x deprecation window; the canonical successor event is `merge.recovered`.
 
 ## The model
 
 `merge_orchestrate` is the SDLC handoff for landing a subagent's worktree branch onto the integration branch in the **main worktree**. Every operation in the orchestrator is a local-git operation:
 
 - **Preflight** — `git status --porcelain`, `git diff --cached --quiet`, `git rev-parse --abbrev-ref HEAD`, `git merge-base --is-ancestor`, `git rev-parse --git-dir`. All run against local refs.
-- **Rollback anchor** — `git rev-parse HEAD` captures the integration branch's tip before the merge.
+- **Recovery point** — `git rev-parse HEAD` captures the integration branch's tip before the merge, persisted as a write-ahead-log marker before any ref mutation.
 - **Merge** — `git merge --no-ff` / `--squash` / rebase + ff-only against local branches, in the main worktree's working directory.
-- **Rollback execution** — `git reset --hard <rollbackSha>` restores the integration branch's tip if the merge or post-merge verification fails.
+- **Recovery execution** — the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) rewinds the integration branch's tip to the recovery point if the merge or post-merge verification fails.
 
 The integration branch may eventually be pushed to a remote and merged into `main` via a PR — that is a separate concern handled by `merge_pr` in the synthesize phase, when the full feature is ready for human review.
 
@@ -20,13 +22,13 @@ An earlier implementation of this orchestrator routed the merge through `provide
 | What runs locally | What runs remotely |
 |-------------------|--------------------|
 | Preflight (drift, ancestry, branch protection, worktree assertion) | (nothing) |
-| Rollback anchor `git rev-parse HEAD` | (nothing) |
-| Rollback `git reset --hard` | (nothing) |
+| Recovery point `git rev-parse HEAD` | (nothing) |
+| Recovery `git reset --keep` | (nothing) |
 | ❌ Merge | ✅ Merge (server-side via VCS API) |
 
-A server-side merge does not move local `HEAD`. So the recorded `rollbackSha` corresponded to a local ref the merge never touched, and `git reset --hard <rollbackSha>` was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
+A server-side merge does not move local `HEAD`. So the recorded recovery point corresponded to a local ref the merge never touched, and the reset back to it was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
 
-The fix was structural: align the merge primitive with the rollback primitive. Both are now local-git, and the rollback is a real undo operation.
+The fix was structural: align the merge primitive with the recovery primitive. Both are now local-git, and the recovery is a real undo operation that rewinds the integration branch to the recorded recovery point.
 
 ## Why the integration branch and not main?
 
@@ -50,14 +52,16 @@ The preflight composer separately asserts main-worktree (`git rev-parse --git-di
 
 `rebase` rewrites the source branch's history. For ephemeral subagent branches (created by `delegate`, deleted after merge), this is fine — the branch has no consumers other than the orchestrator. Don't pick `rebase` for source branches that are pushed and shared.
 
-## What the rollback actually undoes
+## What the recovery actually undoes
 
-`git reset --hard <rollbackSha>` on the integration branch restores `HEAD` to the recorded SHA. This **does** undo:
+The recovery ladder — `git merge --abort` (the operation's own recovery primitive, best-effort) followed by `git reset --keep <recoveryPointSha>` (a refuse-to-discard substrate undo, never `--hard`) — restores the integration branch's `HEAD` to the recorded recovery point. This **does** undo:
 
 - A merge commit created by `--no-ff`
 - A squash commit created by `--squash` + `git commit`
 - A fast-forward advance from a `rebase` strategy (target moves back to its pre-rebase tip)
 
-The reset **does not** undo:
+`--keep` refuses to clobber uncommitted local changes (where `--hard` would silently destroy them); the executor surfaces an indeterminate outcome (`recoveryError` + `recoveryErrorDetail`) rather than masking a stranded worktree as a clean recovery.
+
+The recovery **does not** undo:
 
 - The source branch's history rewrite from a `rebase` strategy. The source branch keeps the rebased commits; only the integration branch's reference returns to its prior state. This is acceptable in the SDLC model because the source branch is ephemeral — it gets deleted after the merge cycle either way. If you need to inspect the original source commits, the reflog still has them until expiry.

--- a/skills/codex/merge-orchestrator/references/recovery-runbook.md
+++ b/skills/codex/merge-orchestrator/references/recovery-runbook.md
@@ -35,9 +35,11 @@ Inspect each guard field in order (the orchestrator evaluates them in this prece
 
 After resolving the underlying condition, re-invoke `merge_orchestrate` with the same arguments. The fresh dispatch re-runs preflight; if all guards now pass, the executor proceeds.
 
-## `phase: 'rolled-back'` — merge attempted, reverted
+## `phase: 'rolled-back'` — merge attempted, recovered
 
-The executor recorded the rollback SHA, attempted the merge, the merge or post-merge verification failed, and `git reset --hard <rollbackSha>` ran. The integration branch is restored to its pre-merge state.
+> The phase value is still `rolled-back` — a load-bearing state token intentionally unchanged by the #1306 recovery reframe. The *behavior* it describes is recovery to the recorded recovery point.
+
+The executor recorded the recovery point, attempted the merge, the merge or post-merge verification failed, and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) ran. The integration branch is rewound to its pre-merge state.
 
 ### Diagnose
 
@@ -49,28 +51,32 @@ Check `data.reason`:
 | `verification-failed` | Post-merge verification step rejected the merge | Custom verification adapter detected a problem (rare in default config) |
 | `timeout` | Underlying operation exceeded the 120s timeout | Repo size, slow disk, lock contention |
 
-### Then check `data.rollbackError`
+### Then check `data.recoveryError` / `data.recoveryErrorDetail`
 
-If present, the reset itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded `rollbackSha`. This is a critical condition requiring manual intervention:
+If present, the recovery itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded recovery point. `data.recoveryError` is the INV-14 discriminator (`reset-keep-blocked` / `reset-failed` / `unexpected-mid-merge-drift`) and `data.recoveryErrorDetail` is the human-readable detail. This is a critical condition requiring manual intervention:
 
 ```bash
 # Verify current state
 git status
 git log --oneline -5
 
-# If the integration branch is in an unexpected state:
+# If the integration branch is in an unexpected state, rewind it to the
+# recovery point. Prefer --keep (refuse-to-discard); use --hard only if you
+# have already confirmed there is no uncommitted work you need to preserve.
 git checkout <integration-branch>
-git reset --hard <rollbackSha-from-the-event-log>
+git reset --keep <recoveryPointSha-from-the-event-log>
 
-# Where <rollbackSha-from-the-event-log> can be retrieved from the most recent
-# merge.executed (completed run) or merge.rollback (rolled-back run) event:
-exarchos_event query stream=<featureId> filter='{"type":"merge.rollback"}'
-# fall back to merge.executed if no rollback was emitted.
-# (merge.preflight does NOT carry rollbackSha — it runs before the rollback
-# anchor is captured.)
+# Where <recoveryPointSha-from-the-event-log> can be retrieved from the most
+# recent recovery event. Prefer the canonical merge.recovered (#1306), which
+# carries recoveryPointSha; fall back to the legacy merge.rollback, whose
+# rollbackSha wire field holds the same value during the deprecation window:
+exarchos_event query stream=<featureId> filter='{"type":"merge.recovered"}'
+# fall back to merge.rollback, then merge.executed, if no recovery event exists.
+# (merge.preflight does NOT carry the recovery point — it runs before the
+# recovery point is captured.)
 ```
 
-If `rollbackError` is absent, the reset succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
+If neither `recoveryError` nor `recoveryErrorDetail` is present, the recovery succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
 
 ### Resolve a `merge-failed` outcome
 
@@ -87,6 +93,8 @@ For merge conflicts (most common cause of `merge-failed`):
 // Event first — the repository treats event append as the commit point.
 // Use the same `strategy` the original dispatch was invoked with so the
 // projected state matches what the auto-emit path would have produced.
+// NOTE: the merge.executed EVENT keeps the legacy `rollbackSha` wire field
+// during the v2.11.x deprecation window — supply the recovery-point SHA there.
 mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: {
   type: "merge.executed",
   data: {
@@ -95,11 +103,14 @@ mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: 
     targetBranch: "<target>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    rollbackSha: "<recovery-point-sha-from-prior-event>",
   },
 }});
 
 // Then update workflow state to reflect the terminal phase.
+// The mergeOrchestrator STATE field is `recoveryPointSha` (renamed from
+// `rollbackSha` in #1306 — the state file follows the canonical recovery frame
+// even while the legacy event wire field above does not yet).
 mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
   updates: { mergeOrchestrator: {
     phase: "completed",
@@ -107,7 +118,7 @@ mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
     taskId: "<task-id>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    recoveryPointSha: "<recovery-point-sha-from-prior-event>",
   } } });
 ```
 

--- a/skills/copilot/merge-orchestrator/SKILL.md
+++ b/skills/copilot/merge-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12,7 +12,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (`git merge --abort` → `git reset --keep`, never `--hard`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
@@ -22,9 +22,9 @@ This skill activates whenever an operator (or an automated `next_actions` dispat
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+3. Records pre-merge `HEAD` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local `git merge` of the source branch into the target branch.
-5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
@@ -51,7 +51,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | `merge`  | `git merge --no-ff --no-edit <source>` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | `squash` | `git merge --squash <source>` then `git commit` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -84,7 +84,7 @@ exarchos merge-orchestrate \
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -94,7 +94,7 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 |---------|---------|-----------------|
 | `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`) ran. The target branch is rewound to the recovery point. (The phase value stays `rolled-back` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect `data.reason`. If `data.recoveryError` / `data.recoveryErrorDetail` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -105,24 +105,27 @@ When `phase === 'aborted'`, the data payload discriminates the cause:
 | `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
-| `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.rollback`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.recovered` | On post-merge failure followed by recovery — the canonical **successor** to `merge.rollback` (#1306); dual-emitted alongside it during the deprecation window | `recoveryPointSha`, `reason`, `recoveryError?`, `recoveryErrorDetail?`, `taskId`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (`merge.recovered`). `merge.recovered` is the additive successor to `merge.rollback`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy `merge.rollback` / `merge.executed` events keep their `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission; `merge.recovered` carries the resolved `recoveryPointSha` / `recoveryErrorDetail` names alongside the unchanged INV-14 `recoveryError` discriminator. The phase value `'rolled-back'` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 
@@ -134,8 +137,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
-| **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Recovery** | INV-14 recovery ladder: `git merge --abort` → `git reset --keep <recoveryPointSha>` (real, rewinds the merge; never `--hard`) | None — the VCS provider owns merge state |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` (legacy) / `merge.recovered` (successor) | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,9 +159,9 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` / `merge.recovered` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.recoveryErrorDetail` (with the `data.recoveryError` discriminator); address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -192,7 +195,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 `mergeOrchestrator.*` fields on workflow state are written by this skill and `mergeOrchestrator.phase` is read by gates; the underlying `phase` workflow field is immutable and must be changed via `transition`, not `update`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the `workflow-state` skill for the full immutable-key list and the typed `RESERVED_FIELD` error envelope.
 
@@ -200,7 +203,7 @@ For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "de
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
-- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
+- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/copilot/merge-orchestrator/references/local-git-semantics.md
+++ b/skills/copilot/merge-orchestrator/references/local-git-semantics.md
@@ -1,15 +1,17 @@
 # Local-Git Semantics
 
-This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the rollback contract.
+This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the recovery contract.
+
+> **Recovery vocabulary (#1306).** The orchestrator's failure handling is modeled as a database transaction, not a saga: it records a **recovery point** (the integration branch's pre-merge HEAD) and, on failure, runs the INV-14 **recovery ladder** (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) to rewind to that point. "Recovery point" and "recovery" replace the older "rollback anchor" / "rollback" / "compensation" framing throughout. The legacy `merge.rollback` event name and its `rollbackSha` wire field are retained during the v2.11.x deprecation window; the canonical successor event is `merge.recovered`.
 
 ## The model
 
 `merge_orchestrate` is the SDLC handoff for landing a subagent's worktree branch onto the integration branch in the **main worktree**. Every operation in the orchestrator is a local-git operation:
 
 - **Preflight** — `git status --porcelain`, `git diff --cached --quiet`, `git rev-parse --abbrev-ref HEAD`, `git merge-base --is-ancestor`, `git rev-parse --git-dir`. All run against local refs.
-- **Rollback anchor** — `git rev-parse HEAD` captures the integration branch's tip before the merge.
+- **Recovery point** — `git rev-parse HEAD` captures the integration branch's tip before the merge, persisted as a write-ahead-log marker before any ref mutation.
 - **Merge** — `git merge --no-ff` / `--squash` / rebase + ff-only against local branches, in the main worktree's working directory.
-- **Rollback execution** — `git reset --hard <rollbackSha>` restores the integration branch's tip if the merge or post-merge verification fails.
+- **Recovery execution** — the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) rewinds the integration branch's tip to the recovery point if the merge or post-merge verification fails.
 
 The integration branch may eventually be pushed to a remote and merged into `main` via a PR — that is a separate concern handled by `merge_pr` in the synthesize phase, when the full feature is ready for human review.
 
@@ -20,13 +22,13 @@ An earlier implementation of this orchestrator routed the merge through `provide
 | What runs locally | What runs remotely |
 |-------------------|--------------------|
 | Preflight (drift, ancestry, branch protection, worktree assertion) | (nothing) |
-| Rollback anchor `git rev-parse HEAD` | (nothing) |
-| Rollback `git reset --hard` | (nothing) |
+| Recovery point `git rev-parse HEAD` | (nothing) |
+| Recovery `git reset --keep` | (nothing) |
 | ❌ Merge | ✅ Merge (server-side via VCS API) |
 
-A server-side merge does not move local `HEAD`. So the recorded `rollbackSha` corresponded to a local ref the merge never touched, and `git reset --hard <rollbackSha>` was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
+A server-side merge does not move local `HEAD`. So the recorded recovery point corresponded to a local ref the merge never touched, and the reset back to it was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
 
-The fix was structural: align the merge primitive with the rollback primitive. Both are now local-git, and the rollback is a real undo operation.
+The fix was structural: align the merge primitive with the recovery primitive. Both are now local-git, and the recovery is a real undo operation that rewinds the integration branch to the recorded recovery point.
 
 ## Why the integration branch and not main?
 
@@ -50,14 +52,16 @@ The preflight composer separately asserts main-worktree (`git rev-parse --git-di
 
 `rebase` rewrites the source branch's history. For ephemeral subagent branches (created by `delegate`, deleted after merge), this is fine — the branch has no consumers other than the orchestrator. Don't pick `rebase` for source branches that are pushed and shared.
 
-## What the rollback actually undoes
+## What the recovery actually undoes
 
-`git reset --hard <rollbackSha>` on the integration branch restores `HEAD` to the recorded SHA. This **does** undo:
+The recovery ladder — `git merge --abort` (the operation's own recovery primitive, best-effort) followed by `git reset --keep <recoveryPointSha>` (a refuse-to-discard substrate undo, never `--hard`) — restores the integration branch's `HEAD` to the recorded recovery point. This **does** undo:
 
 - A merge commit created by `--no-ff`
 - A squash commit created by `--squash` + `git commit`
 - A fast-forward advance from a `rebase` strategy (target moves back to its pre-rebase tip)
 
-The reset **does not** undo:
+`--keep` refuses to clobber uncommitted local changes (where `--hard` would silently destroy them); the executor surfaces an indeterminate outcome (`recoveryError` + `recoveryErrorDetail`) rather than masking a stranded worktree as a clean recovery.
+
+The recovery **does not** undo:
 
 - The source branch's history rewrite from a `rebase` strategy. The source branch keeps the rebased commits; only the integration branch's reference returns to its prior state. This is acceptable in the SDLC model because the source branch is ephemeral — it gets deleted after the merge cycle either way. If you need to inspect the original source commits, the reflog still has them until expiry.

--- a/skills/copilot/merge-orchestrator/references/recovery-runbook.md
+++ b/skills/copilot/merge-orchestrator/references/recovery-runbook.md
@@ -35,9 +35,11 @@ Inspect each guard field in order (the orchestrator evaluates them in this prece
 
 After resolving the underlying condition, re-invoke `merge_orchestrate` with the same arguments. The fresh dispatch re-runs preflight; if all guards now pass, the executor proceeds.
 
-## `phase: 'rolled-back'` — merge attempted, reverted
+## `phase: 'rolled-back'` — merge attempted, recovered
 
-The executor recorded the rollback SHA, attempted the merge, the merge or post-merge verification failed, and `git reset --hard <rollbackSha>` ran. The integration branch is restored to its pre-merge state.
+> The phase value is still `rolled-back` — a load-bearing state token intentionally unchanged by the #1306 recovery reframe. The *behavior* it describes is recovery to the recorded recovery point.
+
+The executor recorded the recovery point, attempted the merge, the merge or post-merge verification failed, and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) ran. The integration branch is rewound to its pre-merge state.
 
 ### Diagnose
 
@@ -49,28 +51,32 @@ Check `data.reason`:
 | `verification-failed` | Post-merge verification step rejected the merge | Custom verification adapter detected a problem (rare in default config) |
 | `timeout` | Underlying operation exceeded the 120s timeout | Repo size, slow disk, lock contention |
 
-### Then check `data.rollbackError`
+### Then check `data.recoveryError` / `data.recoveryErrorDetail`
 
-If present, the reset itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded `rollbackSha`. This is a critical condition requiring manual intervention:
+If present, the recovery itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded recovery point. `data.recoveryError` is the INV-14 discriminator (`reset-keep-blocked` / `reset-failed` / `unexpected-mid-merge-drift`) and `data.recoveryErrorDetail` is the human-readable detail. This is a critical condition requiring manual intervention:
 
 ```bash
 # Verify current state
 git status
 git log --oneline -5
 
-# If the integration branch is in an unexpected state:
+# If the integration branch is in an unexpected state, rewind it to the
+# recovery point. Prefer --keep (refuse-to-discard); use --hard only if you
+# have already confirmed there is no uncommitted work you need to preserve.
 git checkout <integration-branch>
-git reset --hard <rollbackSha-from-the-event-log>
+git reset --keep <recoveryPointSha-from-the-event-log>
 
-# Where <rollbackSha-from-the-event-log> can be retrieved from the most recent
-# merge.executed (completed run) or merge.rollback (rolled-back run) event:
-exarchos_event query stream=<featureId> filter='{"type":"merge.rollback"}'
-# fall back to merge.executed if no rollback was emitted.
-# (merge.preflight does NOT carry rollbackSha — it runs before the rollback
-# anchor is captured.)
+# Where <recoveryPointSha-from-the-event-log> can be retrieved from the most
+# recent recovery event. Prefer the canonical merge.recovered (#1306), which
+# carries recoveryPointSha; fall back to the legacy merge.rollback, whose
+# rollbackSha wire field holds the same value during the deprecation window:
+exarchos_event query stream=<featureId> filter='{"type":"merge.recovered"}'
+# fall back to merge.rollback, then merge.executed, if no recovery event exists.
+# (merge.preflight does NOT carry the recovery point — it runs before the
+# recovery point is captured.)
 ```
 
-If `rollbackError` is absent, the reset succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
+If neither `recoveryError` nor `recoveryErrorDetail` is present, the recovery succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
 
 ### Resolve a `merge-failed` outcome
 
@@ -87,6 +93,8 @@ For merge conflicts (most common cause of `merge-failed`):
 // Event first — the repository treats event append as the commit point.
 // Use the same `strategy` the original dispatch was invoked with so the
 // projected state matches what the auto-emit path would have produced.
+// NOTE: the merge.executed EVENT keeps the legacy `rollbackSha` wire field
+// during the v2.11.x deprecation window — supply the recovery-point SHA there.
 mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: {
   type: "merge.executed",
   data: {
@@ -95,11 +103,14 @@ mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: 
     targetBranch: "<target>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    rollbackSha: "<recovery-point-sha-from-prior-event>",
   },
 }});
 
 // Then update workflow state to reflect the terminal phase.
+// The mergeOrchestrator STATE field is `recoveryPointSha` (renamed from
+// `rollbackSha` in #1306 — the state file follows the canonical recovery frame
+// even while the legacy event wire field above does not yet).
 mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
   updates: { mergeOrchestrator: {
     phase: "completed",
@@ -107,7 +118,7 @@ mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
     taskId: "<task-id>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    recoveryPointSha: "<recovery-point-sha-from-prior-event>",
   } } });
 ```
 

--- a/skills/cursor/merge-orchestrator/SKILL.md
+++ b/skills/cursor/merge-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12,7 +12,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (`git merge --abort` → `git reset --keep`, never `--hard`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
@@ -22,9 +22,9 @@ This skill activates whenever an operator (or an automated `next_actions` dispat
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+3. Records pre-merge `HEAD` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local `git merge` of the source branch into the target branch.
-5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
@@ -51,7 +51,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | `merge`  | `git merge --no-ff --no-edit <source>` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | `squash` | `git merge --squash <source>` then `git commit` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -84,7 +84,7 @@ exarchos merge-orchestrate \
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -94,7 +94,7 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 |---------|---------|-----------------|
 | `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`) ran. The target branch is rewound to the recovery point. (The phase value stays `rolled-back` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect `data.reason`. If `data.recoveryError` / `data.recoveryErrorDetail` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -105,24 +105,27 @@ When `phase === 'aborted'`, the data payload discriminates the cause:
 | `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
-| `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.rollback`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.recovered` | On post-merge failure followed by recovery — the canonical **successor** to `merge.rollback` (#1306); dual-emitted alongside it during the deprecation window | `recoveryPointSha`, `reason`, `recoveryError?`, `recoveryErrorDetail?`, `taskId`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (`merge.recovered`). `merge.recovered` is the additive successor to `merge.rollback`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy `merge.rollback` / `merge.executed` events keep their `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission; `merge.recovered` carries the resolved `recoveryPointSha` / `recoveryErrorDetail` names alongside the unchanged INV-14 `recoveryError` discriminator. The phase value `'rolled-back'` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 
@@ -134,8 +137,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
-| **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Recovery** | INV-14 recovery ladder: `git merge --abort` → `git reset --keep <recoveryPointSha>` (real, rewinds the merge; never `--hard`) | None — the VCS provider owns merge state |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` (legacy) / `merge.recovered` (successor) | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,9 +159,9 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` / `merge.recovered` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.recoveryErrorDetail` (with the `data.recoveryError` discriminator); address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -192,7 +195,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 `mergeOrchestrator.*` fields on workflow state are written by this skill and `mergeOrchestrator.phase` is read by gates; the underlying `phase` workflow field is immutable and must be changed via `transition`, not `update`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the `workflow-state` skill for the full immutable-key list and the typed `RESERVED_FIELD` error envelope.
 
@@ -200,7 +203,7 @@ For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "de
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
-- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
+- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/cursor/merge-orchestrator/references/local-git-semantics.md
+++ b/skills/cursor/merge-orchestrator/references/local-git-semantics.md
@@ -1,15 +1,17 @@
 # Local-Git Semantics
 
-This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the rollback contract.
+This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the recovery contract.
+
+> **Recovery vocabulary (#1306).** The orchestrator's failure handling is modeled as a database transaction, not a saga: it records a **recovery point** (the integration branch's pre-merge HEAD) and, on failure, runs the INV-14 **recovery ladder** (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) to rewind to that point. "Recovery point" and "recovery" replace the older "rollback anchor" / "rollback" / "compensation" framing throughout. The legacy `merge.rollback` event name and its `rollbackSha` wire field are retained during the v2.11.x deprecation window; the canonical successor event is `merge.recovered`.
 
 ## The model
 
 `merge_orchestrate` is the SDLC handoff for landing a subagent's worktree branch onto the integration branch in the **main worktree**. Every operation in the orchestrator is a local-git operation:
 
 - **Preflight** — `git status --porcelain`, `git diff --cached --quiet`, `git rev-parse --abbrev-ref HEAD`, `git merge-base --is-ancestor`, `git rev-parse --git-dir`. All run against local refs.
-- **Rollback anchor** — `git rev-parse HEAD` captures the integration branch's tip before the merge.
+- **Recovery point** — `git rev-parse HEAD` captures the integration branch's tip before the merge, persisted as a write-ahead-log marker before any ref mutation.
 - **Merge** — `git merge --no-ff` / `--squash` / rebase + ff-only against local branches, in the main worktree's working directory.
-- **Rollback execution** — `git reset --hard <rollbackSha>` restores the integration branch's tip if the merge or post-merge verification fails.
+- **Recovery execution** — the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) rewinds the integration branch's tip to the recovery point if the merge or post-merge verification fails.
 
 The integration branch may eventually be pushed to a remote and merged into `main` via a PR — that is a separate concern handled by `merge_pr` in the synthesize phase, when the full feature is ready for human review.
 
@@ -20,13 +22,13 @@ An earlier implementation of this orchestrator routed the merge through `provide
 | What runs locally | What runs remotely |
 |-------------------|--------------------|
 | Preflight (drift, ancestry, branch protection, worktree assertion) | (nothing) |
-| Rollback anchor `git rev-parse HEAD` | (nothing) |
-| Rollback `git reset --hard` | (nothing) |
+| Recovery point `git rev-parse HEAD` | (nothing) |
+| Recovery `git reset --keep` | (nothing) |
 | ❌ Merge | ✅ Merge (server-side via VCS API) |
 
-A server-side merge does not move local `HEAD`. So the recorded `rollbackSha` corresponded to a local ref the merge never touched, and `git reset --hard <rollbackSha>` was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
+A server-side merge does not move local `HEAD`. So the recorded recovery point corresponded to a local ref the merge never touched, and the reset back to it was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
 
-The fix was structural: align the merge primitive with the rollback primitive. Both are now local-git, and the rollback is a real undo operation.
+The fix was structural: align the merge primitive with the recovery primitive. Both are now local-git, and the recovery is a real undo operation that rewinds the integration branch to the recorded recovery point.
 
 ## Why the integration branch and not main?
 
@@ -50,14 +52,16 @@ The preflight composer separately asserts main-worktree (`git rev-parse --git-di
 
 `rebase` rewrites the source branch's history. For ephemeral subagent branches (created by `delegate`, deleted after merge), this is fine — the branch has no consumers other than the orchestrator. Don't pick `rebase` for source branches that are pushed and shared.
 
-## What the rollback actually undoes
+## What the recovery actually undoes
 
-`git reset --hard <rollbackSha>` on the integration branch restores `HEAD` to the recorded SHA. This **does** undo:
+The recovery ladder — `git merge --abort` (the operation's own recovery primitive, best-effort) followed by `git reset --keep <recoveryPointSha>` (a refuse-to-discard substrate undo, never `--hard`) — restores the integration branch's `HEAD` to the recorded recovery point. This **does** undo:
 
 - A merge commit created by `--no-ff`
 - A squash commit created by `--squash` + `git commit`
 - A fast-forward advance from a `rebase` strategy (target moves back to its pre-rebase tip)
 
-The reset **does not** undo:
+`--keep` refuses to clobber uncommitted local changes (where `--hard` would silently destroy them); the executor surfaces an indeterminate outcome (`recoveryError` + `recoveryErrorDetail`) rather than masking a stranded worktree as a clean recovery.
+
+The recovery **does not** undo:
 
 - The source branch's history rewrite from a `rebase` strategy. The source branch keeps the rebased commits; only the integration branch's reference returns to its prior state. This is acceptable in the SDLC model because the source branch is ephemeral — it gets deleted after the merge cycle either way. If you need to inspect the original source commits, the reflog still has them until expiry.

--- a/skills/cursor/merge-orchestrator/references/recovery-runbook.md
+++ b/skills/cursor/merge-orchestrator/references/recovery-runbook.md
@@ -35,9 +35,11 @@ Inspect each guard field in order (the orchestrator evaluates them in this prece
 
 After resolving the underlying condition, re-invoke `merge_orchestrate` with the same arguments. The fresh dispatch re-runs preflight; if all guards now pass, the executor proceeds.
 
-## `phase: 'rolled-back'` — merge attempted, reverted
+## `phase: 'rolled-back'` — merge attempted, recovered
 
-The executor recorded the rollback SHA, attempted the merge, the merge or post-merge verification failed, and `git reset --hard <rollbackSha>` ran. The integration branch is restored to its pre-merge state.
+> The phase value is still `rolled-back` — a load-bearing state token intentionally unchanged by the #1306 recovery reframe. The *behavior* it describes is recovery to the recorded recovery point.
+
+The executor recorded the recovery point, attempted the merge, the merge or post-merge verification failed, and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) ran. The integration branch is rewound to its pre-merge state.
 
 ### Diagnose
 
@@ -49,28 +51,32 @@ Check `data.reason`:
 | `verification-failed` | Post-merge verification step rejected the merge | Custom verification adapter detected a problem (rare in default config) |
 | `timeout` | Underlying operation exceeded the 120s timeout | Repo size, slow disk, lock contention |
 
-### Then check `data.rollbackError`
+### Then check `data.recoveryError` / `data.recoveryErrorDetail`
 
-If present, the reset itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded `rollbackSha`. This is a critical condition requiring manual intervention:
+If present, the recovery itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded recovery point. `data.recoveryError` is the INV-14 discriminator (`reset-keep-blocked` / `reset-failed` / `unexpected-mid-merge-drift`) and `data.recoveryErrorDetail` is the human-readable detail. This is a critical condition requiring manual intervention:
 
 ```bash
 # Verify current state
 git status
 git log --oneline -5
 
-# If the integration branch is in an unexpected state:
+# If the integration branch is in an unexpected state, rewind it to the
+# recovery point. Prefer --keep (refuse-to-discard); use --hard only if you
+# have already confirmed there is no uncommitted work you need to preserve.
 git checkout <integration-branch>
-git reset --hard <rollbackSha-from-the-event-log>
+git reset --keep <recoveryPointSha-from-the-event-log>
 
-# Where <rollbackSha-from-the-event-log> can be retrieved from the most recent
-# merge.executed (completed run) or merge.rollback (rolled-back run) event:
-exarchos_event query stream=<featureId> filter='{"type":"merge.rollback"}'
-# fall back to merge.executed if no rollback was emitted.
-# (merge.preflight does NOT carry rollbackSha — it runs before the rollback
-# anchor is captured.)
+# Where <recoveryPointSha-from-the-event-log> can be retrieved from the most
+# recent recovery event. Prefer the canonical merge.recovered (#1306), which
+# carries recoveryPointSha; fall back to the legacy merge.rollback, whose
+# rollbackSha wire field holds the same value during the deprecation window:
+exarchos_event query stream=<featureId> filter='{"type":"merge.recovered"}'
+# fall back to merge.rollback, then merge.executed, if no recovery event exists.
+# (merge.preflight does NOT carry the recovery point — it runs before the
+# recovery point is captured.)
 ```
 
-If `rollbackError` is absent, the reset succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
+If neither `recoveryError` nor `recoveryErrorDetail` is present, the recovery succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
 
 ### Resolve a `merge-failed` outcome
 
@@ -87,6 +93,8 @@ For merge conflicts (most common cause of `merge-failed`):
 // Event first — the repository treats event append as the commit point.
 // Use the same `strategy` the original dispatch was invoked with so the
 // projected state matches what the auto-emit path would have produced.
+// NOTE: the merge.executed EVENT keeps the legacy `rollbackSha` wire field
+// during the v2.11.x deprecation window — supply the recovery-point SHA there.
 mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: {
   type: "merge.executed",
   data: {
@@ -95,11 +103,14 @@ mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: 
     targetBranch: "<target>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    rollbackSha: "<recovery-point-sha-from-prior-event>",
   },
 }});
 
 // Then update workflow state to reflect the terminal phase.
+// The mergeOrchestrator STATE field is `recoveryPointSha` (renamed from
+// `rollbackSha` in #1306 — the state file follows the canonical recovery frame
+// even while the legacy event wire field above does not yet).
 mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
   updates: { mergeOrchestrator: {
     phase: "completed",
@@ -107,7 +118,7 @@ mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
     taskId: "<task-id>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    recoveryPointSha: "<recovery-point-sha-from-prior-event>",
   } } });
 ```
 

--- a/skills/generic/merge-orchestrator/SKILL.md
+++ b/skills/generic/merge-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12,7 +12,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (`git merge --abort` → `git reset --keep`, never `--hard`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
@@ -22,9 +22,9 @@ This skill activates whenever an operator (or an automated `next_actions` dispat
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+3. Records pre-merge `HEAD` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local `git merge` of the source branch into the target branch.
-5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
@@ -51,7 +51,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | `merge`  | `git merge --no-ff --no-edit <source>` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | `squash` | `git merge --squash <source>` then `git commit` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -84,7 +84,7 @@ exarchos merge-orchestrate \
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -94,7 +94,7 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 |---------|---------|-----------------|
 | `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`) ran. The target branch is rewound to the recovery point. (The phase value stays `rolled-back` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect `data.reason`. If `data.recoveryError` / `data.recoveryErrorDetail` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -105,24 +105,27 @@ When `phase === 'aborted'`, the data payload discriminates the cause:
 | `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
-| `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.rollback`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.recovered` | On post-merge failure followed by recovery — the canonical **successor** to `merge.rollback` (#1306); dual-emitted alongside it during the deprecation window | `recoveryPointSha`, `reason`, `recoveryError?`, `recoveryErrorDetail?`, `taskId`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (`merge.recovered`). `merge.recovered` is the additive successor to `merge.rollback`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy `merge.rollback` / `merge.executed` events keep their `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission; `merge.recovered` carries the resolved `recoveryPointSha` / `recoveryErrorDetail` names alongside the unchanged INV-14 `recoveryError` discriminator. The phase value `'rolled-back'` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 
@@ -134,8 +137,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
-| **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Recovery** | INV-14 recovery ladder: `git merge --abort` → `git reset --keep <recoveryPointSha>` (real, rewinds the merge; never `--hard`) | None — the VCS provider owns merge state |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` (legacy) / `merge.recovered` (successor) | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,9 +159,9 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` / `merge.recovered` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.recoveryErrorDetail` (with the `data.recoveryError` discriminator); address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -192,7 +195,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 `mergeOrchestrator.*` fields on workflow state are written by this skill and `mergeOrchestrator.phase` is read by gates; the underlying `phase` workflow field is immutable and must be changed via `transition`, not `update`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the `workflow-state` skill for the full immutable-key list and the typed `RESERVED_FIELD` error envelope.
 
@@ -200,7 +203,7 @@ For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "de
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
-- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
+- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/generic/merge-orchestrator/references/local-git-semantics.md
+++ b/skills/generic/merge-orchestrator/references/local-git-semantics.md
@@ -1,15 +1,17 @@
 # Local-Git Semantics
 
-This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the rollback contract.
+This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the recovery contract.
+
+> **Recovery vocabulary (#1306).** The orchestrator's failure handling is modeled as a database transaction, not a saga: it records a **recovery point** (the integration branch's pre-merge HEAD) and, on failure, runs the INV-14 **recovery ladder** (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) to rewind to that point. "Recovery point" and "recovery" replace the older "rollback anchor" / "rollback" / "compensation" framing throughout. The legacy `merge.rollback` event name and its `rollbackSha` wire field are retained during the v2.11.x deprecation window; the canonical successor event is `merge.recovered`.
 
 ## The model
 
 `merge_orchestrate` is the SDLC handoff for landing a subagent's worktree branch onto the integration branch in the **main worktree**. Every operation in the orchestrator is a local-git operation:
 
 - **Preflight** — `git status --porcelain`, `git diff --cached --quiet`, `git rev-parse --abbrev-ref HEAD`, `git merge-base --is-ancestor`, `git rev-parse --git-dir`. All run against local refs.
-- **Rollback anchor** — `git rev-parse HEAD` captures the integration branch's tip before the merge.
+- **Recovery point** — `git rev-parse HEAD` captures the integration branch's tip before the merge, persisted as a write-ahead-log marker before any ref mutation.
 - **Merge** — `git merge --no-ff` / `--squash` / rebase + ff-only against local branches, in the main worktree's working directory.
-- **Rollback execution** — `git reset --hard <rollbackSha>` restores the integration branch's tip if the merge or post-merge verification fails.
+- **Recovery execution** — the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) rewinds the integration branch's tip to the recovery point if the merge or post-merge verification fails.
 
 The integration branch may eventually be pushed to a remote and merged into `main` via a PR — that is a separate concern handled by `merge_pr` in the synthesize phase, when the full feature is ready for human review.
 
@@ -20,13 +22,13 @@ An earlier implementation of this orchestrator routed the merge through `provide
 | What runs locally | What runs remotely |
 |-------------------|--------------------|
 | Preflight (drift, ancestry, branch protection, worktree assertion) | (nothing) |
-| Rollback anchor `git rev-parse HEAD` | (nothing) |
-| Rollback `git reset --hard` | (nothing) |
+| Recovery point `git rev-parse HEAD` | (nothing) |
+| Recovery `git reset --keep` | (nothing) |
 | ❌ Merge | ✅ Merge (server-side via VCS API) |
 
-A server-side merge does not move local `HEAD`. So the recorded `rollbackSha` corresponded to a local ref the merge never touched, and `git reset --hard <rollbackSha>` was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
+A server-side merge does not move local `HEAD`. So the recorded recovery point corresponded to a local ref the merge never touched, and the reset back to it was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
 
-The fix was structural: align the merge primitive with the rollback primitive. Both are now local-git, and the rollback is a real undo operation.
+The fix was structural: align the merge primitive with the recovery primitive. Both are now local-git, and the recovery is a real undo operation that rewinds the integration branch to the recorded recovery point.
 
 ## Why the integration branch and not main?
 
@@ -50,14 +52,16 @@ The preflight composer separately asserts main-worktree (`git rev-parse --git-di
 
 `rebase` rewrites the source branch's history. For ephemeral subagent branches (created by `delegate`, deleted after merge), this is fine — the branch has no consumers other than the orchestrator. Don't pick `rebase` for source branches that are pushed and shared.
 
-## What the rollback actually undoes
+## What the recovery actually undoes
 
-`git reset --hard <rollbackSha>` on the integration branch restores `HEAD` to the recorded SHA. This **does** undo:
+The recovery ladder — `git merge --abort` (the operation's own recovery primitive, best-effort) followed by `git reset --keep <recoveryPointSha>` (a refuse-to-discard substrate undo, never `--hard`) — restores the integration branch's `HEAD` to the recorded recovery point. This **does** undo:
 
 - A merge commit created by `--no-ff`
 - A squash commit created by `--squash` + `git commit`
 - A fast-forward advance from a `rebase` strategy (target moves back to its pre-rebase tip)
 
-The reset **does not** undo:
+`--keep` refuses to clobber uncommitted local changes (where `--hard` would silently destroy them); the executor surfaces an indeterminate outcome (`recoveryError` + `recoveryErrorDetail`) rather than masking a stranded worktree as a clean recovery.
+
+The recovery **does not** undo:
 
 - The source branch's history rewrite from a `rebase` strategy. The source branch keeps the rebased commits; only the integration branch's reference returns to its prior state. This is acceptable in the SDLC model because the source branch is ephemeral — it gets deleted after the merge cycle either way. If you need to inspect the original source commits, the reflog still has them until expiry.

--- a/skills/generic/merge-orchestrator/references/recovery-runbook.md
+++ b/skills/generic/merge-orchestrator/references/recovery-runbook.md
@@ -35,9 +35,11 @@ Inspect each guard field in order (the orchestrator evaluates them in this prece
 
 After resolving the underlying condition, re-invoke `merge_orchestrate` with the same arguments. The fresh dispatch re-runs preflight; if all guards now pass, the executor proceeds.
 
-## `phase: 'rolled-back'` — merge attempted, reverted
+## `phase: 'rolled-back'` — merge attempted, recovered
 
-The executor recorded the rollback SHA, attempted the merge, the merge or post-merge verification failed, and `git reset --hard <rollbackSha>` ran. The integration branch is restored to its pre-merge state.
+> The phase value is still `rolled-back` — a load-bearing state token intentionally unchanged by the #1306 recovery reframe. The *behavior* it describes is recovery to the recorded recovery point.
+
+The executor recorded the recovery point, attempted the merge, the merge or post-merge verification failed, and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) ran. The integration branch is rewound to its pre-merge state.
 
 ### Diagnose
 
@@ -49,28 +51,32 @@ Check `data.reason`:
 | `verification-failed` | Post-merge verification step rejected the merge | Custom verification adapter detected a problem (rare in default config) |
 | `timeout` | Underlying operation exceeded the 120s timeout | Repo size, slow disk, lock contention |
 
-### Then check `data.rollbackError`
+### Then check `data.recoveryError` / `data.recoveryErrorDetail`
 
-If present, the reset itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded `rollbackSha`. This is a critical condition requiring manual intervention:
+If present, the recovery itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded recovery point. `data.recoveryError` is the INV-14 discriminator (`reset-keep-blocked` / `reset-failed` / `unexpected-mid-merge-drift`) and `data.recoveryErrorDetail` is the human-readable detail. This is a critical condition requiring manual intervention:
 
 ```bash
 # Verify current state
 git status
 git log --oneline -5
 
-# If the integration branch is in an unexpected state:
+# If the integration branch is in an unexpected state, rewind it to the
+# recovery point. Prefer --keep (refuse-to-discard); use --hard only if you
+# have already confirmed there is no uncommitted work you need to preserve.
 git checkout <integration-branch>
-git reset --hard <rollbackSha-from-the-event-log>
+git reset --keep <recoveryPointSha-from-the-event-log>
 
-# Where <rollbackSha-from-the-event-log> can be retrieved from the most recent
-# merge.executed (completed run) or merge.rollback (rolled-back run) event:
-exarchos_event query stream=<featureId> filter='{"type":"merge.rollback"}'
-# fall back to merge.executed if no rollback was emitted.
-# (merge.preflight does NOT carry rollbackSha — it runs before the rollback
-# anchor is captured.)
+# Where <recoveryPointSha-from-the-event-log> can be retrieved from the most
+# recent recovery event. Prefer the canonical merge.recovered (#1306), which
+# carries recoveryPointSha; fall back to the legacy merge.rollback, whose
+# rollbackSha wire field holds the same value during the deprecation window:
+exarchos_event query stream=<featureId> filter='{"type":"merge.recovered"}'
+# fall back to merge.rollback, then merge.executed, if no recovery event exists.
+# (merge.preflight does NOT carry the recovery point — it runs before the
+# recovery point is captured.)
 ```
 
-If `rollbackError` is absent, the reset succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
+If neither `recoveryError` nor `recoveryErrorDetail` is present, the recovery succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
 
 ### Resolve a `merge-failed` outcome
 
@@ -87,6 +93,8 @@ For merge conflicts (most common cause of `merge-failed`):
 // Event first — the repository treats event append as the commit point.
 // Use the same `strategy` the original dispatch was invoked with so the
 // projected state matches what the auto-emit path would have produced.
+// NOTE: the merge.executed EVENT keeps the legacy `rollbackSha` wire field
+// during the v2.11.x deprecation window — supply the recovery-point SHA there.
 mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: {
   type: "merge.executed",
   data: {
@@ -95,11 +103,14 @@ mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: 
     targetBranch: "<target>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    rollbackSha: "<recovery-point-sha-from-prior-event>",
   },
 }});
 
 // Then update workflow state to reflect the terminal phase.
+// The mergeOrchestrator STATE field is `recoveryPointSha` (renamed from
+// `rollbackSha` in #1306 — the state file follows the canonical recovery frame
+// even while the legacy event wire field above does not yet).
 mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
   updates: { mergeOrchestrator: {
     phase: "completed",
@@ -107,7 +118,7 @@ mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
     taskId: "<task-id>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    recoveryPointSha: "<recovery-point-sha-from-prior-event>",
   } } });
 ```
 

--- a/skills/opencode/merge-orchestrator/SKILL.md
+++ b/skills/opencode/merge-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12,7 +12,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (`git merge --abort` → `git reset --keep`, never `--hard`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
@@ -22,9 +22,9 @@ This skill activates whenever an operator (or an automated `next_actions` dispat
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+3. Records pre-merge `HEAD` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local `git merge` of the source branch into the target branch.
-5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
@@ -51,7 +51,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | `merge`  | `git merge --no-ff --no-edit <source>` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | `squash` | `git merge --squash <source>` then `git commit` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| `rebase` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -84,7 +84,7 @@ exarchos merge-orchestrate \
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -94,7 +94,7 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 |---------|---------|-----------------|
 | `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`) ran. The target branch is rewound to the recovery point. (The phase value stays `rolled-back` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect `data.reason`. If `data.recoveryError` / `data.recoveryErrorDetail` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -105,24 +105,27 @@ When `phase === 'aborted'`, the data payload discriminates the cause:
 | `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
-| `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.rollback`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | `rollbackSha`, `reason`, `taskId`, source/target branches |
+| `merge.recovered` | On post-merge failure followed by recovery — the canonical **successor** to `merge.rollback` (#1306); dual-emitted alongside it during the deprecation window | `recoveryPointSha`, `reason`, `recoveryError?`, `recoveryErrorDetail?`, `taskId`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (`merge.recovered`). `merge.recovered` is the additive successor to `merge.rollback`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy `merge.rollback` / `merge.executed` events keep their `rollbackSha` / `rollbackError` wire fields until v2.12 removes the legacy emission; `merge.recovered` carries the resolved `recoveryPointSha` / `recoveryErrorDetail` names alongside the unchanged INV-14 `recoveryError` discriminator. The phase value `'rolled-back'` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 
@@ -134,8 +137,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
-| **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Recovery** | INV-14 recovery ladder: `git merge --abort` → `git reset --keep <recoveryPointSha>` (real, rewinds the merge; never `--hard`) | None — the VCS provider owns merge state |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` (legacy) / `merge.recovered` (successor) | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,9 +159,9 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` / `merge.recovered` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.recoveryErrorDetail` (with the `data.recoveryError` discriminator); address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -192,7 +195,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })`.
 
 `mergeOrchestrator.*` fields on workflow state are written by this skill and `mergeOrchestrator.phase` is read by gates; the underlying `phase` workflow field is immutable and must be changed via `transition`, not `update`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the `workflow-state` skill for the full immutable-key list and the typed `RESERVED_FIELD` error envelope.
 
@@ -200,7 +203,7 @@ For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "de
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
-- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
+- [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/opencode/merge-orchestrator/references/local-git-semantics.md
+++ b/skills/opencode/merge-orchestrator/references/local-git-semantics.md
@@ -1,15 +1,17 @@
 # Local-Git Semantics
 
-This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the rollback contract.
+This reference explains why `merge_orchestrate` performs a local `git merge` rather than calling the VCS provider — and why that distinction matters for the recovery contract.
+
+> **Recovery vocabulary (#1306).** The orchestrator's failure handling is modeled as a database transaction, not a saga: it records a **recovery point** (the integration branch's pre-merge HEAD) and, on failure, runs the INV-14 **recovery ladder** (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) to rewind to that point. "Recovery point" and "recovery" replace the older "rollback anchor" / "rollback" / "compensation" framing throughout. The legacy `merge.rollback` event name and its `rollbackSha` wire field are retained during the v2.11.x deprecation window; the canonical successor event is `merge.recovered`.
 
 ## The model
 
 `merge_orchestrate` is the SDLC handoff for landing a subagent's worktree branch onto the integration branch in the **main worktree**. Every operation in the orchestrator is a local-git operation:
 
 - **Preflight** — `git status --porcelain`, `git diff --cached --quiet`, `git rev-parse --abbrev-ref HEAD`, `git merge-base --is-ancestor`, `git rev-parse --git-dir`. All run against local refs.
-- **Rollback anchor** — `git rev-parse HEAD` captures the integration branch's tip before the merge.
+- **Recovery point** — `git rev-parse HEAD` captures the integration branch's tip before the merge, persisted as a write-ahead-log marker before any ref mutation.
 - **Merge** — `git merge --no-ff` / `--squash` / rebase + ff-only against local branches, in the main worktree's working directory.
-- **Rollback execution** — `git reset --hard <rollbackSha>` restores the integration branch's tip if the merge or post-merge verification fails.
+- **Recovery execution** — the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) rewinds the integration branch's tip to the recovery point if the merge or post-merge verification fails.
 
 The integration branch may eventually be pushed to a remote and merged into `main` via a PR — that is a separate concern handled by `merge_pr` in the synthesize phase, when the full feature is ready for human review.
 
@@ -20,13 +22,13 @@ An earlier implementation of this orchestrator routed the merge through `provide
 | What runs locally | What runs remotely |
 |-------------------|--------------------|
 | Preflight (drift, ancestry, branch protection, worktree assertion) | (nothing) |
-| Rollback anchor `git rev-parse HEAD` | (nothing) |
-| Rollback `git reset --hard` | (nothing) |
+| Recovery point `git rev-parse HEAD` | (nothing) |
+| Recovery `git reset --keep` | (nothing) |
 | ❌ Merge | ✅ Merge (server-side via VCS API) |
 
-A server-side merge does not move local `HEAD`. So the recorded `rollbackSha` corresponded to a local ref the merge never touched, and `git reset --hard <rollbackSha>` was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
+A server-side merge does not move local `HEAD`. So the recorded recovery point corresponded to a local ref the merge never touched, and the reset back to it was a **no-op** in production. Worse, a server-side merge that succeeded with a post-merge verification failure left a local/remote divergence with no automatic recovery.
 
-The fix was structural: align the merge primitive with the rollback primitive. Both are now local-git, and the rollback is a real undo operation.
+The fix was structural: align the merge primitive with the recovery primitive. Both are now local-git, and the recovery is a real undo operation that rewinds the integration branch to the recorded recovery point.
 
 ## Why the integration branch and not main?
 
@@ -50,14 +52,16 @@ The preflight composer separately asserts main-worktree (`git rev-parse --git-di
 
 `rebase` rewrites the source branch's history. For ephemeral subagent branches (created by `delegate`, deleted after merge), this is fine — the branch has no consumers other than the orchestrator. Don't pick `rebase` for source branches that are pushed and shared.
 
-## What the rollback actually undoes
+## What the recovery actually undoes
 
-`git reset --hard <rollbackSha>` on the integration branch restores `HEAD` to the recorded SHA. This **does** undo:
+The recovery ladder — `git merge --abort` (the operation's own recovery primitive, best-effort) followed by `git reset --keep <recoveryPointSha>` (a refuse-to-discard substrate undo, never `--hard`) — restores the integration branch's `HEAD` to the recorded recovery point. This **does** undo:
 
 - A merge commit created by `--no-ff`
 - A squash commit created by `--squash` + `git commit`
 - A fast-forward advance from a `rebase` strategy (target moves back to its pre-rebase tip)
 
-The reset **does not** undo:
+`--keep` refuses to clobber uncommitted local changes (where `--hard` would silently destroy them); the executor surfaces an indeterminate outcome (`recoveryError` + `recoveryErrorDetail`) rather than masking a stranded worktree as a clean recovery.
+
+The recovery **does not** undo:
 
 - The source branch's history rewrite from a `rebase` strategy. The source branch keeps the rebased commits; only the integration branch's reference returns to its prior state. This is acceptable in the SDLC model because the source branch is ephemeral — it gets deleted after the merge cycle either way. If you need to inspect the original source commits, the reflog still has them until expiry.

--- a/skills/opencode/merge-orchestrator/references/recovery-runbook.md
+++ b/skills/opencode/merge-orchestrator/references/recovery-runbook.md
@@ -35,9 +35,11 @@ Inspect each guard field in order (the orchestrator evaluates them in this prece
 
 After resolving the underlying condition, re-invoke `merge_orchestrate` with the same arguments. The fresh dispatch re-runs preflight; if all guards now pass, the executor proceeds.
 
-## `phase: 'rolled-back'` — merge attempted, reverted
+## `phase: 'rolled-back'` — merge attempted, recovered
 
-The executor recorded the rollback SHA, attempted the merge, the merge or post-merge verification failed, and `git reset --hard <rollbackSha>` ran. The integration branch is restored to its pre-merge state.
+> The phase value is still `rolled-back` — a load-bearing state token intentionally unchanged by the #1306 recovery reframe. The *behavior* it describes is recovery to the recorded recovery point.
+
+The executor recorded the recovery point, attempted the merge, the merge or post-merge verification failed, and the INV-14 recovery ladder (`git merge --abort` → `git reset --keep <recoveryPointSha>`, never `--hard`) ran. The integration branch is rewound to its pre-merge state.
 
 ### Diagnose
 
@@ -49,28 +51,32 @@ Check `data.reason`:
 | `verification-failed` | Post-merge verification step rejected the merge | Custom verification adapter detected a problem (rare in default config) |
 | `timeout` | Underlying operation exceeded the 120s timeout | Repo size, slow disk, lock contention |
 
-### Then check `data.rollbackError`
+### Then check `data.recoveryError` / `data.recoveryErrorDetail`
 
-If present, the reset itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded `rollbackSha`. This is a critical condition requiring manual intervention:
+If present, the recovery itself failed and **the working tree is stranded**. The integration branch may not be back at the recorded recovery point. `data.recoveryError` is the INV-14 discriminator (`reset-keep-blocked` / `reset-failed` / `unexpected-mid-merge-drift`) and `data.recoveryErrorDetail` is the human-readable detail. This is a critical condition requiring manual intervention:
 
 ```bash
 # Verify current state
 git status
 git log --oneline -5
 
-# If the integration branch is in an unexpected state:
+# If the integration branch is in an unexpected state, rewind it to the
+# recovery point. Prefer --keep (refuse-to-discard); use --hard only if you
+# have already confirmed there is no uncommitted work you need to preserve.
 git checkout <integration-branch>
-git reset --hard <rollbackSha-from-the-event-log>
+git reset --keep <recoveryPointSha-from-the-event-log>
 
-# Where <rollbackSha-from-the-event-log> can be retrieved from the most recent
-# merge.executed (completed run) or merge.rollback (rolled-back run) event:
-exarchos_event query stream=<featureId> filter='{"type":"merge.rollback"}'
-# fall back to merge.executed if no rollback was emitted.
-# (merge.preflight does NOT carry rollbackSha — it runs before the rollback
-# anchor is captured.)
+# Where <recoveryPointSha-from-the-event-log> can be retrieved from the most
+# recent recovery event. Prefer the canonical merge.recovered (#1306), which
+# carries recoveryPointSha; fall back to the legacy merge.rollback, whose
+# rollbackSha wire field holds the same value during the deprecation window:
+exarchos_event query stream=<featureId> filter='{"type":"merge.recovered"}'
+# fall back to merge.rollback, then merge.executed, if no recovery event exists.
+# (merge.preflight does NOT carry the recovery point — it runs before the
+# recovery point is captured.)
 ```
 
-If `rollbackError` is absent, the reset succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
+If neither `recoveryError` nor `recoveryErrorDetail` is present, the recovery succeeded and the working tree is back to the recorded state — proceed to the conflict-resolution flow below.
 
 ### Resolve a `merge-failed` outcome
 
@@ -87,6 +93,8 @@ For merge conflicts (most common cause of `merge-failed`):
 // Event first — the repository treats event append as the commit point.
 // Use the same `strategy` the original dispatch was invoked with so the
 // projected state matches what the auto-emit path would have produced.
+// NOTE: the merge.executed EVENT keeps the legacy `rollbackSha` wire field
+// during the v2.11.x deprecation window — supply the recovery-point SHA there.
 mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: {
   type: "merge.executed",
   data: {
@@ -95,11 +103,14 @@ mcp__exarchos__exarchos_event({ action: "append", stream: "<featureId>", event: 
     targetBranch: "<target>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    rollbackSha: "<recovery-point-sha-from-prior-event>",
   },
 }});
 
 // Then update workflow state to reflect the terminal phase.
+// The mergeOrchestrator STATE field is `recoveryPointSha` (renamed from
+// `rollbackSha` in #1306 — the state file follows the canonical recovery frame
+// even while the legacy event wire field above does not yet).
 mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
   updates: { mergeOrchestrator: {
     phase: "completed",
@@ -107,7 +118,7 @@ mcp__exarchos__exarchos_workflow({ action: "update", featureId: "<featureId>",
     taskId: "<task-id>",
     strategy: "<squash|merge|rebase>",
     mergeSha: "<the-manual-merge-commit-sha>",
-    rollbackSha: "<rollbackSha-from-prior-event>",
+    recoveryPointSha: "<recovery-point-sha-from-prior-event>",
   } } });
 ```
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -2241,10 +2241,10 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: claude > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/claude/merge-orchestrator/SKILL.md > skills/claude/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -2253,7 +2253,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep\`, never \`--hard\`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
@@ -2263,9 +2263,9 @@ This skill activates whenever an operator (or an automated \`next_actions\` disp
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+3. Records pre-merge \`HEAD\` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local \`git merge\` of the source branch into the target branch.
-5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`, never \`--hard\`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
@@ -2292,7 +2292,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | \`merge\`  | \`git merge --no-ff --no-edit <source>\` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | \`squash\` | \`git merge --squash <source>\` then \`git commit\` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -2325,7 +2325,7 @@ exarchos merge-orchestrate \\
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -2335,7 +2335,7 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 |---------|---------|-----------------|
 | \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`) ran. The target branch is rewound to the recovery point. (The phase value stays \`rolled-back\` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect \`data.reason\`. If \`data.recoveryError\` / \`data.recoveryErrorDetail\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -2346,24 +2346,27 @@ When \`phase === 'aborted'\`, the data payload discriminates the cause:
 | \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
-| \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.rollback\`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.recovered\` | On post-merge failure followed by recovery — the canonical **successor** to \`merge.rollback\` (#1306); dual-emitted alongside it during the deprecation window | \`recoveryPointSha\`, \`reason\`, \`recoveryError?\`, \`recoveryErrorDetail?\`, \`taskId\`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (\`merge.recovered\`). \`merge.recovered\` is the additive successor to \`merge.rollback\`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy \`merge.rollback\` / \`merge.executed\` events keep their \`rollbackSha\` / \`rollbackError\` wire fields until v2.12 removes the legacy emission; \`merge.recovered\` carries the resolved \`recoveryPointSha\` / \`recoveryErrorDetail\` names alongside the unchanged INV-14 \`recoveryError\` discriminator. The phase value \`'rolled-back'\` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__plugin_exarchos_exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -2375,8 +2378,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
-| **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Recovery** | INV-14 recovery ladder: \`git merge --abort\` → \`git reset --keep <recoveryPointSha>\` (real, rewinds the merge; never \`--hard\`) | None — the VCS provider owns merge state |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` (legacy) / \`merge.recovered\` (successor) | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -2397,9 +2400,9 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` / \`merge.recovered\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.recoveryErrorDetail\` (with the \`data.recoveryError\` discriminator); address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -2433,7 +2436,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 \`mergeOrchestrator.*\` fields on workflow state are written by this skill and \`mergeOrchestrator.phase\` is read by gates; the underlying \`phase\` workflow field is immutable and must be changed via \`transition\`, not \`update\`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the \`workflow-state\` skill for the full immutable-key list and the typed \`RESERVED_FIELD\` error envelope.
 
@@ -2441,7 +2444,7 @@ For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestr
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
-- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
+- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
@@ -7331,10 +7334,10 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: codex > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/codex/merge-orchestrator/SKILL.md > skills/codex/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -7343,7 +7346,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep\`, never \`--hard\`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
@@ -7353,9 +7356,9 @@ This skill activates whenever an operator (or an automated \`next_actions\` disp
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+3. Records pre-merge \`HEAD\` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local \`git merge\` of the source branch into the target branch.
-5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`, never \`--hard\`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
@@ -7382,7 +7385,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | \`merge\`  | \`git merge --no-ff --no-edit <source>\` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | \`squash\` | \`git merge --squash <source>\` then \`git commit\` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -7415,7 +7418,7 @@ exarchos merge-orchestrate \\
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -7425,7 +7428,7 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 |---------|---------|-----------------|
 | \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`) ran. The target branch is rewound to the recovery point. (The phase value stays \`rolled-back\` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect \`data.reason\`. If \`data.recoveryError\` / \`data.recoveryErrorDetail\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -7436,24 +7439,27 @@ When \`phase === 'aborted'\`, the data payload discriminates the cause:
 | \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
-| \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.rollback\`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.recovered\` | On post-merge failure followed by recovery — the canonical **successor** to \`merge.rollback\` (#1306); dual-emitted alongside it during the deprecation window | \`recoveryPointSha\`, \`reason\`, \`recoveryError?\`, \`recoveryErrorDetail?\`, \`taskId\`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (\`merge.recovered\`). \`merge.recovered\` is the additive successor to \`merge.rollback\`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy \`merge.rollback\` / \`merge.executed\` events keep their \`rollbackSha\` / \`rollbackError\` wire fields until v2.12 removes the legacy emission; \`merge.recovered\` carries the resolved \`recoveryPointSha\` / \`recoveryErrorDetail\` names alongside the unchanged INV-14 \`recoveryError\` discriminator. The phase value \`'rolled-back'\` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -7465,8 +7471,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
-| **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Recovery** | INV-14 recovery ladder: \`git merge --abort\` → \`git reset --keep <recoveryPointSha>\` (real, rewinds the merge; never \`--hard\`) | None — the VCS provider owns merge state |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` (legacy) / \`merge.recovered\` (successor) | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -7487,9 +7493,9 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` / \`merge.recovered\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.recoveryErrorDetail\` (with the \`data.recoveryError\` discriminator); address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -7523,7 +7529,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 \`mergeOrchestrator.*\` fields on workflow state are written by this skill and \`mergeOrchestrator.phase\` is read by gates; the underlying \`phase\` workflow field is immutable and must be changed via \`transition\`, not \`update\`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the \`workflow-state\` skill for the full immutable-key list and the typed \`RESERVED_FIELD\` error envelope.
 
@@ -7531,7 +7537,7 @@ For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "d
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
-- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
+- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
@@ -12413,10 +12419,10 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: copilot > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/copilot/merge-orchestrator/SKILL.md > skills/copilot/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -12425,7 +12431,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep\`, never \`--hard\`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
@@ -12435,9 +12441,9 @@ This skill activates whenever an operator (or an automated \`next_actions\` disp
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+3. Records pre-merge \`HEAD\` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local \`git merge\` of the source branch into the target branch.
-5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`, never \`--hard\`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
@@ -12464,7 +12470,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | \`merge\`  | \`git merge --no-ff --no-edit <source>\` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | \`squash\` | \`git merge --squash <source>\` then \`git commit\` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -12497,7 +12503,7 @@ exarchos merge-orchestrate \\
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -12507,7 +12513,7 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 |---------|---------|-----------------|
 | \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`) ran. The target branch is rewound to the recovery point. (The phase value stays \`rolled-back\` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect \`data.reason\`. If \`data.recoveryError\` / \`data.recoveryErrorDetail\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -12518,24 +12524,27 @@ When \`phase === 'aborted'\`, the data payload discriminates the cause:
 | \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
-| \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.rollback\`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.recovered\` | On post-merge failure followed by recovery — the canonical **successor** to \`merge.rollback\` (#1306); dual-emitted alongside it during the deprecation window | \`recoveryPointSha\`, \`reason\`, \`recoveryError?\`, \`recoveryErrorDetail?\`, \`taskId\`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (\`merge.recovered\`). \`merge.recovered\` is the additive successor to \`merge.rollback\`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy \`merge.rollback\` / \`merge.executed\` events keep their \`rollbackSha\` / \`rollbackError\` wire fields until v2.12 removes the legacy emission; \`merge.recovered\` carries the resolved \`recoveryPointSha\` / \`recoveryErrorDetail\` names alongside the unchanged INV-14 \`recoveryError\` discriminator. The phase value \`'rolled-back'\` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -12547,8 +12556,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
-| **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Recovery** | INV-14 recovery ladder: \`git merge --abort\` → \`git reset --keep <recoveryPointSha>\` (real, rewinds the merge; never \`--hard\`) | None — the VCS provider owns merge state |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` (legacy) / \`merge.recovered\` (successor) | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -12569,9 +12578,9 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` / \`merge.recovered\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.recoveryErrorDetail\` (with the \`data.recoveryError\` discriminator); address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -12605,7 +12614,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 \`mergeOrchestrator.*\` fields on workflow state are written by this skill and \`mergeOrchestrator.phase\` is read by gates; the underlying \`phase\` workflow field is immutable and must be changed via \`transition\`, not \`update\`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the \`workflow-state\` skill for the full immutable-key list and the typed \`RESERVED_FIELD\` error envelope.
 
@@ -12613,7 +12622,7 @@ For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "d
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
-- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
+- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
@@ -17505,10 +17514,10 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: cursor > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/cursor/merge-orchestrator/SKILL.md > skills/cursor/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -17517,7 +17526,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep\`, never \`--hard\`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
@@ -17527,9 +17536,9 @@ This skill activates whenever an operator (or an automated \`next_actions\` disp
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+3. Records pre-merge \`HEAD\` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local \`git merge\` of the source branch into the target branch.
-5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`, never \`--hard\`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
@@ -17556,7 +17565,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | \`merge\`  | \`git merge --no-ff --no-edit <source>\` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | \`squash\` | \`git merge --squash <source>\` then \`git commit\` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -17589,7 +17598,7 @@ exarchos merge-orchestrate \\
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -17599,7 +17608,7 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 |---------|---------|-----------------|
 | \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`) ran. The target branch is rewound to the recovery point. (The phase value stays \`rolled-back\` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect \`data.reason\`. If \`data.recoveryError\` / \`data.recoveryErrorDetail\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -17610,24 +17619,27 @@ When \`phase === 'aborted'\`, the data payload discriminates the cause:
 | \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
-| \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.rollback\`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.recovered\` | On post-merge failure followed by recovery — the canonical **successor** to \`merge.rollback\` (#1306); dual-emitted alongside it during the deprecation window | \`recoveryPointSha\`, \`reason\`, \`recoveryError?\`, \`recoveryErrorDetail?\`, \`taskId\`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (\`merge.recovered\`). \`merge.recovered\` is the additive successor to \`merge.rollback\`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy \`merge.rollback\` / \`merge.executed\` events keep their \`rollbackSha\` / \`rollbackError\` wire fields until v2.12 removes the legacy emission; \`merge.recovered\` carries the resolved \`recoveryPointSha\` / \`recoveryErrorDetail\` names alongside the unchanged INV-14 \`recoveryError\` discriminator. The phase value \`'rolled-back'\` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -17639,8 +17651,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
-| **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Recovery** | INV-14 recovery ladder: \`git merge --abort\` → \`git reset --keep <recoveryPointSha>\` (real, rewinds the merge; never \`--hard\`) | None — the VCS provider owns merge state |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` (legacy) / \`merge.recovered\` (successor) | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -17661,9 +17673,9 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` / \`merge.recovered\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.recoveryErrorDetail\` (with the \`data.recoveryError\` discriminator); address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -17697,7 +17709,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 \`mergeOrchestrator.*\` fields on workflow state are written by this skill and \`mergeOrchestrator.phase\` is read by gates; the underlying \`phase\` workflow field is immutable and must be changed via \`transition\`, not \`update\`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the \`workflow-state\` skill for the full immutable-key list and the typed \`RESERVED_FIELD\` error envelope.
 
@@ -17705,7 +17717,7 @@ For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "d
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
-- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
+- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
@@ -22568,10 +22580,10 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: generic > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/generic/merge-orchestrator/SKILL.md > skills/generic/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -22580,7 +22592,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep\`, never \`--hard\`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
@@ -22590,9 +22602,9 @@ This skill activates whenever an operator (or an automated \`next_actions\` disp
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+3. Records pre-merge \`HEAD\` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local \`git merge\` of the source branch into the target branch.
-5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`, never \`--hard\`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
@@ -22619,7 +22631,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | \`merge\`  | \`git merge --no-ff --no-edit <source>\` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | \`squash\` | \`git merge --squash <source>\` then \`git commit\` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -22652,7 +22664,7 @@ exarchos merge-orchestrate \\
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -22662,7 +22674,7 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 |---------|---------|-----------------|
 | \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`) ran. The target branch is rewound to the recovery point. (The phase value stays \`rolled-back\` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect \`data.reason\`. If \`data.recoveryError\` / \`data.recoveryErrorDetail\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -22673,24 +22685,27 @@ When \`phase === 'aborted'\`, the data payload discriminates the cause:
 | \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
-| \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.rollback\`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.recovered\` | On post-merge failure followed by recovery — the canonical **successor** to \`merge.rollback\` (#1306); dual-emitted alongside it during the deprecation window | \`recoveryPointSha\`, \`reason\`, \`recoveryError?\`, \`recoveryErrorDetail?\`, \`taskId\`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (\`merge.recovered\`). \`merge.recovered\` is the additive successor to \`merge.rollback\`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy \`merge.rollback\` / \`merge.executed\` events keep their \`rollbackSha\` / \`rollbackError\` wire fields until v2.12 removes the legacy emission; \`merge.recovered\` carries the resolved \`recoveryPointSha\` / \`recoveryErrorDetail\` names alongside the unchanged INV-14 \`recoveryError\` discriminator. The phase value \`'rolled-back'\` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -22702,8 +22717,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
-| **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Recovery** | INV-14 recovery ladder: \`git merge --abort\` → \`git reset --keep <recoveryPointSha>\` (real, rewinds the merge; never \`--hard\`) | None — the VCS provider owns merge state |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` (legacy) / \`merge.recovered\` (successor) | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -22724,9 +22739,9 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` / \`merge.recovered\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.recoveryErrorDetail\` (with the \`data.recoveryError\` discriminator); address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -22760,7 +22775,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 \`mergeOrchestrator.*\` fields on workflow state are written by this skill and \`mergeOrchestrator.phase\` is read by gates; the underlying \`phase\` workflow field is immutable and must be changed via \`transition\`, not \`update\`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the \`workflow-state\` skill for the full immutable-key list and the typed \`RESERVED_FIELD\` error envelope.
 
@@ -22768,7 +22783,7 @@ For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "d
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
-- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
+- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
@@ -27658,10 +27673,10 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: opencode > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/opencode/merge-orchestrator/SKILL.md > skills/opencode/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded recovery point. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.1.0
+  version: 1.2.0
   mcp-server: exarchos
   category: behavior
 ---
@@ -27670,7 +27685,7 @@ metadata:
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a **recovery point** SHA so the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep\`, never \`--hard\`) can rewind the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
@@ -27680,9 +27695,9 @@ This skill activates whenever an operator (or an automated \`next_actions\` disp
 
 1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
 2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+3. Records pre-merge \`HEAD\` of the target branch as a recovery point (a write-ahead-log marker, persisted before any ref mutation).
 4. Performs a local \`git merge\` of the source branch into the target branch.
-5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+5. On any failure, runs the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`, never \`--hard\`) and surfaces a categorized failure reason.
 6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
@@ -27709,7 +27724,7 @@ Do **not** activate this skill:
 |----------|---------------------|----------------|
 | \`merge\`  | \`git merge --no-ff --no-edit <source>\` — explicit merge commit | Preserves the subagent's commit history with a visible merge boundary. |
 | \`squash\` | \`git merge --squash <source>\` then \`git commit\` — single squash commit on target | Subagent commit history is noise; one logical change should land as one commit. |
-| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor rollback only needs to reset target. |
+| \`rebase\` | rebases an ephemeral copy of source onto target then ff-merges target — linear history | No merge commit; integration branch stays linear. The original source ref is preserved (the rebase runs on a temporary branch that is deleted afterward), so an executor recovery only needs to rewind target to the recovery point. |
 
 Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-visible parity). There is no implicit default — operator intent is always explicit in the event log.
 
@@ -27742,7 +27757,7 @@ exarchos merge-orchestrate \\
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
-CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or rollback executed), 3 = uncaught exception.
+CLI exit codes: 0 = success, 1 = invalid input, 2 = merge failed (preflight blocked or recovery executed), 3 = uncaught exception.
 
 ### Step 3: Interpret the result
 
@@ -27752,7 +27767,7 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 |---------|---------|-----------------|
 | \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
 | \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and the INV-14 recovery ladder (\`git merge --abort\` → \`git reset --keep <recoveryPointSha>\`) ran. The target branch is rewound to the recovery point. (The phase value stays \`rolled-back\` — a load-bearing state token unchanged by the #1306 recovery reframe.) | Inspect \`data.reason\`. If \`data.recoveryError\` / \`data.recoveryErrorDetail\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
 
 #### Abort-reason payload shapes
 
@@ -27763,24 +27778,27 @@ When \`phase === 'aborted'\`, the data payload discriminates the cause:
 | \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
 | *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
 
-The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct recovery point (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
-| \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.rollback\`  | On post-merge failure followed by recovery — **legacy** wire shape, kept during the v2.11.x deprecation window | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
+| \`merge.recovered\` | On post-merge failure followed by recovery — the canonical **successor** to \`merge.rollback\` (#1306); dual-emitted alongside it during the deprecation window | \`recoveryPointSha\`, \`reason\`, \`recoveryError?\`, \`recoveryErrorDetail?\`, \`taskId\`, source/target branches |
+
+> **Recovery vocabulary (#1306).** The canonical frame is database-transaction, not saga: a **recovery point** (the recorded HEAD SHA, persisted before the merge as a write-ahead-log marker) and a **recovery event** (\`merge.recovered\`). \`merge.recovered\` is the additive successor to \`merge.rollback\`; during the v2.11.x deprecation window the executor **dual-emits** both for the same logical recovery. The legacy \`merge.rollback\` / \`merge.executed\` events keep their \`rollbackSha\` / \`rollbackError\` wire fields until v2.12 removes the legacy emission; \`merge.recovered\` carries the resolved \`recoveryPointSha\` / \`recoveryErrorDetail\` names alongside the unchanged INV-14 \`recoveryError\` discriminator. The phase value \`'rolled-back'\` is intentionally retained.
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -27792,8 +27810,8 @@ Two related actions, two distinct concerns:
 | **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
-| **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Recovery** | INV-14 recovery ladder: \`git merge --abort\` → \`git reset --keep <recoveryPointSha>\` (real, rewinds the merge; never \`--hard\`) | None — the VCS provider owns merge state |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` (legacy) / \`merge.recovered\` (successor) | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -27814,9 +27832,9 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` / \`merge.recovered\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
-| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.recoveryErrorDetail\` (with the \`data.recoveryError\` discriminator); address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
@@ -27850,7 +27868,7 @@ Fail-closed: any individual git invocation that fails inside the debug helper de
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback", "merge.recovered"] })\`.
 
 \`mergeOrchestrator.*\` fields on workflow state are written by this skill and \`mergeOrchestrator.phase\` is read by gates; the underlying \`phase\` workflow field is immutable and must be changed via \`transition\`, not \`update\`. See the [Reserved fields](../workflow-state/SKILL.md#reserved-fields) section in the \`workflow-state\` skill for the full immutable-key list and the typed \`RESERVED_FIELD\` error envelope.
 
@@ -27858,7 +27876,7 @@ For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "d
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
 - [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
-- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
+- [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\` (the legacy wire field for the recovery point, retained during the v2.11.x deprecation window)
 - [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.


### PR DESCRIPTION
## Summary

v2.11.0 **preview.3 — Merge-Orchestrator Hardening** (epic #1302). Hardens the autonomous merge orchestrator across recovery semantics, capability posture, observability, and tool guidance. Closes #1305, #1306, #1308, #1309, #1310, #1311; epic #1302 closes modulo #1402 (data-blocked on a Windows preflight dump).

12 planned tasks delivered via 3 parallel TDD dispatch waves, plus 3 orchestrator fix-commits. Full suite green throughout; two-stage review passed with **0 blocking findings**.

## Changes

**#1311 — shared git exec:** extracted `defaultGitExec` into `orchestrate/git-exec-default.ts`; replaced byte-identical definitions (definition-vs-consumer pass).

**#1306 — recovery vocabulary + dual-emit:**
- Renamed `RollbackReason→RecoveryReason`, `rollbackSha→recoveryPointSha`, `rollbackError→recoveryError` (state/`data` surfaces; legacy `merge.rollback` **event-wire** fields retained for the deprecation window).
- Registered `merge.recovered`; recovery path **dual-emits** `merge.recovered` + legacy `merge.rollback` with `_meta.deprecation = {since:"2.11.0",removeIn:"2.12.0",replacement:"merge.recovered"}`.
- **CAS-safe:** independent idempotency keys per event type, each append reads the live tail fresh — the new append is never re-pinned to the legacy append's returned sequence (verified by a real-SQLite retry test).
- HSM `mergePendingExit` accepts both terminal events; docs/skills reframed saga→database-transaction (recovery point / WAL); v2.12 removal tracked in #1570.

**#1308 — bounded timeout retry:** registered `merge.retry_attempt`; retry **only** on `'timeout'` (max 2 retries / 3 total), exp backoff 1000ms ×2.0 ±25% jitter via an **injectable** jitter+sleep seam (determinism-safe); exhaustion → recovery `reason:'timeout'`; non-transient (`merge-failed`/`verification-failed`) → immediate recovery, no retry.

**#1309 — liveness:** registered + emit `merge.executing_started` after the recovery point is recorded, before the first `vcsMerge` (once-latch, best-effort CAS); timeline `executing_started → retry_attempt* → terminal` asserted.

**#1305 — capability posture:** `posture:'shared-mutating'` on `merge_orchestrate`; read-only caller rejected at the resolver gate **before** the handler (INV-11); merge transitions emit `workflow.transition`, never `set({phase})`.

**#1310 — tool guidance:** `merge_orchestrate` description gains Use-for / Do-NOT-use-for negative space pointing to `merge_pr` / `verify_worktree` / `request_synthesize`.

**Orchestrator fixes (integration-level):** realigned 3 stale `merge_orchestrate` data/state assertions to `recoveryPointSha` (T2 broad-blast-radius fallout); bumped a parallel `EventTypes` registry pin; added an explicit `verification-failed` no-retry test.

## Test Plan

- **MCP suite: 7904 passed / 0 failed** (21 skipped); **root suite: 856 passed / 0 failed**; `tsc --noEmit` clean (root + MCP); `npm run skills:guard` in sync.
- New tests cover every issue: dual-emit + CAS idempotency (real-SQLite end-to-end), retry once/exhausted/non-transient, executing_started timeline ordering, posture resolution, read-only-rejection (handler-spy never-called), transition-exclusivity source scan, description guidance.
- Two-stage review: **spec-compliant** + **approve-with-nits**, 0 blocking. Load-bearing logic (CAS, retry, once-latch, resolver gate) independently confirmed correct.

### Follow-ups (non-blocking review nits)
- `merge_orchestrate.autoEmits` should list the 3 new events (touches a pinned runbook contract — separate change).
- Description still says "compensating recovery" (INV-15 vocabulary).
- T17 token-capture proof: hook ships via plugin but live attribution needs `team.teammate.dispatched` with the real worktree path — incompatible with Agent-tool native isolation; gap logged (#1561/#1525).
- T18 Windows ancestry RCA (#1402) remains data-blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
