### PR TITLE
feat(#1592): ship-gate methodology — REVIEW→SYNTHESIZE phase-kind grounding (DR-1..DR-7)

### DIFF
--- a/commands/shepherd.md
+++ b/commands/shepherd.md
@@ -80,9 +80,11 @@ Address each `actionItem` from the assessment (every inline comment — includin
 ### Step 3: Resubmit
 
 ```bash
-git push --force-with-lease
+git push --force-with-lease=<ref>:<expected-sha>
 gh pr merge <number> --auto --squash
 ```
+
+Always use the **explicit-SHA** lease — never a bare `--force-with-lease`. A bare lease anchors to the (possibly stale) local remote-tracking ref and can silently clobber a concurrent push. `<expected-sha>` is the SHA the loop last observed at the remote (from `assess_stack`); if unavailable, read it fresh with `git ls-remote --heads origin <ref>`.
 
 Return to Step 1. Max 5 iterations — escalate if limit reached.
 

--- a/commands/synthesize.md
+++ b/commands/synthesize.md
@@ -74,10 +74,11 @@ You can make direct edits to stack branches at any time:
 
 ## Idempotency
 
-Before synthesizing, check synthesis status:
-1. Check if `synthesis.prUrl` exists in state
-2. If PR exists and is open, skip to merge confirmation
-3. If PR merged, transition phase to "completed" via `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "transition"`, `target: "completed"` (the runtime rejects `updates.phase`; the canonical `transition` action runs the HSM guard and emits `workflow.transition`). Note: the post-merge `completed` transition is normally owned by `/exarchos:cleanup` via `action: "cleanup"`; this idempotency branch is a manual-cleanup escape hatch.
+`create_pr` is the **single authority** for "PR already exists" — do NOT pre-check `synthesis.prUrl`/`artifacts.pr` before deciding whether to create. Just call `create_pr`: it either returns the existing open PR for this (head, base) via its remote-recovery guard, or refuses with `PR_ALREADY_OWNED` when the workflow already owns a PR. Branch on that structured response instead of pre-checking.
+
+The post-merge cleanup case is distinct from create-time idempotency and is NOT governed by `create_pr`:
+
+- If the PR is already **merged**, transition phase to "completed" via `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "transition"`, `target: "completed"` (the runtime rejects `updates.phase`; the canonical `transition` action runs the HSM guard and emits `workflow.transition`). Note: the post-merge `completed` transition is normally owned by `/exarchos:cleanup` via `action: "cleanup"`; this branch is a manual-cleanup escape hatch.
 
 ## Human Checkpoint
 

--- a/commands/synthesize.md
+++ b/commands/synthesize.md
@@ -70,7 +70,7 @@ Tests: X pass | Build: 0 errors
 You can make direct edits to stack branches at any time:
 - Edit files in your IDE
 - Stage and amend: `git add <files> && git commit --amend -m "fix: <description>"`
-- Push the changes: `git push --force-with-lease`
+- Push the changes: `git push --force-with-lease=<ref>:<expected-sha>` — always the **explicit-SHA** form, never a bare `--force-with-lease` (a bare lease anchors to the stale local remote-tracking ref and can clobber a concurrent push). `<expected-sha>` is the remote SHA last observed by the loop via `assess_stack`, or read fresh with `git ls-remote --heads origin <ref>`.
 
 ## Idempotency
 

--- a/docs/designs/2026-06-21-ship-gate-methodology.md
+++ b/docs/designs/2026-06-21-ship-gate-methodology.md
@@ -126,7 +126,7 @@ Synthesize stays the sole PR creator (already true). Close the two residual gaps
 
 **Acceptance criteria:**
 - The shepherd loop has no path to `create_pr` (it can only push/assess); a regression test asserts a shepherd-context `create_pr` is refused, and the existing `create-pr.ts:122-191` double-create guard is retained and unit-pinned.
-- All ship-path pushes use `git push --force-with-lease=<ref>:<expected-sha>` with the SHA the loop last observed at the remote (from `assess_stack`), not a bare lease; a unit test asserts the explicit-SHA form is emitted.
+- All ship-path pushes use `git push --force-with-lease=<ref>:<expected-sha>` with the SHA from a **fresh `git ls-remote` immediately before push** (the tightest TOCTOU window — see Decision Log #5), not the last `assess_stack` observation and not a bare lease; a unit test asserts the explicit-SHA form is emitted.
 - The skill-layer PR idempotency check and the handler-layer guard are reconciled to one authority (remove the redundant second layer noted in grounding) so a single rule governs "PR already exists."
 
 ### DR-5: (Optional) forcing-function trigger — inline pre-push hook, no daemon

--- a/docs/designs/2026-06-21-ship-gate-methodology.md
+++ b/docs/designs/2026-06-21-ship-gate-methodology.md
@@ -157,6 +157,13 @@ Each interim pattern is authored to map onto exactly one Workflow Builder SDK co
 
 **DR-7 SDK mapping.** No new combinator — DR-7 **widens the data contract** the existing shepherd `repeatUntil(s => s.ci.green, …)` loop and the `assess`/`watchCI` step consume. It is a feedback-model enrichment of `Step.handler('watchCI')`/the assess step, not a new step.
 
+**DR-7 implementation grounding (researched 2026-06-22, live GitHub docs).** The harvest aggregates **three REST surfaces**, all `gh api --paginate` (per_page max 100):
+1. `repos/{o}/{r}/issues/{n}/comments` — PR conversation timeline (today's sole source) → `source: 'issue-comment'`.
+2. `repos/{o}/{r}/pulls/{n}/comments` — inline per-line review comments → `source: 'review-inline'`; carry `in_reply_to_id` → `parentId` (threading is **one-level only** — GitHub disallows replies-to-replies, so a flat `parentId` is complete), plus `path`/`line`, `pull_request_review_id`.
+3. `repos/{o}/{r}/pulls/{n}/reviews` — review verdict bodies → `source: 'review-summary'`; carry `body` + `state` (APPROVED | CHANGES_REQUESTED | COMMENTED). (`getReviewStatus` already reads this for *state*; DR-7 also needs the *body*.)
+
+`author` = `user.login` for every surface (bots included — `user.type === 'Bot'`; the existing `review/registry.ts detectKind` already classifies CodeRabbit/Sentry). **Resolved status** is **GraphQL-only** (REST omits it — the `github.ts:126` comment is right about REST): a best-effort `reviewThreads(first:100){ nodes { isResolved isOutdated comments(first:1){ nodes { databaseId } } } }` pass maps `databaseId === REST id` → `resolved`. This enrichment is **fail-soft** (warn + proceed on GraphQL error; map miss ⇒ leave `resolved` absent — *absent ≠ false*, the contract's unknown-is-explicit rule, independently confirmed by the bun/thunderbird harvesters). The `addComment` verify path stays correct: its posted comment is an issue-comment, still present in surface (1) of the superset; matching stays id/marker-based.
+
 ---
 
 ## Roadmap & End-State Migration

--- a/docs/designs/2026-06-21-ship-gate-methodology.md
+++ b/docs/designs/2026-06-21-ship-gate-methodology.md
@@ -145,6 +145,18 @@ Each interim pattern is authored to map onto exactly one Workflow Builder SDK co
 - The interim escalation policy's parameter names/semantics (`maxIterations`, ask-user) match the SDK's `repeatUntil` options and `awaitApproval` shape, so consolidation re-uses values, not re-derives them.
 - A guard (lint/test) flags divergence between the interim escalation defaults and the documented SDK combinator semantics, so the two cannot silently fork before consolidation.
 
+### DR-7: Comprehensive, platform-generic PR-feedback ingestion in `assess_stack`
+*(Added at `/plan`, 2026-06-22 — user requirement.)* The shepherd loop's `assess_stack` must harvest **every** comment on a PR — top-level conversation, inline per-line review comments, and review-summary bodies — from **any** author (human, bot like CodeRabbit/Sentry, or the PR owner), preserving **thread nesting** (replies), so the escalation policy (DR-3) and review consumption decide on the complete feedback set. Today `github.getPrComments` deliberately reads **only** the issues-comments endpoint (`repos/{owner}/{repo}/issues/{id}/comments`) to make the `addComment` post-then-verify round-trip work; inline review comments (`/pulls/{id}/comments`), review summaries (`/pulls/{id}/reviews`), and `in_reply_to_id` threading are invisible, and `getReviewStatus` returns only reviewer *states*, not finding text. The fix is a **contract widening, not a GitHub special-case**: generalize `PrComment` to a platform-neutral, thread-aware shape and have `assess_stack` consume it without overfitting to one provider's quirks (INV-6 workload-agnosticism — no workflow-type branch in the harvest; the provider abstraction owns the platform axis).
+
+**Acceptance criteria:**
+- `PrComment` (in `vcs/provider.ts`) gains a platform-neutral, thread-aware shape: a `source` discriminator (`issue-comment | review-inline | review-summary`), `author` (any party), an optional `parentId`/`threadId` for nesting, an optional `resolved?` (absent ≠ false — unknown is explicit), retaining `path`/`line`. No GitHub field names leak into the contract.
+- `github.getPrComments` aggregates **all three sources** — issues comments + inline review comments + review-summary bodies — paginated (`--paginate`), from every author, with replies linked via `parentId`. The existing `addComment` verify path keeps working (the posted comment is still present in the superset; matching stays id/marker-based, not endpoint-shape-based).
+- `assess_stack` consumes the richer feed generically: unresolved-comment and review-address action items are derived from the unified set regardless of source or author; no provider-name or workflow-type conditional in the harvest loop (INV-6). A bot's inline review comment and a human's threaded reply both surface as action items.
+- `gitlab`/`azure-devops` `getPrComments` conform to the **new signature** (compile against the widened `PrComment`); they keep throwing `UnsupportedOperationError` (status quo for every comment op on those providers) — full harvesting impls are deferred follow-ups, explicitly out of scope here. **The deferral is tracked, not silent:** filing two follow-up issues (GitLab notes/discussions harvesting; Azure DevOps threads-API harvesting), each linked to DR-7/#1592 and carrying the platform-neutral `PrComment` contract as its conformance target, is itself a deliverable of the DR-7 bundle.
+- CLI≡MCP parity + registered `outputSchema` preserved for `get_pr_comments`/`assess_stack` (INV-2); the widened `PrComment` is reflected in any registered shape.
+
+**DR-7 SDK mapping.** No new combinator — DR-7 **widens the data contract** the existing shepherd `repeatUntil(s => s.ci.green, …)` loop and the `assess`/`watchCI` step consume. It is a feedback-model enrichment of `Step.handler('watchCI')`/the assess step, not a new step.
+
 ---
 
 ## Roadmap & End-State Migration
@@ -230,6 +242,28 @@ Sub-issues (one per DR, independently shippable):
 3. **Forcing function default (DR-5):** ship opt-in only (chosen), or also document a "run after synthesize" convention? No auto-install regardless (POLA).
 4. **Escalation bound defaults (DR-3):** adopt `no-mistakes`' per-step `auto_fix` limits verbatim, or keep Exarchos's current shepherd `5` as the uniform default and let config tune per loop? Lean: uniform default + per-loop config override.
 5. **Lease SHA source (DR-4):** the SHA from the loop's last `assess_stack` observation vs a fresh `git ls-remote` immediately before push (tighter TOCTOU window). Lean: fresh `ls-remote` at push time.
+
+---
+
+## Decision Log — `/ideate`, 2026-06-22
+
+Resolved at ideate entry (epic addressed as a unit: #1592 → #1593–#1598). The five "Lean" answers above are **adopted as final**; the open questions are closed:
+
+| # | Decision (CHOSEN) | DR |
+|---|---|---|
+| 1 | Docs ships as a **`synthesis-readiness` leg** (structural "docs changed when surface changed"); a REVIEW *dimension* is deferred until doc *quality* (not coverage) is shown to be the gap. | DR-2 |
+| 2 | Intent is **diff-derived (always-available INV-4 floor) + transcript enrichment when present** — single code path, no per-runtime branch. | DR-1 |
+| 3 | Forcing function is **opt-in only, never auto-installed** (POLA); a "run after synthesize" convention may be documented but installs nothing. | DR-5 |
+| 4 | Escalation uses a **uniform default (Exarchos's shepherd `5`) + per-loop config override**, not `no-mistakes`' per-step limits verbatim. | DR-3 |
+| 5 | Lease SHA comes from a **fresh `git ls-remote` immediately before push** (tightest TOCTOU window), not the last `assess_stack` observation. | DR-4 |
+
+**Build structure.** Drive #1592 as **one feature workflow** (`1592-ship-gate-methodology`) whose plan decomposes into six independently-mergeable task-bundles, shipped as a short stack of focused PRs in an overlap-minimizing order:
+
+**DR-2 → DR-1 → DR-4 → DR-7 → DR-3 → DR-5 → DR-6.** Rationale: DR-2 is the isolated resolver change (establishes the leg pattern first); DR-1 and DR-4 both touch `create-pr.ts`/`prepare-synthesis.ts` so DR-1's intent edits land before DR-4 hardens the same file; **DR-7 widens the `assess_stack` feedback contract and DR-3 consumes it, so DR-7 precedes DR-3** (both are the `assess-stack.ts`-heavy cluster, sequenced after DR-4's lighter create-pr touch); DR-5 is isolated (git-hook); DR-6 documents the final shapes, so it goes last and captures the as-shipped escalation defaults **and the widened `PrComment` contract** for the divergence guard / SDK migration table.
+
+DR-7 was added at `/plan` from a user requirement (comprehensive, platform-generic PR-feedback harvesting) with the **contract-generic + GitHub-complete** scope chosen: generalize `PrComment` + complete GitHub's three comment sources now; GitLab/ADO conform to the signature but stay `UnsupportedOperationError`, with their full harvesting tracked via two filed follow-up issues (a DR-7 deliverable).
+
+**Reference refresh (since design date, post #1515-Phase4 + #1581).** Structure unchanged, line numbers drifted: `SynthesisLeg` now `phase-kind.ts:76` (was `:66`); `synthesis-readiness` resolver roster at `phase-kind.ts:215`; `create-pr.ts` double-create guard at `:124–193` (was `:122-191`). The shared `ResolveGateSetCtx` coordination risk (roadmap #1599 rule 1) is cleared now that both `riskTier` (#1515) and `designDepth` (#1581) have merged — #1592's additive obligations extend the same struct with no live contender.
 
 ---
 

--- a/docs/designs/2026-06-23-ship-gate-sdk-migration.md
+++ b/docs/designs/2026-06-23-ship-gate-sdk-migration.md
@@ -1,0 +1,44 @@
+# Ship-gate → Workflow SDK migration contract (DR-6)
+
+**Date:** 2026-06-23
+**Epic:** [#1592](https://github.com/lvlup-sw/exarchos/issues/1592) (ship-gate methodology)
+**Parent design:** [`2026-06-21-ship-gate-methodology.md`](2026-06-21-ship-gate-methodology.md)
+**SDK target:** [#1258](https://github.com/lvlup-sw/exarchos/issues/1258) — Workflow Builder SDK — design [`2026-05-06-workflow-builder-sdk.md`](2026-05-06-workflow-builder-sdk.md)
+
+## Purpose
+
+The ship-gate methodology (DR-1…DR-7) shipped as small, additive patterns on the existing REVIEW/SYNTHESIZE kinds — deliberately, so the eventual `ship-gate.workflow.ts` is a **behavior-preserving consolidation, not a redesign** (DR-6).
+This note records the durable contract: each as-shipped pattern ↦ the exact Workflow Builder SDK combinator it lowers into, with the **real symbol names and parameter values** so the consolidation re-uses values rather than re-deriving them.
+
+When the SDK (#1258) lands, this table is the checklist for collapsing review + synthesize + shepherd into one declarative IR. The divergence guard (DR-6 task 023, in `escalation-policy.ts`) enforces that the interim escalation defaults cannot silently fork from the semantics recorded here before that consolidation.
+
+## Pattern ↦ combinator map (as shipped)
+
+| DR | Pattern (as shipped) | Key symbols / values | SDK combinator |
+|----|----------------------|----------------------|----------------|
+| **DR-1** | Intent grounding — `artifacts.intent` derived once, consumed by REVIEW + PR-body | `orchestrate/extract-intent.ts`: `deriveIntent` / `persistIntent` (single `state.patched`); read by `prepare_review` grounding + `validate_pr_body`/`create_pr` (`readIntent`/`groundBodyInIntent`) | **`Step.handler('extractIntent')`** — the workflow's start step (`startWith(extractIntent)`) |
+| **DR-2** | Document-readiness leg in SYNTHESIZE | `prepare-synthesis.ts`: `evaluateDocumentLeg` / `documentLegBlocks`; config `synthesis.documentLeg.{severity,surfaceGlobs,docGlobs}` (advisory→blocking) | **`Step.handler('updateDocs')`** / **`Step.gate`** document step in the readiness sequence |
+| **DR-3** | Uniform bounded auto-fix + ask-user escalation | `orchestrate/escalation-policy.ts`: `resolveEscalationPolicy({ maxIterations })` (default **5**, config `escalation.maxIterations`, per-loop override), `decideEscalation` (mechanical → auto-fix to bound; intent-touching → escalate now), `countShepherdIterations` (single counter), `shepherd.escalated` event surfaced via `shepherd_status` | **`repeatUntil(cond, body, { maxIterations })`** (the bounded auto-fix) **+ `awaitApproval(approver).onTimeout(...).onRejection(...)`** (the ask-user escalation) |
+| **DR-4** | Single PR owner + explicit-SHA lease | `vcs/create-pr.ts`: `PR_ALREADY_OWNED` structural guard + retained double-create guard; `vcs/push-with-lease.ts`: `buildForceWithLeaseArgs` / `resolveExpectedSha` (explicit `--force-with-lease=<ref>:<sha>`) | single **`Step.handler('openPR')`** owner + **`Step.handler('pushWithLease')`** |
+| **DR-5** | Opt-in pre-push ship-gate hook | `hooks/pre-push.ship-gate.sample` (thin trigger, blocks on a blocking finding, degrades open) | **outside the IR** — git-domain trigger; engine = the workflow, trigger = the git gate |
+| **DR-7** | Platform-generic PR-feedback ingestion | `vcs/provider.ts` widened `PrComment` (`source`/`parentId`/tri-state `resolved`); `vcs/github.ts` `getPrComments` 3-surface aggregation + fail-soft GraphQL `resolved`; `assess_stack` generic consumption | **no new combinator** — a data-contract widening of the feed the shepherd `repeatUntil(s => s.ci.green, …)` / `Step.handler('watchCI')` step already consumes |
+
+## SDK-contract values (the durable anchor)
+
+The interim escalation policy is authored to map onto the SDK's `repeatUntil` / `awaitApproval` combinators **by value**, so consolidation is a rename of the call site, not a re-derivation of the semantics:
+
+- **`repeatUntil` option name:** the bound is named **`maxIterations`** — identical to the SDK's `repeatUntil(condition, body, { maxIterations })` option. The interim `EscalationPolicy.maxIterations` and `resolveEscalationPolicy({ maxIterations })` re-use that exact name.
+- **Default bound:** **5** (`DEFAULT_MAX_ITERATIONS`). Config-resolvable via `escalation.maxIterations`; per-loop override supported. This is the value the `repeatUntil({ maxIterations })` body inherits on consolidation.
+- **Approval semantics (`awaitApproval`):** the ask-user escalation fires when **either** the bound is reached **or** a finding is **intent-touching** (escalate immediately, regardless of remaining budget). `decideEscalation` returns `escalate` in exactly those two cases — the same shape as `awaitApproval(...).onTimeout(/* bound */)` + an immediate approval gate for intent-touching findings. Mechanical findings auto-fix within the bound (the `repeatUntil` body).
+- **Single iteration source:** `countShepherdIterations(events)` (count of `shepherd.iteration` events) is the one counter both the loop and the `shepherd-status` view read — the SDK's `repeatUntil` iteration count maps onto it 1:1.
+
+These values are mirrored as a machine-checkable constant (`SDK_MIGRATION_CONTRACT`) in `escalation-policy.ts`; the DR-6 divergence guard test asserts the live policy conforms to them, so the interim defaults and the documented SDK semantics cannot drift apart before #1258 consolidates them.
+
+## What stays outside the consolidation
+
+- **DR-5 pre-push hook** — a git-domain trigger, never part of the IR (INV-15: no daemon; the workflow is the engine).
+- **Provider/platform axis (DR-7)** — owned by the `VcsProvider` abstraction, not the workflow; the IR consumes the platform-neutral `PrComment` feed.
+
+## Roadmap caveat
+
+The SDK's milestone is inconsistent across artifacts (SDK design says v3.1.0; #1573 says v3.2.0; roadmap memory places it under v3.0). This contract is anchored on the **combinator mapping**, which is durable regardless of which milestone the SDK ships under. Reconciling the milestone label is a separate, out-of-scope task.

--- a/docs/guides/ship-gate-pre-push-hook.md
+++ b/docs/guides/ship-gate-pre-push-hook.md
@@ -1,0 +1,70 @@
+# Ship-gate pre-push hook (opt-in)
+
+A documented, **opt-in** git `pre-push` hook that runs an Exarchos ship-path verb before every `git push` and blocks the push when the gate reports a blocking finding.
+It is the forcing-function trigger from the ship-gate methodology (DR-5, [#1597](https://github.com/lvlup-sw/exarchos/issues/1597)) — quality is enforced at the push boundary rather than left to memory.
+
+The hook ships as a sample at [`hooks/pre-push.ship-gate.sample`](../../hooks/pre-push.ship-gate.sample) and does **nothing** until you explicitly install it.
+
+## Posture (why it is shaped this way)
+
+- **Opt-in, never auto-installed (POLA).** Cloning or pulling this repo never installs the hook and never runs it. Installing a hook that can block every push is a user decision, not a repo-side side effect. This mirrors the worktree design's user-scope-hooks rule — no surprise execution on a cloned repo.
+- **A thin trigger, not a daemon (INV-15).** The hook is ~3 lines of logic: ask the ship-path gate, honor the answer. There is no background process, no bare gate repo, and no second orchestrator — the engine stays Exarchos. This is deliberately **not** a `post-receive` daemon.
+- **Harness/OS-neutral (INV-4).** It is a POSIX `sh` script in the git domain. It carries no bashisms and needs no `jq`; it runs the same on macOS, Linux, and Git-for-Windows.
+- **Degrades open.** If Exarchos is not installed (or the gate cannot reach a verdict), the hook prints a clear message and **allows** the push. You opted into a quality gate, not into "every push fails when an optional tool is missing."
+
+## Install
+
+Installing is a single explicit action in your local clone:
+
+```sh
+cp hooks/pre-push.ship-gate.sample .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+That is the whole install. The hook now runs on each `git push`.
+
+> Git only runs hooks from `.git/hooks/` (or `core.hooksPath`). The `.sample` file under `hooks/` is inert until you copy it into place — exactly so that pulling the repo cannot arm it.
+
+## Behaviour
+
+On `git push` the hook:
+
+1. Resolves the Exarchos binary (`EXARCHOS_BIN`, default `exarchos`). If it is not on `PATH`, it prints a skip message to stderr and **exits 0** (push allowed).
+2. Runs the ship-path verb with JSON output — by default `exarchos orch check_static_analysis --feature-id pre-push --json` (lint + typecheck).
+3. Inspects the result:
+   - A **blocking finding** (`data.passed: false` / `data.ready: false`) → prints a summary and **exits 1**, so git aborts the push.
+   - A **clean gate** (`data.passed: true` / `data.ready: true`) → **exits 0**, push proceeds.
+   - **No recognizable verdict** (the verb errored, was skipped for lack of a toolchain, or returned an unexpected shape) → prints a diagnostic and **exits 0** (degrade-open — an inconclusive gate never blocks a push).
+
+### Exit contract
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Gate passed, **or** the engine was unavailable / could not reach a verdict (degrade-open). |
+| `1` | The ship-path gate reported a blocking finding — git aborts the push. |
+
+## Configuration
+
+The hook reads three environment variables (all optional):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EXARCHOS_BIN` | `exarchos` | The Exarchos binary to invoke. Point it at a custom build, or rely on `PATH`. |
+| `EXARCHOS_SHIP_VERB` | `orch check_static_analysis` | The ship-path verb (and subcommand) to run. Any verb that emits a `ToolResult` with a `data.passed` / `data.ready` boolean works. |
+| `EXARCHOS_SHIP_FEATURE_ID` | `pre-push` | The synthetic feature id passed to the verb. It only labels the emitted gate event. |
+
+Set them in your shell profile, or inline per push:
+
+```sh
+EXARCHOS_SHIP_VERB="orch prepare_synthesis" git push
+```
+
+## Bypass and uninstall
+
+- **One-off bypass:** `git push --no-verify` skips all pre-push hooks for that push.
+- **Uninstall:** delete the installed hook — `rm .git/hooks/pre-push`.
+
+## Relationship to the rest of the ship path
+
+The hook is only a *trigger*. It runs the same verbs the SYNTHESIZE kind and the shepherd loop already run (`check_static_analysis`, `prepare_synthesis`, …), so a clean local push and a clean CI run check the same gate.
+It does not replace review or CI — it moves the cheapest, most mechanical checks to the earliest point where they are free to fix, before the push leaves your machine.

--- a/docs/plans/2026-06-22-ship-gate-methodology.md
+++ b/docs/plans/2026-06-22-ship-gate-methodology.md
@@ -52,9 +52,16 @@ All five original open questions are resolved (design Decision Log); DR-7 added 
 ### Task 003: Config-resolvable docs-leg severity (advisory → blocking)
 **Implements:** DR-2
 **Risk Tier:** medium
-**Verification:** scoped tests + kill-probe.
-**Files:** `servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts`, `src/config/*` (severity resolution), `prepare-synthesis.test.ts`
-**Tests:** `DocumentLeg_SeverityConfig_ResolvesAdvisoryToBlocking`, `DocumentLeg_DefaultSeverity_IsAdvisory`
+**Boundary Touching:** true  *(config-resolution surface — re-tiered at /plan after a blast-radius discovery, not a re-plan)*
+**Verification:** scoped tests + kill-probe + full MCP suite (the `config:true` describe path is snapshot-sensitive).
+**Files (config plumbing mirrors the `storage` block precedent):**
+- `servers/exarchos-mcp/src/config/exarchos-config-schema.ts` — `SynthesisConfigSchema` (`.strict()` zod, `documentLeg: { severity, surfaceGlobs, docGlobs }`), wired into `ExarchosConfigSchema`.
+- `config/yaml-schema.ts` — `synthesis: SynthesisConfigSchema.optional()`.
+- `config/resolve.ts` — `ResolvedProjectConfig.synthesis` + DEFAULTS + one-line resolve map.
+- `orchestrate/composite.ts` — **new `adaptWithEventStoreAndConfig` adapter** (mirrors `adaptLadderGate`'s `ctx.projectConfig`→args injection); switch `prepare_synthesis` to it. *Required because `handlePrepareSynthesis` is dispatched via `adaptWithEventStore` and does NOT receive `projectConfig` today.*
+- `orchestrate/prepare-synthesis.ts` — read `args.projectConfig`; reuse `architecture/glob-to-regexp.ts` for surface/doc matching.
+- Defaults: `severity:'advisory'`, `docGlobs:['docs/**','**/*.md']`, **empty `surfaceGlobs` ⇒ auto-waive** (opt-in per consumer, non-overfit).
+**Tests:** `DocumentLeg_SeverityConfig_ResolvesAdvisoryToBlocking`, `DocumentLeg_DefaultSeverity_IsAdvisory`, `PrepareSynthesis_AdapterThreadsProjectConfig`
 **Dependencies:** 002
 **Parallelizable:** No
 
@@ -141,8 +148,9 @@ All five original open questions are resolved (design Decision Log); DR-7 added 
 **Risk Tier:** high
 **Boundary Touching:** true  *(VCS I/O adapter)*
 **Verification:** medium set + integration suite; kill-probe. The `addComment` verify path must still find its posted comment in the superset.
+**Researched endpoints (live GitHub docs, 2026-06-22 — see design §DR-7 grounding):** aggregate three `gh api --paginate` surfaces — `issues/{n}/comments` (`source:'issue-comment'`), `pulls/{n}/comments` (`source:'review-inline'`, `in_reply_to_id`→`parentId` [one-level only], `path`/`line`), `pulls/{n}/reviews` (`source:'review-summary'`, `body`+`state`). Then a **fail-soft GraphQL `reviewThreads` enrichment** for `resolved` (`databaseId === REST id`; on error/miss leave `resolved` absent — *absent ≠ false*).
 **Files:** `servers/exarchos-mcp/src/vcs/github.ts` (`getPrComments` :243, `GhPrCommentEntry` :41), `github.test.ts`
-**Tests:** `GetPrComments_AggregatesAllThreeSources`, `GetPrComments_LinksRepliesViaParentId`, `GetPrComments_AnyAuthor_IncludesBots`, `GetPrComments_AddCommentVerifyPath_StillFindsPostedComment`
+**Tests:** `GetPrComments_AggregatesAllThreeSources`, `GetPrComments_LinksRepliesViaParentId`, `GetPrComments_AnyAuthor_IncludesBots`, `GetPrComments_AddCommentVerifyPath_StillFindsPostedComment`, `GetPrComments_ResolvedStatus_GraphqlEnrichmentFailSoft`
 **Dependencies:** 010
 **Parallelizable:** No
 

--- a/docs/plans/2026-06-22-ship-gate-methodology.md
+++ b/docs/plans/2026-06-22-ship-gate-methodology.md
@@ -1,0 +1,290 @@
+# Implementation Plan: Ship-Gate Methodology (#1592)
+
+**Date:** 2026-06-22
+**Design (SoT):** [`docs/designs/2026-06-21-ship-gate-methodology.md`](../designs/2026-06-21-ship-gate-methodology.md)
+**Epic:** [#1592](https://github.com/lvlup-sw/exarchos/issues/1592) → #1593–#1598 (+ DR-7, new)
+**Feature workflow:** `1592-ship-gate-methodology`
+**Milestone:** v2.11.0 (`build:preview.4`)
+
+## Scope & structure
+
+One feature workflow decomposed into **seven independently-mergeable bundles** (one per DR), shipped as a short stack of focused PRs in the overlap-minimizing build order:
+
+**DR-2 → DR-1 → DR-4 → DR-7 → DR-3 → DR-5 → DR-6**
+
+All five original open questions are resolved (design Decision Log); DR-7 added at plan-time per user requirement with **contract-generic + GitHub-complete** scope. Every task is additive on the REVIEW/SYNTHESIZE kinds — no new `PhaseKind`, no workflow-typed branch (INV-6).
+
+## Traceability matrix (DR-N → tasks)
+
+| DR | Requirement | Tasks | Bundle |
+|----|-------------|-------|--------|
+| DR-2 | Document-readiness leg in SYNTHESIZE | 001–003 | A |
+| DR-1 | Intent grounding (REVIEW + PR-body) | 004–006 | B |
+| DR-4 | Harden single PR owner (lease + structural guard) | 007–009 | C |
+| DR-7 | Platform-generic PR-feedback ingestion in `assess_stack` | 010–014 | D |
+| DR-3 | Uniform bounded auto-fix + ask-user escalation | 015–019 | E |
+| DR-5 | Opt-in pre-push ship-gate hook (no daemon) | 020–021 | F |
+| DR-6 | SDK combinator migration contract | 022–023 | G |
+
+---
+
+## Bundle A — DR-2: Document-readiness leg
+
+### Task 001: Extend `SynthesisLeg` with `'document'` + update resolver roster SoT pin
+**Implements:** DR-2
+**Risk Tier:** high
+**Boundary Touching:** true  *(shared resolver contract consumed across the synthesis path)*
+**Verification:** medium set + integration suite across the resolver seam; `check_test_adequacy` kill-probe.
+**Files:** `servers/exarchos-mcp/src/workflow/phase-kind.ts` (`SynthesisLeg` :76, `synthesis-readiness` resolver :215), `servers/exarchos-mcp/src/workflow/phase-kind.test.ts`
+**Tests:** `SynthesisReadinessResolver_Roster_PinsDocumentAfterTypecheck`, `ResolveGateSet_Synthesis_EmitsDocumentLegInSequence`
+**Dependencies:** None
+**Parallelizable:** No (foundation for 002–003)
+
+### Task 002: Evaluate docs-coverage leg in `prepare_synthesis` + emit `gate.executed`
+**Implements:** DR-2
+**Risk Tier:** medium
+**Verification:** scoped tests + `check_test_adequacy` kill-probe (test-after).
+**Files:** `servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts`, `prepare-synthesis.test.ts`
+**Tests:** `PrepareSynthesis_DocBearingSurfaceNoDocChange_FailsDocumentLeg`, `PrepareSynthesis_NonDocBearingChange_AutoWaivesDocumentLeg`, `PrepareSynthesis_DocumentLeg_EmitsGateExecutedEvent`
+**Dependencies:** 001
+**Parallelizable:** No
+
+### Task 003: Config-resolvable docs-leg severity (advisory → blocking)
+**Implements:** DR-2
+**Risk Tier:** medium
+**Verification:** scoped tests + kill-probe.
+**Files:** `servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts`, `src/config/*` (severity resolution), `prepare-synthesis.test.ts`
+**Tests:** `DocumentLeg_SeverityConfig_ResolvesAdvisoryToBlocking`, `DocumentLeg_DefaultSeverity_IsAdvisory`
+**Dependencies:** 002
+**Parallelizable:** No
+
+---
+
+## Bundle B — DR-1: Intent grounding
+
+### Task 004: `artifacts.intent` state field + diff-derived floor (+ transcript enrichment) written via single state-patch
+**Implements:** DR-1
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Verification:** scoped tests + `check_test_adequacy` kill-probe.
+**Files:** `servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts` (or a folded `extract_intent` in `prepare-review.ts`), workflow-state types, co-located test
+**Tests:** `ExtractIntent_DiffDerivedFloor_WritesArtifactsIntent`, `ExtractIntent_TranscriptPresent_EnrichesIntent`, `ExtractIntent_WorkflowAgnostic_NoTypeBranch`
+**Dependencies:** None
+**Parallelizable:** No (foundation for 005–006); ⚠ touches `prepare-synthesis.ts` — sequence after Bundle A
+
+### Task 005: REVIEW dispatch prompt reads `artifacts.intent` (intended-vs-delivered)
+**Implements:** DR-1
+**Risk Tier:** medium
+**Verification:** scoped tests on the prepare_review dispatch shape; kill-probe. Skill-body edit also requires snapshot + batch-baseline update.
+**Files:** `servers/exarchos-mcp/src/orchestrate/prepare-review.ts`, `skills-src/spec-review/SKILL.md`, co-located test
+**Tests:** `PrepareReview_WithIntent_GroundsSpecReviewChecklist`, `PrepareReview_NoIntent_DegradesToDiffOnly`
+**Dependencies:** 004
+**Parallelizable:** No
+
+### Task 006: `validate_pr_body` + `create_pr` body generation read `artifacts.intent`
+**Implements:** DR-1
+**Risk Tier:** medium
+**Verification:** scoped tests + kill-probe.
+**Files:** `servers/exarchos-mcp/src/orchestrate/vcs/validate-pr-body.ts`, `vcs/create-pr.ts`, co-located tests
+**Tests:** `ValidatePrBody_WithIntent_GroundsBody`, `CreatePr_Body_ReferencesIntent`
+**Dependencies:** 004
+**Parallelizable:** Yes (with 005)
+
+---
+
+## Bundle C — DR-4: Harden single PR owner
+
+### Task 007: Harden single PR owner — structural no-`create_pr` guard for shepherd context + retain/pin double-create guard
+**Implements:** DR-4
+**Risk Tier:** high
+**Boundary Touching:** true  *(posture/dispatch boundary — INV-11)*
+**Verification:** medium set + integration suite; kill-probe. The guard must be by-construction, not prose.
+**Files:** `servers/exarchos-mcp/src/orchestrate/vcs/create-pr.ts` (guard :124–193 retained), dispatch/posture layer, `create-pr.test.ts`
+**Tests:** `CreatePr_ShepherdContext_Refused`, `CreatePr_DoubleCreateGuard_RetainedAndPinned`
+**Dependencies:** None
+**Parallelizable:** No
+
+### Task 008: Explicit-SHA `--force-with-lease` via fresh `git ls-remote` at push time
+**Implements:** DR-4
+**Risk Tier:** medium
+**Verification:** scoped tests asserting the explicit-SHA lease form is emitted; kill-probe.
+**Files:** push helper / `commands/shepherd.md` (:83), `commands/synthesize.md` (:73), co-located test
+**Tests:** `PushWithLease_EmitsExplicitShaForm`, `PushWithLease_FreshLsRemote_AnchorsToObservedSha`
+**Dependencies:** None
+**Parallelizable:** Yes (with 007)
+
+### Task 009: Collapse dual skill-vs-handler PR-idempotency layers to one authority
+**Implements:** DR-4
+**Risk Tier:** medium
+**Verification:** scoped tests; kill-probe. Skill edit → snapshot + batch-baseline update.
+**Files:** `skills-src/shepherd/SKILL.md` (:177), `vcs/create-pr.ts`, co-located test
+**Tests:** `PrIdempotency_SingleAuthority_HandlerGuardOnly`
+**Dependencies:** 007
+**Parallelizable:** No
+
+---
+
+## Bundle D — DR-7: Platform-generic PR-feedback ingestion
+
+### Task 010: Widen `PrComment` to a platform-neutral, thread-aware shape
+**Implements:** DR-7
+**Risk Tier:** high
+**Boundary Touching:** true  *(cross-cutting provider contract)*
+**Verification:** medium set + integration suite across provider consumers; kill-probe. No GitHub field names leak.
+**Files:** `servers/exarchos-mcp/src/vcs/provider.ts` (`PrComment` :62), `provider.test.ts`
+**Tests:** `PrComment_Shape_CarriesSourceAuthorThreadResolved`, `PrComment_Resolved_AbsentIsUnknownNotFalse`
+**Dependencies:** None
+**Parallelizable:** No (foundation for 011–013)
+
+### Task 011: `github.getPrComments` aggregates issues + inline-review + review-summary, paginated, threaded, any author
+**Implements:** DR-7
+**Risk Tier:** high
+**Boundary Touching:** true  *(VCS I/O adapter)*
+**Verification:** medium set + integration suite; kill-probe. The `addComment` verify path must still find its posted comment in the superset.
+**Files:** `servers/exarchos-mcp/src/vcs/github.ts` (`getPrComments` :243, `GhPrCommentEntry` :41), `github.test.ts`
+**Tests:** `GetPrComments_AggregatesAllThreeSources`, `GetPrComments_LinksRepliesViaParentId`, `GetPrComments_AnyAuthor_IncludesBots`, `GetPrComments_AddCommentVerifyPath_StillFindsPostedComment`
+**Dependencies:** 010
+**Parallelizable:** No
+
+### Task 012: `assess_stack` consumes the unified feed generically (no provider/workflow branch)
+**Implements:** DR-7
+**Risk Tier:** high
+**Boundary Touching:** true
+**Verification:** medium set + integration suite; kill-probe. INV-6 — no workflow-type conditional in the harvest loop.
+**Files:** `servers/exarchos-mcp/src/orchestrate/assess-stack.ts` (harvest :124–178, mapping :230–256), `assess-stack.test.ts`
+**Tests:** `AssessStack_InlineReviewComment_BecomesActionItem`, `AssessStack_ThreadedReply_Surfaced`, `AssessStack_ReviewSummaryBody_Surfaced`, `AssessStack_HarvestLoop_NoWorkflowTypeBranch`
+**Dependencies:** 011
+**Parallelizable:** No
+
+### Task 013: `gitlab` + `azure-devops` `getPrComments` conform to the widened signature (still throw)
+**Implements:** DR-7
+**Risk Tier:** low
+**Verification:** static analysis (must compile against widened `PrComment`); existing throw-tests updated.
+**Files:** `servers/exarchos-mcp/src/vcs/gitlab.ts` (:209), `vcs/azure-devops.ts` (:270), their tests
+**Tests:** `GitLab_GetPrComments_ThrowsUnsupported`, `AzureDevOps_GetPrComments_ThrowsUnsupported` (signature-conformance compile-check)
+**Dependencies:** 010
+**Parallelizable:** Yes (with 011–012)
+
+### Task 014: File GitLab + ADO harvesting follow-up issues (DR-7 deliverable)
+**Implements:** DR-7
+**Risk Tier:** low
+**Verification:** N/A (process deliverable) — two issues created via `gh api POST`, each linked to DR-7/#1592, carrying the platform-neutral `PrComment` contract as the conformance target.
+**Files:** none (GitHub issues) — record issue numbers back in the DR-7 PR description
+**Dependencies:** 010 (contract must exist to cite as conformance target)
+**Parallelizable:** Yes
+
+---
+
+## Bundle E — DR-3: Uniform bounded auto-fix + ask-user escalation
+
+### Task 015: Shared config-resolvable escalation policy (uniform default `5` + per-loop override)
+**Implements:** DR-3
+**Risk Tier:** high
+**Boundary Touching:** true  *(shared policy contract consumed by 3 loops)*
+**Verification:** medium set + integration suite; kill-probe.
+**Files:** new `servers/exarchos-mcp/src/orchestrate/escalation-policy.ts` (+ test), `src/workflow/hsm-definitions.ts` (`maxFixCycles`)
+**Tests:** `EscalationPolicy_DefaultFive_PerLoopOverride`, `EscalationPolicy_MechanicalFinding_AutoFixesWithinBound`, `EscalationPolicy_IntentTouchingFinding_EscalatesImmediately`
+**Dependencies:** None
+**Parallelizable:** No (foundation for 016–019)
+
+### Task 016: Bound spec-review's unbounded re-dispatch via the shared policy
+**Implements:** DR-3
+**Risk Tier:** medium
+**Verification:** scoped tests; kill-probe. Skill edit → snapshot + batch-baseline update.
+**Files:** `skills-src/spec-review/SKILL.md`, the spec-review fix-loop handler, co-located test
+**Tests:** `SpecReview_FixLoop_BoundedByPolicy`, `SpecReview_BoundHit_Escalates`
+**Dependencies:** 015
+**Parallelizable:** Yes (with 017, 019)
+
+### Task 017: Single event-sourced iteration counter (collapse shepherd-state vs `assess_stack`-events dual source)
+**Implements:** DR-3
+**Risk Tier:** high
+**Boundary Touching:** true  *(event-sourced counter authority — INV-1)*
+**Verification:** medium set + integration suite; kill-probe.
+**Files:** `servers/exarchos-mcp/src/orchestrate/assess-stack.ts`, shepherd-status view, co-located test
+**Tests:** `IterationCounter_SingleEventSourcedAuthority`, `ShepherdStatus_AndLoop_AgreeOnCount`
+**Dependencies:** 015; ⚠ touches `assess-stack.ts` — sequence after Bundle D
+**Parallelizable:** No
+
+### Task 018: Bound-hit emits structured escalation surfaced via `shepherd_status`/`ps` (no hang)
+**Implements:** DR-3
+**Risk Tier:** medium
+**Verification:** scoped tests; kill-probe. INV-10 — structured terminal, not a hang.
+**Files:** `servers/exarchos-mcp/src/orchestrate/assess-stack.ts`, liveness/status view, co-located test
+**Tests:** `BoundHit_EmitsStructuredEscalation_NotHang`, `Escalation_SurfacedViaShepherdStatus`
+**Dependencies:** 017
+**Parallelizable:** No
+
+### Task 019: Apply uniform policy to quality-review (replace ad-hoc `3`+pause)
+**Implements:** DR-3
+**Risk Tier:** low
+**Verification:** static analysis; skill edit → snapshot + batch-baseline update.
+**Files:** `skills-src/quality-review/SKILL.md`
+**Tests:** snapshot/baseline regeneration only
+**Dependencies:** 015
+**Parallelizable:** Yes (with 016)
+
+---
+
+## Bundle F — DR-5: Opt-in pre-push ship-gate hook
+
+### Task 020: Opt-in `pre-push` hook invoking ship-path verbs; blocks on a blocking finding
+**Implements:** DR-5
+**Risk Tier:** medium
+**Verification:** scoped tests on the hook script's pass/block decision; kill-probe where scriptable.
+**Files:** `hooks/pre-push.ship-gate.sample`, `hooks/pre-push.test.ts`
+**Tests:** `PrePushHook_BlockingFinding_BlocksPush`, `PrePushHook_Pass_AllowsPush`
+**Dependencies:** None (engine = existing ship-path verbs)
+**Parallelizable:** Yes (isolated; can run alongside Bundles A–E once verbs exist)
+
+### Task 021: Document explicit opt-in install (no auto-install) + degrade message when verbs unavailable
+**Implements:** DR-5
+**Risk Tier:** low
+**Verification:** static analysis; INV-4 — git-domain, harness/OS-neutral, no repo-side auto-run.
+**Files:** `docs/guides/ship-gate-pre-push-hook.md`
+**Tests:** N/A (docs) — degrade-message path covered in 020 if scriptable
+**Dependencies:** 020
+**Parallelizable:** No
+
+---
+
+## Bundle G — DR-6: SDK combinator migration contract
+
+### Task 022: Migration note — pattern↦combinator table (incl. DR-7 contract-widening) referenced from #1258
+**Implements:** DR-6
+**Risk Tier:** low
+**Verification:** static analysis (docs). Captures as-shipped DR-1..DR-7 → combinator mapping.
+**Files:** `docs/designs/2026-06-21-ship-gate-methodology.md` neighborhood / dedicated migration note, cross-link from #1258
+**Tests:** N/A (docs)
+**Dependencies:** 001–021 (documents final shapes)
+**Parallelizable:** No
+
+### Task 023: Divergence guard — lint/test flags interim escalation defaults vs SDK `repeatUntil`/`awaitApproval` semantics
+**Implements:** DR-6
+**Risk Tier:** medium
+**Verification:** scoped tests; kill-probe. The guard fails if interim `maxIterations`/ask-user defaults drift from the documented SDK combinator semantics.
+**Files:** new guard test/lint, `escalation-policy.ts`
+**Tests:** `DivergenceGuard_EscalationDefaults_MatchSdkRepeatUntilSemantics`
+**Dependencies:** 015, 022
+**Parallelizable:** No
+
+---
+
+## Parallelization summary
+
+The seven bundles ship as a **stacked-PR sequence** in build order (DR-2 → DR-1 → DR-4 → DR-7 → DR-3 → DR-5 → DR-6) because of two file-overlap chokepoints:
+- `prepare-synthesis.ts` — Bundle A (DR-2) and Bundle B (DR-1) both edit it → A before B.
+- `assess-stack.ts` — Bundle D (DR-7, task 012/consumption) and Bundle E (DR-3, tasks 017–018) both edit it → D before E.
+
+**Parallel-safe across the stack:**
+- **Bundle F (DR-5)** is isolated (git-hook + docs) — can run concurrently once the ship-path verbs exist.
+- **Task 013** (gitlab/azure conform) parallel with 011–012 inside Bundle D.
+- **Tasks 016 / 019** (spec-review / quality-review skill edits) parallel inside Bundle E.
+- **Task 006** parallel with 005 inside Bundle B.
+
+**Risk-tier distribution:** high = 001, 007, 010, 011, 012, 015, 017 (the shared contracts / boundary seams); medium = the consumption/logic tasks; low = signature-conform, skill-policy-application, docs, issue-filing.
+
+## Cross-cutting verification notes (from project memory)
+- **MCP-server type/test isolation:** root `npm run typecheck`/`vitest` do **not** cover `servers/exarchos-mcp/`; every task touching MCP TS must run `cd servers/exarchos-mcp && npm run typecheck && npm run test:run`.
+- **Skill edits** (005, 009, 016, 019, 021) need the dual baseline update: `vitest -u snapshots.test.ts` **and** `cp` the claude render over `batch-baselines/<name>.md`; `skills:guard` exit-1 pre-commit is expected.
+- **Worktree dispatch:** scoped tests in a sub-agent worktree need `cd servers/exarchos-mcp && npm install` first (nested node_modules).

--- a/hooks/pre-push.ship-gate.sample
+++ b/hooks/pre-push.ship-gate.sample
@@ -1,0 +1,99 @@
+#!/bin/sh
+# ─── Exarchos opt-in ship-gate pre-push hook (DR-5, #1597) ──────────────────
+#
+# WHAT THIS DOES
+#   A THIN TRIGGER that runs an Exarchos ship-path verb before `git push` and
+#   BLOCKS the push when the gate reports a blocking finding (a lint/typecheck
+#   failure). A clean gate lets the push through. The engine stays Exarchos —
+#   this script is just the git-domain trigger that calls it (no logic of its
+#   own beyond "ask the gate, honor the answer").
+#
+# WHY IT IS A `.sample` (NOT auto-installed) — POLA
+#   This file ships as `hooks/pre-push.ship-gate.sample` and does NOTHING until
+#   YOU explicitly install it. Installing a hook that can block every push is a
+#   user decision, never a repo-side side effect. To opt in:
+#
+#       cp hooks/pre-push.ship-gate.sample .git/hooks/pre-push
+#       chmod +x .git/hooks/pre-push
+#
+#   To opt out, delete `.git/hooks/pre-push` (or `git push --no-verify` for a
+#   one-off bypass).
+#
+# POSTURE (INV-15 / INV-4)
+#   - INV-15: NOT a `post-receive`/`pre-receive` server daemon, no bare gate
+#     repo, no second orchestrator. The hook is a thin client-side trigger; the
+#     verification engine is the existing Exarchos CLI.
+#   - INV-4: git-domain and harness/OS-neutral. POSIX `sh`, no bashisms, no
+#     `jq` dependency — it parses the verb's `--json` output with `grep`.
+#   - Degrades to a clear message (and DOES NOT block the push) whenever the
+#     ship-path engine is unavailable or cannot actually run — a missing or
+#     broken optional tool must never wedge every push (POLA). "Gate says
+#     block" and "gate couldn't run" are deliberately distinct outcomes.
+#
+# ENV-VAR KNOBS
+#   EXARCHOS_BIN        Path/name of the Exarchos binary. Default: `exarchos`
+#                       (resolved on PATH). Point this at a custom binary, or
+#                       leave it for the installed CLI.
+#   EXARCHOS_SHIP_VERB  The ship-path verb (tool + action) to run, as a
+#                       space-separated argument list. Default:
+#                       `orch check_static_analysis` (lint + typecheck). The
+#                       hook appends `--feature-id <id>` and `--json`.
+#   EXARCHOS_SHIP_FEATURE_ID
+#                       Synthetic feature id passed to the verb (it is required
+#                       by the schema but only labels the gate event here).
+#                       Default: `pre-push`.
+#
+# EXIT CONTRACT
+#   0  gate passed, OR engine unavailable / could not run (degrade-open).
+#   1  gate reported a BLOCKING finding (git aborts the push).
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -u
+
+EXARCHOS_BIN="${EXARCHOS_BIN:-exarchos}"
+EXARCHOS_SHIP_VERB="${EXARCHOS_SHIP_VERB:-orch check_static_analysis}"
+EXARCHOS_SHIP_FEATURE_ID="${EXARCHOS_SHIP_FEATURE_ID:-pre-push}"
+
+# ── 1. Resolve the engine. Degrade-open if it isn't installed/executable. ────
+# A missing optional tool must NOT block pushes (POLA): the user opted into a
+# quality gate, not into "every push fails if Exarchos isn't on PATH".
+if ! command -v "$EXARCHOS_BIN" >/dev/null 2>&1; then
+  echo "ship-gate: '$EXARCHOS_BIN' not found on PATH — pre-push ship-gate skipped." >&2
+  echo "ship-gate: install Exarchos, set EXARCHOS_BIN, or remove .git/hooks/pre-push to silence this." >&2
+  exit 0
+fi
+
+# ── 2. Run the ship-path verb with JSON output. ──────────────────────────────
+# Advisory verbs return success (exit 0) with `data.passed:false` on a finding —
+# they DO NOT signal a block via the process exit code. So we capture stdout and
+# parse the JSON signal below; the exit code only tells us whether the CLI
+# itself ran. `# shellcheck disable` is not needed — word-splitting the verb is
+# intentional so EXARCHOS_SHIP_VERB can carry "tool action".
+# shellcheck disable=SC2086
+gate_output="$("$EXARCHOS_BIN" $EXARCHOS_SHIP_VERB --feature-id "$EXARCHOS_SHIP_FEATURE_ID" --json 2>/dev/null)"
+gate_status=$?
+
+# ── 3. Decide. Distinguish "couldn't run" from "gate says block". ────────────
+# If the CLI crashed (non-zero exit) AND its JSON does not carry an explicit
+# blocking signal, treat it as "couldn't run" → degrade-open. A genuine
+# blocking finding is signalled in the JSON payload, not by the exit code.
+case "$gate_output" in
+  *'"passed":false'* | *'"passed": false'* | *'"ready":false'* | *'"ready": false'*)
+    echo "ship-gate: BLOCKED — the ship-path gate reported a blocking finding." >&2
+    echo "ship-gate: run '$EXARCHOS_BIN $EXARCHOS_SHIP_VERB --feature-id $EXARCHOS_SHIP_FEATURE_ID' to see details, then re-push." >&2
+    echo "ship-gate: (bypass once with 'git push --no-verify' if you understand the risk.)" >&2
+    exit 1
+    ;;
+  *'"passed":true'* | *'"passed": true'* | *'"ready":true'* | *'"ready": true'*)
+    echo "ship-gate: passed." >&2
+    exit 0
+    ;;
+  *)
+    # No recognizable pass/block signal — the verb errored, was skipped (no
+    # toolchain), or emitted an unexpected shape. Degrade-open: don't block a
+    # push on an inconclusive gate.
+    echo "ship-gate: could not determine a verdict from the ship-path gate (exit $gate_status) — push allowed." >&2
+    echo "ship-gate: run '$EXARCHOS_BIN $EXARCHOS_SHIP_VERB --feature-id $EXARCHOS_SHIP_FEATURE_ID --json' to investigate." >&2
+    exit 0
+    ;;
+esac

--- a/hooks/pre-push.test.ts
+++ b/hooks/pre-push.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  existsSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ─── Black-box tests for the opt-in pre-push ship-gate hook (DR-5, #1597) ────
+//
+// We drive `hooks/pre-push.ship-gate.sample` as a real POSIX `sh` script — the
+// same way git would invoke `.git/hooks/pre-push` — via `spawnSync('sh', ...)`,
+// so the test is independent of the file's on-disk mode. Per test we write a
+// fake `exarchos` stub into a tmp dir and prepend it to PATH; the stub's stdout
+// stands in for the ship-path verb's `--json` ToolResult. We assert on the
+// hook's EXIT CODE (the block/allow signal git honors) and, where load-bearing,
+// its stderr.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH = path.join(__dirname, 'pre-push.ship-gate.sample');
+
+/** Write an executable `exarchos` shell stub that prints `stdout` and exits `code`. */
+function writeStub(dir: string, stdout: string, exitCode = 0): void {
+  const stubPath = path.join(dir, 'exarchos');
+  // The stub ignores all args and just emits the canned ToolResult line, so the
+  // hook's verb/flag wiring is exercised end-to-end without a real CLI.
+  const script = `#!/bin/sh\ncat <<'EXARCHOS_STUB_EOF'\n${stdout}\nEXARCHOS_STUB_EOF\nexit ${exitCode}\n`;
+  writeFileSync(stubPath, script);
+  chmodSync(stubPath, 0o755);
+}
+
+/**
+ * Run the hook under `sh`, returning the spawn result.
+ *
+ * `binName` is the name the hook resolves on PATH (`EXARCHOS_BIN`). Tests that
+ * exercise a present engine point it at `exarchos` with the stub dir prepended
+ * to PATH; the degrade-open test points it at a guaranteed-absent name so the
+ * lookup fails regardless of whether a real `exarchos` is installed — while
+ * keeping the inherited PATH intact so `sh` itself still resolves.
+ */
+function runHook(pathEnv: string, binName = 'exarchos'): ReturnType<typeof spawnSync> {
+  return spawnSync('sh', [HOOK_PATH], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      PATH: pathEnv,
+      EXARCHOS_BIN: binName,
+    },
+  });
+}
+
+describe('pre-push ship-gate hook (DR-5, #1597)', () => {
+  let binDir: string;
+
+  beforeEach(() => {
+    binDir = mkdtempSync(path.join(tmpdir(), 'ship-gate-hook-'));
+  });
+
+  afterEach(() => {
+    rmSync(binDir, { recursive: true, force: true });
+  });
+
+  it('HookSample_Exists', () => {
+    // Guard against the script being renamed/removed out from under the hook
+    // installer documented in its header.
+    expect(existsSync(HOOK_PATH)).toBe(true);
+  });
+
+  it('PrePushHook_BlockingFinding_BlocksPush', () => {
+    // Advisory verbs emit success:true with data.passed:false on a finding —
+    // the hook must parse the JSON signal, not the (zero) exit code.
+    writeStub(
+      binDir,
+      '{"success":true,"data":{"passed":false,"passCount":1,"failCount":3,"report":"3 lint errors"}}',
+      0,
+    );
+    const result = runHook(`${binDir}:${process.env.PATH ?? ''}`);
+    expect(result.status, `stderr: ${result.stderr}`).toBe(1);
+    expect(result.stderr).toMatch(/BLOCKED/);
+  });
+
+  it('PrePushHook_Pass_AllowsPush', () => {
+    writeStub(
+      binDir,
+      '{"success":true,"data":{"passed":true,"passCount":4,"failCount":0,"report":"ok"}}',
+      0,
+    );
+    const result = runHook(`${binDir}:${process.env.PATH ?? ''}`);
+    expect(result.status, `stderr: ${result.stderr}`).toBe(0);
+    expect(result.stderr).toMatch(/passed/);
+  });
+
+  it('PrePushHook_VerbUnavailable_DegradesOpen', () => {
+    // Engine unavailable: point EXARCHOS_BIN at a name that resolves on no
+    // PATH so `command -v` fails — regardless of whether a real `exarchos` is
+    // installed on the test host. The inherited PATH stays intact so `sh`
+    // itself still resolves. The hook must degrade-open (exit 0) with an
+    // actionable message, never wedge the push on a missing optional tool
+    // (POLA).
+    const absentBin = 'exarchos-ship-gate-absent-binary';
+    const result = runHook(process.env.PATH ?? '', absentBin);
+    expect(result.status, `stderr: ${result.stderr}`).toBe(0);
+    expect(result.stderr).toMatch(/not found on PATH/);
+  });
+
+  it('PrePushHook_InconclusiveVerb_DegradesOpen', () => {
+    // The verb ran but emitted no pass/block signal (e.g. a crash or a skipped
+    // gate). "Couldn't run" must be distinct from "gate says block": allow the
+    // push rather than wedge it on an inconclusive verdict.
+    writeStub(
+      binDir,
+      '{"success":false,"error":{"code":"SCRIPT_ERROR","message":"boom"}}',
+      2,
+    );
+    const result = runHook(`${binDir}:${process.env.PATH ?? ''}`);
+    expect(result.status, `stderr: ${result.stderr}`).toBe(0);
+    expect(result.stderr).toMatch(/could not determine a verdict/);
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -490,7 +490,10 @@ describe('EventTypes', () => {
     // #1309 T12: bumped 128 → 129 to include `merge.executing_started` (the
     // merge-executor liveness event, emitted after the recovery point is recorded
     // and before the first vcsMerge — INV-10 executing_started + paired terminal).
-    expect(EventTypes).toHaveLength(129);
+    // DR-3 #1595: bumped 129 → 130 to include `shepherd.escalated` (structured
+    // bound-hit escalation emitted by assess-stack — a structured terminal, NOT a
+    // hang, surfaced via shepherd_status/ps, INV-10).
+    expect(EventTypes).toHaveLength(130);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('merge.executing_started');

--- a/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
+++ b/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
@@ -263,6 +263,30 @@ export const StorageConfigSchema = z
 
 export type StorageConfig = z.infer<typeof StorageConfigSchema>;
 
+/**
+ * `synthesis.documentLeg` (DR-2, #1594) — tunes the SYNTHESIZE-kind `document`
+ * readiness leg. `severity` selects whether an uncovered doc-bearing change
+ * blocks synthesis (`'blocking'`) or merely warns (`'advisory'`, the default —
+ * a safe rollout). `surfaceGlobs` declares which changed paths count as a
+ * doc-bearing surface (default empty ⇒ the leg auto-waives, so it is opt-in and
+ * never overfit to one repo's layout); `docGlobs` declares what counts as a
+ * documentation change (default `docs/**` + any `*.md`).
+ */
+export const SynthesisConfigSchema = z
+  .object({
+    documentLeg: z
+      .object({
+        severity: z.enum(['advisory', 'blocking']).optional(),
+        surfaceGlobs: z.array(z.string()).optional(),
+        docGlobs: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export type SynthesisConfig = z.infer<typeof SynthesisConfigSchema>;
+
 export const ExarchosConfigSchema = z
   .object({
     test: safeCommand.optional(),
@@ -281,6 +305,7 @@ export const ExarchosConfigSchema = z
     cli: CliConfigSchema.optional(),
     invariants: InvariantsConfigSchema.optional(),
     storage: StorageConfigSchema.optional(),
+    synthesis: SynthesisConfigSchema.optional(),
   })
   .strict();
 

--- a/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
+++ b/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
@@ -287,6 +287,23 @@ export const SynthesisConfigSchema = z
 
 export type SynthesisConfig = z.infer<typeof SynthesisConfigSchema>;
 
+/**
+ * `escalation` (DR-3, #1595) — tunes the shared escalation policy consumed by
+ * the spec-review, quality-review, and shepherd fix-loops. `maxIterations` is
+ * the per-loop auto-fix bound: how many times a loop may auto-fix a mechanical
+ * finding before escalating to the user. Resolves to a uniform default of `5`
+ * (see `DEFAULT_MAX_ITERATIONS` in `orchestrate/escalation-policy.ts`); a
+ * project raises or lowers the bound here. A per-loop call-site override takes
+ * precedence over this config value.
+ */
+export const EscalationConfigSchema = z
+  .object({
+    maxIterations: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export type EscalationConfig = z.infer<typeof EscalationConfigSchema>;
+
 export const ExarchosConfigSchema = z
   .object({
     test: safeCommand.optional(),
@@ -306,6 +323,7 @@ export const ExarchosConfigSchema = z
     invariants: InvariantsConfigSchema.optional(),
     storage: StorageConfigSchema.optional(),
     synthesis: SynthesisConfigSchema.optional(),
+    escalation: EscalationConfigSchema.optional(),
   })
   .strict();
 

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -415,9 +415,15 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
       documentLeg: {
         severity:
           project.synthesis?.documentLeg?.severity ?? DEFAULTS.synthesis.documentLeg.severity,
-        surfaceGlobs:
-          project.synthesis?.documentLeg?.surfaceGlobs ?? DEFAULTS.synthesis.documentLeg.surfaceGlobs,
-        docGlobs: project.synthesis?.documentLeg?.docGlobs ?? DEFAULTS.synthesis.documentLeg.docGlobs,
+        // Spread-clone the arrays so the subsequent deepFreeze() freezes a fresh
+        // copy, never the caller-owned `project.*` input nor the shared DEFAULTS
+        // arrays (both would be a no-freeze-caller-input violation).
+        surfaceGlobs: [
+          ...(project.synthesis?.documentLeg?.surfaceGlobs ?? DEFAULTS.synthesis.documentLeg.surfaceGlobs),
+        ],
+        docGlobs: [
+          ...(project.synthesis?.documentLeg?.docGlobs ?? DEFAULTS.synthesis.documentLeg.docGlobs),
+        ],
       },
     },
     escalation: {

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -1,4 +1,5 @@
 import type { ProjectConfig, VerificationPolicyOverlay } from './yaml-schema.js';
+import { DEFAULT_MAX_ITERATIONS } from '../orchestrate/escalation-policy.js';
 
 // ─── Resolved Types ─────────────────────────────────────────────────────────
 
@@ -95,6 +96,15 @@ export interface ResolvedProjectConfig {
       readonly surfaceGlobs: readonly string[];
       readonly docGlobs: readonly string[];
     };
+  };
+  /**
+   * Shared escalation policy (DR-3, #1595). `maxIterations` is the per-loop
+   * auto-fix bound threaded to the spec-review, quality-review, and shepherd
+   * fix-loops; consumers pass it as `configMaxIterations` to
+   * `resolveEscalationPolicy`. Always fully resolved (default applied).
+   */
+  readonly escalation: {
+    readonly maxIterations: number;
   };
 }
 
@@ -207,6 +217,9 @@ export const DEFAULTS: ResolvedProjectConfig = deepFreeze({
       surfaceGlobs: [],
       docGlobs: ['docs/**', '**/*.md'],
     },
+  },
+  escalation: {
+    maxIterations: DEFAULT_MAX_ITERATIONS,
   },
 });
 
@@ -406,6 +419,9 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
           project.synthesis?.documentLeg?.surfaceGlobs ?? DEFAULTS.synthesis.documentLeg.surfaceGlobs,
         docGlobs: project.synthesis?.documentLeg?.docGlobs ?? DEFAULTS.synthesis.documentLeg.docGlobs,
       },
+    },
+    escalation: {
+      maxIterations: project.escalation?.maxIterations ?? DEFAULTS.escalation.maxIterations,
     },
   };
 

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -83,6 +83,19 @@ export interface ResolvedProjectConfig {
   readonly storage: {
     readonly synchronous: 'normal' | 'full';
   };
+  /**
+   * SYNTHESIZE-kind `document` readiness leg config (DR-2, #1594). `severity`
+   * gates whether an uncovered doc-bearing change blocks synthesis; `surfaceGlobs`
+   * declares the doc-bearing paths (empty ⇒ auto-waive); `docGlobs` declares what
+   * counts as a doc change. Always fully resolved (defaults applied).
+   */
+  readonly synthesis: {
+    readonly documentLeg: {
+      readonly severity: 'advisory' | 'blocking';
+      readonly surfaceGlobs: readonly string[];
+      readonly docGlobs: readonly string[];
+    };
+  };
 }
 
 // ─── Default Values ─────────────────────────────────────────────────────────
@@ -187,6 +200,13 @@ export const DEFAULTS: ResolvedProjectConfig = deepFreeze({
   },
   storage: {
     synchronous: 'normal',
+  },
+  synthesis: {
+    documentLeg: {
+      severity: 'advisory',
+      surfaceGlobs: [],
+      docGlobs: ['docs/**', '**/*.md'],
+    },
   },
 });
 
@@ -377,6 +397,15 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
     verification: { policy: verificationPolicy },
     storage: {
       synchronous: project.storage?.synchronous ?? DEFAULTS.storage.synchronous,
+    },
+    synthesis: {
+      documentLeg: {
+        severity:
+          project.synthesis?.documentLeg?.severity ?? DEFAULTS.synthesis.documentLeg.severity,
+        surfaceGlobs:
+          project.synthesis?.documentLeg?.surfaceGlobs ?? DEFAULTS.synthesis.documentLeg.surfaceGlobs,
+        docGlobs: project.synthesis?.documentLeg?.docGlobs ?? DEFAULTS.synthesis.documentLeg.docGlobs,
+      },
     },
   };
 

--- a/servers/exarchos-mcp/src/config/yaml-schema.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.ts
@@ -4,6 +4,7 @@ import {
   ExarchosConfigSchema,
   StorageConfigSchema,
   SynthesisConfigSchema,
+  EscalationConfigSchema,
 } from './exarchos-config-schema.js';
 import { VERIFICATION_GATE_NAMES } from '../workflow/verification-policy.js';
 
@@ -238,6 +239,7 @@ export const ProjectConfigSchema = z.object({
   invariants: InvariantsConfigSchema.optional(),
   storage: StorageConfigSchema.optional(),
   synthesis: SynthesisConfigSchema.optional(),
+  escalation: EscalationConfigSchema.optional(),
 }).strict();
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;

--- a/servers/exarchos-mcp/src/config/yaml-schema.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { InvariantsConfigSchema, ExarchosConfigSchema, StorageConfigSchema } from './exarchos-config-schema.js';
+import {
+  InvariantsConfigSchema,
+  ExarchosConfigSchema,
+  StorageConfigSchema,
+  SynthesisConfigSchema,
+} from './exarchos-config-schema.js';
 import { VERIFICATION_GATE_NAMES } from '../workflow/verification-policy.js';
 
 // ─── Dimension Configuration ────────────────────────────────────────────────
@@ -232,6 +237,7 @@ export const ProjectConfigSchema = z.object({
   verification: VerificationConfig.optional(),
   invariants: InvariantsConfigSchema.optional(),
   storage: StorageConfigSchema.optional(),
+  synthesis: SynthesisConfigSchema.optional(),
 }).strict();
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -565,7 +565,10 @@ describe('EventTypes', () => {
     //   event; emitted after the recovery point is recorded, before the first
     //   vcsMerge, so a long-running merge is observable as started-but-unterminated,
     //   the INV-10 executing_started + paired terminal pattern).
-    expect(EventTypes).toHaveLength(129);
+    // Bumped 129 → 130: shepherd.escalated (DR-3 #1595 — structured bound-hit
+    //   escalation emitted by assess-stack on the escalate path; a structured
+    //   terminal (NOT a hang) surfaced via shepherd_status/ps, INV-10).
+    expect(EventTypes).toHaveLength(130);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('merge.executing_started');
@@ -1272,7 +1275,7 @@ describe('ShepherdCompletedData validation', () => {
 
 describe('EventType_ShepherdTypes_ExistInUnion', () => {
   it('EventType_ShepherdTypes_ExistInUnion', () => {
-    const shepherdTypes = ['shepherd.started', 'shepherd.iteration', 'shepherd.approval_requested', 'shepherd.completed'];
+    const shepherdTypes = ['shepherd.started', 'shepherd.iteration', 'shepherd.approval_requested', 'shepherd.escalated', 'shepherd.completed'];
     for (const t of shepherdTypes) {
       expect(EventTypes).toContain(t);
     }

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1172,9 +1172,15 @@ export const ShepherdApprovalRequestedData = z.object({
 // can surface the WHY (reason + counts), not just the derived 'escalate' status.
 export const ShepherdEscalatedData = z.object({
   featureId: z.string(),
-  prNumbers: z.array(z.number().int()).describe('PRs in the stack at the time the bound was hit'),
+  prNumbers: z
+    .array(z.number().int().positive())
+    .describe('PRs in the stack at the time the bound was hit'),
   iterationCount: z.number().int().nonnegative().describe('Iterations run when the bound was hit'),
-  maxIterations: z.number().int().nonnegative().describe('The resolved auto-fix bound that was reached'),
+  maxIterations: z
+    .number()
+    .int()
+    .positive()
+    .describe('The resolved auto-fix bound that was reached (a positive integer, per escalation-policy)'),
   reason: z.string().describe('Human-readable escalation reason'),
 });
 

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -79,6 +79,7 @@ export const EventTypes = [
   'shepherd.started',
   'shepherd.iteration',
   'shepherd.approval_requested',
+  'shepherd.escalated',
   'shepherd.completed',
   'remediation.attempted',
   'remediation.succeeded',
@@ -462,6 +463,9 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // auto — emitted by assess-stack orchestration
   'shepherd.started': 'auto',
   'shepherd.approval_requested': 'auto',
+  // auto — emitted by assess-stack on the bound-hit escalate path (DR-3, #1595):
+  // a structured terminal escalation (NOT a hang), surfaced via shepherd_status/ps.
+  'shepherd.escalated': 'auto',
   'shepherd.completed': 'auto',
 
   // auto — emitted by VCS orchestration handlers
@@ -1161,6 +1165,17 @@ export const ShepherdIterationData = z.object({
 
 export const ShepherdApprovalRequestedData = z.object({
   prUrl: z.string(),
+});
+
+// DR-3 (#1595): structured bound-hit escalation. Hitting the auto-fix bound
+// emits this (a structured terminal, NOT a hang — INV-10) so shepherd_status/ps
+// can surface the WHY (reason + counts), not just the derived 'escalate' status.
+export const ShepherdEscalatedData = z.object({
+  featureId: z.string(),
+  prNumbers: z.array(z.number().int()).describe('PRs in the stack at the time the bound was hit'),
+  iterationCount: z.number().int().nonnegative().describe('Iterations run when the bound was hit'),
+  maxIterations: z.number().int().nonnegative().describe('The resolved auto-fix bound that was reached'),
+  reason: z.string().describe('Human-readable escalation reason'),
 });
 
 export const ShepherdCompletedData = z.object({
@@ -2452,6 +2467,7 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'shepherd.started': ShepherdStartedData,
   'shepherd.iteration': ShepherdIterationData,
   'shepherd.approval_requested': ShepherdApprovalRequestedData,
+  'shepherd.escalated': ShepherdEscalatedData,
   'shepherd.completed': ShepherdCompletedData,
 
   // Eval
@@ -2617,6 +2633,7 @@ export type RefinementSuggestedData = z.infer<typeof RefinementSuggestedDataSche
 export type ShepherdStarted = z.infer<typeof ShepherdStartedData>;
 export type ShepherdIteration = z.infer<typeof ShepherdIterationData>;
 export type ShepherdApprovalRequested = z.infer<typeof ShepherdApprovalRequestedData>;
+export type ShepherdEscalated = z.infer<typeof ShepherdEscalatedData>;
 export type ShepherdCompleted = z.infer<typeof ShepherdCompletedData>;
 export type EvalRunStarted = z.infer<typeof EvalRunStartedData>;
 export type EvalCaseCompleted = z.infer<typeof EvalCaseCompletedData>;
@@ -2747,6 +2764,7 @@ export type EventDataMap = {
   'shepherd.started': ShepherdStarted;
   'shepherd.iteration': ShepherdIteration;
   'shepherd.approval_requested': ShepherdApprovalRequested;
+  'shepherd.escalated': ShepherdEscalated;
   'shepherd.completed': ShepherdCompleted;
   'eval.judge.calibrated': JudgeCalibrated;
   'remediation.attempted': RemediationAttempted;

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -410,6 +410,87 @@ describe('handleAssessStack', () => {
       const data = result.data as { recommendation: string };
       expect(data.recommendation).toBe('escalate');
     });
+
+    // DR-3 (#1595): the loop's iteration count is the COUNT of
+    // `shepherd.iteration` events (the single event-sourced authority,
+    // `countShepherdIterations`), NOT any `iteration` value stamped in a payload.
+    // Five events with arbitrary / non-monotonic / duplicate payload `iteration`
+    // values still report count 5 and escalate at maxIterations — proving the
+    // loop never reads the payload value, so it can never disagree with the view.
+    it('IterationCounter_SingleEventSourcedAuthority', async () => {
+      const garbagePayloads = [99, 99, 1, 0, -3]; // duplicate, non-monotonic, garbage
+      const iterationEvents = garbagePayloads.map((iteration, i) => ({
+        type: 'shepherd.iteration',
+        streamId: 'test-feature',
+        sequence: i + 1,
+        timestamp: new Date().toISOString(),
+        data: { prUrl: 'https://github.com/test/42', iteration, action: 'fix', outcome: 'retry' },
+      }));
+      // Only the `shepherd.iteration` query returns the events; every other
+      // query (started/completed) is empty so the count is purely the event tally.
+      mockQuery.mockImplementation(async (_streamId: string, opts?: { type?: string }) =>
+        opts?.type === 'shepherd.iteration' ? iterationEvents : [],
+      );
+
+      const provider = createMockProvider({
+        checkCi: { status: 'fail', checks: [{ name: 'ci/build', status: 'fail' }] },
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        recommendation: string;
+        status: { iterationCount: number };
+      };
+      // The count is exactly the number of events (5), independent of the
+      // garbage/duplicate/non-monotonic payload `iteration` values.
+      expect(data.status.iterationCount).toBe(garbagePayloads.length);
+      // …and the bound (5) is reached by that count, so the loop escalates.
+      expect(data.recommendation).toBe('escalate');
+    });
+
+    // DR-3 (#1595): the loop's escalation bound is config-resolvable via the
+    // shared escalation policy. With `escalation.maxIterations: 3` injected, the
+    // count reaches the bound at 3 events (where the default 5 would not yet
+    // escalate). Same single counter, smaller resolved bound.
+    it('IterationBound_ConfigResolvable_LowersEscalationThreshold', async () => {
+      const iterationEvents = Array.from({ length: 3 }, (_, i) => ({
+        type: 'shepherd.iteration',
+        streamId: 'test-feature',
+        sequence: i + 1,
+        timestamp: new Date().toISOString(),
+        data: { prUrl: 'https://github.com/test/42', iteration: i + 1, action: 'fix', outcome: 'retry' },
+      }));
+      mockQuery.mockImplementation(async (_streamId: string, opts?: { type?: string }) =>
+        opts?.type === 'shepherd.iteration' ? iterationEvents : [],
+      );
+
+      const provider = createMockProvider({
+        checkCi: { status: 'fail', checks: [{ name: 'ci/build', status: 'fail' }] },
+      });
+
+      const result = await handleAssessStack(
+        {
+          featureId: 'test-feature',
+          prNumbers: [42],
+          projectConfig: { escalation: { maxIterations: 3 } } as never,
+        },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { recommendation: string };
+      // 3 events hit the config bound of 3 (the default 5 would say fix-and-resubmit).
+      expect(data.recommendation).toBe('escalate');
+    });
   });
 
   // ─── Shepherd Lifecycle Events ──────────────────────────────────────────

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -674,6 +674,78 @@ describe('handleAssessStack', () => {
       );
       expect(approvalCalls).toHaveLength(0);
     });
+
+    // DR-3 (#1595): hitting the auto-fix bound emits a STRUCTURED escalation
+    // (NOT a hang — INV-10). The handler records reason + counts, then RETURNS
+    // its normal terminal result with `recommendation:'escalate'`; it does not
+    // loop or wait. Re-assessing at the same iteration count reuses the same
+    // idempotency key, so the store dedups (no double-emit).
+    it('BoundHit_EmitsStructuredEscalation_NotHang', async () => {
+      // Seed N = default-maxIterations (5) `shepherd.iteration` events so the
+      // single event-sourced counter reaches the bound, plus failing CI so there
+      // are findings to fix — `computeRecommendation` returns 'escalate'.
+      const iterationEvents = Array.from({ length: 5 }, (_, i) => ({
+        type: 'shepherd.iteration',
+        streamId: 'test-feature',
+        sequence: i + 1,
+        timestamp: new Date().toISOString(),
+        data: { prUrl: 'https://github.com/test/42', iteration: i + 1, action: 'fix', outcome: 'retry' },
+      }));
+      mockQuery.mockImplementation(async (_streamId: string, opts?: { type?: string }) =>
+        opts?.type === 'shepherd.iteration' ? iterationEvents : [],
+      );
+
+      const provider = createMockProvider({
+        checkCi: { status: 'fail', checks: [{ name: 'ci/build', status: 'fail' }] },
+        prState: 'OPEN',
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42, 43] },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+
+      // (b) The handler RETURNS a terminal result with recommendation:'escalate'
+      // — it returned (did not hang).
+      expect(result.success).toBe(true);
+      const data = result.data as { recommendation: string };
+      expect(data.recommendation).toBe('escalate');
+
+      // (a) A structured shepherd.escalated event is appended with the data.
+      const escalatedCalls = mockAppend.mock.calls.filter(
+        (call: unknown[]) => (call[1] as { type: string }).type === 'shepherd.escalated',
+      );
+      expect(escalatedCalls.length).toBe(1);
+      expect(escalatedCalls[0][0]).toBe('test-feature');
+      const escalatedData = (escalatedCalls[0][1] as { data: Record<string, unknown> }).data;
+      expect(escalatedData.featureId).toBe('test-feature');
+      expect(escalatedData.prNumbers).toEqual([42, 43]);
+      expect(escalatedData.iterationCount).toBe(5);
+      expect(escalatedData.maxIterations).toBe(5);
+      expect(escalatedData.reason).toBe('auto-fix bound (5) reached after 5 iterations');
+      const firstKey = (escalatedCalls[0][2] as { idempotencyKey: string })?.idempotencyKey;
+      expect(firstKey).toBe('test-feature:shepherd.escalated:5');
+
+      // (c) Idempotency — re-assessing at the same count reuses the same key, so
+      // the store dedups (no double-emit). Assert the key is stable across calls.
+      mockAppend.mockClear();
+      const result2 = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42, 43] },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+      const data2 = result2.data as { recommendation: string };
+      expect(data2.recommendation).toBe('escalate');
+      const escalatedCalls2 = mockAppend.mock.calls.filter(
+        (call: unknown[]) => (call[1] as { type: string }).type === 'shepherd.escalated',
+      );
+      expect(escalatedCalls2.length).toBe(1);
+      const secondKey = (escalatedCalls2[0][2] as { idempotencyKey: string })?.idempotencyKey;
+      expect(secondKey).toBe(firstKey);
+    });
   });
 
   // ─── Event Emission ──────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -1016,4 +1016,210 @@ describe('handleAssessStack', () => {
       expect(bodies).toContain('explodes');
     });
   });
+
+  // ─── Unified PR-Feedback Feed (DR-7, #1592 task 012) ──────────────────────
+  // assess_stack consumes the widened, aggregated PrComment[] generically:
+  // every source (issue-comment | review-inline | review-summary) and threaded
+  // replies flow through the same harvest path with no source/workflowType
+  // branch (INV-6). Tri-state `resolved` is honored: only resolved === true is
+  // filtered out; absent (unknown) stays surfaced (absent ≠ false).
+
+  describe('unified PR-feedback feed consumption', () => {
+    it('AssessStack_InlineReviewComment_BecomesActionItem', async () => {
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 1,
+            author: 'alice',
+            body: 'This branch is unreachable',
+            createdAt: '2026-01-01T00:00:00Z',
+            source: 'review-inline',
+            path: 'src/handler.ts',
+            line: 88,
+            // resolved absent → unknown → surfaced
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        actionItems: Array<{ type: string; pr: number; file?: string; line?: number }>;
+      };
+      const commentReply = data.actionItems.find((i) => i.type === 'comment-reply');
+      expect(commentReply).toBeDefined();
+      expect(commentReply?.pr).toBe(42);
+      expect(commentReply?.file).toBe('src/handler.ts');
+      expect(commentReply?.line).toBe(88);
+    });
+
+    it('AssessStack_ThreadedReply_Surfaced', async () => {
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 2,
+            author: 'bob',
+            body: 'Replying to the earlier thread — still not addressed',
+            createdAt: '2026-01-01T00:00:00Z',
+            source: 'review-inline',
+            path: 'src/handler.ts',
+            line: 88,
+            parentId: 1, // a reply — must NOT be dropped
+            // resolved absent → unknown → surfaced
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        actionItems: Array<{ type: string; pr: number }>;
+        status: { prs: Array<{ unresolvedComments: Array<{ parentId?: number }> }> };
+      };
+      const commentReply = data.actionItems.find((i) => i.type === 'comment-reply');
+      expect(commentReply).toBeDefined();
+      // Threading is carried through for observability without branching.
+      expect(data.status.prs[0].unresolvedComments[0].parentId).toBe(1);
+    });
+
+    it('AssessStack_ReviewSummaryBody_Surfaced', async () => {
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 3,
+            author: 'carol',
+            body: 'Overall this needs another pass on error handling.',
+            createdAt: '2026-01-01T00:00:00Z',
+            source: 'review-summary',
+            state: 'COMMENTED',
+            // resolved absent → unknown → surfaced
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        actionItems: Array<{ type: string }>;
+        status: { prs: Array<{ unresolvedComments: Array<{ source?: string }> }> };
+      };
+      const commentReply = data.actionItems.find((i) => i.type === 'comment-reply');
+      expect(commentReply).toBeDefined();
+      expect(data.status.prs[0].unresolvedComments[0].source).toBe('review-summary');
+    });
+
+    it('AssessStack_ResolvedComment_NotSurfaced', async () => {
+      // Pins absent ≠ resolved: an explicitly-resolved comment is excluded from
+      // comment-reply action items, while an absent-`resolved` comment is kept.
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 10,
+            author: 'alice',
+            body: 'Resolved thread — already handled',
+            createdAt: '2026-01-01T00:00:00Z',
+            source: 'review-inline',
+            path: 'src/a.ts',
+            line: 1,
+            resolved: true, // explicitly resolved → filtered out
+          },
+          {
+            id: 11,
+            author: 'bob',
+            body: 'Unknown-resolution thread — still needs attention',
+            createdAt: '2026-01-01T00:00:00Z',
+            source: 'review-inline',
+            path: 'src/b.ts',
+            line: 2,
+            // resolved absent → unknown → surfaced
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        mockEventStore,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        actionItems: Array<{ type: string; file?: string }>;
+        status: { prs: Array<{ unresolvedComments: Array<{ body: string }> }> };
+      };
+      const commentReplies = data.actionItems.filter((i) => i.type === 'comment-reply');
+      // Only the absent-resolved comment is surfaced as an action item.
+      expect(commentReplies).toHaveLength(1);
+      expect(commentReplies[0].file).toBe('src/b.ts');
+
+      const surfacedBodies = data.status.prs[0].unresolvedComments.map((c) => c.body);
+      expect(surfacedBodies).toContain('Unknown-resolution thread — still needs attention');
+      expect(surfacedBodies).not.toContain('Resolved thread — already handled');
+    });
+
+    it('AssessStack_HarvestLoop_NoWorkflowTypeBranch', async () => {
+      // INV-6: the harvest path must consume comments generically — no
+      // source-specific or workflowType-specific branch. Two assertions:
+      //  (1) the assess-stack source carries no `workflowType` token at all;
+      //  (2) behavior is identical regardless of comment `source` — every
+      //      surface yields a comment-reply action item via the same path.
+      const fs = await import('node:fs');
+      const path = await import('node:url');
+      const srcPath = path.fileURLToPath(new URL('./assess-stack.ts', import.meta.url));
+      const src = fs.readFileSync(srcPath, 'utf8');
+      expect(src).not.toMatch(/workflowType/);
+
+      const mkProvider = (source: PrComment['source']): VcsProvider =>
+        createMockProvider({
+          checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+          prComments: [
+            {
+              id: 1,
+              author: 'alice',
+              body: 'needs attention',
+              createdAt: '2026-01-01T00:00:00Z',
+              source,
+              ...(source === 'review-inline' ? { path: 'src/x.ts', line: 3 } : {}),
+            },
+          ],
+        });
+
+      const sources: PrComment['source'][] = ['issue-comment', 'review-inline', 'review-summary'];
+      for (const source of sources) {
+        const result = await handleAssessStack(
+          { featureId: 'test-feature', prNumbers: [42] },
+          STATE_DIR,
+          mockEventStore,
+          mkProvider(source),
+        );
+        expect(result.success).toBe(true);
+        const data = result.data as { actionItems: Array<{ type: string }> };
+        const commentReplies = data.actionItems.filter((i) => i.type === 'comment-reply');
+        expect(commentReplies).toHaveLength(1);
+      }
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -426,6 +426,33 @@ async function emitShepherdApprovalRequested(
   });
 }
 
+// DR-3 (#1595): on the bound-hit escalate path, emit a STRUCTURED escalation
+// (NOT a hang — INV-10). The handler records the reason + counts, then returns
+// its normal terminal result carrying `recommendation:'escalate'`; it does not
+// loop or wait. Idempotency-keyed on `iterationCount` so re-assessment at the
+// same count does not double-emit. Mirrors `emitShepherdApprovalRequested`.
+async function emitShepherdEscalated(
+  eventStore: EventStore,
+  featureId: string,
+  prNumbers: readonly number[],
+  iterationCount: number,
+  maxIterations: number,
+): Promise<void> {
+  const reason = `auto-fix bound (${maxIterations}) reached after ${iterationCount} iterations`;
+  await eventStore.append(featureId, {
+    type: 'shepherd.escalated' as const,
+    data: {
+      featureId,
+      prNumbers: [...prNumbers],
+      iterationCount,
+      maxIterations,
+      reason,
+    },
+  }, {
+    idempotencyKey: `${featureId}:shepherd.escalated:${iterationCount}`,
+  });
+}
+
 async function queryPrMergeState(provider: VcsProvider, prNumber: number): Promise<number | null> {
   try {
     const prs = await provider.listPrs({ head: undefined, state: 'all' });
@@ -540,6 +567,21 @@ export async function handleAssessStack(
     if (completedEvents.length === 0) {
       await emitShepherdApprovalRequested(eventStore, args.featureId, args.prNumbers, iterationCount);
     }
+  }
+
+  // Emit shepherd.escalated on the bound-hit path (DR-3, #1595): a STRUCTURED
+  // terminal escalation, NOT a hang (INV-10). The handler records the reason +
+  // counts here, then falls through to RETURN its normal terminal result with
+  // `recommendation:'escalate'` — it does not loop or wait. Idempotency on
+  // `iterationCount` prevents a double-emit if assessed again at the same count.
+  if (recommendation === 'escalate') {
+    await emitShepherdEscalated(
+      eventStore,
+      args.featureId,
+      args.prNumbers,
+      iterationCount,
+      maxIterations,
+    );
   }
 
   // Build result

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -40,6 +40,12 @@ interface PrComment {
   readonly fullBody: string;   // untruncated; consumed by review provider adapters (#1159)
   readonly isResolved: boolean;
   readonly actionItem?: ActionItem;  // populated by provider adapter dispatch (#1159)
+  // Observability only — carried through from the unified PR-feedback feed so
+  // callers can see which surface a comment came from and whether it threads a
+  // reply. NOT a dispatch branch: the harvest loop treats every source the same
+  // (INV-6). `source`/`parentId` are absent only when the provider omits them.
+  readonly source?: VcsPrComment['source'];
+  readonly parentId?: number;
 }
 
 import type { Severity, ReviewerKind, ActionItem, ReviewAdapterRegistry } from '../review/types.js';
@@ -122,8 +128,13 @@ async function queryPrComments(
 ): Promise<PrComment[]> {
   try {
     const comments: VcsPrComment[] = await provider.getPrComments(String(prNumber));
-    // All comments from VcsProvider are treated as unresolved
-    // (GitHub API doesn't provide isResolved for review comments)
+    // `getPrComments` now returns the unified, aggregated PR-feedback feed
+    // (issue-comment | review-inline | review-summary, with one-level threading)
+    // and a tri-state `resolved`. The github provider enriches review threads via
+    // GraphQL; other surfaces leave `resolved` absent. We honor that tri-state
+    // below: ONLY `resolved === true` is treated as resolved. Absent = unknown,
+    // and an unknown-resolution comment still needs attention, so it stays
+    // surfaced (absent ≠ false).
     const results: PrComment[] = [];
     for (const c of comments) {
       const kind = detectKind(c.author);
@@ -168,8 +179,12 @@ async function queryPrComments(
       results.push({
         body: truncateBody(c.body),
         fullBody: c.body,
-        isResolved: false,
+        // Tri-state gate: resolved ONLY when the provider explicitly says so.
+        // `resolved === false` and absent/unknown both stay unresolved.
+        isResolved: c.resolved === true,
         actionItem,
+        source: c.source,
+        ...(c.parentId !== undefined ? { parentId: c.parentId } : {}),
       });
     }
     return results;

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -12,7 +12,13 @@ import { requiresGitHub } from '../vcs/require-github.js';
 import { createVcsProvider } from '../vcs/factory.js';
 import type { EventStore } from '../event-store/store.js';
 import type { ToolResult } from '../format.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { orchestrateLogger } from '../logger.js';
+import {
+  countShepherdIterations,
+  resolveEscalationPolicy,
+  DEFAULT_MAX_ITERATIONS,
+} from './escalation-policy.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -65,7 +71,10 @@ export interface AssessStackResult {
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
-const MAX_SHEPHERD_ITERATIONS = 5;
+// Module default auto-fix bound for the shepherd loop. It is the SAME value
+// `resolveEscalationPolicy` falls back to (`DEFAULT_MAX_ITERATIONS`); the live
+// bound is resolved per-dispatch from config (DR-3, #1595), not read from here.
+const MAX_SHEPHERD_ITERATIONS = DEFAULT_MAX_ITERATIONS;
 
 // ─── Comment Truncation ─────────────────────────────────────────────────────
 
@@ -285,8 +294,9 @@ export function computeRecommendation(
   actionItems: readonly ActionItem[],
   iterationCount: number,
   prStatuses?: readonly PrStatus[],
+  maxIterations: number = MAX_SHEPHERD_ITERATIONS,
 ): 'request-approval' | 'fix-and-resubmit' | 'wait' | 'escalate' {
-  if (iterationCount >= MAX_SHEPHERD_ITERATIONS) {
+  if (iterationCount >= maxIterations) {
     return 'escalate';
   }
 
@@ -366,12 +376,17 @@ async function emitGateExecutedEvents(
 
 // ─── Iteration Count from Event Store ───────────────────────────────────────
 
+// The loop's iteration count derives from the SINGLE event-sourced authority
+// (`countShepherdIterations`, DR-3 #1595) — the number of `shepherd.iteration`
+// events — NOT from any `iteration` value stamped in a payload. The shepherd-
+// status view folds the same rule, so the loop and `shepherd_status`/`ps` can
+// never disagree about how many iterations have run (INV-1: one counter).
 async function getIterationCount(
   eventStore: EventStore,
   featureId: string,
 ): Promise<number> {
   const events = await eventStore.query(featureId, { type: 'shepherd.iteration' });
-  return events.length;
+  return countShepherdIterations(events);
 }
 
 // ─── Shepherd Lifecycle Helpers ──────────────────────────────────────────────
@@ -443,7 +458,7 @@ async function emitShepherdCompleted(
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
 export async function handleAssessStack(
-  args: { featureId: string; prNumbers: number[] },
+  args: { featureId: string; prNumbers: number[]; projectConfig?: ResolvedProjectConfig },
   _stateDir: string,
   injectedEventStore: EventStore,
   provider?: VcsProvider,
@@ -501,8 +516,21 @@ export async function handleAssessStack(
   // Classify action items
   const actionItems = classifyActionItems(prStatuses);
 
+  // Resolve the auto-fix bound from the shared escalation policy (DR-3, #1595):
+  // config-resolvable, falls back to the module default. The loop and the
+  // recommendation gate use the SAME resolved bound (INV-1; the bound is
+  // workload-agnostic — no per-workflow branch, INV-6).
+  const { maxIterations } = resolveEscalationPolicy({
+    configMaxIterations: args.projectConfig?.escalation?.maxIterations,
+  });
+
   // Compute recommendation
-  const recommendation = computeRecommendation(actionItems, iterationCount, prStatuses);
+  const recommendation = computeRecommendation(
+    actionItems,
+    iterationCount,
+    prStatuses,
+    maxIterations,
+  );
 
   // Emit shepherd.approval_requested when recommendation is request-approval
   // Guard: never emit approval_requested when a PR is already merged (shepherd.completed wins)

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -408,7 +408,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   check_context_economy: adaptWithEventStore(handleContextEconomy),
   check_operational_resilience: adaptWithEventStore(handleOperationalResilience),
   check_workflow_determinism: adaptWithEventStore(handleWorkflowDeterminism),
-  check_review_verdict: adaptWithEventStore(handleReviewVerdict),
+  check_review_verdict: adaptWithEventStoreAndConfig(handleReviewVerdict),
   check_convergence: adaptWithEventStore(handleCheckConvergence),
   check_provenance_chain: adaptWithEventStore(handleProvenanceChain),
   check_task_decomposition: adaptWithEventStore(handleTaskDecomposition),

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -383,7 +383,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   review_triage: adaptWithEventStore(handleReviewTriage),
   prepare_delegation: adaptWithCtx(handlePrepareDelegation),
   prepare_synthesis: adaptWithEventStoreAndConfig(handlePrepareSynthesis),
-  assess_stack: adaptWithEventStore(handleAssessStack),
+  assess_stack: adaptWithEventStoreAndConfig(handleAssessStack),
   check_design_completeness: adaptWithEventStore(handleDesignCompleteness),
   check_plan_coverage: adaptWithEventStore(handlePlanCoverage),
   // Verification-ladder gates (task 005): wrapped in adaptLadderGate so a

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -422,7 +422,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   check_coverage_thresholds: adaptArgs(handleCheckCoverageThresholds),
   assess_refactor_scope: adaptArgsWithEventStore(handleAssessRefactorScope),
   check_pr_comments: adaptArgs(handleCheckPrComments),
-  validate_pr_body: adaptArgs(handleValidatePrBody),
+  validate_pr_body: adaptWithOptionalEventStore(handleValidatePrBody),
   validate_pr_stack: adaptArgs(handleValidatePrStack),
   debug_review_gate: adaptArgs(handleDebugReviewGate),
   extract_fix_tasks: adaptArgsWithStateDirAndEventStore(handleExtractFixTasks),

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -154,6 +154,32 @@ function adaptWithEventStore<T>(
   };
 }
 
+/**
+ * Like {@link adaptWithEventStore}, but ALSO threads the dispatch-time
+ * `ctx.projectConfig` into the handler's args (when the args do not already
+ * carry one — an explicit arg-level `projectConfig`, e.g. from a test, still
+ * wins). Use for handlers that need both the event store AND resolved config —
+ * e.g. `prepare_synthesis`'s DR-2 `document`-leg severity. The injection mirrors
+ * {@link adaptLadderGate}; the handler reads `args.projectConfig`.
+ */
+function adaptWithEventStoreAndConfig<T>(
+  handler: (args: T, stateDir: string, eventStore: EventStore) => Promise<ToolResult>,
+): ActionHandler {
+  return async (args, stateDir, ctx) => {
+    if (!ctx?.eventStore) {
+      throw new Error(
+        `${handler.name}: ctx.eventStore required (handler dispatched without DispatchContext)`,
+      );
+    }
+    const enrichedArgs =
+      ctx.projectConfig !== undefined &&
+      (args as { projectConfig?: unknown }).projectConfig === undefined
+        ? { ...(args as Record<string, unknown>), projectConfig: ctx.projectConfig }
+        : args;
+    return handler(enrichedArgs as unknown as T, stateDir, ctx.eventStore);
+  };
+}
+
 // ─── Verification-ladder severity dispatch (task 005) ────────────────────────
 //
 // The five verification-ladder gates are INV-5b advisory carriers
@@ -356,7 +382,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   task_fail: adaptWithEventStore(handleTaskFail),
   review_triage: adaptWithEventStore(handleReviewTriage),
   prepare_delegation: adaptWithCtx(handlePrepareDelegation),
-  prepare_synthesis: adaptWithEventStore(handlePrepareSynthesis),
+  prepare_synthesis: adaptWithEventStoreAndConfig(handlePrepareSynthesis),
   assess_stack: adaptWithEventStore(handleAssessStack),
   check_design_completeness: adaptWithEventStore(handleDesignCompleteness),
   check_plan_coverage: adaptWithEventStore(handlePlanCoverage),

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -440,7 +440,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   needs_schema_sync: adaptArgs(handleNeedsSchemaSync),
   verify_doc_links: adaptArgs(handleVerifyDocLinks),
   verify_review_triage: adaptArgsWithStateDirAndEventStore(handleVerifyReviewTriage),
-  prepare_review: adapt(handlePrepareReview),
+  prepare_review: adaptWithEventStore(handlePrepareReview),
   discover_bridge: adaptWithOptionalEventStore(handleDiscoverBridge),
   check_invariant_conformance: adaptWithEventStore(handleCheckInvariantConformance),
   // Oneshot + pruning (T4): handlePruneStaleWorkflows already matches the

--- a/servers/exarchos-mcp/src/orchestrate/escalation-policy.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/escalation-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_MAX_ITERATIONS,
+  SDK_MIGRATION_CONTRACT,
   resolveEscalationPolicy,
   decideEscalation,
   classifyFinding,
@@ -142,6 +143,103 @@ describe('escalation-policy (DR-3, #1595)', () => {
       expect(
         countShepherdIterations([{ type: 'shepherd.started' }, { type: 'shepherd.completed' }]),
       ).toBe(0);
+    });
+  });
+
+  // ─── DR-6 divergence guard (#1598, task 023) ────────────────────────────────
+  //
+  // This is the DR-6 divergence guard. It pins the interim escalation defaults
+  // to the documented Workflow SDK (#1258) combinator semantics recorded in
+  // `docs/designs/2026-06-23-ship-gate-sdk-migration.md` ("SDK-contract
+  // values"), mirrored as `SDK_MIGRATION_CONTRACT`. The assertions run the LIVE
+  // policy and compare it to that constant — never to hardcoded literals — so a
+  // FAILURE here means the interim policy and the documented SDK semantics have
+  // FORKED. Fix one or the other (code or the migration note + constant), never
+  // silently let them drift.
+  describe('DivergenceGuard_EscalationDefaults_MatchSdkRepeatUntilSemantics', () => {
+    it("names the bound exactly the SDK repeatUntil option ('maxIterations')", () => {
+      // The interim policy's bound field must be named identically to the SDK's
+      // `repeatUntil(cond, body, { maxIterations })` option, so consolidation is
+      // a rename of the call site, not a re-derivation.
+      expect(SDK_MIGRATION_CONTRACT.repeatUntilOption).toBe('maxIterations');
+      const policy = resolveEscalationPolicy();
+      expect(SDK_MIGRATION_CONTRACT.repeatUntilOption in policy).toBe(true);
+      // The bound field is the ONLY field — i.e. `maxIterations` is the policy's
+      // bound, not some incidentally-present key.
+      expect(Object.keys(policy)).toEqual([SDK_MIGRATION_CONTRACT.repeatUntilOption]);
+    });
+
+    it('inherits the contract default bound as the no-config default (kill-probe on DEFAULT_MAX_ITERATIONS)', () => {
+      // Changing DEFAULT_MAX_ITERATIONS without updating the contract breaks
+      // this guard: both the constant and the resolved no-config policy must
+      // equal the documented SDK `repeatUntil({ maxIterations })` default.
+      expect(DEFAULT_MAX_ITERATIONS).toBe(SDK_MIGRATION_CONTRACT.defaultMaxIterations);
+      expect(resolveEscalationPolicy().maxIterations).toBe(
+        SDK_MIGRATION_CONTRACT.defaultMaxIterations,
+      );
+    });
+
+    it('maps the ask-user escalation onto the SDK awaitApproval combinator', () => {
+      expect(SDK_MIGRATION_CONTRACT.approvalCombinator).toBe('awaitApproval');
+    });
+
+    it('escalates in EXACTLY the contract awaitApproval triggers, auto-fixing otherwise', () => {
+      const policy = resolveEscalationPolicy(); // { maxIterations: 5 }, the no-config default
+
+      // Drive `decideEscalation` across the behavioral axes and derive, from the
+      // LIVE policy, the set of triggers under which it escalates. Each probe is
+      // labelled with the contract trigger it is meant to exercise; `null` means
+      // "must NOT escalate" (the `repeatUntil` body auto-fixes).
+      const probes: ReadonlyArray<{
+        readonly decision: ReturnType<typeof decideEscalation>;
+        readonly expectedTrigger: 'bound-reached' | 'intent-touching' | null;
+      }> = [
+        // intent-touching at iteration 0 (well under bound): the
+        // 'intent-touching' trigger fires regardless of remaining budget.
+        {
+          decision: decideEscalation({ findingClass: 'intent-touching', iteration: 0, policy }),
+          expectedTrigger: 'intent-touching',
+        },
+        // mechanical under the bound: no trigger — auto-fix (the repeatUntil body).
+        {
+          decision: decideEscalation({ findingClass: 'mechanical', iteration: 0, policy }),
+          expectedTrigger: null,
+        },
+        // mechanical at the bound: the 'bound-reached' trigger fires.
+        {
+          decision: decideEscalation({
+            findingClass: 'mechanical',
+            iteration: policy.maxIterations,
+            policy,
+          }),
+          expectedTrigger: 'bound-reached',
+        },
+        // mechanical over the bound: still the 'bound-reached' trigger.
+        {
+          decision: decideEscalation({
+            findingClass: 'mechanical',
+            iteration: policy.maxIterations + 4,
+            policy,
+          }),
+          expectedTrigger: 'bound-reached',
+        },
+      ];
+
+      // 1. Each probe's live action must agree with whether a trigger is expected.
+      for (const { decision, expectedTrigger } of probes) {
+        expect(decision.action).toBe(expectedTrigger === null ? 'auto-fix' : 'escalate');
+      }
+
+      // 2. The set of triggers actually observed escalating from the LIVE policy
+      //    must equal the documented contract set 1:1. Adding or removing an
+      //    escalation case in `decideEscalation` without updating
+      //    SDK_MIGRATION_CONTRACT.escalationTriggers breaks this guard.
+      const observedTriggers = new Set(
+        probes
+          .filter((p) => p.decision.action === 'escalate')
+          .map((p) => p.expectedTrigger),
+      );
+      expect(observedTriggers).toEqual(new Set(SDK_MIGRATION_CONTRACT.escalationTriggers));
     });
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/escalation-policy.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/escalation-policy.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_MAX_ITERATIONS,
+  resolveEscalationPolicy,
+  decideEscalation,
+  classifyFinding,
+  countShepherdIterations,
+} from './escalation-policy.js';
+
+describe('escalation-policy (DR-3, #1595)', () => {
+  describe('EscalationPolicy_DefaultFive_PerLoopOverride', () => {
+    it('resolves to the uniform default of 5 with no input', () => {
+      expect(DEFAULT_MAX_ITERATIONS).toBe(5);
+      expect(resolveEscalationPolicy()).toEqual({ maxIterations: 5 });
+      expect(resolveEscalationPolicy({})).toEqual({ maxIterations: 5 });
+    });
+
+    it('honors a config-resolved bound', () => {
+      expect(resolveEscalationPolicy({ configMaxIterations: 8 })).toEqual({ maxIterations: 8 });
+    });
+
+    it('honors a per-loop override', () => {
+      expect(resolveEscalationPolicy({ perLoopOverride: 2 })).toEqual({ maxIterations: 2 });
+    });
+
+    it('lets the per-loop override win over the config value', () => {
+      expect(
+        resolveEscalationPolicy({ perLoopOverride: 2, configMaxIterations: 8 }),
+      ).toEqual({ maxIterations: 2 });
+    });
+
+    it('ignores non-positive / non-integer values at each layer, falling through', () => {
+      // Per-loop override is garbage → fall through to config.
+      expect(
+        resolveEscalationPolicy({ perLoopOverride: 0, configMaxIterations: 8 }),
+      ).toEqual({ maxIterations: 8 });
+      expect(
+        resolveEscalationPolicy({ perLoopOverride: -3, configMaxIterations: 8 }),
+      ).toEqual({ maxIterations: 8 });
+      expect(
+        resolveEscalationPolicy({ perLoopOverride: 2.5, configMaxIterations: 8 }),
+      ).toEqual({ maxIterations: 8 });
+      // Both layers garbage → fall through to the default.
+      expect(
+        resolveEscalationPolicy({ perLoopOverride: -1, configMaxIterations: 0 }),
+      ).toEqual({ maxIterations: 5 });
+      expect(
+        resolveEscalationPolicy({ perLoopOverride: Number.NaN, configMaxIterations: Number.NaN }),
+      ).toEqual({ maxIterations: 5 });
+    });
+  });
+
+  describe('EscalationPolicy_MechanicalFinding_AutoFixesWithinBound', () => {
+    it('auto-fixes a mechanical finding while under the bound', () => {
+      const decision = decideEscalation({
+        findingClass: 'mechanical',
+        iteration: 2,
+        policy: { maxIterations: 5 },
+      });
+      expect(decision.action).toBe('auto-fix');
+    });
+
+    it('escalates a mechanical finding once the bound is hit (bound-hit reason)', () => {
+      const decision = decideEscalation({
+        findingClass: 'mechanical',
+        iteration: 5,
+        policy: { maxIterations: 5 },
+      });
+      expect(decision.action).toBe('escalate');
+      expect(decision.reason).toContain('auto-fix bound');
+      expect(decision.reason).toContain('5');
+    });
+
+    it('escalates when the iteration exceeds the bound', () => {
+      const decision = decideEscalation({
+        findingClass: 'mechanical',
+        iteration: 9,
+        policy: { maxIterations: 5 },
+      });
+      expect(decision.action).toBe('escalate');
+    });
+  });
+
+  describe('EscalationPolicy_IntentTouchingFinding_EscalatesImmediately', () => {
+    it('escalates an intent-touching finding at iteration 0 (not bound-gated)', () => {
+      const decision = decideEscalation({
+        findingClass: 'intent-touching',
+        iteration: 0,
+        policy: { maxIterations: 5 },
+      });
+      expect(decision.action).toBe('escalate');
+      expect(decision.reason).toContain('intent-touching');
+    });
+
+    it('escalates an intent-touching finding regardless of iteration', () => {
+      for (const iteration of [0, 1, 4, 100]) {
+        expect(
+          decideEscalation({
+            findingClass: 'intent-touching',
+            iteration,
+            policy: { maxIterations: 5 },
+          }).action,
+        ).toBe('escalate');
+      }
+    });
+  });
+
+  describe('classifyFinding', () => {
+    it('classifies an explicitly intent-touching finding', () => {
+      expect(classifyFinding({ intentTouching: true })).toBe('intent-touching');
+    });
+
+    it('classifies a spec-category finding as intent-touching', () => {
+      expect(classifyFinding({ category: 'spec' })).toBe('intent-touching');
+    });
+
+    it('classifies lint/format/style/coverage findings as mechanical', () => {
+      expect(classifyFinding({ category: 'lint' })).toBe('mechanical');
+      expect(classifyFinding({ category: 'format' })).toBe('mechanical');
+      expect(classifyFinding({ category: 'style' })).toBe('mechanical');
+      expect(classifyFinding({ category: 'coverage' })).toBe('mechanical');
+      expect(classifyFinding({})).toBe('mechanical');
+      expect(classifyFinding({ intentTouching: false })).toBe('mechanical');
+    });
+  });
+
+  describe('countShepherdIterations', () => {
+    it('counts only shepherd.iteration events', () => {
+      const events = [
+        { type: 'shepherd.started' },
+        { type: 'shepherd.iteration' },
+        { type: 'task.completed' },
+        { type: 'shepherd.iteration' },
+        { type: 'shepherd.iteration' },
+        { type: 'shepherd.completed' },
+      ];
+      expect(countShepherdIterations(events)).toBe(3);
+    });
+
+    it('returns 0 for an empty stream or a stream with no iterations', () => {
+      expect(countShepherdIterations([])).toBe(0);
+      expect(
+        countShepherdIterations([{ type: 'shepherd.started' }, { type: 'shepherd.completed' }]),
+      ).toBe(0);
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/escalation-policy.ts
+++ b/servers/exarchos-mcp/src/orchestrate/escalation-policy.ts
@@ -1,0 +1,130 @@
+// ─── Shared Escalation Policy (DR-3, #1595) ─────────────────────────────────
+//
+// One escalation policy, consumed by the three fix-loops of the ship-gate
+// methodology: spec-review, quality-review, and the shepherd loop (tasks
+// 016–019 are the consumers). The policy is two primitives:
+//
+//   1. A bounded `maxIterations` per loop — how many times a loop may auto-fix
+//      a mechanical finding before it must escalate to the user.
+//   2. An explicit ask-user escalation when the bound is hit OR a finding is
+//      INTENT-TOUCHING (a spec/intent finding the loop must not silently
+//      "fix" — it changes what was asked for, so a human decides).
+//
+// Defaults are config-resolvable (mirror the `synthesis` precedent, task 003):
+// a uniform default of `5` with a per-loop override. Consumers read
+// `projectConfig.escalation.maxIterations` and pass it as `configMaxIterations`.
+//
+// Every function here is pure and total — the load-bearing testable unit is
+// `decideEscalation`. `classifyFinding` and `countShepherdIterations` are the
+// thin, explicit feeders around it.
+
+/**
+ * Uniform default auto-fix bound for every fix-loop. A loop may auto-fix a
+ * mechanical finding while `iteration < maxIterations`; on hitting the bound it
+ * escalates to the user. Overridable per-loop and via config.
+ */
+export const DEFAULT_MAX_ITERATIONS = 5;
+
+/** A fully-resolved escalation policy for a single fix-loop. */
+export interface EscalationPolicy {
+  readonly maxIterations: number;
+}
+
+/**
+ * Resolves an {@link EscalationPolicy}, applying precedence
+ * `perLoopOverride > configMaxIterations > DEFAULT_MAX_ITERATIONS`. At each
+ * layer a value that is not a positive integer (non-positive, non-integer, or
+ * `undefined`) is ignored and resolution falls through to the next layer — so a
+ * garbage override can never weaken the bound below the resolvable default.
+ */
+export function resolveEscalationPolicy(opts?: {
+  readonly configMaxIterations?: number;
+  readonly perLoopOverride?: number;
+}): EscalationPolicy {
+  const layers = [opts?.perLoopOverride, opts?.configMaxIterations, DEFAULT_MAX_ITERATIONS];
+  for (const candidate of layers) {
+    if (isPositiveInteger(candidate)) {
+      return { maxIterations: candidate };
+    }
+  }
+  // DEFAULT_MAX_ITERATIONS is a positive integer, so the loop above always
+  // returns; this is unreachable and exists only to satisfy totality.
+  return { maxIterations: DEFAULT_MAX_ITERATIONS };
+}
+
+/**
+ * Whether a finding can be auto-fixed by the loop (`mechanical` — lint, format,
+ * style, coverage) or must be escalated to the user (`intent-touching` —
+ * spec/intent findings that change what was asked for).
+ */
+export type FindingClass = 'mechanical' | 'intent-touching';
+
+/** The decision a fix-loop takes for a finding at a given iteration. */
+export interface EscalationDecision {
+  readonly action: 'auto-fix' | 'escalate';
+  readonly reason: string;
+}
+
+/**
+ * Decides whether a fix-loop should auto-fix a finding or escalate to the user.
+ * Pure and total:
+ *   - An `intent-touching` finding ALWAYS escalates immediately, regardless of
+ *     iteration — the loop never silently "fixes" something that changes intent.
+ *   - A `mechanical` finding is auto-fixed while `iteration < maxIterations`;
+ *     once `iteration >= maxIterations` the auto-fix bound is hit and the loop
+ *     escalates.
+ */
+export function decideEscalation(args: {
+  readonly findingClass: FindingClass;
+  readonly iteration: number;
+  readonly policy: EscalationPolicy;
+}): EscalationDecision {
+  if (args.findingClass === 'intent-touching') {
+    return { action: 'escalate', reason: 'intent-touching finding — escalate immediately' };
+  }
+  if (args.iteration >= args.policy.maxIterations) {
+    return { action: 'escalate', reason: `auto-fix bound (${args.policy.maxIterations}) reached` };
+  }
+  return { action: 'auto-fix', reason: 'mechanical finding within auto-fix bound' };
+}
+
+/**
+ * Classifies a review finding into a {@link FindingClass}. Minimal and
+ * explicit: a finding is `intent-touching` when it is flagged as such
+ * (`intentTouching === true`) OR it is a spec finding (`category === 'spec'`) —
+ * both change what was asked for and need a human. Everything else (lint,
+ * format, style, coverage, …) is `mechanical` and may be auto-fixed within the
+ * bound. The load-bearing decision lives in {@link decideEscalation}; this is
+ * just the feeder that maps a finding's shape onto its class.
+ */
+export function classifyFinding(finding: {
+  readonly intentTouching?: boolean;
+  readonly category?: string;
+}): FindingClass {
+  if (finding.intentTouching === true || finding.category === 'spec') {
+    return 'intent-touching';
+  }
+  return 'mechanical';
+}
+
+/**
+ * The SINGLE event-sourced iteration-count authority: the number of
+ * `shepherd.iteration` events in a stream. Task 017 reconciles BOTH the
+ * `assess_stack` loop and the shepherd-status view onto THIS rule so they can
+ * never disagree about how many iterations a loop has run. Pure and total over
+ * any event array — only the `type` discriminant is read.
+ */
+export function countShepherdIterations(
+  events: ReadonlyArray<{ readonly type: string }>,
+): number {
+  let count = 0;
+  for (const event of events) {
+    if (event.type === 'shepherd.iteration') count++;
+  }
+  return count;
+}
+
+/** A positive integer is a valid bound at any resolution layer. */
+function isPositiveInteger(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}

--- a/servers/exarchos-mcp/src/orchestrate/escalation-policy.ts
+++ b/servers/exarchos-mcp/src/orchestrate/escalation-policy.ts
@@ -25,6 +25,30 @@
  */
 export const DEFAULT_MAX_ITERATIONS = 5;
 
+/**
+ * The durable, machine-checkable mirror of the Workflow SDK (#1258) combinator
+ * semantics that this interim escalation policy is authored to lower onto. The
+ * prose source-of-truth is `docs/designs/2026-06-23-ship-gate-sdk-migration.md`
+ * ("SDK-contract values"); this constant is the anchor that the DR-6 divergence
+ * guard test asserts the live policy against, so the as-shipped defaults and
+ * the documented SDK semantics cannot silently fork before consolidation.
+ *
+ * On consolidation each interim symbol is a rename of a call site, not a
+ * re-derivation: the bounded auto-fix becomes
+ * `repeatUntil(cond, body, { maxIterations })` and the ask-user escalation
+ * becomes `awaitApproval(approver)`.
+ */
+export const SDK_MIGRATION_CONTRACT = {
+  /** The interim bound re-uses the SDK `repeatUntil(cond, body, { maxIterations })` option name verbatim. */
+  repeatUntilOption: 'maxIterations',
+  /** The default bound the SDK `repeatUntil({ maxIterations })` body inherits on consolidation. */
+  defaultMaxIterations: DEFAULT_MAX_ITERATIONS,
+  /** The ask-user escalation maps onto the SDK `awaitApproval(...)` combinator. */
+  approvalCombinator: 'awaitApproval',
+  /** decideEscalation escalates in EXACTLY these cases (awaitApproval triggers): bound reached OR an intent-touching finding. */
+  escalationTriggers: ['bound-reached', 'intent-touching'],
+} as const;
+
 /** A fully-resolved escalation policy for a single fix-loop. */
 export interface EscalationPolicy {
   readonly maxIterations: number;

--- a/servers/exarchos-mcp/src/orchestrate/extract-intent.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/extract-intent.test.ts
@@ -1,0 +1,127 @@
+// ─── Extract Intent Tests (DR-1 #1593, task 004) ────────────────────────────
+//
+// Covers the intent FOUNDATION: a diff-derived floor written to
+// `artifacts.intent` via a single state-patch event, optional transcript
+// enrichment, and the structural INV-6 guarantee (no `workflowType` branch on
+// the intent path). The persist tests drive a REAL event store + stateDir and
+// read the intent back via `resolveWorkflowState` — the same canonical surface
+// the gates use.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { deriveIntent, persistIntent, type WorkflowIntent } from './extract-intent.js';
+import { handleInit } from '../workflow/tools.js';
+import { resolveWorkflowState } from './resolve-state.js';
+import { EventStore } from '../event-store/store.js';
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let eventStore: EventStore;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-intent-'));
+  eventStore = new EventStore(tmpDir);
+  await eventStore.initialize();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Read `artifacts.intent` back through the canonical event-store projection. */
+async function readStoredIntent(featureId: string): Promise<WorkflowIntent | undefined> {
+  const resolved = await resolveWorkflowState({ featureId, eventStore });
+  if ('error' in resolved) return undefined;
+  const artifacts = resolved.state.artifacts as { intent?: WorkflowIntent } | undefined;
+  return artifacts?.intent;
+}
+
+describe('extract-intent (DR-1 #1593)', () => {
+  it('ExtractIntent_DiffDerivedFloor_WritesArtifactsIntent', async () => {
+    // ── Pure floor ──────────────────────────────────────────────────────────
+    const intent = deriveIntent(['servers/a.ts', 'docs/b.md']);
+    expect(intent.source).toBe('diff');
+    expect(intent.changedFiles).toEqual(['servers/a.ts', 'docs/b.md']);
+    expect(intent.surfaces).toEqual(['docs', 'servers']); // de-duped, sorted top-level prefixes
+    expect(intent.summary).toBe('2 files changed across 2 surfaces: docs, servers');
+    expect(intent.transcriptSummary).toBeUndefined();
+
+    // ── Persist + read back through the canonical projection ─────────────────
+    const featureId = 'intent-floor-feat';
+    const init = await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore);
+    expect(init.success).toBe(true);
+
+    const result = await persistIntent(featureId, intent, tmpDir, eventStore);
+    expect(result.persisted).toBe(true);
+    expect(result.warning).toBeUndefined();
+
+    const stored = await readStoredIntent(featureId);
+    expect(stored).toBeDefined();
+    expect(stored).toEqual(intent);
+  });
+
+  it('ExtractIntent_TranscriptPresent_EnrichesIntent', async () => {
+    // With a transcript: enriched source + a bounded transcriptSummary.
+    const enriched = deriveIntent(['servers/a.ts'], {
+      transcript: 'Refactor the dispatch adapter to thread eventStore.\nMore detail follows.',
+    });
+    expect(enriched.source).toBe('diff+transcript');
+    expect(enriched.transcriptSummary).toBe('Refactor the dispatch adapter to thread eventStore.');
+
+    // Without a transcript (and with an empty/whitespace one): floor, no summary.
+    const floor = deriveIntent(['servers/a.ts']);
+    expect(floor.source).toBe('diff');
+    expect(floor.transcriptSummary).toBeUndefined();
+
+    const blank = deriveIntent(['servers/a.ts'], { transcript: '   \n  ' });
+    expect(blank.source).toBe('diff');
+    expect(blank.transcriptSummary).toBeUndefined();
+  });
+
+  it('ExtractIntent_WorkflowAgnostic_NoTypeBranch', async () => {
+    // INV-6: the SAME derived intent persists identically regardless of workflow
+    // type. `deriveIntent` takes no workflowType (proven by its arity / call
+    // shape), and the persist path is type-blind — so a `feature` and a
+    // `oneshot` workflow store byte-identical `artifacts.intent`.
+    const intent = deriveIntent(['servers/a.ts', 'skills-src/x/SKILL.md', 'docs/y.md']);
+
+    const featureId = 'intent-agnostic-feature';
+    const oneshotId = 'intent-agnostic-oneshot';
+    expect((await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore)).success).toBe(true);
+    expect((await handleInit({ featureId: oneshotId, workflowType: 'oneshot' }, tmpDir, eventStore)).success).toBe(true);
+
+    expect((await persistIntent(featureId, intent, tmpDir, eventStore)).persisted).toBe(true);
+    expect((await persistIntent(oneshotId, intent, tmpDir, eventStore)).persisted).toBe(true);
+
+    const featureIntent = await readStoredIntent(featureId);
+    const oneshotIntent = await readStoredIntent(oneshotId);
+    expect(featureIntent).toEqual(oneshotIntent);
+    expect(featureIntent).toEqual(intent);
+
+    // Structural assertion: the derivation's only positional inputs are
+    // `(changedFiles, opts?)` — there is NO workflowType parameter. A
+    // workflowType would have to be a third positional arg; the function's arity
+    // (`changedFiles` + the optional `opts`) is exactly 2, leaving no slot for
+    // it. The byte-identical feature/oneshot intents above prove the same code
+    // path runs for every type.
+    expect(deriveIntent.length).toBe(2);
+    // And `opts` carries only `transcript` — never a workflowType-like key — so
+    // a type can't sneak in through the options bag either.
+    const probe = deriveIntent(['servers/a.ts'], { transcript: 'x' });
+    expect(Object.keys(probe).filter((k) => k.toLowerCase().includes('workflowtype'))).toEqual([]);
+  });
+
+  it('ExtractIntent_PersistWithoutWorkflow_FailsSoft', async () => {
+    // Fail-soft contract: persisting against a featureId with no inited workflow
+    // returns `{ persisted: false, warning }` and NEVER throws — review
+    // provisioning must survive a state-patch miss.
+    const intent = deriveIntent(['servers/a.ts']);
+    const result = await persistIntent('no-such-workflow', intent, tmpDir, eventStore);
+    expect(result.persisted).toBe(false);
+    expect(result.warning).toBeTruthy();
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/extract-intent.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/extract-intent.test.ts
@@ -12,7 +12,17 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
-import { deriveIntent, persistIntent, type WorkflowIntent } from './extract-intent.js';
+import {
+  deriveIntent,
+  persistIntent,
+  readIntent,
+  groundBodyInIntent,
+  bodyHasIntentMarker,
+  isMeaningfulIntent,
+  buildIntentSection,
+  INTENT_GROUNDING_MARKER,
+  type WorkflowIntent,
+} from './extract-intent.js';
 import { handleInit } from '../workflow/tools.js';
 import { resolveWorkflowState } from './resolve-state.js';
 import { EventStore } from '../event-store/store.js';
@@ -123,5 +133,80 @@ describe('extract-intent (DR-1 #1593)', () => {
     const result = await persistIntent('no-such-workflow', intent, tmpDir, eventStore);
     expect(result.persisted).toBe(false);
     expect(result.warning).toBeTruthy();
+  });
+});
+
+// ─── readIntent (DR-1 task 006) ──────────────────────────────────────────────
+
+describe('readIntent (DR-1 task 006)', () => {
+  it('ReadIntent_PersistedMeaningfulIntent_RoundTrips', async () => {
+    // The READ counterpart of persistIntent: persist a meaningful intent, read it
+    // back through the canonical projection-backed reader.
+    const intent = deriveIntent(['servers/a.ts', 'docs/b.md']);
+    const featureId = 'read-intent-feat';
+    expect((await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore)).success).toBe(true);
+    expect((await persistIntent(featureId, intent, tmpDir, eventStore)).persisted).toBe(true);
+
+    const read = await readIntent(featureId, eventStore);
+    expect(read).toEqual(intent);
+  });
+
+  it('ReadIntent_NoFeatureId_ReturnsUndefined', async () => {
+    // Degrade: no featureId → undefined, never throws.
+    expect(await readIntent(undefined, eventStore)).toBeUndefined();
+  });
+
+  it('ReadIntent_NoEventStore_ReturnsUndefined', async () => {
+    // Degrade: no event store → undefined, never throws.
+    expect(await readIntent('some-feat', undefined)).toBeUndefined();
+  });
+
+  it('ReadIntent_NoPersistedIntent_ReturnsUndefined', async () => {
+    // A workflow with no `artifacts.intent` → undefined (absent is not an error).
+    const featureId = 'read-intent-absent';
+    expect((await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore)).success).toBe(true);
+    expect(await readIntent(featureId, eventStore)).toBeUndefined();
+  });
+
+  it('ReadIntent_UnknownWorkflow_FailsSoftToUndefined', async () => {
+    // Unreadable / unknown workflow state → undefined, never throws.
+    expect(await readIntent('no-such-workflow-at-all', eventStore)).toBeUndefined();
+  });
+});
+
+// ─── Body grounding helpers (DR-1 task 006) ──────────────────────────────────
+
+describe('intent body grounding (DR-1 task 006)', () => {
+  it('GroundBody_MeaningfulIntent_AppendsIntentSectionAndMarker', () => {
+    const intent = deriveIntent(['servers/a.ts', 'docs/b.md']);
+    const grounded = groundBodyInIntent('## Summary\n\nDoes a thing.', intent);
+    expect(grounded).toContain('## Intent');
+    expect(bodyHasIntentMarker(grounded)).toBe(true);
+    expect(grounded).toContain('docs, servers'); // surfaces
+    expect(grounded).toContain(intent.summary);
+    // Original body content is preserved ahead of the appended section.
+    expect(grounded.startsWith('## Summary')).toBe(true);
+  });
+
+  it('GroundBody_TranscriptSummary_IncludedWhenPresent', () => {
+    const intent = deriveIntent(['servers/a.ts'], { transcript: 'Thread the event store through.' });
+    const section = buildIntentSection(intent);
+    expect(section).toContain('**Context:** Thread the event store through.');
+  });
+
+  it('GroundBody_EmptyIntent_LeavesBodyUntouched', () => {
+    const empty = deriveIntent([]);
+    expect(isMeaningfulIntent(empty)).toBe(false);
+    const body = '## Summary\n\nNo files.';
+    expect(groundBodyInIntent(body, empty)).toBe(body);
+  });
+
+  it('GroundBody_AlreadyMarked_IsIdempotent', () => {
+    const intent = deriveIntent(['servers/a.ts']);
+    const once = groundBodyInIntent('## Summary\n\nBody.', intent);
+    const twice = groundBodyInIntent(once, intent);
+    // Second pass is a no-op — the marker appears exactly once.
+    expect(twice).toBe(once);
+    expect(twice.split(INTENT_GROUNDING_MARKER).length - 1).toBe(1);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/extract-intent.ts
+++ b/servers/exarchos-mcp/src/orchestrate/extract-intent.ts
@@ -17,10 +17,14 @@
 //
 // `changedFilesAgainstBase` mirrors the proven diff helper in
 // `prepare-synthesis.ts` (kept self-contained here — Bundle A's file is left
-// untouched to keep blast radius off it).
+// untouched to keep blast radius off it). The two now deliberately DIVERGE on
+// failure: intent is fail-SOFT (`[]` floor on git error — a degraded intent is
+// fine), whereas prepare-synthesis fails CLOSED (`null` → a blocking document
+// leg cannot be silently waived). Same shape, intentionally different failure
+// semantics — which is why the helper is not hoisted into one shared symbol.
 // ────────────────────────────────────────────────────────────────────────────
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import type { EventStore } from '../event-store/store.js';
 import { handleUpdate } from '../workflow/tools.js';
 import { WorkflowIntentSchema } from '../workflow/schemas.js';
@@ -34,7 +38,7 @@ export type { WorkflowIntent } from '../workflow/schemas.js';
 /** The default base branch, via origin/HEAD with a sanitizing fallback to `main`. */
 function detectDefaultBranch(cwd?: string): string {
   try {
-    const ref = execSync('git symbolic-ref refs/remotes/origin/HEAD', {
+    const ref = execFileSync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
       encoding: 'utf-8',
       timeout: 5_000,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -52,7 +56,7 @@ function detectDefaultBranch(cwd?: string): string {
 export function changedFilesAgainstBase(cwd?: string): string[] {
   try {
     const baseBranch = detectDefaultBranch(cwd);
-    const output = execSync(`git diff --name-only ${baseBranch}...HEAD`, {
+    const output = execFileSync('git', ['diff', '--name-only', `${baseBranch}...HEAD`], {
       encoding: 'buffer',
       timeout: 15_000,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/servers/exarchos-mcp/src/orchestrate/extract-intent.ts
+++ b/servers/exarchos-mcp/src/orchestrate/extract-intent.ts
@@ -1,0 +1,173 @@
+// ─── Extract Intent (DR-1 #1593) ─────────────────────────────────────────────
+//
+// A transcript/diff-derived **intent** captured as workflow state so that
+// REVIEW (task 005) and PR-body generation (task 006) can later read it back.
+// This module WRITES the intent; downstream tasks READ it.
+//
+// Two pieces:
+//   1. `deriveIntent` — PURE: changed-file list (+ optional transcript) → the
+//      `WorkflowIntent` floor. No I/O, no `workflowType` parameter. The absence
+//      of a `workflowType` parameter is the structural guarantee of INV-6
+//      (workflow-agnosticism): the SAME derivation runs for feature / debug /
+//      refactor / oneshot with no type switch anywhere on the path.
+//   2. `persistIntent` — fail-soft persist via the CANONICAL state-patch surface
+//      (`handleUpdate` → exactly one `state.patched` event). Never throws; on
+//      any failure it returns `{ persisted: false, warning }` so review
+//      provisioning is never broken by a state-write hiccup.
+//
+// `changedFilesAgainstBase` mirrors the proven diff helper in
+// `prepare-synthesis.ts` (kept self-contained here — Bundle A's file is left
+// untouched to keep blast radius off it).
+// ────────────────────────────────────────────────────────────────────────────
+
+import { execSync } from 'node:child_process';
+import type { EventStore } from '../event-store/store.js';
+import { handleUpdate } from '../workflow/tools.js';
+import type { WorkflowIntent } from '../workflow/schemas.js';
+
+export type { WorkflowIntent } from '../workflow/schemas.js';
+
+// ─── Diff Helper (self-contained — mirrors prepare-synthesis.ts) ─────────────
+
+/** The default base branch, via origin/HEAD with a sanitizing fallback to `main`. */
+function detectDefaultBranch(cwd?: string): string {
+  try {
+    const ref = execSync('git symbolic-ref refs/remotes/origin/HEAD', {
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(cwd ? { cwd } : {}),
+    }).trim();
+    const branch = ref.replace('refs/remotes/origin/', '');
+    // Sanitize to prevent command injection via crafted ref names.
+    return /^[a-zA-Z0-9/_.-]+$/.test(branch) ? branch : 'main';
+  } catch {
+    return 'main';
+  }
+}
+
+/** Changed files between the default base branch and HEAD (name-only). `[]` on any error. */
+export function changedFilesAgainstBase(cwd?: string): string[] {
+  try {
+    const baseBranch = detectDefaultBranch(cwd);
+    const output = execSync(`git diff --name-only ${baseBranch}...HEAD`, {
+      encoding: 'buffer',
+      timeout: 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(cwd ? { cwd } : {}),
+    });
+    return output
+      .toString('utf-8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// ─── Pure Derivation ─────────────────────────────────────────────────────────
+
+/** Upper bound on the transcript-summary length (chars). */
+const TRANSCRIPT_SUMMARY_MAX = 280;
+
+/**
+ * De-duped, sorted top-level surface prefixes of the changed files. The surface
+ * is the first path segment (e.g. `servers/a/b.ts` → `servers`); a top-level
+ * file with no slash (e.g. `README.md`) is its own surface.
+ */
+function surfacesOf(changedFiles: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const f of changedFiles) {
+    const trimmed = f.trim();
+    if (!trimmed) continue;
+    const slash = trimmed.indexOf('/');
+    seen.add(slash === -1 ? trimmed : trimmed.slice(0, slash));
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Bound a transcript to a single human-readable summary line: the first
+ * non-empty line, length-capped. Pure — never throws on odd input.
+ */
+function summarizeTranscript(transcript: string): string {
+  const firstLine =
+    transcript
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? transcript.trim();
+  return firstLine.length > TRANSCRIPT_SUMMARY_MAX
+    ? `${firstLine.slice(0, TRANSCRIPT_SUMMARY_MAX - 1)}…`
+    : firstLine;
+}
+
+/**
+ * Derive the `WorkflowIntent` floor from the cumulative changed-file list, with
+ * optional transcript enrichment. PURE — no I/O, and (deliberately) NO
+ * `workflowType` parameter: the same derivation holds for every workflow type
+ * (INV-6). When a non-empty `transcript` is supplied the intent is enriched
+ * (`source: 'diff+transcript'`, `transcriptSummary` set); otherwise it is the
+ * diff-only floor (`source: 'diff'`, no `transcriptSummary`).
+ */
+export function deriveIntent(
+  changedFiles: readonly string[],
+  opts?: { transcript?: string },
+): WorkflowIntent {
+  const files = changedFiles.map((f) => f.trim()).filter(Boolean);
+  const surfaces = surfacesOf(files);
+  const summary =
+    `${files.length} file${files.length === 1 ? '' : 's'} changed across ` +
+    `${surfaces.length} surface${surfaces.length === 1 ? '' : 's'}` +
+    (surfaces.length > 0 ? `: ${surfaces.join(', ')}` : '');
+
+  const transcript = opts?.transcript;
+  if (typeof transcript === 'string' && transcript.trim().length > 0) {
+    return {
+      source: 'diff+transcript',
+      changedFiles: files,
+      surfaces,
+      summary,
+      transcriptSummary: summarizeTranscript(transcript),
+    };
+  }
+
+  return {
+    source: 'diff',
+    changedFiles: files,
+    surfaces,
+    summary,
+  };
+}
+
+// ─── Fail-Soft Persist ───────────────────────────────────────────────────────
+
+/**
+ * Persist the derived intent to `artifacts.intent` via the canonical state-patch
+ * surface (`handleUpdate`), which emits exactly ONE `state.patched` event — no
+ * custom event type. Fail-soft: on a non-success result or a thrown error this
+ * returns `{ persisted: false, warning }` and NEVER throws, so a state-write
+ * failure cannot break review provisioning.
+ */
+export async function persistIntent(
+  featureId: string,
+  intent: WorkflowIntent,
+  stateDir: string,
+  eventStore: EventStore,
+): Promise<{ persisted: boolean; warning?: string }> {
+  try {
+    const result = await handleUpdate(
+      { featureId, updates: { 'artifacts.intent': intent } },
+      stateDir,
+      eventStore,
+    );
+    if (result.success) {
+      return { persisted: true };
+    }
+    const message = result.error?.message ?? 'state-patch returned a non-success result';
+    return { persisted: false, warning: `intent persistence skipped: ${message}` };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { persisted: false, warning: `intent persistence failed: ${message}` };
+  }
+}

--- a/servers/exarchos-mcp/src/orchestrate/extract-intent.ts
+++ b/servers/exarchos-mcp/src/orchestrate/extract-intent.ts
@@ -23,7 +23,9 @@
 import { execSync } from 'node:child_process';
 import type { EventStore } from '../event-store/store.js';
 import { handleUpdate } from '../workflow/tools.js';
+import { WorkflowIntentSchema } from '../workflow/schemas.js';
 import type { WorkflowIntent } from '../workflow/schemas.js';
+import { resolveWorkflowState } from './resolve-state.js';
 
 export type { WorkflowIntent } from '../workflow/schemas.js';
 
@@ -170,4 +172,99 @@ export async function persistIntent(
     const message = err instanceof Error ? err.message : String(err);
     return { persisted: false, warning: `intent persistence failed: ${message}` };
   }
+}
+
+// ─── Fail-Soft Read (DR-1 task 006) ──────────────────────────────────────────
+
+/**
+ * Read the persisted `artifacts.intent` back from workflow state — the READ
+ * counterpart of {@link persistIntent}. Resolves state via the canonical
+ * {@link resolveWorkflowState} (SQLite event store is the source of truth) and
+ * safe-parses `artifacts.intent` through {@link WorkflowIntentSchema}.
+ *
+ * FAIL-SOFT by design (DR-1 acceptance): returns `undefined` — never throws and
+ * never surfaces an error envelope — when `featureId` is absent, no event store
+ * is supplied, state is unreadable, the intent is absent, or it fails schema
+ * validation. PR-body grounding (create_pr / validate_pr_body) consumes this and
+ * degrades to its unchanged legacy behavior when the result is `undefined`, so a
+ * state hiccup can never break PR creation or validation. No `workflowType`
+ * branch (INV-6): the same read holds for every workflow type.
+ */
+export async function readIntent(
+  featureId: string | undefined,
+  eventStore: EventStore | undefined,
+): Promise<WorkflowIntent | undefined> {
+  if (!featureId || !eventStore) return undefined;
+  try {
+    const resolved = await resolveWorkflowState({ featureId, eventStore });
+    if ('error' in resolved) return undefined;
+    const artifacts = resolved.state['artifacts'];
+    if (typeof artifacts !== 'object' || artifacts === null) return undefined;
+    const rawIntent = (artifacts as Record<string, unknown>)['intent'];
+    if (rawIntent === undefined) return undefined;
+    const parsed = WorkflowIntentSchema.safeParse(rawIntent);
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── Intent Grounding Marker (DR-1 task 006) ─────────────────────────────────
+
+/**
+ * Idempotency marker for the `## Intent` grounding section injected into a PR
+ * body. An HTML comment so it renders invisibly on GitHub while remaining a
+ * deterministic presence check for both the create_pr enrichment (don't
+ * double-inject) and the validate_pr_body advisory (is the body grounded?).
+ */
+export const INTENT_GROUNDING_MARKER = '<!-- intent-grounded -->';
+
+/**
+ * Whether a body already carries the intent-grounding marker. Used by both the
+ * create_pr enrichment (idempotency guard) and the validate_pr_body advisory.
+ */
+export function bodyHasIntentMarker(body: string): boolean {
+  return body.includes(INTENT_GROUNDING_MARKER);
+}
+
+/**
+ * An intent is "meaningful" — worth grounding a PR body in — only when it
+ * references at least one changed file. The empty/un-resolvable-diff floor
+ * (`changedFiles.length === 0`) is NOT grounded; the body is left untouched.
+ * Mirrors the `buildIntentGrounding` meaningfulness gate in prepare-review.ts
+ * (task 005) so the grounded-PR and grounded-review paths agree on the floor.
+ */
+export function isMeaningfulIntent(intent: WorkflowIntent): boolean {
+  return intent.changedFiles.length > 0;
+}
+
+/**
+ * Build the deterministic `## Intent` grounding section appended to a PR body.
+ * Pure — no `workflowType` branch. Carries surfaces, the human-floor summary,
+ * the optional transcript line, and the idempotency marker so the section is
+ * both human-readable and machine-detectable on a later validate pass.
+ */
+export function buildIntentSection(intent: WorkflowIntent): string {
+  const lines: string[] = ['## Intent', '', INTENT_GROUNDING_MARKER, ''];
+  lines.push(`**Surfaces:** ${intent.surfaces.length > 0 ? intent.surfaces.join(', ') : '(none)'}`);
+  lines.push('');
+  lines.push(intent.summary);
+  if (intent.transcriptSummary) {
+    lines.push('');
+    lines.push(`**Context:** ${intent.transcriptSummary}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Append the `## Intent` grounding section to a PR body when the intent is
+ * meaningful AND the body is not already grounded (idempotent). Returns the body
+ * UNCHANGED when the intent is not meaningful or the marker is already present.
+ * Pure / total — never throws.
+ */
+export function groundBodyInIntent(body: string, intent: WorkflowIntent): string {
+  if (!isMeaningfulIntent(intent)) return body;
+  if (bodyHasIntentMarker(body)) return body;
+  const section = buildIntentSection(intent);
+  return body.trimEnd().length === 0 ? section : `${body.trimEnd()}\n\n${section}`;
 }

--- a/servers/exarchos-mcp/src/orchestrate/prepare-review.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-review.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { handlePrepareReview } from './prepare-review.js';
+import { handlePrepareReview, type PrepareReviewArgs } from './prepare-review.js';
 import { QUALITY_CHECK_CATALOG } from '../review/check-catalog.js';
+import { EventStore } from '../event-store/store.js';
 import type { ToolResult } from '../format.js';
 
 // ─── Typed assertion helpers ────────────────────────────────────────────────
@@ -28,55 +29,77 @@ function expectError(result: ToolResult): { code: string; message: string } {
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
-const stateDir = '/tmp/test-prepare-review';
+// DR-1 (#1593): the handler now takes (args, stateDir, eventStore). A real
+// store + stateDir is provisioned per-test so the code-review path's
+// `persistIntent` has a canonical surface to write to (and, for featureIds with
+// no inited workflow, fail soft without breaking the catalog response). The
+// plan-review path early-returns before touching intent, so the store is inert
+// there.
+let stateDir: string;
+let eventStore: EventStore;
+
+beforeEach(async () => {
+  stateDir = mkdtempSync(join(tmpdir(), 'prepare-review-state-'));
+  eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+/** Thread the per-test real EventStore + stateDir into the 3-arg handler. */
+function callPrepareReview(args: PrepareReviewArgs): Promise<ToolResult> {
+  return handlePrepareReview(args, stateDir, eventStore);
+}
 
 describe('handlePrepareReview', () => {
   it('HandlePrepareReview_DefaultArgs_ReturnsCatalogWithAllDimensions', async () => {
-    const data = expectSuccess(await handlePrepareReview({ featureId: 'test-default' }, stateDir));
+    const data = expectSuccess(await callPrepareReview({ featureId: 'test-default' }));
     expect(data.catalog.dimensions.length).toBe(QUALITY_CHECK_CATALOG.dimensions.length);
   });
 
   it('HandlePrepareReview_DimensionFilter_ReturnsOnlyRequestedDimensions', async () => {
-    const data = expectSuccess(await handlePrepareReview({
+    const data = expectSuccess(await callPrepareReview({
       featureId: 'test-filter',
       dimensions: ['error-handling', 'resilience'],
-    }, stateDir));
+    }));
     expect(data.catalog.dimensions.length).toBe(2);
     expect(data.catalog.dimensions.map(d => d.id)).toEqual(['error-handling', 'resilience']);
   });
 
   it('HandlePrepareReview_InvalidDimension_ReturnsError', async () => {
-    const err = expectError(await handlePrepareReview({
+    const err = expectError(await callPrepareReview({
       featureId: 'test-invalid',
       dimensions: ['nonexistent-dimension'],
-    }, stateDir));
+    }));
     expect(err.code).toBe('INVALID_INPUT');
   });
 
   it('HandlePrepareReview_PluginStatusNoConfig_DefaultsToEnabled', async () => {
-    const data = expectSuccess(await handlePrepareReview({ featureId: 'test-plugin-default' }, stateDir));
+    const data = expectSuccess(await callPrepareReview({ featureId: 'test-plugin-default' }));
     expect(data.pluginStatus.impeccable.enabled).toBe(true);
   });
 
   it('PrepareReview_PluginStatus_OmitsAxiom', async () => {
     // axiom is excised (#1477) — pluginStatus must not carry an axiom entry.
-    const data = expectSuccess(await handlePrepareReview({ featureId: 'test-omits-axiom' }, stateDir));
+    const data = expectSuccess(await callPrepareReview({ featureId: 'test-omits-axiom' }));
     expect('axiom' in data.pluginStatus).toBe(false);
   });
 
   it('HandlePrepareReview_FindingFormatIncluded_IsNonEmptyString', async () => {
-    const data = expectSuccess(await handlePrepareReview({ featureId: 'test-format' }, stateDir));
+    const data = expectSuccess(await callPrepareReview({ featureId: 'test-format' }));
     expect(typeof data.findingFormat).toBe('string');
     expect(data.findingFormat.length).toBeGreaterThan(0);
   });
 
   it('HandlePrepareReview_CatalogVersion_MatchesCatalogConstant', async () => {
-    const data = expectSuccess(await handlePrepareReview({ featureId: 'test-version' }, stateDir));
+    const data = expectSuccess(await callPrepareReview({ featureId: 'test-version' }));
     expect(data.catalog.version).toBe(QUALITY_CHECK_CATALOG.version);
   });
 
   it('HandlePrepareReview_MissingFeatureId_ReturnsError', async () => {
-    const err = expectError(await handlePrepareReview({ featureId: '' }, stateDir));
+    const err = expectError(await callPrepareReview({ featureId: '' }));
     expect(err.code).toBe('INVALID_INPUT');
   });
 
@@ -95,17 +118,17 @@ describe('handlePrepareReview', () => {
 
     it('HandlePrepareReview_RepoRootWithConfig_ReadsPluginStatus', async () => {
       writeFileSync(join(tempDir, '.exarchos.yml'), `plugins:\n  impeccable:\n    enabled: false\n`);
-      const data = expectSuccess(await handlePrepareReview({ featureId: 'test-config', repoRoot: tempDir }, stateDir));
+      const data = expectSuccess(await callPrepareReview({ featureId: 'test-config', repoRoot: tempDir }));
       expect(data.pluginStatus.impeccable.enabled).toBe(false);
     });
 
     it('HandlePrepareReview_RepoRootNoConfig_DefaultsToEnabled', async () => {
-      const data = expectSuccess(await handlePrepareReview({ featureId: 'test-no-config', repoRoot: tempDir }, stateDir));
+      const data = expectSuccess(await callPrepareReview({ featureId: 'test-no-config', repoRoot: tempDir }));
       expect(data.pluginStatus.impeccable.enabled).toBe(true);
     });
 
     it('HandlePrepareReview_NoRepoRoot_DefaultsToEnabled', async () => {
-      const data = expectSuccess(await handlePrepareReview({ featureId: 'test-no-root' }, stateDir));
+      const data = expectSuccess(await callPrepareReview({ featureId: 'test-no-root' }));
       expect(data.pluginStatus.impeccable.enabled).toBe(true);
     });
   });
@@ -135,14 +158,13 @@ describe('handlePrepareReview', () => {
       // The reviewer is provisioned with ONLY {artifact, spec} — never the
       // authoring transcript (INV-11 read-only, fresh context).
       const data = planData(
-        await handlePrepareReview(
+        await callPrepareReview(
           {
             featureId: 'pr-feat',
             scope: 'plan',
             artifact: 'docs/specs/2026-06-22-feat.md',
             spec: 'docs/specs/2026-06-22-feat.md#requirements',
           },
-          stateDir,
         ),
       );
       expect(data.mode).toBe('plan-review');
@@ -160,9 +182,8 @@ describe('handlePrepareReview', () => {
 
     it('PlanReview_RefutationPosture_EmitsEvidenceVerdict', async () => {
       const data = planData(
-        await handlePrepareReview(
+        await callPrepareReview(
           { featureId: 'pr-feat', scope: 'plan-review', artifact: 'docs/specs/x.md' },
-          stateDir,
         ),
       );
       expect(data.adversarial).toBe(true);
@@ -178,9 +199,8 @@ describe('handlePrepareReview', () => {
       // thin → the light rung, single voter — cost stays risk-proportional and
       // must NOT escalate to the multi-voter panel.
       const data = planData(
-        await handlePrepareReview(
+        await callPrepareReview(
           { featureId: 'pr-feat', scope: 'plan', artifact: 'docs/specs/x.md', designDepth: 'thin' },
-          stateDir,
         ),
       );
       expect(data.rung.name).toBe('light');
@@ -189,9 +209,8 @@ describe('handlePrepareReview', () => {
 
     it('PlanReview_DeepDepth_UsesMultiVoterPanel', async () => {
       const data = planData(
-        await handlePrepareReview(
+        await callPrepareReview(
           { featureId: 'pr-feat', scope: 'plan', artifact: 'docs/specs/x.md', designDepth: 'deep' },
-          stateDir,
         ),
       );
       expect(data.rung.name).toBe('panel');
@@ -200,9 +219,8 @@ describe('handlePrepareReview', () => {
 
     it('PlanReview_AbsentDesignDepth_DefaultsStandardRung', async () => {
       const data = planData(
-        await handlePrepareReview(
+        await callPrepareReview(
           { featureId: 'pr-feat', scope: 'plan', artifact: 'docs/specs/x.md' },
-          stateDir,
         ),
       );
       expect(data.rung.name).toBe('standard');
@@ -212,9 +230,8 @@ describe('handlePrepareReview', () => {
       // In the collapsed world the artifact carries its own design-rationale §,
       // so an omitted spec falls back to the artifact itself.
       const data = planData(
-        await handlePrepareReview(
+        await callPrepareReview(
           { featureId: 'pr-feat', scope: 'plan', artifact: 'docs/specs/x.md' },
-          stateDir,
         ),
       );
       expect(data.provisionedContext.spec).toBe('docs/specs/x.md');
@@ -222,7 +239,7 @@ describe('handlePrepareReview', () => {
 
     it('PlanReview_MissingArtifact_ReturnsError', async () => {
       const err = expectError(
-        await handlePrepareReview({ featureId: 'pr-feat', scope: 'plan' }, stateDir),
+        await callPrepareReview({ featureId: 'pr-feat', scope: 'plan' }),
       );
       expect(err.code).toBe('INVALID_INPUT');
       expect(err.message).toContain('artifact');
@@ -232,7 +249,7 @@ describe('handlePrepareReview', () => {
       // A non-plan scope (or absent) still serves the back-of-pipeline catalog —
       // the plan-review branch must not capture code-review traffic.
       const data = expectSuccess(
-        await handlePrepareReview({ featureId: 'cr-feat', scope: 'code' }, stateDir),
+        await callPrepareReview({ featureId: 'cr-feat', scope: 'code' }),
       );
       expect((data as { catalog?: unknown }).catalog).toBeDefined();
     });

--- a/servers/exarchos-mcp/src/orchestrate/prepare-review.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-review.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { handlePrepareReview, type PrepareReviewArgs } from './prepare-review.js';
@@ -9,12 +10,20 @@ import type { ToolResult } from '../format.js';
 
 // ─── Typed assertion helpers ────────────────────────────────────────────────
 
+interface IntentGrounding {
+  mode: string;
+  intended: { surfaces: string[]; summary: string; transcriptSummary?: string };
+  instruction: string;
+}
+
 interface PrepareReviewData {
   catalog: { version: string; dimensions: readonly { id: string }[] };
   findingFormat: string;
   pluginStatus: {
     impeccable: { enabled: boolean };
   };
+  intent?: { changedFiles: string[]; surfaces: string[]; summary: string };
+  intentGrounding?: IntentGrounding;
 }
 
 function expectSuccess(result: ToolResult): PrepareReviewData {
@@ -252,6 +261,77 @@ describe('handlePrepareReview', () => {
         await callPrepareReview({ featureId: 'cr-feat', scope: 'code' }),
       );
       expect((data as { catalog?: unknown }).catalog).toBeDefined();
+    });
+  });
+
+  // ─── DR-1 (#1593) task 005: REVIEW grounds the spec-review checklist in the ──
+  //     captured intent (intended-vs-delivered), degrading to diff-only when no
+  //     intent is resolvable.
+  describe('intent grounding (DR-1 task 005)', () => {
+    /**
+     * A self-contained git repo whose `main...HEAD` diff is a single
+     * deterministic file — so `changedFilesAgainstBase(repoRoot)` resolves a
+     * non-empty changed-file set without depending on the live working tree.
+     */
+    function seedRepoWithDiff(): string {
+      const repo = mkdtempSync(join(tmpdir(), 'prepare-review-repo-'));
+      const git = (...a: string[]): void => {
+        execFileSync('git', a, { cwd: repo, stdio: ['pipe', 'pipe', 'pipe'] });
+      };
+      git('init', '-q', '-b', 'main');
+      git('config', 'user.email', 'test@example.com');
+      git('config', 'user.name', 'Test');
+      writeFileSync(join(repo, 'base.txt'), 'base\n');
+      git('add', '-A');
+      git('commit', '-qm', 'base');
+      git('checkout', '-q', '-b', 'feat');
+      mkdirSync(join(repo, 'servers'), { recursive: true });
+      writeFileSync(join(repo, 'servers', 'a.ts'), 'export const x = 1;\n');
+      git('add', '-A');
+      git('commit', '-qm', 'change');
+      return repo;
+    }
+
+    it('PrepareReview_WithIntent_GroundsSpecReviewChecklist', async () => {
+      const repo = seedRepoWithDiff();
+      try {
+        const data = expectSuccess(
+          await callPrepareReview({ featureId: 'cr-grounded', repoRoot: repo, scope: 'code' }),
+        );
+        // Intent is meaningful (non-empty diff) → the grounding directive is present.
+        expect(data.intent?.changedFiles).toContain('servers/a.ts');
+        expect(data.intentGrounding).toBeDefined();
+        const grounding = data.intentGrounding as IntentGrounding;
+        expect(grounding.mode).toBe('intended-vs-delivered');
+        // It references the intent's surfaces + summary (intended-vs-delivered).
+        expect(grounding.intended.surfaces).toEqual(data.intent?.surfaces);
+        expect(grounding.intended.summary).toBe(data.intent?.summary);
+        expect(grounding.intended.surfaces).toContain('servers');
+        expect(grounding.instruction.toLowerCase()).toContain('intended');
+        expect(grounding.instruction.toLowerCase()).toContain('delivered');
+        // The catalog is still served alongside the grounding.
+        expect(data.catalog.dimensions.length).toBe(QUALITY_CHECK_CATALOG.dimensions.length);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    it('PrepareReview_NoIntent_DegradesToDiffOnly', async () => {
+      // A non-git repoRoot ⇒ `changedFilesAgainstBase` returns [] ⇒ empty intent.
+      const emptyDir = mkdtempSync(join(tmpdir(), 'prepare-review-empty-'));
+      try {
+        const data = expectSuccess(
+          await callPrepareReview({ featureId: 'cr-no-intent', repoRoot: emptyDir, scope: 'code' }),
+        );
+        // No resolvable diff → no fabricated intent grounding (diff-only review).
+        expect(data.intent?.changedFiles).toEqual([]);
+        expect(data.intentGrounding).toBeUndefined();
+        expect('intentGrounding' in data).toBe(false);
+        // The catalog is returned unchanged.
+        expect(data.catalog.dimensions.length).toBe(QUALITY_CHECK_CATALOG.dimensions.length);
+      } finally {
+        rmSync(emptyDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/prepare-review.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-review.ts
@@ -13,6 +13,7 @@ import { resolveConfig, DEFAULTS } from '../config/resolve.js';
 import { resolvePlanReviewDepth, type PlanReviewRung } from '../workflow/phase-kind.js';
 import type { DesignDepth } from '../workflow/plan-depth-policy.js';
 import { changedFilesAgainstBase, deriveIntent, persistIntent } from './extract-intent.js';
+import type { WorkflowIntent } from '../workflow/schemas.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -64,6 +65,56 @@ const FINDING_FORMAT = `interface PluginFinding {
   line?: number;
   message: string;
 }`;
+
+// ─── DR-1 (#1593): intended-vs-delivered review grounding ─────────────────────
+
+/**
+ * The structured review-grounding directive the orchestrator threads into the
+ * spec-review subagent on the code-review path (DR-1 task 005). It pins the
+ * INTENDED change (the captured `artifacts.intent` — surfaces + summary +
+ * optional transcript line) against the DELIVERED diff so the reviewer can flag
+ * intended-but-missing and delivered-but-unintended (scope-creep) work.
+ *
+ * Emitted ONLY when the intent is meaningful (`intent.changedFiles.length > 0`).
+ * On the `NoIntent` path (empty/un-resolvable diff) the directive is omitted and
+ * the review degrades to diff-only — no fabricated intent. INV-6: no
+ * `workflowType` branch; the same shape rides for every workflow type.
+ */
+export interface IntentGrounding {
+  readonly mode: 'intended-vs-delivered';
+  /** The captured intent the delivered diff is checked against. */
+  readonly intended: {
+    readonly surfaces: readonly string[];
+    readonly summary: string;
+    readonly transcriptSummary?: string;
+  };
+  /** The reviewer instruction: verify INTENDED vs DELIVERED, flag both gaps. */
+  readonly instruction: string;
+}
+
+const INTENT_GROUNDING_INSTRUCTION =
+  'Verify INTENDED vs DELIVERED. The orchestrator captured the intended change ' +
+  'in `artifacts.intent` (the `intended` surfaces/summary below); the DELIVERED ' +
+  'change is the diff under review. Confirm the diff fulfils the intended ' +
+  'change, and flag (a) intended-but-missing work and (b) delivered-but-' +
+  'unintended work (scope creep) as spec issues.';
+
+/**
+ * Build the grounding directive when the intent is meaningful, else `undefined`
+ * (the `NoIntent` degrade-to-diff-only path). Pure — no `workflowType` branch.
+ */
+function buildIntentGrounding(intent: WorkflowIntent): IntentGrounding | undefined {
+  if (intent.changedFiles.length === 0) return undefined;
+  return {
+    mode: 'intended-vs-delivered',
+    intended: {
+      surfaces: intent.surfaces,
+      summary: intent.summary,
+      ...(intent.transcriptSummary ? { transcriptSummary: intent.transcriptSummary } : {}),
+    },
+    instruction: INTENT_GROUNDING_INSTRUCTION,
+  };
+}
 
 // ─── DR-10: plan-review provisioning (front-of-pipeline adversarial gate) ─────
 
@@ -193,6 +244,10 @@ export async function handlePrepareReview(
     transcript: args.transcript,
   });
   const persisted = await persistIntent(args.featureId, intent, stateDir, eventStore);
+  // DR-1 task 005: the review-grounding directive the orchestrator passes into
+  // the spec-review subagent. Present only when the intent is meaningful;
+  // omitted on the `NoIntent` path so the review degrades to diff-only.
+  const intentGrounding = buildIntentGrounding(intent);
 
   // 2. Filter catalog by dimensions if requested
   let dimensions = QUALITY_CHECK_CATALOG.dimensions;
@@ -238,6 +293,9 @@ export async function handlePrepareReview(
       // The warning surfaces a fail-soft persist so callers aren't silent.
       intent,
       ...(persisted.warning ? { intentWarning: persisted.warning } : {}),
+      // DR-1 task 005: the intended-vs-delivered grounding directive — present
+      // only when the intent is meaningful, omitted on the `NoIntent` path.
+      ...(intentGrounding ? { intentGrounding } : {}),
     },
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/prepare-review.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-review.ts
@@ -232,24 +232,9 @@ export async function handlePrepareReview(
     return buildPlanReviewProvisioning(args);
   }
 
-  // 1b. DR-1 (#1593) — back-of-pipeline code-review path ONLY: derive the
-  // diff-floor intent (enriched when a transcript is supplied) and persist it to
-  // `artifacts.intent` via a single state-patch event. This is the intent
-  // FOUNDATION: REVIEW (task 005) and PR-body generation (task 006) read it
-  // back. Fail-soft — `persistIntent` never throws, so the quality-check catalog
-  // is still served even when the state-patch hiccups (an `intentWarning` rides
-  // along on the response). INV-6: the derivation takes no `workflowType`, so
-  // the same path runs for every workflow type.
-  const intent = deriveIntent(changedFilesAgainstBase(args.repoRoot), {
-    transcript: args.transcript,
-  });
-  const persisted = await persistIntent(args.featureId, intent, stateDir, eventStore);
-  // DR-1 task 005: the review-grounding directive the orchestrator passes into
-  // the spec-review subagent. Present only when the intent is meaningful;
-  // omitted on the `NoIntent` path so the review degrades to diff-only.
-  const intentGrounding = buildIntentGrounding(intent);
-
-  // 2. Filter catalog by dimensions if requested
+  // 1b. Validate `dimensions` BEFORE any state mutation. An unknown dimension is
+  // INVALID_INPUT and must fail without persisting intent — otherwise a bad
+  // request would still mutate `artifacts.intent` before erroring.
   let dimensions = QUALITY_CHECK_CATALOG.dimensions;
   if (args.dimensions?.length) {
     const validIds = new Set(QUALITY_CHECK_CATALOG.dimensions.map((d) => d.id));
@@ -266,6 +251,24 @@ export async function handlePrepareReview(
     const requested = new Set(args.dimensions);
     dimensions = QUALITY_CHECK_CATALOG.dimensions.filter((d) => requested.has(d.id));
   }
+
+  // 1c. DR-1 (#1593) — back-of-pipeline code-review path ONLY: derive the
+  // diff-floor intent (enriched when a transcript is supplied) and persist it to
+  // `artifacts.intent` via a single state-patch event. This is the intent
+  // FOUNDATION: REVIEW (task 005) and PR-body generation (task 006) read it
+  // back. Fail-soft — `persistIntent` never throws, so the quality-check catalog
+  // is still served even when the state-patch hiccups (an `intentWarning` rides
+  // along on the response). INV-6: the derivation takes no `workflowType`, so
+  // the same path runs for every workflow type. Runs AFTER dimension validation
+  // so an invalid request never reaches this state-mutating step.
+  const intent = deriveIntent(changedFilesAgainstBase(args.repoRoot), {
+    transcript: args.transcript,
+  });
+  const persisted = await persistIntent(args.featureId, intent, stateDir, eventStore);
+  // DR-1 task 005: the review-grounding directive the orchestrator passes into
+  // the spec-review subagent. Present only when the intent is meaningful;
+  // omitted on the `NoIntent` path so the review degrades to diff-only.
+  const intentGrounding = buildIntentGrounding(intent);
 
   // 3. Resolve plugin status from .exarchos.yml if repoRoot provided, else defaults
   const resolved = args.repoRoot

--- a/servers/exarchos-mcp/src/orchestrate/prepare-review.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-review.ts
@@ -6,15 +6,17 @@
 // ──────────────────────────────────────────────────────────────────────────────
 
 import type { ToolResult } from '../format.js';
+import type { EventStore } from '../event-store/store.js';
 import { QUALITY_CHECK_CATALOG } from '../review/check-catalog.js';
 import { loadProjectConfig } from '../config/yaml-loader.js';
 import { resolveConfig, DEFAULTS } from '../config/resolve.js';
 import { resolvePlanReviewDepth, type PlanReviewRung } from '../workflow/phase-kind.js';
 import type { DesignDepth } from '../workflow/plan-depth-policy.js';
+import { changedFilesAgainstBase, deriveIntent, persistIntent } from './extract-intent.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-interface PrepareReviewArgs {
+export interface PrepareReviewArgs {
   readonly featureId: string;
   /**
    * Review scope. `'plan'` / `'plan-review'` selects the DR-10 front-of-pipeline
@@ -43,6 +45,13 @@ interface PrepareReviewArgs {
    * consumer (DR-10). Absent ⇒ the `'standard'` rung.
    */
   readonly designDepth?: DesignDepth;
+  /**
+   * The authoring transcript (code-review scope, DR-1 #1593). When supplied, the
+   * extracted `WorkflowIntent` is enriched beyond the diff floor. Used ONLY on
+   * the back-of-pipeline code-review path; the plan-review path is deliberately
+   * transcript-free (adversarial, fresh-context — DR-10) and never reads this.
+   */
+  readonly transcript?: string;
 }
 
 // ─── Finding Format Schema ──────────────────────────────────────────────────
@@ -153,7 +162,8 @@ function buildPlanReviewProvisioning(args: PrepareReviewArgs): ToolResult {
 
 export async function handlePrepareReview(
   args: PrepareReviewArgs,
-  _stateDir: string,
+  stateDir: string,
+  eventStore: EventStore,
 ): Promise<ToolResult> {
   // 1. Validate required fields
   if (!args.featureId) {
@@ -165,10 +175,24 @@ export async function handlePrepareReview(
 
   // 1a. DR-10 — front-of-pipeline plan-review provisioning. A dispatched,
   // fresh-context, adversarial pass over the unified artifact; distinct from the
-  // back-of-pipeline code-review catalog served below.
+  // back-of-pipeline code-review catalog served below. The plan-review path is
+  // deliberately transcript-free — NO intent extraction happens here.
   if (args.scope && PLAN_REVIEW_SCOPES.has(args.scope)) {
     return buildPlanReviewProvisioning(args);
   }
+
+  // 1b. DR-1 (#1593) — back-of-pipeline code-review path ONLY: derive the
+  // diff-floor intent (enriched when a transcript is supplied) and persist it to
+  // `artifacts.intent` via a single state-patch event. This is the intent
+  // FOUNDATION: REVIEW (task 005) and PR-body generation (task 006) read it
+  // back. Fail-soft — `persistIntent` never throws, so the quality-check catalog
+  // is still served even when the state-patch hiccups (an `intentWarning` rides
+  // along on the response). INV-6: the derivation takes no `workflowType`, so
+  // the same path runs for every workflow type.
+  const intent = deriveIntent(changedFilesAgainstBase(args.repoRoot), {
+    transcript: args.transcript,
+  });
+  const persisted = await persistIntent(args.featureId, intent, stateDir, eventStore);
 
   // 2. Filter catalog by dimensions if requested
   let dimensions = QUALITY_CHECK_CATALOG.dimensions;
@@ -209,6 +233,11 @@ export async function handlePrepareReview(
       },
       findingFormat: FINDING_FORMAT,
       pluginStatus,
+      // DR-1 (#1593): the derived intent rides along for convenience; the
+      // load-bearing contract is its persistence to `artifacts.intent` above.
+      // The warning surfaces a fail-soft persist so callers aren't silent.
+      intent,
+      ...(persisted.warning ? { intentWarning: persisted.warning } : {}),
     },
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/prepare-synthesis.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-synthesis.test.ts
@@ -25,7 +25,13 @@ import { getOrCreateMaterializer } from '../views/tools.js';
 
 // ─── Import handler under test ─────────────────────────────────────────────
 
-import { handlePrepareSynthesis } from './prepare-synthesis.js';
+import {
+  handlePrepareSynthesis,
+  evaluateDocumentLeg,
+  documentLegBlocks,
+  type DocumentLegConfig,
+} from './prepare-synthesis.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
 
 // ─── Test Helpers ──────────────────────────────────────────────────────────
 
@@ -527,5 +533,145 @@ describe('handlePrepareSynthesis', () => {
     expect(data.ready).toBe(false);
     expect(data.typecheck.passed).toBe(false);
     expect(data.typecheck.errorCount).toBeGreaterThan(0);
+  });
+
+  // ─── DR-2 (#1594): document-readiness leg ─────────────────────────────────
+
+  it('PrepareSynthesis_DocBearingSurfaceNoDocChange_FailsDocumentLeg', async () => {
+    // Arrange — tasks complete; git diff returns a doc-bearing source file with
+    // no doc change; config marks **/*.ts a surface, severity blocking. Also
+    // exercises the adapter-equivalent projectConfig threading at the handler.
+    const mockMaterializer = createMockMaterializer(mockTaskDetailView({ t1: { status: 'completed' } }));
+    const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+    vi.mocked(getOrCreateMaterializer).mockReturnValue(
+      mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>,
+    );
+    vi.mocked(execSync).mockReturnValue(Buffer.from('src/registry.ts'));
+
+    // Act
+    const result = await handlePrepareSynthesis(
+      {
+        featureId: 'test-feature',
+        projectConfig: {
+          synthesis: {
+            documentLeg: { severity: 'blocking', surfaceGlobs: ['**/*.ts'], docGlobs: ['docs/**'] },
+          },
+        } as unknown as ResolvedProjectConfig,
+      },
+      tmpDir,
+      mockStore as unknown as EventStore,
+    );
+
+    // Assert — document-coverage gate emitted passed:false; synthesis blocked.
+    const docGate = mockStore.append.mock.calls.find((call: unknown[]) => {
+      const e = call[1] as { type: string; data: { gateName: string } };
+      return e.type === 'gate.executed' && e.data.gateName === 'document-coverage';
+    });
+    expect(docGate).toBeDefined();
+    expect((docGate![1] as { data: { passed: boolean; layer: string } }).data.passed).toBe(false);
+    expect((docGate![1] as { data: { layer: string } }).data.layer).toBe('synthesize');
+    const data = result.data as { ready: boolean; readiness: { documentReady: boolean } };
+    expect(data.readiness.documentReady).toBe(false);
+    expect(data.ready).toBe(false);
+  });
+
+  it('PrepareSynthesis_AdvisoryUncoveredDoc_EmitsGateButDoesNotBlock', async () => {
+    // Same surface gap, but advisory severity (the default) ⇒ gate records
+    // passed:false (visible) yet documentReady stays true (warns, never blocks).
+    const mockMaterializer = createMockMaterializer(mockTaskDetailView({ t1: { status: 'completed' } }));
+    const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+    vi.mocked(getOrCreateMaterializer).mockReturnValue(
+      mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>,
+    );
+    vi.mocked(execSync).mockReturnValue(Buffer.from('src/registry.ts'));
+
+    const result = await handlePrepareSynthesis(
+      {
+        featureId: 'test-feature',
+        projectConfig: {
+          synthesis: {
+            documentLeg: { severity: 'advisory', surfaceGlobs: ['**/*.ts'], docGlobs: ['docs/**'] },
+          },
+        } as unknown as ResolvedProjectConfig,
+      },
+      tmpDir,
+      mockStore as unknown as EventStore,
+    );
+
+    const docGate = mockStore.append.mock.calls.find((call: unknown[]) => {
+      const e = call[1] as { type: string; data: { gateName: string } };
+      return e.type === 'gate.executed' && e.data.gateName === 'document-coverage';
+    });
+    expect((docGate![1] as { data: { passed: boolean } }).data.passed).toBe(false);
+    const data = result.data as { readiness: { documentReady: boolean } };
+    expect(data.readiness.documentReady).toBe(true);
+  });
+});
+
+// ─── DR-2 (#1594): document-leg pure evaluation ─────────────────────────────
+
+describe('evaluateDocumentLeg (DR-2)', () => {
+  const cfg = (over: Partial<DocumentLegConfig> = {}): DocumentLegConfig => ({
+    severity: 'advisory',
+    surfaceGlobs: [],
+    docGlobs: ['docs/**', '**/*.md'],
+    ...over,
+  });
+
+  it('DocumentLeg_NoSurfaceTouched_AutoWaives', () => {
+    const r = evaluateDocumentLeg(['src/foo.ts'], cfg({ surfaceGlobs: ['commands/**'] }));
+    expect(r.evaluated).toBe(false);
+    expect(r.covered).toBe(true);
+  });
+
+  it('DocumentLeg_SurfaceTouchedDocsChanged_Covered', () => {
+    const r = evaluateDocumentLeg(
+      ['servers/exarchos-mcp/src/registry.ts', 'docs/guide.md'],
+      cfg({ surfaceGlobs: ['**/registry.ts'] }),
+    );
+    expect(r.evaluated).toBe(true);
+    expect(r.covered).toBe(true);
+  });
+
+  it('DocumentLeg_SurfaceTouchedNoDocs_FailsWithMessage', () => {
+    const r = evaluateDocumentLeg(
+      ['servers/exarchos-mcp/src/registry.ts'],
+      cfg({ surfaceGlobs: ['**/registry.ts'] }),
+    );
+    expect(r.evaluated).toBe(true);
+    expect(r.covered).toBe(false);
+    expect(r.surfaceFiles).toContain('servers/exarchos-mcp/src/registry.ts');
+    expect(r.message).toMatch(/without a documentation update/);
+  });
+});
+
+describe('documentLegBlocks (DR-2)', () => {
+  it('DocumentLeg_DefaultSeverity_IsAdvisory', () => {
+    const r = evaluateDocumentLeg(['src/registry.ts'], {
+      severity: 'advisory',
+      surfaceGlobs: ['**/*.ts'],
+      docGlobs: ['docs/**'],
+    });
+    expect(r.covered).toBe(false);
+    expect(documentLegBlocks(r)).toBe(false);
+  });
+
+  it('DocumentLeg_SeverityConfig_ResolvesAdvisoryToBlocking', () => {
+    const r = evaluateDocumentLeg(['src/registry.ts'], {
+      severity: 'blocking',
+      surfaceGlobs: ['**/*.ts'],
+      docGlobs: ['docs/**'],
+    });
+    expect(r.covered).toBe(false);
+    expect(documentLegBlocks(r)).toBe(true);
+  });
+
+  it('DocumentLegBlocks_CoveredLeg_NeverBlocks', () => {
+    const r = evaluateDocumentLeg(['src/registry.ts', 'docs/x.md'], {
+      severity: 'blocking',
+      surfaceGlobs: ['**/*.ts'],
+      docGlobs: ['docs/**'],
+    });
+    expect(documentLegBlocks(r)).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts
@@ -5,7 +5,7 @@
 // SynthesisReadinessView and CodeQualityView flywheel integration.
 // ────────────────────────────────────────────────────────────────────────────
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { resolveWorkflowState } from './resolve-state.js';
@@ -220,11 +220,18 @@ export function documentLegBlocks(result: DocumentLegResult): boolean {
   return result.evaluated && !result.covered && result.severity === 'blocking';
 }
 
-/** Changed files between the default base branch and HEAD (name-only). */
-function changedFilesAgainstBase(): string[] {
+/**
+ * Changed files between the default base branch and HEAD (name-only). Returns
+ * `null` — NOT `[]` — when git detection fails, so the document-leg caller can
+ * tell "no surface changed" apart from "couldn't determine" and fail CLOSED on
+ * the latter rather than silently auto-waiving a blocking leg. argv-form
+ * `execFileSync` (not shell-form `execSync`) eliminates the shell surface even
+ * though `baseBranch` is already sanitized by `detectDefaultBranch`.
+ */
+function changedFilesAgainstBase(): string[] | null {
   try {
     const baseBranch = detectDefaultBranch();
-    const output = execSync(`git diff --name-only ${baseBranch}...HEAD`, {
+    const output = execFileSync('git', ['diff', '--name-only', `${baseBranch}...HEAD`], {
       encoding: 'buffer',
       timeout: 15_000,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -235,7 +242,7 @@ function changedFilesAgainstBase(): string[] {
       .map((line) => line.trim())
       .filter(Boolean);
   } catch {
-    return [];
+    return null;
   }
 }
 
@@ -354,8 +361,23 @@ export async function handlePrepareSynthesis(
     //    gate.executed by name), so the leg is evaluated after the stack check.
     //    `passed` reflects structural coverage; whether an uncovered leg BLOCKS
     //    readiness is the severity decision (documentLegBlocks).
-    const docCfg = args.projectConfig?.synthesis.documentLeg ?? DEFAULT_DOCUMENT_LEG;
-    const documentLeg = evaluateDocumentLeg(changedFilesAgainstBase(), docCfg);
+    const docCfg = args.projectConfig?.synthesis?.documentLeg ?? DEFAULT_DOCUMENT_LEG;
+    const changedFiles = changedFilesAgainstBase();
+    // Fail CLOSED when git detection is unavailable: report the leg as
+    // evaluated-but-uncovered so a `blocking` severity blocks readiness instead
+    // of being silently auto-waived (an empty-list waive would bypass the gate).
+    // An `advisory` leg still only records a visible `gate.executed{passed:false}`.
+    const documentLeg: DocumentLegResult = changedFiles === null
+      ? {
+          evaluated: true,
+          covered: false,
+          severity: docCfg.severity,
+          surfaceFiles: [],
+          message:
+            'Changed-file detection failed (git unavailable); document-readiness leg '
+            + 'could not be verified. Re-run synthesis, or waive via synthesis.documentLeg.',
+        }
+      : evaluateDocumentLeg(changedFiles, docCfg);
     await emitGateEvent(store, streamId, 'document-coverage', 'synthesize', documentLeg.covered, {
       dimension: 'D1',
       phase: 'synthesize',

--- a/servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts
@@ -10,6 +10,8 @@ import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { resolveWorkflowState } from './resolve-state.js';
 import { emitGateEvent } from './gate-utils.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { globToRegExp } from '../architecture/glob-to-regexp.js';
 
 // ─── Result Types ──────────────────────────────────────────────────────────
 
@@ -17,6 +19,7 @@ interface SynthesisReadinessState {
   tasksComplete: boolean;
   testsPass: boolean;
   typecheckPass: boolean;
+  documentReady: boolean;
   stackHealthy: boolean;
 }
 
@@ -45,6 +48,7 @@ interface PrepareSynthesisResult {
   blockers?: string[];
   tests: TestResult;
   typecheck: TypecheckResult;
+  document: DocumentLegResult;
   stack: StackResult;
 }
 
@@ -147,6 +151,94 @@ function verifyStack(): StackResult {
   }
 }
 
+// ─── DR-2: Document-Readiness Leg (#1594) ───────────────────────────────────
+
+export type DocumentLegConfig = ResolvedProjectConfig['synthesis']['documentLeg'];
+
+/**
+ * Behavior-neutral default when no resolved config is threaded (e.g. a unit
+ * test invoking the handler without `projectConfig`): advisory severity + empty
+ * surface globs ⇒ the leg auto-waives, so the absence of config is never a
+ * blocker.
+ */
+const DEFAULT_DOCUMENT_LEG: DocumentLegConfig = {
+  severity: 'advisory',
+  surfaceGlobs: [],
+  docGlobs: ['docs/**', '**/*.md'],
+};
+
+export interface DocumentLegResult {
+  /** false ⇒ auto-waived: no doc-bearing surface was touched. */
+  readonly evaluated: boolean;
+  /** docs changed (or auto-waived). false ⇒ a doc-bearing surface changed with no doc update. */
+  readonly covered: boolean;
+  readonly severity: 'advisory' | 'blocking';
+  readonly surfaceFiles: readonly string[];
+  readonly message?: string;
+}
+
+/**
+ * Evaluate the `document` readiness leg structurally: when the changeset touches
+ * a configured doc-bearing surface, a configured doc path must also have changed
+ * — otherwise the leg is uncovered. Pure: the caller supplies the changed-file
+ * list (from `git diff --name-only`), so the rule itself is deterministic and
+ * directly testable. No doc-bearing surface touched ⇒ auto-waive (the
+ * no-ceremony default for ordinary changes). INV-6: no workflow-type branch —
+ * the same rule holds for every workflow type.
+ */
+export function evaluateDocumentLeg(
+  files: readonly string[],
+  cfg: DocumentLegConfig,
+): DocumentLegResult {
+  const matchesAny = (globs: readonly string[], f: string): boolean =>
+    globs.some((g) => globToRegExp(g).test(f));
+  const surfaceFiles = files.filter((f) => matchesAny(cfg.surfaceGlobs, f));
+  if (surfaceFiles.length === 0) {
+    return { evaluated: false, covered: true, severity: cfg.severity, surfaceFiles: [] };
+  }
+  const docsChanged = files.some((f) => matchesAny(cfg.docGlobs, f));
+  if (docsChanged) {
+    return { evaluated: true, covered: true, severity: cfg.severity, surfaceFiles };
+  }
+  return {
+    evaluated: true,
+    covered: false,
+    severity: cfg.severity,
+    surfaceFiles,
+    message:
+      `Doc-bearing surface changed without a documentation update: ${surfaceFiles.join(', ')}. ` +
+      `Update the relevant docs, or tune synthesis.documentLeg in .exarchos.yml to waive.`,
+  };
+}
+
+/**
+ * Whether the document leg BLOCKS synthesis readiness. Only a `'blocking'`
+ * severity on an evaluated-and-uncovered leg blocks; an advisory uncovered leg
+ * still records `gate.executed { passed:false }` (visible) but does not block.
+ */
+export function documentLegBlocks(result: DocumentLegResult): boolean {
+  return result.evaluated && !result.covered && result.severity === 'blocking';
+}
+
+/** Changed files between the default base branch and HEAD (name-only). */
+function changedFilesAgainstBase(): string[] {
+  try {
+    const baseBranch = detectDefaultBranch();
+    const output = execSync(`git diff --name-only ${baseBranch}...HEAD`, {
+      encoding: 'buffer',
+      timeout: 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return output
+      .toString('utf-8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 // ─── Task Readiness Check ──────────────────────────────────────────────────
 
 /** Minimal shape of a task entry in the canonical workflow-state projection. */
@@ -179,7 +271,7 @@ function checkTaskCompletion(
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 export async function handlePrepareSynthesis(
-  args: { featureId: string },
+  args: { featureId: string; projectConfig?: ResolvedProjectConfig },
   stateDir: string,
   eventStore: EventStore,
 ): Promise<ToolResult> {
@@ -214,6 +306,7 @@ export async function handlePrepareSynthesis(
         tasksComplete: false,
         testsPass: false,
         typecheckPass: false,
+        documentReady: false,
         stackHealthy: false,
       };
 
@@ -223,6 +316,7 @@ export async function handlePrepareSynthesis(
         blockers,
         tests: { passed: false, passCount: 0, failCount: 0 },
         typecheck: { passed: false, errorCount: 0 },
+        document: { evaluated: false, covered: false, severity: 'advisory', surfaceFiles: [] },
         stack: { healthy: false },
       };
 
@@ -254,22 +348,44 @@ export async function handlePrepareSynthesis(
     // 8. Verify branch stack
     const stack = verifyStack();
 
-    // 9. Build readiness state
+    // 9. Evaluate the document-readiness leg (DR-2, #1594) and emit its gate.
+    //    Roster order is task-completion→tests→typecheck→document→stack; gate
+    //    EMISSION order here is immaterial (the readiness view folds
+    //    gate.executed by name), so the leg is evaluated after the stack check.
+    //    `passed` reflects structural coverage; whether an uncovered leg BLOCKS
+    //    readiness is the severity decision (documentLegBlocks).
+    const docCfg = args.projectConfig?.synthesis.documentLeg ?? DEFAULT_DOCUMENT_LEG;
+    const documentLeg = evaluateDocumentLeg(changedFilesAgainstBase(), docCfg);
+    await emitGateEvent(store, streamId, 'document-coverage', 'synthesize', documentLeg.covered, {
+      dimension: 'D1',
+      phase: 'synthesize',
+      evaluated: documentLeg.evaluated,
+      severity: documentLeg.severity,
+      surfaceFiles: documentLeg.surfaceFiles,
+      ...(documentLeg.message !== undefined ? { message: documentLeg.message } : {}),
+    });
+
+    // 10. Build readiness state
     const readiness: SynthesisReadinessState = {
       tasksComplete: allComplete,
       testsPass: tests.passed,
       typecheckPass: typecheck.passed,
+      documentReady: !documentLegBlocks(documentLeg),
       stackHealthy: stack.healthy,
     };
 
     const ready = readiness.tasksComplete
       && readiness.testsPass
       && readiness.typecheckPass
+      && readiness.documentReady
       && readiness.stackHealthy;
 
     const allBlockers: string[] = [];
     if (!readiness.testsPass) allBlockers.push('Test suite failed');
     if (!readiness.typecheckPass) allBlockers.push('Typecheck failed');
+    if (!readiness.documentReady) {
+      allBlockers.push(documentLeg.message ?? 'Documentation not updated for a doc-bearing change');
+    }
     if (!readiness.stackHealthy) allBlockers.push('Stack not healthy');
 
     const result: PrepareSynthesisResult = {
@@ -278,6 +394,7 @@ export async function handlePrepareSynthesis(
       ...(allBlockers.length > 0 ? { blockers: allBlockers } : {}),
       tests,
       typecheck,
+      document: documentLeg,
       stack,
     };
 

--- a/servers/exarchos-mcp/src/orchestrate/review-verdict.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/review-verdict.test.ts
@@ -499,4 +499,183 @@ describe('handleReviewVerdict', () => {
       });
     });
   });
+
+  // ─── Bounded Fix-Loop (DR-3, #1595) ──────────────────────────────────────
+
+  describe('bounded fix-loop escalation', () => {
+    /**
+     * Build a prior `review-verdict` NEEDS_FIXES `gate.executed` event — the
+     * single event-sourced source the handler counts to derive the fix-cycle
+     * iteration. `count` of these seeds an iteration of `count`.
+     */
+    const needsFixesGateEvent = () => ({
+      type: 'gate.executed',
+      data: {
+        gateName: 'review-verdict',
+        layer: 'review',
+        passed: false,
+        details: { verdict: 'NEEDS_FIXES', phase: 'review', high: 1, medium: 0, low: 0 },
+      },
+    });
+
+    const seedPriorFixCycles = (n: number) => {
+      mockStore.query.mockResolvedValue(
+        Array.from({ length: n }, () => needsFixesGateEvent()),
+      );
+    };
+
+    it('SpecReview_FixLoop_BoundedByPolicy', async () => {
+      // 2 prior fix cycles, default bound of 5, mechanical findings → still
+      // routes to fixes, no escalation, report surfaces the remaining budget.
+      seedPriorFixCycles(2);
+      const result = await handleReviewVerdict(
+        { featureId: 'feat-bound', high: 1, medium: 0, low: 0 },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { verdict: string; escalate?: boolean; report: string };
+      expect(data.verdict).toBe('NEEDS_FIXES');
+      expect(data.escalate).toBeFalsy();
+      // Routes to fixes as today, with the next-cycle budget surfaced.
+      expect(data.report).toMatch(/delegate.*fixes/i);
+      expect(data.report).toContain('fix cycle 3/5');
+
+      // No escalation gate event emitted on the still-auto-fixable path: only the
+      // summary review-verdict event for this pass.
+      const gateNames = mockStore.append.mock.calls.map(
+        (c) => (c[1] as { data: { gateName: string } }).data.gateName,
+      );
+      expect(gateNames).toContain('review-verdict');
+      expect(gateNames).not.toContain('review-escalation');
+    });
+
+    it('SpecReview_BoundHit_Escalates', async () => {
+      // 5 prior fix cycles == default bound → escalate, no further fix loop, and
+      // a structured escalation event is emitted.
+      seedPriorFixCycles(5);
+      const result = await handleReviewVerdict(
+        { featureId: 'feat-hit', high: 2, medium: 0, low: 0 },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        verdict: string;
+        escalate?: boolean;
+        escalationReason?: string;
+        report: string;
+      };
+      expect(data.verdict).toBe('NEEDS_FIXES');
+      expect(data.escalate).toBe(true);
+      expect(data.escalationReason).toMatch(/bound/i);
+      // The escalation report does NOT re-issue a /delegate --fixes instruction.
+      expect(data.report).not.toMatch(/Route to `\/delegate --fixes`/);
+      expect(data.report).toMatch(/escalat/i);
+
+      // A structured review-escalation gate event is emitted (event-sourced).
+      const escalationCall = mockStore.append.mock.calls.find(
+        (c) => (c[1] as { data: { gateName: string } }).data.gateName === 'review-escalation',
+      );
+      expect(escalationCall).toBeDefined();
+      const escalationEvent = escalationCall![1] as {
+        type: string;
+        data: { gateName: string; passed: boolean; details: Record<string, unknown> };
+      };
+      expect(escalationEvent.type).toBe('gate.executed');
+      expect(escalationEvent.data.passed).toBe(false);
+      expect(escalationEvent.data.details.priorFixCount).toBe(5);
+      expect(escalationEvent.data.details.maxIterations).toBe(5);
+      expect(escalationEvent.data.details.findingClass).toBe('mechanical');
+    });
+
+    it('SpecReview_IntentTouchingFinding_EscalatesImmediately', async () => {
+      // No prior fix cycles (iteration 0, well under the bound) but a
+      // spec-category finding → escalate immediately, never loop.
+      seedPriorFixCycles(0);
+      const result = await handleReviewVerdict(
+        {
+          featureId: 'feat-intent',
+          high: 1,
+          medium: 0,
+          low: 0,
+          pluginFindings: [
+            { source: 'spec-review', severity: 'HIGH', category: 'spec', message: 'Intended-but-missing surface' },
+          ],
+        },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { verdict: string; escalate?: boolean; escalationReason?: string };
+      expect(data.verdict).toBe('NEEDS_FIXES');
+      expect(data.escalate).toBe(true);
+      expect(data.escalationReason).toMatch(/intent-touching/i);
+
+      const escalationCall = mockStore.append.mock.calls.find(
+        (c) => (c[1] as { data: { gateName: string } }).data.gateName === 'review-escalation',
+      );
+      expect(escalationCall).toBeDefined();
+      const escalationEvent = escalationCall![1] as {
+        data: { details: Record<string, unknown> };
+      };
+      expect(escalationEvent.data.details.findingClass).toBe('intent-touching');
+      expect(escalationEvent.data.details.priorFixCount).toBe(0);
+    });
+
+    it('SpecReview_PerLoopOverride_TightensBound', async () => {
+      // maxFixCycles override of 2 (vs default 5): 2 prior cycles hits the bound.
+      seedPriorFixCycles(2);
+      const result = await handleReviewVerdict(
+        { featureId: 'feat-override', high: 1, medium: 0, low: 0, maxFixCycles: 2 },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      const data = result.data as { escalate?: boolean; escalationReason?: string };
+      expect(data.escalate).toBe(true);
+      expect(data.escalationReason).toMatch(/bound \(2\)/);
+    });
+
+    it('SpecReview_ConfigBound_Resolves', async () => {
+      // projectConfig.escalation.maxIterations of 3: 3 prior cycles hits the bound.
+      seedPriorFixCycles(3);
+      const result = await handleReviewVerdict(
+        {
+          featureId: 'feat-config',
+          high: 1,
+          medium: 0,
+          low: 0,
+          projectConfig: { escalation: { maxIterations: 3 } } as never,
+        },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      const data = result.data as { escalate?: boolean; report: string };
+      expect(data.escalate).toBe(true);
+      expect(data.report).toContain('3/3');
+    });
+
+    it('SpecReview_Approved_NoEscalationFields', async () => {
+      // APPROVED is unchanged — no escalate fields, no escalation event.
+      seedPriorFixCycles(9);
+      const result = await handleReviewVerdict(
+        { featureId: 'feat-approved', high: 0, medium: 2, low: 0 },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      const data = result.data as { verdict: string; escalate?: boolean };
+      expect(data.verdict).toBe('APPROVED');
+      expect(data.escalate).toBeUndefined();
+      const gateNames = mockStore.append.mock.calls.map(
+        (c) => (c[1] as { data: { gateName: string } }).data.gateName,
+      );
+      expect(gateNames).not.toContain('review-escalation');
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/review-verdict.ts
+++ b/servers/exarchos-mcp/src/orchestrate/review-verdict.ts
@@ -280,8 +280,10 @@ export async function handleReviewVerdict(
   // terminal here. For a NEEDS_FIXES verdict, resolve the auto-fix bound, read
   // the event-sourced prior fix-cycle count, classify the findings, and decide
   // whether the loop may auto-fix once more or must escalate to the user.
-  // Fail-soft: any read error falls back to iteration 0 (still bounded) so a
-  // flaky store never turns the bound off. No `workflowType` branch (INV-6).
+  // Fail-CLOSED: if the prior-cycle count can't be read we can't prove the loop
+  // is within bounds, so we pin to maxIterations and force escalation rather
+  // than reset to 0 (which would let a flaky store silently disable the bound).
+  // No `workflowType` branch (INV-6).
   let escalation: FixLoopEscalation | undefined;
   if (verdict === 'NEEDS_FIXES') {
     const policy = resolveEscalationPolicy({

--- a/servers/exarchos-mcp/src/orchestrate/review-verdict.ts
+++ b/servers/exarchos-mcp/src/orchestrate/review-verdict.ts
@@ -290,13 +290,28 @@ export async function handleReviewVerdict(
     });
 
     let priorFixCount = 0;
+    let countUnavailable = false;
     try {
       const priorGateEvents = await eventStore.query(args.featureId, { type: 'gate.executed' });
       priorFixCount = countPriorFixCycles(priorGateEvents);
-    } catch { /* fail-soft: treat as the first cycle, still bounded */ }
+    } catch {
+      // Fail CLOSED: if the event-sourced cycle count can't be read we cannot
+      // prove the loop is within bounds. Silently resetting to 0 would, on a
+      // persistently failing store, let the loop auto-fix forever — disabling
+      // the DR-3 bound. Pin the count to the bound and force escalation instead.
+      countUnavailable = true;
+      priorFixCount = policy.maxIterations;
+    }
 
     const findingClass = classifyFindings(args.pluginFindings);
-    const decision = decideEscalation({ findingClass, iteration: priorFixCount, policy });
+    const decision = countUnavailable
+      ? {
+          action: 'escalate' as const,
+          reason:
+            'Fix-cycle count unavailable (event-store query failed); escalating to '
+            + 'preserve the bounded-loop guarantee.',
+        }
+      : decideEscalation({ findingClass, iteration: priorFixCount, policy });
     escalation = {
       action: decision.action,
       reason: decision.reason,

--- a/servers/exarchos-mcp/src/orchestrate/review-verdict.ts
+++ b/servers/exarchos-mcp/src/orchestrate/review-verdict.ts
@@ -8,7 +8,14 @@
 import type { ToolResult } from '../format.js';
 import type { PluginFinding } from '../review/check-catalog.js';
 import type { EventStore } from '../event-store/store.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { emitGateEvent } from './gate-utils.js';
+import {
+  resolveEscalationPolicy,
+  decideEscalation,
+  classifyFinding,
+  type FindingClass,
+} from './escalation-policy.js';
 
 // ─── Argument & Result Types ────────────────────────────────────────────────
 
@@ -19,7 +26,31 @@ interface ReviewVerdictArgs {
   readonly low: number;
   readonly blockedReason?: string;
   readonly dimensionResults?: Record<string, { passed: boolean; findingCount: number }>;
-  readonly pluginFindings?: readonly PluginFinding[];
+  /**
+   * Findings from a plugin review pass. Optional `category`/`intentTouching`
+   * fields (when supplied by the caller — e.g. spec-review issues carry a
+   * `category: 'spec' | 'tdd' | 'coverage'`) drive the escalation
+   * classification: a `category === 'spec'` (or `intentTouching === true`)
+   * finding is intent-touching and escalates immediately (DR-3, #1595).
+   */
+  readonly pluginFindings?: readonly (PluginFinding & {
+    readonly category?: string;
+    readonly intentTouching?: boolean;
+  })[];
+  /**
+   * Resolved project config — supplies the config-resolvable auto-fix bound
+   * (`escalation.maxIterations`) for the spec-review fix-loop. Injected by the
+   * `adaptWithEventStoreAndConfig` dispatch adapter; an explicit arg-level value
+   * (e.g. from a test) wins. Absent ⇒ the policy falls through to its default.
+   */
+  readonly projectConfig?: ResolvedProjectConfig;
+  /**
+   * Per-loop override of the auto-fix bound (highest precedence in
+   * {@link resolveEscalationPolicy}). Lets a single review invocation tighten or
+   * loosen the bound without a config edit; a garbage value falls through to the
+   * config/default layers.
+   */
+  readonly maxFixCycles?: number;
 }
 
 interface ReviewVerdictResult {
@@ -29,6 +60,16 @@ interface ReviewVerdictResult {
   readonly low: number;
   readonly blockedReason?: string;
   readonly report: string;
+  /**
+   * Set on a `NEEDS_FIXES` verdict when the shared escalation policy says the
+   * fix-loop must stop auto-fixing and ask the user — either the auto-fix bound
+   * was hit OR a finding is intent-touching (DR-3). The spec-review fix-loop
+   * MUST honor this instead of re-dispatching to `/delegate --fixes`. Absent on
+   * APPROVED/BLOCKED and on a still-auto-fixable NEEDS_FIXES.
+   */
+  readonly escalate?: boolean;
+  /** Human-readable reason for {@link escalate}, surfaced to the user. */
+  readonly escalationReason?: string;
 }
 
 // ─── Verdict Logic ──────────────────────────────────────────────────────────
@@ -56,14 +97,41 @@ export function computeVerdict(args: {
   return 'APPROVED';
 }
 
+// ─── Escalation Decision (DR-3) ─────────────────────────────────────────────
+
+/**
+ * The escalation outcome a NEEDS_FIXES verdict carries: whether the fix-loop
+ * may auto-fix (re-dispatch to the implementer once more) or must escalate to
+ * the user, plus the bound state the report surfaces. Resolved from the shared
+ * escalation policy (DR-3, #1595).
+ */
+interface FixLoopEscalation {
+  /** `escalate` ⇒ stop the loop and ask the user; `auto-fix` ⇒ re-dispatch. */
+  readonly action: 'auto-fix' | 'escalate';
+  readonly reason: string;
+  /** Fix cycles already run (event-sourced) — the iteration the policy decided on. */
+  readonly priorFixCount: number;
+  /** The resolved auto-fix bound, surfaced as remaining budget in the report. */
+  readonly maxIterations: number;
+  /** The class that drove the decision (intent-touching escalates immediately). */
+  readonly findingClass: FindingClass;
+}
+
 // ─── Report Generation ──────────────────────────────────────────────────────
 
 /**
  * Generate a markdown verdict report matching the bash script's output format.
+ *
+ * On `NEEDS_FIXES`, an optional {@link FixLoopEscalation} shapes the routing
+ * instruction (DR-3): while UNDER the bound and mechanical, the report routes to
+ * `/delegate --fixes` and surfaces the remaining budget; when the bound is hit
+ * OR a finding is intent-touching, the report becomes an ask-user escalation —
+ * NOT another fix loop.
  */
 export function generateVerdictReport(
   verdict: 'APPROVED' | 'NEEDS_FIXES' | 'BLOCKED',
   args: { high: number; medium: number; low: number; blockedReason?: string },
+  escalation?: FixLoopEscalation,
 ): string {
   const lines: string[] = [];
   const total = args.high + args.medium + args.low;
@@ -77,13 +145,33 @@ export function generateVerdictReport(
       'Return to design phase. Route to `/ideate --redesign`.',
     );
   } else if (verdict === 'NEEDS_FIXES') {
-    lines.push(
-      '## Review Verdict: NEEDS_FIXES',
-      '',
-      `Found ${args.high} HIGH-severity findings. Route to \`/delegate --fixes\`.`,
-      '',
-      `**Finding summary:** ${args.high} high, ${args.medium} medium, ${args.low} low (${total} total)`,
-    );
+    if (escalation?.action === 'escalate') {
+      // Bound hit OR intent-touching — escalate to the user, do NOT loop.
+      lines.push(
+        '## Review Verdict: NEEDS_FIXES (escalating to user)',
+        '',
+        `Found ${args.high} HIGH-severity findings, but the fix-loop must escalate: ${escalation.reason}.`,
+        '',
+        'Do NOT re-dispatch `/delegate --fixes`. Surface these findings to the user',
+        'and ask how to proceed (accept, redesign, or adjust scope).',
+        '',
+        `**Fix cycles run:** ${escalation.priorFixCount}/${escalation.maxIterations}`,
+        '',
+        `**Finding summary:** ${args.high} high, ${args.medium} medium, ${args.low} low (${total} total)`,
+      );
+    } else {
+      // Under the bound with mechanical findings — re-dispatch as today, with budget.
+      const budgetSuffix = escalation
+        ? ` (fix cycle ${escalation.priorFixCount + 1}/${escalation.maxIterations})`
+        : '';
+      lines.push(
+        '## Review Verdict: NEEDS_FIXES',
+        '',
+        `Found ${args.high} HIGH-severity findings. Route to \`/delegate --fixes\`${budgetSuffix}.`,
+        '',
+        `**Finding summary:** ${args.high} high, ${args.medium} medium, ${args.low} low (${total} total)`,
+      );
+    }
   } else {
     lines.push(
       '## Review Verdict: APPROVED',
@@ -95,6 +183,50 @@ export function generateVerdictReport(
   }
 
   return lines.join('\n');
+}
+
+// ─── Fix-cycle counting (event-sourced) ──────────────────────────────────────
+
+/**
+ * The SINGLE event-sourced source of how many fix cycles a spec review has
+ * already run: the count of prior `review-verdict` `gate.executed` events whose
+ * recorded verdict was `NEEDS_FIXES` (DR-3, #1595). Each NEEDS_FIXES pass emits
+ * exactly one such event before re-dispatching, so this is the iteration the
+ * escalation policy decides on — there is NO parallel counter. Pure over any
+ * event array; only the `gateName` + `details.verdict` discriminants are read.
+ */
+function countPriorFixCycles(
+  events: ReadonlyArray<{ readonly data?: unknown }>,
+): number {
+  let count = 0;
+  for (const event of events) {
+    const data = event.data as
+      | { gateName?: unknown; details?: { verdict?: unknown } }
+      | undefined;
+    if (data?.gateName === 'review-verdict' && data.details?.verdict === 'NEEDS_FIXES') {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Classify a NEEDS_FIXES finding SET into a single {@link FindingClass} via the
+ * shared {@link classifyFinding} feeder (DR-3). The set is `intent-touching`
+ * (escalate immediately) if ANY finding is intent-touching — a spec-category or
+ * explicitly-flagged finding must not be silently looped on, regardless of how
+ * many mechanical findings accompany it. With no findings carrying a class
+ * signal it defaults to `mechanical` (the bound, not immediate escalation,
+ * governs).
+ */
+function classifyFindings(
+  findings: readonly { readonly category?: string; readonly intentTouching?: boolean }[]
+    | undefined,
+): FindingClass {
+  if (findings?.some((f) => classifyFinding(f) === 'intent-touching')) {
+    return 'intent-touching';
+  }
+  return 'mechanical';
 }
 
 // ─── Handler ───────────────────────────────────────────────────────────────
@@ -141,7 +273,40 @@ export async function handleReviewVerdict(
   // Compute verdict in pure TypeScript using merged counts
   const mergedCounts = { high: mergedHigh, medium: mergedMedium, low: mergedLow, blockedReason: args.blockedReason };
   const verdict = computeVerdict(mergedCounts);
-  const report = generateVerdictReport(verdict, mergedCounts);
+
+  // ── Bound the fix-loop via the shared escalation policy (DR-3, #1595) ──────
+  //
+  // Only NEEDS_FIXES routes back to the implementer; APPROVED/BLOCKED are
+  // terminal here. For a NEEDS_FIXES verdict, resolve the auto-fix bound, read
+  // the event-sourced prior fix-cycle count, classify the findings, and decide
+  // whether the loop may auto-fix once more or must escalate to the user.
+  // Fail-soft: any read error falls back to iteration 0 (still bounded) so a
+  // flaky store never turns the bound off. No `workflowType` branch (INV-6).
+  let escalation: FixLoopEscalation | undefined;
+  if (verdict === 'NEEDS_FIXES') {
+    const policy = resolveEscalationPolicy({
+      configMaxIterations: args.projectConfig?.escalation?.maxIterations,
+      perLoopOverride: args.maxFixCycles,
+    });
+
+    let priorFixCount = 0;
+    try {
+      const priorGateEvents = await eventStore.query(args.featureId, { type: 'gate.executed' });
+      priorFixCount = countPriorFixCycles(priorGateEvents);
+    } catch { /* fail-soft: treat as the first cycle, still bounded */ }
+
+    const findingClass = classifyFindings(args.pluginFindings);
+    const decision = decideEscalation({ findingClass, iteration: priorFixCount, policy });
+    escalation = {
+      action: decision.action,
+      reason: decision.reason,
+      priorFixCount,
+      maxIterations: policy.maxIterations,
+      findingClass,
+    };
+  }
+
+  const report = generateVerdictReport(verdict, mergedCounts, escalation);
 
   const result: ReviewVerdictResult = {
     verdict,
@@ -150,6 +315,9 @@ export async function handleReviewVerdict(
     low: mergedLow,
     ...(args.blockedReason ? { blockedReason: args.blockedReason } : {}),
     report,
+    ...(escalation?.action === 'escalate'
+      ? { escalate: true, escalationReason: escalation.reason }
+      : {}),
   };
 
   // Emit per-dimension gate events (fire-and-forget)
@@ -182,6 +350,25 @@ export async function handleReviewVerdict(
       ...(pluginSources ? { pluginSources } : {}),
     });
   } catch { /* fire-and-forget */ }
+
+  // Emit a structured escalation gate event (DR-3) so the ask-user escalation is
+  // event-sourced and surfaceable — distinct from the `review-verdict` summary
+  // above (which `countPriorFixCycles` reads). Only on an actual escalate
+  // decision; a still-auto-fixable NEEDS_FIXES emits no extra row. The gate is
+  // recorded as FAILED (passed:false) — escalation means the bounded loop could
+  // not converge unattended. Fire-and-forget like its siblings.
+  if (escalation?.action === 'escalate') {
+    try {
+      const store = eventStore;
+      await emitGateEvent(store, args.featureId, 'review-escalation', 'review', false, {
+        phase: 'review',
+        reason: escalation.reason,
+        findingClass: escalation.findingClass,
+        priorFixCount: escalation.priorFixCount,
+        maxIterations: escalation.maxIterations,
+      });
+    } catch { /* fire-and-forget */ }
+  }
 
   return { success: true, data: result };
 }

--- a/servers/exarchos-mcp/src/orchestrate/validate-pr-body.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/validate-pr-body.test.ts
@@ -2,13 +2,20 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleValidatePrBody } from './validate-pr-body.js';
+import type { EventStore } from '../event-store/store.js';
+import { deriveIntent, INTENT_GROUNDING_MARKER } from './extract-intent.js';
 
-// Mock child_process and fs
-vi.mock('node:child_process', () => ({
+// Mock child_process and fs. We partially mock `node:child_process` —
+// preserving the real exports (e.g. `execFile`, which `compensation.ts`
+// `promisify`s at import time on the now-wider intent-grounding module graph)
+// and overriding only `execFileSync`, which this handler calls for `gh pr view`.
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
   execFileSync: vi.fn(),
 }));
 
-vi.mock('node:fs', () => ({
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs')>()),
   readFileSync: vi.fn(),
 }));
 
@@ -166,5 +173,110 @@ describe('handleValidatePrBody', () => {
     expect(result.success).toBe(true);
     const data = result.data as { passed: boolean };
     expect(data.passed).toBe(true);
+  });
+});
+
+// ─── DR-1 task 006: advisory intent-grounding ────────────────────────────────
+//
+// When `featureId` + an event store are supplied and a meaningful
+// `artifacts.intent` resolves, the handler surfaces an ADVISORY `intentGrounded`
+// flag + report line. It is advisory ONLY — never changes the `passed`
+// (required-sections) gate. With no featureId / intent / event store the
+// grounding fields are absent (unchanged legacy result).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ValidatePrBody_WithIntent_GroundsBody (DR-1 task 006)', () => {
+  interface GroundedResult {
+    passed: boolean;
+    missingSections: readonly string[];
+    report: string;
+    intentGrounded?: boolean;
+  }
+
+  /**
+   * An event store whose `query` returns a real `state.patched` event so
+   * `resolveWorkflowState` materializes `artifacts.intent` through the REAL
+   * projection — the exact read path the handler uses.
+   */
+  function storeWithIntent(patch: Record<string, unknown>): EventStore {
+    return {
+      query: vi.fn().mockResolvedValue([
+        {
+          streamId: 'feat-x',
+          sequence: 1,
+          type: 'state.patched',
+          timestamp: new Date().toISOString(),
+          data: { patch },
+        },
+      ]),
+    } as unknown as EventStore;
+  }
+
+  it('GroundedBody_IntentReferenced_AdvisoryGroundedTrue', async () => {
+    const intent = deriveIntent(['servers/a.ts', 'docs/b.md']);
+    // Body carries the grounding marker (the create_pr enrichment).
+    const body = `${VALID_BODY}\n\n## Intent\n\n${INTENT_GROUNDING_MARKER}\n\n${intent.summary}`;
+    const store = storeWithIntent({ 'artifacts.intent': intent });
+
+    const result = await handleValidatePrBody({ body, featureId: 'feat-x' }, undefined, store);
+
+    expect(result.success).toBe(true);
+    const data = result.data as GroundedResult;
+    expect(data.passed).toBe(true); // required sections still present
+    expect(data.intentGrounded).toBe(true);
+    expect(data.report).toMatch(/grounded in artifacts\.intent/i);
+  });
+
+  it('UngroundedBody_IntentNotReferenced_AdvisoryGroundedFalse_PassUnchanged', async () => {
+    const intent = deriveIntent(['servers/a.ts', 'docs/b.md']);
+    // Valid sections, but NO reference to the intent's marker / summary / surfaces.
+    const body = '## Summary\nUnrelated.\n\n## Changes\n- x\n\n## Test Plan\n- y\n';
+    const store = storeWithIntent({ 'artifacts.intent': intent });
+
+    const result = await handleValidatePrBody({ body, featureId: 'feat-x' }, undefined, store);
+
+    const data = result.data as GroundedResult;
+    expect(data.intentGrounded).toBe(false);
+    // Advisory does NOT flip the required-sections gate — body has all sections.
+    expect(data.passed).toBe(true);
+    expect(data.report).toMatch(/does NOT reference artifacts\.intent/i);
+  });
+
+  it('Advisory_NeverChangesPassed_OnMissingSections', async () => {
+    const intent = deriveIntent(['servers/a.ts']);
+    // Missing Changes + Test Plan — required gate must FAIL regardless of grounding.
+    const body = '## Summary\nOnly summary.\n';
+    const store = storeWithIntent({ 'artifacts.intent': intent });
+
+    const result = await handleValidatePrBody({ body, featureId: 'feat-x' }, undefined, store);
+
+    const data = result.data as GroundedResult;
+    expect(data.passed).toBe(false); // gate stays the gate
+    expect(data.missingSections).toContain('Changes');
+    expect(data.missingSections).toContain('Test Plan');
+    // Grounding advisory is still surfaced alongside the failing gate.
+    expect(typeof data.intentGrounded).toBe('boolean');
+  });
+
+  it('NoFeatureId_GroundingFieldsAbsent_LegacyResult', async () => {
+    // No featureId / event store → unchanged legacy result, no grounding fields.
+    const result = await handleValidatePrBody({ body: VALID_BODY });
+
+    const data = result.data as GroundedResult;
+    expect(data.passed).toBe(true);
+    expect(data.intentGrounded).toBeUndefined();
+    expect(data.report).not.toMatch(/artifacts\.intent/i);
+  });
+
+  it('EmptyIntent_NotMeaningful_GroundingFieldsAbsent', async () => {
+    // A persisted but empty intent (changedFiles: []) is not meaningful — omit.
+    const empty = deriveIntent([]);
+    const store = storeWithIntent({ 'artifacts.intent': empty });
+
+    const result = await handleValidatePrBody({ body: VALID_BODY, featureId: 'feat-x' }, undefined, store);
+
+    const data = result.data as GroundedResult;
+    expect(data.passed).toBe(true);
+    expect(data.intentGrounded).toBeUndefined();
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/validate-pr-body.ts
+++ b/servers/exarchos-mcp/src/orchestrate/validate-pr-body.ts
@@ -8,6 +8,9 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import type { ToolResult } from '../format.js';
+import type { EventStore } from '../event-store/store.js';
+import type { WorkflowIntent } from '../workflow/schemas.js';
+import { readIntent, bodyHasIntentMarker, isMeaningfulIntent } from './extract-intent.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -16,6 +19,16 @@ export interface ValidatePrBodyArgs {
   readonly bodyFile?: string;
   readonly body?: string;
   readonly template?: string;
+  /**
+   * DR-1 (#1593) task 006: when present (with an event store), the handler
+   * fail-soft reads `artifacts.intent` and adds an ADVISORY grounding check —
+   * does the body reference the intent (its `## Intent` marker, or its summary /
+   * surfaces)? Surfaced as `intentGrounded` + an advisory report line. ADVISORY
+   * ONLY: it never changes `passed` (the required-sections gate stays the gate).
+   * Absent featureId / intent / event store → the grounding fields are omitted
+   * (unchanged legacy result).
+   */
+  readonly featureId?: string;
 }
 
 interface ValidatePrBodyResult {
@@ -23,6 +36,12 @@ interface ValidatePrBodyResult {
   readonly missingSections: readonly string[];
   readonly report: string;
   readonly skipped?: boolean;
+  /**
+   * ADVISORY (DR-1 task 006): whether the body is grounded in `artifacts.intent`.
+   * Present only when a meaningful intent was resolved; omitted otherwise. Does
+   * NOT affect `passed`.
+   */
+  readonly intentGrounded?: boolean;
 }
 
 // ─── Constants ─────────────────────────────────────────────────────────────
@@ -112,10 +131,31 @@ function validateSections(
   };
 }
 
+// ─── DR-1 task 006: advisory intent-grounding check ──────────────────────────
+
+/**
+ * Whether the PR body references the captured intent. A body is considered
+ * grounded when it carries the `## Intent` grounding marker (the deterministic
+ * create_pr enrichment) OR independently references the intent's `summary` or
+ * any of its `surfaces`. Pure — case-insensitive substring match, never throws.
+ */
+function isBodyGroundedInIntent(body: string, intent: WorkflowIntent): boolean {
+  if (bodyHasIntentMarker(body)) return true;
+  const haystack = body.toLowerCase();
+  if (intent.summary.trim().length > 0 && haystack.includes(intent.summary.toLowerCase())) {
+    return true;
+  }
+  return intent.surfaces.some(
+    (s) => s.trim().length > 0 && haystack.includes(s.toLowerCase()),
+  );
+}
+
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 export async function handleValidatePrBody(
   args: ValidatePrBodyArgs,
+  _stateDir?: string,
+  eventStore?: EventStore,
 ): Promise<ToolResult> {
   let body: string;
   let author = '';
@@ -184,9 +224,33 @@ export async function handleValidatePrBody(
     requiredSections = DEFAULT_SECTIONS;
   }
 
-  // Validate
+  // Validate (required-sections gate — the load-bearing pass/fail)
   const { passed, missingSections, report } = validateSections(body, requiredSections);
-  const result: ValidatePrBodyResult = { passed, missingSections, report };
 
+  // ─── DR-1 task 006 — ADVISORY intent-grounding check ──────────────────────
+  //
+  // Fail-soft read `artifacts.intent`; when it is meaningful, surface whether
+  // the body references it (`intentGrounded`) plus an advisory report line. This
+  // is ADVISORY ONLY — it MUST NOT change `passed` (the required-sections gate
+  // stays the gate). When no featureId / event store / meaningful intent is
+  // available, the grounding fields are omitted (unchanged legacy result).
+  // INV-6: no `workflowType` branch. Never throws out of validation.
+  const intent = await readIntent(args.featureId, eventStore);
+  if (intent !== undefined && isMeaningfulIntent(intent)) {
+    const intentGrounded = isBodyGroundedInIntent(body, intent);
+    const advisory = intentGrounded
+      ? `Advisory: PR body is grounded in artifacts.intent (${intent.summary}).`
+      : `Advisory: PR body does NOT reference artifacts.intent (${intent.summary}). ` +
+        'Consider grounding it in the intended change (surfaces/summary).';
+    const result: ValidatePrBodyResult = {
+      passed,
+      missingSections,
+      report: `${report}\n${advisory}`,
+      intentGrounded,
+    };
+    return { success: true, data: result };
+  }
+
+  const result: ValidatePrBodyResult = { passed, missingSections, report };
   return { success: true, data: result };
 }

--- a/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.test.ts
@@ -3,6 +3,7 @@ import type { VcsProvider } from '../../vcs/provider.js';
 import type { EventStore } from '../../event-store/store.js';
 import type { DispatchContext } from '../../core/dispatch.js';
 import { ConcurrencyError } from '../../event-store/index.js';
+import { deriveIntent, INTENT_GROUNDING_MARKER } from '../extract-intent.js';
 
 // Mock the factory before importing the handler
 vi.mock('../../vcs/factory.js', () => ({
@@ -430,5 +431,133 @@ describe('CreatePr_RecoveryAppendFailure_DoesNotFallThroughToCreatePr', () => {
 
     // Sanity: Phase A append + failed recovery append = 2 calls.
     expect(appendCallCount).toBe(2);
+  });
+});
+
+// ─── DR-1 task 006: create_pr grounds the body in artifacts.intent ───────────
+//
+// When `featureId` is supplied and a meaningful `artifacts.intent` is persisted,
+// the handler enriches the PR body with a deterministic `## Intent` section +
+// idempotency marker BEFORE Phase A — so BOTH the durable `pr.create.requested`
+// event AND the created PR carry the grounded body. Degrades cleanly (body
+// unchanged) when there is no featureId / no meaningful intent / the body is
+// already grounded.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CreatePr_Body_ReferencesIntent (DR-1 task 006)', () => {
+  /**
+   * A `state.patched` event whose dot-path patch materializes `artifacts.intent`
+   * through the real projection — the same surface `readIntent` resolves through.
+   */
+  function intentPatchEvent(patch: Record<string, unknown>) {
+    return {
+      streamId: 'feat-x',
+      sequence: 1,
+      type: 'state.patched',
+      timestamp: new Date().toISOString(),
+      data: { patch },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+  });
+
+  it('CreatePr_MeaningfulIntent_EnrichesRequestedEventAndCreatedPrBody', async () => {
+    const intent = deriveIntent(['servers/a.ts', 'docs/b.md']);
+    const ctx = makeTwoEventCtx({
+      queryResult: [intentPatchEvent({ 'artifacts.intent': intent })],
+    });
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+
+    const result = await handleCreatePr(
+      {
+        title: 'feat: thing',
+        body: '## Summary\n\nDoes a thing.',
+        base: 'main',
+        head: 'feature/thing',
+        featureId: 'feat-x',
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+
+    // The created PR body carries the grounded `## Intent` section + marker.
+    const createArg = vi.mocked(provider.createPr).mock.calls[0][0];
+    expect(createArg.body).toContain('## Intent');
+    expect(createArg.body).toContain(INTENT_GROUNDING_MARKER);
+    expect(createArg.body).toContain(intent.summary);
+    // Original body content is preserved.
+    expect(createArg.body).toContain('Does a thing.');
+
+    // The durable `pr.create.requested` event carries the SAME grounded body.
+    const requestedCall = vi
+      .mocked(ctx.eventStore.append)
+      .mock.calls.find((call) => (call[1] as { type: string }).type === 'pr.create.requested');
+    expect(requestedCall).toBeDefined();
+    const requestedBody = (requestedCall![1] as { data: { body: string } }).data.body;
+    expect(requestedBody).toContain(INTENT_GROUNDING_MARKER);
+    expect(requestedBody).toBe(createArg.body);
+  });
+
+  it('CreatePr_NoFeatureId_LeavesBodyUntouched', async () => {
+    const ctx = makeTwoEventCtx();
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+
+    const body = '## Summary\n\nNo grounding here.';
+    await handleCreatePr(
+      { title: 'feat: thing', body, base: 'main', head: 'feature/thing' },
+      ctx,
+    );
+
+    const createArg = vi.mocked(provider.createPr).mock.calls[0][0];
+    expect(createArg.body).toBe(body);
+    expect(createArg.body).not.toContain(INTENT_GROUNDING_MARKER);
+  });
+
+  it('CreatePr_EmptyIntent_LeavesBodyUntouched', async () => {
+    // A persisted but EMPTY intent (changedFiles: []) is not meaningful — degrade.
+    const empty = deriveIntent([]);
+    const ctx = makeTwoEventCtx({
+      queryResult: [intentPatchEvent({ 'artifacts.intent': empty })],
+    });
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+
+    const body = '## Summary\n\nNothing changed.';
+    await handleCreatePr(
+      { title: 'feat: thing', body, base: 'main', head: 'feature/thing', featureId: 'feat-x' },
+      ctx,
+    );
+
+    const createArg = vi.mocked(provider.createPr).mock.calls[0][0];
+    expect(createArg.body).toBe(body);
+    expect(createArg.body).not.toContain(INTENT_GROUNDING_MARKER);
+  });
+
+  it('CreatePr_BodyAlreadyGrounded_DoesNotDoubleInject', async () => {
+    const intent = deriveIntent(['servers/a.ts']);
+    const ctx = makeTwoEventCtx({
+      queryResult: [intentPatchEvent({ 'artifacts.intent': intent })],
+    });
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+
+    // Body ALREADY carries the marker — the handler must not append a second section.
+    const body = `## Summary\n\nBody.\n\n## Intent\n\n${INTENT_GROUNDING_MARKER}\n\n**Surfaces:** servers`;
+    await handleCreatePr(
+      { title: 'feat: thing', body, base: 'main', head: 'feature/thing', featureId: 'feat-x' },
+      ctx,
+    );
+
+    const createArg = vi.mocked(provider.createPr).mock.calls[0][0];
+    expect(createArg.body).toBe(body);
+    // Marker appears exactly once.
+    expect(createArg.body.split(INTENT_GROUNDING_MARKER).length - 1).toBe(1);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.test.ts
@@ -747,3 +747,88 @@ describe('CreatePr_SinglePrOwnerGuard (DR-4 task 007)', () => {
     expect(provider.createPr).toHaveBeenCalledTimes(1);
   });
 });
+
+// ─── DR-4 task 009: PR idempotency is single-authority, handler-side ─────────
+//
+// DR-4 collapses the dual PR-idempotency layers to ONE authority. The redundant
+// second layer was the skill/command create-time PR-exists pre-check (the
+// `commands/synthesize.md` "## Idempotency" guidance to check `synthesis.prUrl`
+// before deciding whether to create). That pre-check is removed; the handler is
+// now the SINGLE authority for "PR already exists."
+//
+// This test pins that the handler is SUFFICIENT WITHOUT any external pre-check:
+// in the realistic synthesis call shape (featureId always passed), a workflow
+// whose state does NOT yet record a PR but whose remote already has an open PR
+// for (head, base) — the requested-but-not-executed crash-recovery window —
+// gets idempotent dedup PURELY from the handler. The state-owned guard
+// (task 007) correctly degrades (no PR recorded), and the listPrs
+// remote-recovery guard returns the existing PR with NO duplicate
+// provider.createPr. No caller pre-check is relied upon.
+//
+// Complement to task 007's CreatePr_DoubleCreateGuard_RetainedAndPinned, which
+// exercises the listPrs path with NO featureId (state-owned guard skipped
+// entirely). This one keeps the featureId present — proving the two handler
+// guards coexist and the handler alone governs idempotency in the real call
+// shape, so no skill/command pre-check is needed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PrIdempotency_SingleAuthority_HandlerGuardOnly (DR-4 task 009)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('PrIdempotency_SingleAuthority_HandlerGuardOnly', async () => {
+    // Workflow state records NO PR (queryResult: []) → the task-007 state-owned
+    // guard degrades to the legacy create path. But the remote already has an
+    // open PR for this (head, base): the handler's listPrs remote-recovery guard
+    // must return it idempotently — WITHOUT any caller-side pre-check having run.
+    const existingPr = {
+      number: 55,
+      url: 'https://github.com/repo/pull/55',
+      title: 'feat: single-authority',
+      headRefName: 'feature/single-authority',
+      baseRefName: 'main',
+      state: 'open',
+    };
+    const provider = makeMockProvider({
+      listPrs: vi.fn().mockResolvedValue([existingPr]),
+    });
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+    // featureId present (the real synthesis call shape) but NO recorded PR.
+    const ctx = makeTwoEventCtx({ queryResult: [] });
+
+    // A SINGLE handleCreatePr call — no caller pre-check, no skip-create logic.
+    const result = await handleCreatePr(
+      {
+        title: 'feat: single-authority',
+        body: 'Body',
+        base: 'main',
+        head: 'feature/single-authority',
+        featureId: 'feat-single-authority',
+      },
+      ctx,
+    );
+
+    // The handler ALONE governs "PR already exists": it returns the existing PR.
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ url: existingPr.url, number: existingPr.number });
+
+    // NO duplicate side effect — provider.createPr was never called.
+    expect(provider.createPr).not.toHaveBeenCalled();
+
+    // Idempotency resolved purely handler-side: it emits pr.create.executed
+    // referencing the existing PR (no second create) — pinning that no
+    // skill/command create-time pre-check is relied upon.
+    const executedAppend = vi
+      .mocked(ctx.eventStore.append)
+      .mock.calls.find(
+        (call) => (call[1] as { type: string }).type === 'pr.create.executed',
+      );
+    expect(executedAppend).toBeDefined();
+    const executedData = (
+      executedAppend![1] as { data: { prNumber: number; url: string } }
+    ).data;
+    expect(executedData.prNumber).toBe(55);
+    expect(executedData.url).toBe(existingPr.url);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.test.ts
@@ -561,3 +561,189 @@ describe('CreatePr_Body_ReferencesIntent (DR-1 task 006)', () => {
     expect(createArg.body.split(INTENT_GROUNDING_MARKER).length - 1).toBe(1);
   });
 });
+
+// ─── DR-4 task 007: structural single-PR-owner guard ────────────────────────
+//
+// Synthesize is the sole PR creator. The shepherd loop that follows runs WITHIN
+// the SYNTHESIZE phase (so phase-gating cannot fence the initial create from a
+// shepherd resubmit) and can only push/assess. The by-construction
+// differentiator is workflow STATE: once the initial create succeeds the
+// workflow already OWNS a PR. handleCreatePr therefore refuses create_pr when
+// the feature's projected state already records a PR — a shepherd-context
+// create_pr is refused (PR_ALREADY_OWNED) with NO side effect. The refusal is
+// derived from event-sourced state, not a caller-passed boolean (INV-6).
+//
+// The complementary listPrs remote-recovery guard (the requested-but-not-
+// executed crash-recovery window, before state records the PR) is pinned here
+// so a future refactor cannot silently drop it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CreatePr_SinglePrOwnerGuard (DR-4 task 007)', () => {
+  /**
+   * A `state.patched` event whose dot-path patch materializes a PR reference
+   * through the real projection — the same `artifacts.pr` / `synthesis.prUrl`
+   * surface `resolveWorkflowState` resolves through. This is the canonical
+   * update path: the projection applies the dot-path onto the view exactly as
+   * the on-disk write does.
+   */
+  function prPatchEvent(patch: Record<string, unknown>) {
+    return {
+      streamId: 'feat-owned',
+      sequence: 1,
+      type: 'state.patched',
+      timestamp: new Date().toISOString(),
+      data: { patch },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('CreatePr_ShepherdContext_Refused', async () => {
+    // Seed a feature workflow whose projected state records a PR via BOTH the
+    // primary `artifacts.pr` reference and the `synthesis.prUrl` mirror — the
+    // exact state a workflow is in AFTER the initial synthesize created its PR,
+    // i.e. the shepherd loop's documented precondition ("create_pr already ran").
+    const ctx = makeTwoEventCtx({
+      queryResult: [
+        prPatchEvent({
+          'artifacts.pr': 'https://github.com/repo/pull/100',
+          'synthesis.prUrl': 'https://github.com/repo/pull/100',
+        }),
+      ],
+    });
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+
+    const result = await handleCreatePr(
+      {
+        title: 'feat: resubmit from shepherd',
+        body: 'Body',
+        base: 'main',
+        head: 'feature/owned',
+        featureId: 'feat-owned',
+      },
+      ctx,
+    );
+
+    // Refused with the structured single-owner error.
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('PR_ALREADY_OWNED');
+    expect(result.error?.message).toContain('feat-owned');
+
+    // NO provider side effect — createPr was NEVER called.
+    expect(provider.createPr).not.toHaveBeenCalled();
+
+    // NO `pr.create.requested` event appended to the vcs stream (the guard fires
+    // before Phase A). Only the state-resolution query ran against the store.
+    const requestedAppend = vi
+      .mocked(ctx.eventStore.append)
+      .mock.calls.find(
+        (call) => (call[1] as { type: string }).type === 'pr.create.requested',
+      );
+    expect(requestedAppend).toBeUndefined();
+    expect(vi.mocked(ctx.eventStore.append)).not.toHaveBeenCalled();
+  });
+
+  it('CreatePr_OwnedViaPrUrlOnly_Refused', async () => {
+    // The mirror-only case: `synthesis.prUrl` records the PR but `artifacts.pr`
+    // is still null. Either field owning a PR must trigger the refusal.
+    const ctx = makeTwoEventCtx({
+      queryResult: [
+        prPatchEvent({ 'synthesis.prUrl': 'https://github.com/repo/pull/101' }),
+      ],
+    });
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+
+    const result = await handleCreatePr(
+      {
+        title: 'feat: resubmit',
+        body: 'Body',
+        base: 'main',
+        head: 'feature/owned',
+        featureId: 'feat-owned',
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('PR_ALREADY_OWNED');
+    expect(provider.createPr).not.toHaveBeenCalled();
+    expect(vi.mocked(ctx.eventStore.append)).not.toHaveBeenCalled();
+  });
+
+  it('CreatePr_DoubleCreateGuard_RetainedAndPinned', async () => {
+    // The existing remote-recovery (listPrs-by-(head,base)) guard is intact and
+    // COMPLEMENTARY to the state-owned guard: it fires in the crash-recovery
+    // window where the workflow state does NOT yet record a PR but the remote
+    // already has one (a prior gh pr create that crashed before
+    // pr.create.executed committed). With NO featureId the state-owned guard is
+    // skipped entirely, exercising this path in isolation.
+    const existingPr = {
+      number: 88,
+      url: 'https://github.com/repo/pull/88',
+      title: 'feat: recovered',
+      headRefName: 'feature/recovered',
+      baseRefName: 'main',
+      state: 'open',
+    };
+    const provider = makeMockProvider({
+      listPrs: vi.fn().mockResolvedValue([existingPr]),
+    });
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+    const ctx = makeTwoEventCtx();
+
+    const result = await handleCreatePr(
+      {
+        title: 'feat: recovered',
+        body: 'Body',
+        base: 'main',
+        head: 'feature/recovered',
+      },
+      ctx,
+    );
+
+    // Returns the existing PR (success) without re-firing the side effect.
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ url: existingPr.url, number: existingPr.number });
+    expect(provider.createPr).not.toHaveBeenCalled();
+
+    // Emits pr.create.executed referencing the existing PR — not a duplicate create.
+    const executedAppend = vi
+      .mocked(ctx.eventStore.append)
+      .mock.calls.find(
+        (call) => (call[1] as { type: string }).type === 'pr.create.executed',
+      );
+    expect(executedAppend).toBeDefined();
+    const executedData = (
+      executedAppend![1] as { data: { prNumber: number; url: string } }
+    ).data;
+    expect(executedData.prNumber).toBe(88);
+    expect(executedData.url).toBe(existingPr.url);
+  });
+
+  it('CreatePr_FeatureIdButNoPrRecorded_ProceedsToNormalCreate', async () => {
+    // Degrade path: featureId present, but the workflow state records NO PR (the
+    // initial synthesize — the FIRST create). The state-owned guard must NOT
+    // refuse, and with listPrs returning none, normal creation proceeds.
+    const ctx = makeTwoEventCtx({ queryResult: [] });
+    const provider = makeMockProvider();
+    vi.mocked(createVcsProvider).mockResolvedValue(provider);
+
+    const result = await handleCreatePr(
+      {
+        title: 'feat: initial synthesize',
+        body: 'Body',
+        base: 'main',
+        head: 'feature/fresh',
+        featureId: 'feat-fresh',
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(provider.createPr).toHaveBeenCalledTimes(1);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.ts
@@ -42,6 +42,7 @@ import {
   ConcurrencyError,
   StorageBusyError,
 } from '../../event-store/index.js';
+import { readIntent, groundBodyInIntent } from '../extract-intent.js';
 
 export interface HandleCreatePrArgs {
   readonly title: string;
@@ -50,6 +51,14 @@ export interface HandleCreatePrArgs {
   readonly head: string;
   readonly draft?: boolean;
   readonly labels?: string[];
+  /**
+   * DR-1 (#1593) task 006: when present, the handler fail-soft reads
+   * `artifacts.intent` and grounds the PR body in it (a deterministic `##
+   * Intent` section) so BOTH the durable `pr.create.requested` event AND the
+   * created PR carry the grounded body. Absent / unreadable / empty intent →
+   * the body is left untouched (unchanged legacy behavior).
+   */
+  readonly featureId?: string;
 }
 
 export async function handleCreatePr(
@@ -65,6 +74,20 @@ export async function handleCreatePr(
   const operationId = randomUUID();
   const phaseAKey = `pr.create.requested:${operationId}`;
   const phaseBKey = `pr.create.executed:${operationId}`;
+
+  // ─── DR-1 task 006 — ground the PR body in artifacts.intent ───────────────
+  //
+  // BEFORE Phase A: fail-soft read the persisted intent and, when it is
+  // meaningful and the body is not already grounded, append a deterministic `##
+  // Intent` section + idempotency marker. The ENRICHED body is used for the
+  // rest of the handler so BOTH the durable `pr.create.requested` event AND the
+  // created PR carry the grounded body. `readIntent`/`groundBodyInIntent` never
+  // throw and degrade to the unchanged body when no featureId / no meaningful
+  // intent / state unreadable — never breaking PR creation on a state hiccup.
+  // INV-6: no `workflowType` branch.
+  const intent = await readIntent(args.featureId, ctx.eventStore);
+  const effectiveBody =
+    intent !== undefined ? groundBodyInIntent(args.body, intent) : args.body;
 
   const provider = await createVcsProvider({ config: ctx.projectConfig });
 
@@ -87,7 +110,7 @@ export async function handleCreatePr(
           data: {
             operationId,
             title: args.title,
-            body: args.body,
+            body: effectiveBody,
             base: args.base,
             head: args.head,
             ...(args.draft !== undefined ? { draft: args.draft } : {}),
@@ -194,7 +217,7 @@ export async function handleCreatePr(
   try {
     const result = await provider.createPr({
       title: args.title,
-      body: args.body,
+      body: effectiveBody,
       baseBranch: args.base,
       headBranch: args.head,
       draft: args.draft,

--- a/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/create-pr.ts
@@ -43,6 +43,7 @@ import {
   StorageBusyError,
 } from '../../event-store/index.js';
 import { readIntent, groundBodyInIntent } from '../extract-intent.js';
+import { resolveWorkflowState } from '../resolve-state.js';
 
 export interface HandleCreatePrArgs {
   readonly title: string;
@@ -61,10 +62,70 @@ export interface HandleCreatePrArgs {
   readonly featureId?: string;
 }
 
+/**
+ * A workflow "owns a PR" when its projected state records a non-empty PR
+ * reference — either `artifacts.pr` or `synthesis.prUrl`. The projection types
+ * both as `string | string[] | null`, so a recorded PR is a non-empty string OR
+ * a non-empty array. `null`, `undefined`, `''`, and `[]` all mean "no PR yet".
+ */
+function recordsPr(value: unknown): boolean {
+  if (typeof value === 'string') return value.length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return false;
+}
+
 export async function handleCreatePr(
   args: HandleCreatePrArgs,
   ctx: DispatchContext,
 ): Promise<ToolResult> {
+  // ─── DR-4 (#1596) task 007 — structural single-PR-owner guard ─────────────
+  //
+  // FIRST step, before ANY side effect (body grounding, Phase A, provider
+  // calls). Synthesize is the sole PR creator: the initial /synthesize runs
+  // create_pr exactly once, and the shepherd loop that follows can only
+  // push/assess — it has no create_pr path. Shepherd runs WITHIN the SYNTHESIZE
+  // phase, so phase-gating cannot separate the initial create from a shepherd
+  // resubmit. The only by-construction differentiator is workflow STATE: once
+  // the initial create succeeds, the workflow already OWNS a PR. That is exactly
+  // shepherd's documented precondition ("create_pr already ran"). So we refuse
+  // any create_pr whose feature already records a PR.
+  //
+  // The refusal is derived from authoritative event-sourced state (the
+  // projection), NOT a caller-passed boolean — there is no `shepherdContext`
+  // flag and no `workflowType` branch (INV-6). Fail-soft: a missing featureId,
+  // an unreadable state, or no recorded PR all DEGRADE to the unchanged legacy
+  // create path (the listPrs remote-recovery guard below still backstops the
+  // crash-recovery window before state records the PR). The state read NEVER
+  // throws out of this guard.
+  if (args.featureId !== undefined) {
+    const resolved = await resolveWorkflowState({
+      featureId: args.featureId,
+      eventStore: ctx.eventStore,
+    });
+    if ('state' in resolved) {
+      const artifacts = resolved.state.artifacts as
+        | { pr?: unknown }
+        | undefined;
+      const synthesis = resolved.state.synthesis as
+        | { prUrl?: unknown }
+        | undefined;
+      if (recordsPr(artifacts?.pr) || recordsPr(synthesis?.prUrl)) {
+        return {
+          success: false,
+          error: {
+            code: 'PR_ALREADY_OWNED',
+            message:
+              `create_pr refused: feature '${args.featureId}' already owns a PR. ` +
+              `Only the initial synthesize creates a PR for a feature; the ` +
+              `shepherd loop can only push/assess, never create_pr (single PR ` +
+              `owner — DR-4). No PR was created.`,
+          },
+        };
+      }
+    }
+    // `{ error }` (state unreadable) → degrade to the legacy create path.
+  }
+
   // ─── Generate stable operationId for this invocation ──────────────────────
   // The operationId is the idempotency anchor for both Phase A and Phase B.
   // Using randomUUID() at handler entry means each top-level invocation gets a

--- a/servers/exarchos-mcp/src/orchestrate/vcs/push-with-lease.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/push-with-lease.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildForceWithLeaseArgs,
+  buildPushWithLease,
+  parseLsRemoteSha,
+  readRemoteSha,
+  resolveExpectedSha,
+  type RunGit,
+} from './push-with-lease.js';
+
+// A valid 40-hex git SHA used throughout the explicit-form assertions.
+const OBSERVED_SHA = 'a'.repeat(40);
+const REMOTE_SHA = 'b'.repeat(40);
+
+describe('buildForceWithLeaseArgs', () => {
+  it('PushWithLease_EmitsExplicitShaForm', () => {
+    const args = buildForceWithLeaseArgs('feat/x', OBSERVED_SHA);
+
+    // The lease MUST carry the explicit `=<ref>:<sha>` payload …
+    expect(args).toContain(`--force-with-lease=feat/x:${OBSERVED_SHA}`);
+    // … and the full argv must be exactly the expected push command.
+    expect(args).toEqual([
+      'push',
+      `--force-with-lease=feat/x:${OBSERVED_SHA}`,
+      'origin',
+      'feat/x',
+    ]);
+
+    // NEVER a bare `--force-with-lease` (the stale-lease footgun this guards).
+    expect(args).not.toContain('--force-with-lease');
+    expect(args.some((a) => a === '--force-with-lease')).toBe(false);
+  });
+
+  it('honors a custom remote', () => {
+    const args = buildForceWithLeaseArgs('feat/x', OBSERVED_SHA, 'upstream');
+    expect(args).toEqual([
+      'push',
+      `--force-with-lease=feat/x:${OBSERVED_SHA}`,
+      'upstream',
+      'feat/x',
+    ]);
+  });
+
+  it('rejects an empty ref', () => {
+    expect(() => buildForceWithLeaseArgs('', OBSERVED_SHA)).toThrow(/non-empty/);
+  });
+
+  it('rejects a ref with unsafe characters', () => {
+    expect(() => buildForceWithLeaseArgs('feat/x; rm -rf /', OBSERVED_SHA)).toThrow(
+      /unsafe characters/,
+    );
+    expect(() => buildForceWithLeaseArgs('feat/x $(whoami)', OBSERVED_SHA)).toThrow(
+      /unsafe characters/,
+    );
+  });
+
+  it('rejects an empty or garbage expected SHA', () => {
+    expect(() => buildForceWithLeaseArgs('feat/x', '')).toThrow(/non-empty/);
+    expect(() => buildForceWithLeaseArgs('feat/x', 'not-a-sha')).toThrow(/hex git SHA/);
+    // A 7-char short SHA is NOT acceptable — ls-remote always yields the full 40.
+    expect(() => buildForceWithLeaseArgs('feat/x', 'abc1234')).toThrow(/hex git SHA/);
+  });
+});
+
+describe('parseLsRemoteSha', () => {
+  it('parses the leading SHA from an ls-remote line', () => {
+    expect(parseLsRemoteSha(`${REMOTE_SHA}\trefs/heads/feat/x\n`)).toBe(REMOTE_SHA);
+  });
+
+  it('returns undefined for empty / whitespace stdout (branch absent)', () => {
+    expect(parseLsRemoteSha('')).toBeUndefined();
+    expect(parseLsRemoteSha('   \n  \n')).toBeUndefined();
+  });
+
+  it('returns undefined when the leading token is not a full SHA', () => {
+    expect(parseLsRemoteSha('garbage\trefs/heads/feat/x')).toBeUndefined();
+  });
+});
+
+describe('resolveExpectedSha', () => {
+  it('PushWithLease_FreshLsRemote_AnchorsToObservedSha — falls back to ls-remote', () => {
+    const runGit = vi.fn<RunGit>().mockReturnValue(`${REMOTE_SHA}\trefs/heads/feat/x\n`);
+
+    const sha = resolveExpectedSha('feat/x', { runGit });
+
+    expect(sha).toBe(REMOTE_SHA);
+    expect(runGit).toHaveBeenCalledWith(['ls-remote', '--heads', 'origin', 'feat/x']);
+  });
+
+  it('prefers observedSha and never shells out when it is supplied', () => {
+    const runGit = vi.fn<RunGit>();
+
+    const sha = resolveExpectedSha('feat/x', { observedSha: OBSERVED_SHA, runGit });
+
+    expect(sha).toBe(OBSERVED_SHA);
+    expect(runGit).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ls-remote when observedSha is not a valid SHA', () => {
+    const runGit = vi.fn<RunGit>().mockReturnValue(`${REMOTE_SHA}\trefs/heads/feat/x\n`);
+
+    const sha = resolveExpectedSha('feat/x', { observedSha: 'bogus', runGit });
+
+    expect(sha).toBe(REMOTE_SHA);
+    expect(runGit).toHaveBeenCalledOnce();
+  });
+
+  it('returns undefined when the branch is absent on the remote', () => {
+    const runGit = vi.fn<RunGit>().mockReturnValue('');
+    expect(resolveExpectedSha('feat/x', { runGit })).toBeUndefined();
+  });
+});
+
+describe('readRemoteSha', () => {
+  it('reads via git ls-remote --heads against the named remote', () => {
+    const runGit = vi.fn<RunGit>().mockReturnValue(`${REMOTE_SHA}\trefs/heads/feat/x\n`);
+
+    const sha = readRemoteSha('feat/x', 'upstream', runGit);
+
+    expect(sha).toBe(REMOTE_SHA);
+    expect(runGit).toHaveBeenCalledWith(['ls-remote', '--heads', 'upstream', 'feat/x']);
+  });
+});
+
+describe('buildPushWithLease', () => {
+  it('PushWithLease_FreshLsRemote_AnchorsToObservedSha — anchors to the ls-remote SHA', () => {
+    const runGit = vi.fn<RunGit>().mockReturnValue(`${REMOTE_SHA}\trefs/heads/feat/x\n`);
+
+    const result = buildPushWithLease('feat/x', { runGit });
+
+    expect(result).toBeDefined();
+    expect(result?.source).toBe('ls-remote');
+    expect(result?.expectedSha).toBe(REMOTE_SHA);
+    expect(result?.args).toEqual([
+      'push',
+      `--force-with-lease=feat/x:${REMOTE_SHA}`,
+      'origin',
+      'feat/x',
+    ]);
+    expect(result?.args).not.toContain('--force-with-lease');
+  });
+
+  it('prefers the observed SHA (source observed, no git call)', () => {
+    const runGit = vi.fn<RunGit>();
+
+    const result = buildPushWithLease('feat/x', { observedSha: OBSERVED_SHA, runGit });
+
+    expect(result?.source).toBe('observed');
+    expect(result?.expectedSha).toBe(OBSERVED_SHA);
+    expect(result?.args).toEqual([
+      'push',
+      `--force-with-lease=feat/x:${OBSERVED_SHA}`,
+      'origin',
+      'feat/x',
+    ]);
+    expect(runGit).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when no SHA can be resolved (cannot build an explicit lease)', () => {
+    const runGit = vi.fn<RunGit>().mockReturnValue('');
+    expect(buildPushWithLease('feat/x', { runGit })).toBeUndefined();
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/vcs/push-with-lease.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/push-with-lease.ts
@@ -1,0 +1,193 @@
+// ─── VCS Helper: explicit-SHA force-with-lease push (DR-4 / #1596) ───────────
+//
+// A bare `git push --force-with-lease` (no `=<ref>:<sha>`) leases against the
+// LOCAL remote-tracking ref, which can be stale — it silently clobbers a
+// concurrent push the loop never observed. The explicit
+// `--force-with-lease=<ref>:<expected-sha>` form anchors the lease to a SHA the
+// shepherd loop actually observed at the remote (via `assess_stack`, else a
+// fresh `git ls-remote`), so the push fails closed when the remote has moved.
+//
+// This module locks that contract: PURE argv construction is split from the
+// IMPURE git read of the remote SHA, with the git exec behind an injectable
+// seam so tests never touch a real remote. Production call sites (the SDK push
+// consolidation) adopt `buildPushWithLease` later — forward-compatible by
+// design.
+
+import { execFileSync } from 'node:child_process';
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Safe ref charset — mirrors the sanitizer used in `prepare-synthesis.ts` and
+ * `extract-intent.ts`. Rejects shell-metacharacters and ref names that could
+ * smuggle extra argv into the git invocation.
+ */
+const SAFE_REF_RE = /^[a-zA-Z0-9/_.-]+$/;
+
+/** Full git object name: 40 lowercase hex. ls-remote always prints the full SHA. */
+const FULL_SHA_RE = /^[0-9a-f]{40}$/;
+
+function assertSafeRef(ref: string): void {
+  if (ref.length === 0) {
+    throw new Error('push-with-lease: ref must be a non-empty string');
+  }
+  if (!SAFE_REF_RE.test(ref)) {
+    throw new Error(
+      `push-with-lease: ref "${ref}" contains unsafe characters (allowed: ${SAFE_REF_RE.source})`,
+    );
+  }
+}
+
+function assertValidSha(sha: string): void {
+  if (sha.length === 0) {
+    throw new Error('push-with-lease: expectedSha must be a non-empty string');
+  }
+  if (!FULL_SHA_RE.test(sha)) {
+    throw new Error(
+      `push-with-lease: expectedSha "${sha}" is not a 40-char lowercase hex git SHA`,
+    );
+  }
+}
+
+// ─── Pure argv construction ───────────────────────────────────────────────────
+
+/**
+ * Build the `git push` argv for an explicit-SHA force-with-lease.
+ *
+ * Returns `['push', '--force-with-lease=<ref>:<expectedSha>', <remote>, <ref>]`.
+ * NEVER emits a bare `--force-with-lease` — the whole point of this helper is to
+ * anchor the lease to an observed remote SHA. Inputs are validated (non-empty,
+ * sanitized ref, 40-hex SHA); bad input throws rather than degrading to an
+ * un-anchored push.
+ */
+export function buildForceWithLeaseArgs(
+  ref: string,
+  expectedSha: string,
+  remote = 'origin',
+): string[] {
+  assertSafeRef(ref);
+  assertValidSha(expectedSha);
+  assertSafeRef(remote);
+  return ['push', `--force-with-lease=${ref}:${expectedSha}`, remote, ref];
+}
+
+// ─── Git exec seam ─────────────────────────────────────────────────────────────
+
+/**
+ * Injectable git runner: takes the argv (sans the `git` binary) and returns
+ * stdout as a string. Defaults to a synchronous `execFileSync` with a 30s
+ * ceiling and piped stdio — tests override it so they never hit a real remote.
+ */
+export type RunGit = (args: readonly string[]) => string;
+
+const GIT_TIMEOUT_MS = 30_000;
+
+const defaultRunGit: RunGit = (args) =>
+  execFileSync('git', [...args], {
+    timeout: GIT_TIMEOUT_MS,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+/**
+ * Parse the leading 40-hex SHA from `git ls-remote --heads` output. ls-remote
+ * prints `<sha>\t<ref>` lines; an empty/whitespace stdout means the branch is
+ * absent on the remote — return `undefined` so the caller knows there is no SHA
+ * to anchor a lease to.
+ */
+export function parseLsRemoteSha(stdout: string): string | undefined {
+  const firstLine = stdout.split('\n').find((line) => line.trim().length > 0);
+  if (firstLine === undefined) return undefined;
+  const [sha] = firstLine.trim().split(/\s+/, 1);
+  return sha !== undefined && FULL_SHA_RE.test(sha) ? sha : undefined;
+}
+
+/**
+ * Read the current SHA of `<ref>` at `<remote>` via `git ls-remote --heads`.
+ * Mirrors the `remoteBranchExists` pattern in `workflow/compensation.ts`.
+ * Returns `undefined` when the branch is absent (empty stdout). The git exec is
+ * injectable so tests stub the network read.
+ */
+export function readRemoteSha(
+  ref: string,
+  remote = 'origin',
+  runGit: RunGit = defaultRunGit,
+): string | undefined {
+  assertSafeRef(ref);
+  assertSafeRef(remote);
+  const stdout = runGit(['ls-remote', '--heads', remote, ref]);
+  return parseLsRemoteSha(stdout);
+}
+
+// ─── Expected-SHA resolution ───────────────────────────────────────────────────
+
+/** Where the resolved expected SHA came from — diagnostic for callers/tests. */
+export type ExpectedShaSource = 'observed' | 'ls-remote';
+
+export interface ResolveExpectedShaOptions {
+  /** Remote name; defaults to `origin`. */
+  readonly remote?: string;
+  /**
+   * The SHA the shepherd loop last observed at the remote (via `assess_stack`).
+   * PREFERRED when present — it avoids a redundant network round-trip and uses
+   * the exact SHA the loop reasoned about.
+   */
+  readonly observedSha?: string;
+  /** Injectable git runner; defaults to a real `execFileSync`. */
+  readonly runGit?: RunGit;
+}
+
+/**
+ * Resolve the SHA to anchor the lease to. Prefers `observedSha` (the SHA the
+ * shepherd loop last saw via `assess_stack`); falls back to a fresh
+ * `git ls-remote` when absent. Returns `undefined` when neither yields a valid
+ * SHA — the caller then knows it cannot build an explicit-SHA lease (and must
+ * NOT silently degrade to a bare lease).
+ */
+export function resolveExpectedSha(
+  ref: string,
+  options: ResolveExpectedShaOptions = {},
+): string | undefined {
+  assertSafeRef(ref);
+  const { remote = 'origin', observedSha, runGit = defaultRunGit } = options;
+  if (observedSha !== undefined && FULL_SHA_RE.test(observedSha)) {
+    return observedSha;
+  }
+  return readRemoteSha(ref, remote, runGit);
+}
+
+// ─── Convenience: resolve + build ──────────────────────────────────────────────
+
+export interface BuildPushWithLeaseResult {
+  /** The `git push` argv (sans the `git` binary). */
+  readonly args: string[];
+  /** The expected SHA the lease is anchored to. */
+  readonly expectedSha: string;
+  /** Where that SHA came from. */
+  readonly source: ExpectedShaSource;
+}
+
+/**
+ * Resolve the expected remote SHA (observed > fresh ls-remote), then build the
+ * explicit-SHA force-with-lease argv. Returns `undefined` when no SHA can be
+ * resolved — meaning an explicit-SHA lease cannot be built and the caller must
+ * decide how to proceed rather than fall back to an un-anchored push.
+ *
+ * Kept pure-ish via the injectable `runGit` seam: with `observedSha` supplied,
+ * no git process runs at all.
+ */
+export function buildPushWithLease(
+  ref: string,
+  options: ResolveExpectedShaOptions = {},
+): BuildPushWithLeaseResult | undefined {
+  const { remote = 'origin', observedSha, runGit = defaultRunGit } = options;
+  const source: ExpectedShaSource =
+    observedSha !== undefined && FULL_SHA_RE.test(observedSha) ? 'observed' : 'ls-remote';
+  const expectedSha = resolveExpectedSha(ref, { remote, observedSha, runGit });
+  if (expectedSha === undefined) return undefined;
+  return {
+    args: buildForceWithLeaseArgs(ref, expectedSha, remote),
+    expectedSha,
+    source,
+  };
+}

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1561,7 +1561,7 @@ const orchestrateActions: readonly ToolAction[] = [
   },
   {
     name: 'check_review_verdict',
-    description: 'Compute review verdict from finding counts. Emits per-dimension and summary gate.executed events.',
+    description: 'Compute review verdict from finding counts. Emits per-dimension and summary gate.executed events. On NEEDS_FIXES, bounds the fix-loop via the shared escalation policy (DR-3): returns escalate:true when the auto-fix bound is hit or a finding is intent-touching.',
     schema: z.object({
       featureId: z.string().min(1),
       high: coercedNonnegativeInt(),
@@ -1579,7 +1579,14 @@ const orchestrateActions: readonly ToolAction[] = [
         file: z.string().optional(),
         line: z.number().int().positive().optional(),
         message: z.string(),
+        // DR-3: intent-touching classification for the escalation policy. A
+        // spec-category (or explicitly-flagged) finding escalates immediately.
+        category: z.string().optional(),
+        intentTouching: z.boolean().optional(),
       })).optional(),
+      // DR-3: per-loop override of the auto-fix bound (highest precedence over
+      // config `escalation.maxIterations` and the built-in default of 5).
+      maxFixCycles: coercedPositiveInt().optional(),
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -2062,6 +2062,9 @@ const orchestrateActions: readonly ToolAction[] = [
       bodyFile: z.string().optional(),
       body: z.string().optional(),
       template: z.string().optional(),
+      // DR-1 (#1593) task 006: optional — enables the advisory intent-grounding
+      // check (reads `artifacts.intent`). Absent → unchanged legacy validation.
+      featureId: featureIdSchema.optional(),
     }),
     phases: SYNTHESIS_REVIEW_PHASES,
     roles: ROLE_LEAD,
@@ -2511,6 +2514,10 @@ const orchestrateActions: readonly ToolAction[] = [
       head: z.string().min(1),
       draft: z.boolean().optional(),
       labels: z.array(z.string()).optional(),
+      // DR-1 (#1593) task 006: optional — grounds the PR body in
+      // `artifacts.intent` (a deterministic `## Intent` section). Absent /
+      // unreadable / empty intent → the body is left untouched.
+      featureId: featureIdSchema.optional(),
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,

--- a/servers/exarchos-mcp/src/vcs/azure-devops.test.ts
+++ b/servers/exarchos-mcp/src/vcs/azure-devops.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AzureDevOpsProvider } from './azure-devops.js';
+import { UnsupportedOperationError } from './provider.js';
 
 // Mock the shell execution helper
 vi.mock('./shell.js', () => ({
@@ -460,5 +461,21 @@ describe('AzureDevOpsProvider', () => {
     // vote=5 is "approved with suggestions" — maps to approved
     expect(result.state).toBe('approved');
     expect(result.reviewers[0].state).toBe('approved');
+  });
+
+  // ── getPrComments (DR-7 #1592 task 013 — signature conformance) ───────────
+  // The PrComment contract was widened (source/parentId/resolved/state) in task
+  // 010. Azure DevOps still does not implement harvesting (tracked as a DR-7
+  // follow-up issue), so getPrComments must conform to the widened
+  // `Promise<PrComment[]>` signature — which it does by throwing (it returns no
+  // value) — and surface a structured UnsupportedOperationError, not a no-op.
+
+  it('AzureDevOps_GetPrComments_ThrowsUnsupported', async () => {
+    await expect(provider.getPrComments('100')).rejects.toThrow(
+      UnsupportedOperationError,
+    );
+    await expect(provider.getPrComments('100')).rejects.toThrow(
+      'azure-devops: getPrComments is not yet supported',
+    );
   });
 });

--- a/servers/exarchos-mcp/src/vcs/github.test.ts
+++ b/servers/exarchos-mcp/src/vcs/github.test.ts
@@ -416,16 +416,50 @@ describe('GitHubProvider', () => {
 
   // ─── T8: getPrComments + getRepository ────────────────────────────────────────
 
+  // Routes a mocked `exec` call to canned JSON keyed by the gh endpoint the
+  // args reference. `getPrComments` now hits five surfaces (3 REST aggregates
+  // + repo view + graphql enrichment), so every getPrComments test stubs via
+  // this matcher rather than a single mockResolvedValue.
+  function stubGhComments(opts: {
+    issues?: unknown;
+    inline?: unknown;
+    reviews?: unknown;
+    repoView?: unknown;
+    graphql?: unknown | (() => never);
+  }): void {
+    mockExec.mockImplementation((_cmd: string, args?: readonly string[]) => {
+      const argv = args ?? [];
+      const joined = argv.join(' ');
+      const isGraphql = argv.includes('graphql');
+      const isRepoView = argv.includes('repo') && argv.includes('view');
+      if (isGraphql) {
+        if (typeof opts.graphql === 'function') return (opts.graphql as () => never)();
+        return Promise.resolve(JSON.stringify(opts.graphql ?? { data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }));
+      }
+      if (isRepoView) {
+        return Promise.resolve(JSON.stringify(opts.repoView ?? { nameWithOwner: 'lvlup-sw/exarchos' }));
+      }
+      if (joined.includes('issues/') && joined.includes('/comments')) {
+        return Promise.resolve(JSON.stringify(opts.issues ?? []));
+      }
+      if (joined.includes('pulls/') && joined.includes('/comments')) {
+        return Promise.resolve(JSON.stringify(opts.inline ?? []));
+      }
+      if (joined.includes('pulls/') && joined.includes('/reviews')) {
+        return Promise.resolve(JSON.stringify(opts.reviews ?? []));
+      }
+      return Promise.resolve('[]');
+    });
+  }
+
   it('GitHubProvider_GetPrComments_ReturnsParsedComments', async () => {
-    mockExec.mockResolvedValue(
-      JSON.stringify([
+    stubGhComments({
+      issues: [
         {
           id: 100,
           user: { login: 'reviewer1' },
           body: 'Looks good!',
           created_at: '2026-04-15T10:00:00Z',
-          path: 'src/main.ts',
-          line: 42,
         },
         {
           id: 101,
@@ -433,8 +467,8 @@ describe('GitHubProvider', () => {
           body: 'Needs a fix here',
           created_at: '2026-04-15T11:00:00Z',
         },
-      ])
-    );
+      ],
+    });
 
     const result = await provider.getPrComments('42');
 
@@ -453,8 +487,6 @@ describe('GitHubProvider', () => {
       body: 'Looks good!',
       createdAt: '2026-04-15T10:00:00Z',
       source: 'issue-comment',
-      path: 'src/main.ts',
-      line: 42,
     });
     expect(result[1]).toEqual({
       id: 101,
@@ -462,9 +494,275 @@ describe('GitHubProvider', () => {
       body: 'Needs a fix here',
       createdAt: '2026-04-15T11:00:00Z',
       source: 'issue-comment',
-      path: undefined,
-      line: undefined,
     });
+  });
+
+  // ─── DR-7 task 011: aggregate all three GitHub feedback surfaces ─────────────
+
+  it('GetPrComments_AggregatesAllThreeSources', async () => {
+    stubGhComments({
+      issues: [
+        {
+          id: 100,
+          user: { login: 'human1' },
+          body: 'PR-level note',
+          created_at: '2026-04-15T10:00:00Z',
+        },
+      ],
+      inline: [
+        {
+          id: 200,
+          user: { login: 'human2' },
+          body: 'inline nit',
+          created_at: '2026-04-15T10:05:00Z',
+          path: 'src/main.ts',
+          line: 42,
+        },
+      ],
+      reviews: [
+        {
+          id: 300,
+          user: { login: 'human3' },
+          body: 'Please address the above',
+          state: 'CHANGES_REQUESTED',
+          submitted_at: '2026-04-15T10:10:00Z',
+        },
+      ],
+    });
+
+    const result = await provider.getPrComments('42');
+
+    const bySource = Object.fromEntries(result.map((c) => [c.source, c]));
+    expect(result).toHaveLength(3);
+
+    expect(bySource['issue-comment']).toEqual({
+      id: 100,
+      author: 'human1',
+      body: 'PR-level note',
+      createdAt: '2026-04-15T10:00:00Z',
+      source: 'issue-comment',
+    });
+    expect(bySource['review-inline']).toEqual({
+      id: 200,
+      author: 'human2',
+      body: 'inline nit',
+      createdAt: '2026-04-15T10:05:00Z',
+      source: 'review-inline',
+      path: 'src/main.ts',
+      line: 42,
+    });
+    expect(bySource['review-summary']).toEqual({
+      id: 300,
+      author: 'human3',
+      body: 'Please address the above',
+      createdAt: '2026-04-15T10:10:00Z',
+      source: 'review-summary',
+      state: 'CHANGES_REQUESTED',
+    });
+
+    // All three REST endpoints were queried with --paginate.
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['api', 'repos/{owner}/{repo}/pulls/42/comments', '--paginate']),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['api', 'repos/{owner}/{repo}/pulls/42/reviews', '--paginate']),
+    );
+  });
+
+  it('GetPrComments_LinksRepliesViaParentId', async () => {
+    stubGhComments({
+      inline: [
+        {
+          id: 201,
+          user: { login: 'human1' },
+          body: 'top-level inline',
+          created_at: '2026-04-15T10:00:00Z',
+          path: 'src/a.ts',
+          line: 10,
+        },
+        {
+          id: 202,
+          user: { login: 'human2' },
+          body: 'a reply',
+          created_at: '2026-04-15T10:01:00Z',
+          path: 'src/a.ts',
+          line: 10,
+          in_reply_to_id: 201,
+        },
+      ],
+    });
+
+    const result = await provider.getPrComments('42');
+    const top = result.find((c) => c.id === 201);
+    const reply = result.find((c) => c.id === 202);
+
+    expect(top?.parentId).toBeUndefined();
+    expect(reply?.parentId).toBe(201);
+  });
+
+  // Bots (e.g. CodeRabbit) are real feedback authors and MUST NOT be filtered.
+  it('GetPrComments_AnyAuthor_IncludesBots', async () => {
+    stubGhComments({
+      inline: [
+        {
+          id: 210,
+          user: { login: 'coderabbitai[bot]' },
+          body: 'Potential issue: …',
+          created_at: '2026-04-15T10:00:00Z',
+          path: 'src/x.ts',
+          line: 3,
+        },
+      ],
+    });
+
+    const result = await provider.getPrComments('42');
+    expect(result).toHaveLength(1);
+    expect(result[0].author).toBe('coderabbitai[bot]');
+  });
+
+  // Pins the post-then-verify contract: a comment posted via `gh pr comment`
+  // lands on the issues endpoint and must still surface in the aggregate.
+  it('GetPrComments_AddCommentVerifyPath_StillFindsPostedComment', async () => {
+    stubGhComments({
+      issues: [
+        {
+          id: 999,
+          user: { login: 'exarchos-bot' },
+          body: 'exarchos: synthesis ready',
+          created_at: '2026-04-15T12:00:00Z',
+        },
+      ],
+    });
+
+    const result = await provider.getPrComments('42');
+    const posted = result.find((c) => c.body === 'exarchos: synthesis ready');
+    expect(posted).toBeDefined();
+    expect(posted?.source).toBe('issue-comment');
+  });
+
+  // State-only reviews (empty/whitespace body) are getReviewStatus's job —
+  // they must NOT appear as review-summary comments.
+  it('GetPrComments_BodylessReview_Excluded', async () => {
+    stubGhComments({
+      reviews: [
+        {
+          id: 400,
+          user: { login: 'approver' },
+          body: '',
+          state: 'APPROVED',
+          submitted_at: '2026-04-15T10:00:00Z',
+        },
+        {
+          id: 401,
+          user: { login: 'whitespace' },
+          body: '   \n  ',
+          state: 'COMMENTED',
+          submitted_at: '2026-04-15T10:01:00Z',
+        },
+        {
+          id: 402,
+          user: { login: 'critic' },
+          body: 'Real review feedback',
+          state: 'CHANGES_REQUESTED',
+          submitted_at: '2026-04-15T10:02:00Z',
+        },
+      ],
+    });
+
+    const result = await provider.getPrComments('42');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(402);
+    expect(result[0].source).toBe('review-summary');
+  });
+
+  it('GetPrComments_ResolvedStatus_GraphqlEnrichmentFailSoft', async () => {
+    // (a) GraphQL rejects → getPrComments still resolves, resolved absent.
+    stubGhComments({
+      inline: [
+        {
+          id: 500,
+          user: { login: 'r1' },
+          body: 'inline a',
+          created_at: '2026-04-15T10:00:00Z',
+          path: 'src/a.ts',
+          line: 1,
+        },
+      ],
+      graphql: () => {
+        throw new Error('graphql exploded');
+      },
+    });
+
+    const failSoft = await provider.getPrComments('42');
+    expect(failSoft).toHaveLength(1);
+    expect(failSoft[0].resolved).toBeUndefined();
+
+    // (b) GraphQL succeeds: id 500 is in a resolved thread → resolved:true;
+    // id 501 is in no thread → resolved stays absent (unknown, not false).
+    stubGhComments({
+      inline: [
+        {
+          id: 500,
+          user: { login: 'r1' },
+          body: 'inline a',
+          created_at: '2026-04-15T10:00:00Z',
+          path: 'src/a.ts',
+          line: 1,
+        },
+        {
+          id: 501,
+          user: { login: 'r2' },
+          body: 'inline b (no thread)',
+          created_at: '2026-04-15T10:01:00Z',
+          path: 'src/b.ts',
+          line: 2,
+        },
+      ],
+      graphql: {
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [
+                  {
+                    isResolved: true,
+                    comments: { nodes: [{ databaseId: 500 }] },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const enriched = await provider.getPrComments('42');
+    const c500 = enriched.find((c) => c.id === 500);
+    const c501 = enriched.find((c) => c.id === 501);
+    expect(c500?.resolved).toBe(true);
+    expect(c501?.resolved).toBeUndefined();
+
+    // The exact graphql invocation shape: `gh api graphql` with -F typed
+    // owner/repo/pr and the -f query string.
+    const graphqlCall = mockExec.mock.calls.find((call) =>
+      (call[1] as string[] | undefined)?.includes('graphql'),
+    );
+    expect(graphqlCall?.[1]).toEqual(
+      expect.arrayContaining([
+        'api',
+        'graphql',
+        '-F',
+        'owner=lvlup-sw',
+        '-F',
+        'repo=exarchos',
+        '-F',
+        'pr=42',
+        '-f',
+        expect.stringContaining('reviewThreads'),
+      ]),
+    );
   });
 
   it('GitHubProvider_GetRepository_ReturnsNameWithOwner', async () => {

--- a/servers/exarchos-mcp/src/vcs/github.test.ts
+++ b/servers/exarchos-mcp/src/vcs/github.test.ts
@@ -452,6 +452,7 @@ describe('GitHubProvider', () => {
       author: 'reviewer1',
       body: 'Looks good!',
       createdAt: '2026-04-15T10:00:00Z',
+      source: 'issue-comment',
       path: 'src/main.ts',
       line: 42,
     });
@@ -460,6 +461,7 @@ describe('GitHubProvider', () => {
       author: 'reviewer2',
       body: 'Needs a fix here',
       createdAt: '2026-04-15T11:00:00Z',
+      source: 'issue-comment',
       path: undefined,
       line: undefined,
     });

--- a/servers/exarchos-mcp/src/vcs/github.ts
+++ b/servers/exarchos-mcp/src/vcs/github.ts
@@ -38,13 +38,45 @@ interface GhReviewResponse {
   readonly reviewDecision: string;
 }
 
-interface GhPrCommentEntry {
+// `repos/{owner}/{repo}/issues/{pr}/comments` — PR-level conversation
+// (`gh pr comment` posts here). No diff anchor, no threading.
+interface GhIssueCommentEntry {
+  readonly id: number;
+  readonly user: { readonly login: string };
+  readonly body: string;
+  readonly created_at: string;
+}
+
+// `repos/{owner}/{repo}/pulls/{pr}/comments` — per-line review threads.
+// `in_reply_to_id` (when present) is the id of the top-level comment this one
+// replies to; threading is one level only.
+interface GhReviewCommentEntry {
   readonly id: number;
   readonly user: { readonly login: string };
   readonly body: string;
   readonly created_at: string;
   readonly path?: string;
   readonly line?: number;
+  readonly in_reply_to_id?: number;
+}
+
+// `repos/{owner}/{repo}/pulls/{pr}/reviews` — review submissions. Only those
+// with a non-empty body become `review-summary` comments; state-only reviews
+// are handled by getReviewStatus, not here.
+interface GhReviewSummaryEntry {
+  readonly id: number;
+  readonly user: { readonly login: string };
+  readonly body: string;
+  readonly state: string;
+  readonly submitted_at: string;
+}
+
+// A `reviewThreads` node from the GraphQL resolved-status query. Each thread
+// carries its resolution flag plus the databaseIds of the inline comments it
+// contains, which map back to the REST `pulls/comments` ids.
+interface GhReviewThreadNode {
+  readonly isResolved: boolean;
+  readonly comments: { readonly nodes: ReadonlyArray<{ readonly databaseId: number | null }> };
 }
 
 interface GhRepoViewResponse {
@@ -241,30 +273,151 @@ export class GitHubProvider implements VcsProvider {
   }
 
   async getPrComments(prId: string): Promise<PrComment[]> {
-    // The `/pulls/{prId}/comments` endpoint returns *inline review*
-    // comments — the per-line discussion attached to a diff. General
-    // PR-level conversation (what `gh pr comment` posts) lives on the
-    // shared issues comment endpoint. Reading from the wrong endpoint
-    // means the post-then-verify path never finds the comment it just
-    // wrote, the verification fails, and the recovery branch posts a
-    // duplicate. We fetch the issues endpoint so producer and consumer
-    // see the same comment stream.
-    const output = await exec('gh', [
-      'api',
-      `repos/{owner}/{repo}/issues/${prId}/comments`,
-      '--paginate',
+    // Aggregate all three GitHub feedback surfaces into one PrComment[],
+    // for ANY author (bots included). A single surface never sees the
+    // whole conversation: issue comments, inline review threads, and
+    // review summaries each live on a distinct endpoint.
+    //
+    //  1. issues/{pr}/comments  → 'issue-comment'  (PR-level discussion;
+    //     `gh pr comment` posts here, so this surface is load-bearing for
+    //     add-comment's post-then-verify path).
+    //  2. pulls/{pr}/comments   → 'review-inline'  (per-line threads;
+    //     `in_reply_to_id` → parentId, one level only).
+    //  3. pulls/{pr}/reviews    → 'review-summary' (review bodies only;
+    //     state-only reviews are getReviewStatus's job, not ours).
+    const [issueOut, inlineOut, reviewOut] = await Promise.all([
+      exec('gh', ['api', `repos/{owner}/{repo}/issues/${prId}/comments`, '--paginate']),
+      exec('gh', ['api', `repos/{owner}/{repo}/pulls/${prId}/comments`, '--paginate']),
+      exec('gh', ['api', `repos/{owner}/{repo}/pulls/${prId}/reviews`, '--paginate']),
     ]);
 
-    const entries = JSON.parse(output) as readonly GhPrCommentEntry[];
-    return entries.map((entry) => ({
-      id: entry.id,
-      author: entry.user.login,
-      body: entry.body,
-      createdAt: entry.created_at,
-      source: 'issue-comment' as const,
-      path: entry.path,
-      line: entry.line,
-    }));
+    const issueEntries = JSON.parse(issueOut) as readonly GhIssueCommentEntry[];
+    const inlineEntries = JSON.parse(inlineOut) as readonly GhReviewCommentEntry[];
+    const reviewEntries = JSON.parse(reviewOut) as readonly GhReviewSummaryEntry[];
+
+    const comments: PrComment[] = [];
+
+    for (const entry of issueEntries) {
+      comments.push({
+        id: entry.id,
+        author: entry.user.login,
+        body: entry.body,
+        createdAt: entry.created_at,
+        source: 'issue-comment',
+      });
+    }
+
+    for (const entry of inlineEntries) {
+      comments.push({
+        id: entry.id,
+        author: entry.user.login,
+        body: entry.body,
+        createdAt: entry.created_at,
+        source: 'review-inline',
+        path: entry.path,
+        line: entry.line,
+        // One-level threading: a reply points straight at the top-level
+        // comment it answers. Absent in_reply_to_id ⇒ top-level.
+        ...(entry.in_reply_to_id !== undefined ? { parentId: entry.in_reply_to_id } : {}),
+      });
+    }
+
+    for (const entry of reviewEntries) {
+      // Only reviews with an actual body are feedback; a CHANGES_REQUESTED
+      // or APPROVED review with no body is a verdict getReviewStatus reports.
+      if (typeof entry.body !== 'string' || entry.body.trim() === '') continue;
+      comments.push({
+        id: entry.id,
+        author: entry.user.login,
+        body: entry.body,
+        createdAt: entry.submitted_at,
+        source: 'review-summary',
+        state: entry.state,
+      });
+    }
+
+    return this.enrichResolvedStatus(prId, comments);
+  }
+
+  /**
+   * Fail-soft enrichment of `resolved` on `review-inline` comments.
+   *
+   * REST inline comments don't carry resolution state — it lives on GraphQL
+   * `reviewThreads`. We query that, build a `databaseId → isResolved` map, and
+   * stamp `resolved` onto any inline comment whose id appears in it. An inline
+   * comment NOT in the map keeps `resolved` absent (unknown — never coerced to
+   * false); issue-comment and review-summary always stay absent (threads are
+   * inline-only).
+   *
+   * Load-bearing fail-soft: the entire GraphQL pass (exec + parse + mapping) is
+   * wrapped in try/catch. On ANY failure we return the REST comments untouched
+   * with every `resolved` absent, rather than throwing — a missing resolution
+   * signal must degrade to "unknown", not block the whole read.
+   */
+  private async enrichResolvedStatus(
+    prId: string,
+    comments: PrComment[],
+  ): Promise<PrComment[]> {
+    try {
+      const prNumber = Number.parseInt(prId, 10);
+      if (!Number.isFinite(prNumber)) return comments;
+
+      const repoOut = await exec('gh', ['repo', 'view', '--json', 'nameWithOwner']);
+      const { nameWithOwner } = JSON.parse(repoOut) as { nameWithOwner: string };
+      const [owner, repo] = nameWithOwner.split('/');
+      if (!owner || !repo) return comments;
+
+      const query =
+        'query($owner:String!,$repo:String!,$pr:Int!){' +
+        'repository(owner:$owner,name:$repo){' +
+        'pullRequest(number:$pr){' +
+        'reviewThreads(first:100){nodes{isResolved comments(first:100){nodes{databaseId}}}}' +
+        '}}}';
+
+      const graphqlOut = await exec('gh', [
+        'api',
+        'graphql',
+        '-F',
+        `owner=${owner}`,
+        '-F',
+        `repo=${repo}`,
+        '-F',
+        `pr=${prNumber}`,
+        '-f',
+        `query=${query}`,
+      ]);
+
+      const parsed = JSON.parse(graphqlOut) as {
+        data?: {
+          repository?: {
+            pullRequest?: { reviewThreads?: { nodes?: readonly GhReviewThreadNode[] } };
+          };
+        };
+      };
+
+      const nodes = parsed.data?.repository?.pullRequest?.reviewThreads?.nodes;
+      if (!Array.isArray(nodes)) return comments;
+
+      const resolvedById = new Map<number, boolean>();
+      for (const thread of nodes) {
+        for (const c of thread.comments?.nodes ?? []) {
+          if (typeof c.databaseId === 'number') {
+            resolvedById.set(c.databaseId, thread.isResolved);
+          }
+        }
+      }
+
+      return comments.map((comment) => {
+        if (comment.source !== 'review-inline') return comment;
+        const resolved = resolvedById.get(comment.id);
+        return resolved === undefined ? comment : { ...comment, resolved };
+      });
+    } catch {
+      // GraphQL enrichment is best-effort — any failure leaves every
+      // `resolved` absent (unknown), and getPrComments still returns the
+      // REST comments rather than throwing.
+      return comments;
+    }
   }
 
   async getPrDiff(prId: string): Promise<string> {

--- a/servers/exarchos-mcp/src/vcs/github.ts
+++ b/servers/exarchos-mcp/src/vcs/github.ts
@@ -261,6 +261,7 @@ export class GitHubProvider implements VcsProvider {
       author: entry.user.login,
       body: entry.body,
       createdAt: entry.created_at,
+      source: 'issue-comment' as const,
       path: entry.path,
       line: entry.line,
     }));

--- a/servers/exarchos-mcp/src/vcs/github.ts
+++ b/servers/exarchos-mcp/src/vcs/github.ts
@@ -367,44 +367,70 @@ export class GitHubProvider implements VcsProvider {
       const [owner, repo] = nameWithOwner.split('/');
       if (!owner || !repo) return comments;
 
+      // Paginate `reviewThreads` with an `after` cursor so resolution is
+      // enriched for EVERY thread, not just the first 100 — on a large PR the
+      // overflow threads would otherwise keep `resolved` absent (unknown). Inner
+      // `comments(first:100)` stays single-page: >100 replies in ONE thread is
+      // not a realistic shape, and an overflow there still degrades safe (absent
+      // → surfaced, never wrongly resolved).
       const query =
-        'query($owner:String!,$repo:String!,$pr:Int!){' +
+        'query($owner:String!,$repo:String!,$pr:Int!,$after:String){' +
         'repository(owner:$owner,name:$repo){' +
         'pullRequest(number:$pr){' +
-        'reviewThreads(first:100){nodes{isResolved comments(first:100){nodes{databaseId}}}}' +
-        '}}}';
-
-      const graphqlOut = await exec('gh', [
-        'api',
-        'graphql',
-        '-F',
-        `owner=${owner}`,
-        '-F',
-        `repo=${repo}`,
-        '-F',
-        `pr=${prNumber}`,
-        '-f',
-        `query=${query}`,
-      ]);
-
-      const parsed = JSON.parse(graphqlOut) as {
-        data?: {
-          repository?: {
-            pullRequest?: { reviewThreads?: { nodes?: readonly GhReviewThreadNode[] } };
-          };
-        };
-      };
-
-      const nodes = parsed.data?.repository?.pullRequest?.reviewThreads?.nodes;
-      if (!Array.isArray(nodes)) return comments;
+        'reviewThreads(first:100,after:$after){' +
+        'pageInfo{hasNextPage endCursor}' +
+        'nodes{isResolved comments(first:100){nodes{databaseId}}}' +
+        '}}}}';
 
       const resolvedById = new Map<number, boolean>();
-      for (const thread of nodes) {
-        for (const c of thread.comments?.nodes ?? []) {
-          if (typeof c.databaseId === 'number') {
-            resolvedById.set(c.databaseId, thread.isResolved);
+      let after: string | null = null;
+      // Defensive page cap (50 × 100 = 5000 threads) so a misbehaving
+      // `pageInfo` can never spin this into an unbounded loop.
+      for (let page = 0; page < 50; page++) {
+        const graphqlArgs = [
+          'api',
+          'graphql',
+          '-F',
+          `owner=${owner}`,
+          '-F',
+          `repo=${repo}`,
+          '-F',
+          `pr=${prNumber}`,
+          '-f',
+          `query=${query}`,
+        ];
+        if (after) graphqlArgs.push('-F', `after=${after}`);
+
+        const graphqlOut = await exec('gh', graphqlArgs);
+
+        const parsed = JSON.parse(graphqlOut) as {
+          data?: {
+            repository?: {
+              pullRequest?: {
+                reviewThreads?: {
+                  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+                  nodes?: readonly GhReviewThreadNode[];
+                };
+              };
+            };
+          };
+        };
+
+        const threads = parsed.data?.repository?.pullRequest?.reviewThreads;
+        const nodes = threads?.nodes;
+        if (!Array.isArray(nodes)) break;
+
+        for (const thread of nodes) {
+          for (const c of thread.comments?.nodes ?? []) {
+            if (typeof c.databaseId === 'number') {
+              resolvedById.set(c.databaseId, thread.isResolved);
+            }
           }
         }
+
+        const pageInfo = threads?.pageInfo;
+        if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+        after = pageInfo.endCursor;
       }
 
       return comments.map((comment) => {

--- a/servers/exarchos-mcp/src/vcs/gitlab.test.ts
+++ b/servers/exarchos-mcp/src/vcs/gitlab.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GitLabProvider } from './gitlab.js';
+import { UnsupportedOperationError } from './provider.js';
 
 // Mock the shell execution helper
 vi.mock('./shell.js', () => ({
@@ -361,5 +362,21 @@ describe('GitLabProvider', () => {
     const result = await provider.getReviewStatus('10');
     expect(result.state).toBe('pending');
     expect(result.reviewers).toHaveLength(0);
+  });
+
+  // ── getPrComments (DR-7 #1592 task 013 — signature conformance) ───────────
+  // The PrComment contract was widened (source/parentId/resolved/state) in task
+  // 010. GitLab still does not implement harvesting (tracked as a DR-7 follow-up
+  // issue), so getPrComments must conform to the widened `Promise<PrComment[]>`
+  // signature — which it does by throwing (it returns no value) — and surface a
+  // structured UnsupportedOperationError rather than a silent no-op.
+
+  it('GitLab_GetPrComments_ThrowsUnsupported', async () => {
+    await expect(provider.getPrComments('10')).rejects.toThrow(
+      UnsupportedOperationError,
+    );
+    await expect(provider.getPrComments('10')).rejects.toThrow(
+      'gitlab: getPrComments is not yet supported',
+    );
   });
 });

--- a/servers/exarchos-mcp/src/vcs/provider.test.ts
+++ b/servers/exarchos-mcp/src/vcs/provider.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { GitLabProvider } from './gitlab.js';
 import { AzureDevOpsProvider } from './azure-devops.js';
-import type { VcsProvider } from './provider.js';
+import { isResolvedKnown } from './provider.js';
+import type { PrComment, VcsProvider } from './provider.js';
 
 describe('VcsProvider', () => {
   it('VcsProvider_Interface_DefinesRequiredMethods', () => {
@@ -77,5 +78,71 @@ describe('VcsProvider', () => {
     await expect(provider.createIssue({ title: 't', body: 'b' })).rejects.toThrow(/not yet supported/i);
     await expect(provider.searchIssuesByMarker('op-1')).rejects.toThrow(/not yet supported/i);
     await expect(provider.getRepository()).rejects.toThrow(/not yet supported/i);
+  });
+
+  it('PrComment_Shape_CarriesSourceAuthorThreadResolved', () => {
+    // Exercise every field of the widened, platform-neutral contract and
+    // assert each round-trips / is accessible.
+    const comment: PrComment = {
+      id: 42,
+      author: 'octocat',
+      body: 'please address this',
+      createdAt: '2026-06-22T00:00:00Z',
+      source: 'review-inline',
+      path: 'src/foo.ts',
+      line: 17,
+      parentId: 7,
+      resolved: true,
+    };
+    expect(comment.id).toBe(42);
+    expect(comment.author).toBe('octocat');
+    expect(comment.body).toBe('please address this');
+    expect(comment.createdAt).toBe('2026-06-22T00:00:00Z');
+    expect(comment.source).toBe('review-inline');
+    expect(comment.path).toBe('src/foo.ts');
+    expect(comment.line).toBe(17);
+    expect(comment.parentId).toBe(7);
+    expect(comment.resolved).toBe(true);
+
+    // `state` rides only on review-summary sources.
+    const summary: PrComment = {
+      id: 1,
+      author: 'reviewer',
+      body: '',
+      createdAt: '2026-06-22T00:00:00Z',
+      source: 'review-summary',
+      state: 'CHANGES_REQUESTED',
+    };
+    expect(summary.source).toBe('review-summary');
+    expect(summary.state).toBe('CHANGES_REQUESTED');
+  });
+
+  it('PrComment_Resolved_AbsentIsUnknownNotFalse', () => {
+    // Tri-state pin: absent `resolved` must stay distinguishable from an
+    // explicit `false`, so a consumer can never silently coerce absent → false.
+    const explicit: PrComment = {
+      id: 1,
+      author: 'a',
+      body: 'b',
+      createdAt: '2026-06-22T00:00:00Z',
+      source: 'issue-comment',
+      resolved: false,
+    };
+    const unknown: PrComment = {
+      id: 2,
+      author: 'a',
+      body: 'b',
+      createdAt: '2026-06-22T00:00:00Z',
+      source: 'issue-comment',
+    };
+
+    // The two are distinguishable at the value level.
+    expect(explicit.resolved).toBe(false);
+    expect(unknown.resolved).toBeUndefined();
+    expect(unknown.resolved).not.toBe(false);
+
+    // The exposed helper treats absent as "unknown", not as resolved/false.
+    expect(isResolvedKnown(explicit)).toBe(true);
+    expect(isResolvedKnown(unknown)).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/vcs/provider.ts
+++ b/servers/exarchos-mcp/src/vcs/provider.ts
@@ -59,13 +59,70 @@ export interface PrSummary {
   readonly state: string;
 }
 
+/**
+ * A single piece of PR feedback, normalized across providers.
+ *
+ * Three feedback surfaces collapse into one platform-neutral shape via
+ * `source`:
+ *  - `'issue-comment'`   — PR-level conversation (the shared discussion thread,
+ *                          not anchored to a diff line).
+ *  - `'review-inline'`   — a per-line review thread anchored to `path`/`line`.
+ *  - `'review-summary'`  — the body of a review submission (its top-level
+ *                          verdict); `state` carries the review state.
+ * The discriminant is named for the feedback *kind*, never for a provider's
+ * endpoint or field (e.g. not GitHub's `subject_type`), so consumers stay
+ * provider-agnostic.
+ *
+ * Threading is **one level only**: a reply sets `parentId` to the id of the
+ * top-level comment it answers; a reply's parent is always top-level. We do not
+ * model deeper nesting. An absent `parentId` means the comment is top-level.
+ *
+ * `resolved` is **tri-state** and the distinction is load-bearing:
+ *  - `true`              — the thread is resolved.
+ *  - `false`             — the thread is explicitly unresolved.
+ *  - absent / `undefined`— resolution status is *unknown* (e.g. the provider
+ *                          does not report it for this surface). Consumers MUST
+ *                          treat absent as "unknown" and MUST NOT coerce it to
+ *                          `false`. Use {@link isResolvedKnown} to gate on this.
+ */
 export interface PrComment {
   readonly id: number;
   readonly author: string;
   readonly body: string;
   readonly createdAt: string;
+  /**
+   * Which feedback surface this comment came from. Platform-neutral
+   * discriminant — see the interface doc for the three kinds.
+   */
+  readonly source: 'issue-comment' | 'review-inline' | 'review-summary';
   readonly path?: string;
   readonly line?: number;
+  /**
+   * Id of the top-level comment this one replies to (one-level threading).
+   * Absent ⇒ this comment is top-level.
+   */
+  readonly parentId?: number;
+  /**
+   * Tri-state resolution status: `true` (resolved), `false` (explicitly
+   * unresolved), absent (unknown — NOT false). Never coerce absent to `false`.
+   */
+  readonly resolved?: boolean;
+  /**
+   * For `source: 'review-summary'`, the review state (e.g. `'APPROVED'`,
+   * `'CHANGES_REQUESTED'`, `'COMMENTED'`). Absent on non-summary sources. A
+   * string, not a provider-specific enum, to keep the contract platform-neutral.
+   */
+  readonly state?: string;
+}
+
+/**
+ * Whether a comment's resolution status is *known* — i.e. `resolved` was set to
+ * an explicit boolean rather than left absent. Returns `false` for the absent
+ * (unknown) case so consumers can distinguish "unknown" from "unresolved"
+ * instead of silently coercing absent → `false`.
+ */
+export function isResolvedKnown(comment: PrComment): boolean {
+  return comment.resolved !== undefined;
 }
 
 export interface CreateIssueOpts {

--- a/servers/exarchos-mcp/src/views/shepherd-status-view.test.ts
+++ b/servers/exarchos-mcp/src/views/shepherd-status-view.test.ts
@@ -323,6 +323,35 @@ describe('ShepherdStatusView', () => {
     expect(view.overallStatus).toBe('escalate');
   });
 
+  // DR-3 (#1595): the structured `shepherd.escalated` event surfaces the WHY of
+  // an escalation (reason + counts + when) via shepherd_status/ps — not just the
+  // derived 'escalate' status. Folding the event populates `view.escalation`.
+  it('Escalation_SurfacedViaShepherdStatus', () => {
+    const events = [
+      makeEvent(1, 'ci.status', { pr: 42, status: 'failing' }),
+      makeEvent(2, 'shepherd.escalated', {
+        featureId: 'feat-x',
+        prNumbers: [42, 43],
+        iterationCount: 5,
+        maxIterations: 5,
+        reason: 'auto-fix bound (5) reached after 5 iterations',
+      }),
+    ];
+
+    const view = materializer.materialize<ShepherdStatusState>(
+      'wf-001',
+      SHEPHERD_STATUS_VIEW,
+      events,
+    );
+
+    expect(view.escalation).toBeDefined();
+    expect(view.escalation!.reason).toBe('auto-fix bound (5) reached after 5 iterations');
+    expect(view.escalation!.iterationCount).toBe(5);
+    expect(view.escalation!.maxIterations).toBe(5);
+    expect(view.escalation!.escalatedAt).toBe(events[1].timestamp);
+    expect(view.overallStatus).toBe('escalate');
+  });
+
   it('Apply_MultiplePrs_TracksIndependently', () => {
     const events = [
       makeEvent(1, 'ci.status', { pr: 1, status: 'passing' }),

--- a/servers/exarchos-mcp/src/views/shepherd-status-view.test.ts
+++ b/servers/exarchos-mcp/src/views/shepherd-status-view.test.ts
@@ -6,6 +6,7 @@ import {
 } from './shepherd-status-view.js';
 import type { ShepherdStatusState } from './shepherd-status-view.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import { countShepherdIterations } from '../orchestrate/escalation-policy.js';
 
 function makeEvent(
   seq: number,
@@ -178,11 +179,28 @@ describe('ShepherdStatusView', () => {
     expect(view.prs[0].comments.unresolved).toBe(0);
   });
 
+  // DR-3 (#1595): the view's `iteration` is the COUNT of `shepherd.iteration`
+  // events, not the `iteration` value stamped in any payload. Three events with
+  // garbage/duplicate payload values still fold to `iteration === 3`. (Was a
+  // single event with `iteration: 3` expecting `3` — the OLD payload-value
+  // semantics this task removes.)
   it('Apply_ShepherdIteration_IncrementsIteration', () => {
     const events = [
       makeEvent(1, 'shepherd.iteration', {
         prUrl: 'https://github.com/pr/42',
-        iteration: 3,
+        iteration: 99, // payload value is no longer the authority
+        action: 'push-fix',
+        outcome: 'ci-passed',
+      }),
+      makeEvent(2, 'shepherd.iteration', {
+        prUrl: 'https://github.com/pr/42',
+        iteration: 99, // duplicate payload value
+        action: 'push-fix',
+        outcome: 'ci-passed',
+      }),
+      makeEvent(3, 'shepherd.iteration', {
+        prUrl: 'https://github.com/pr/42',
+        // payload `iteration` omitted entirely — count still increments
         action: 'push-fix',
         outcome: 'ci-passed',
       }),
@@ -195,6 +213,39 @@ describe('ShepherdStatusView', () => {
     );
 
     expect(view.iteration).toBe(3);
+  });
+
+  // DR-3 (#1595): the view's `iteration` and the loop's `countShepherdIterations`
+  // are the SAME single event-sourced authority — both are the COUNT of
+  // `shepherd.iteration` events. Folding N events through the view (with garbage,
+  // duplicate, omitted payload `iteration` values) yields `view.iteration === N`,
+  // which equals `countShepherdIterations` of the same events. So
+  // `shepherd_status`/`ps` and the loop can never disagree (INV-1).
+  it('ShepherdStatus_AndLoop_AgreeOnCount', () => {
+    const N = 4;
+    const garbagePayloads = [42, 42, 0, -7]; // non-monotonic, duplicate, garbage
+    const events: WorkflowEvent[] = [];
+    for (let i = 0; i < N; i++) {
+      events.push(
+        makeEvent(i + 1, 'shepherd.iteration', {
+          prUrl: 'https://github.com/pr/1',
+          iteration: garbagePayloads[i], // payload value is NOT the authority
+          action: 'push-fix',
+          outcome: 'ci-passed',
+        }),
+      );
+    }
+
+    const view = materializer.materialize<ShepherdStatusState>(
+      'wf-001',
+      SHEPHERD_STATUS_VIEW,
+      events,
+    );
+
+    // The view's iteration === the count, independent of payload values.
+    expect(view.iteration).toBe(N);
+    // …and that count IS the loop's single authority over the same events.
+    expect(view.iteration).toBe(countShepherdIterations(events));
   });
 
   it('Apply_AllPrsPassing_NoUnresolved_SetsHealthy', () => {
@@ -248,15 +299,18 @@ describe('ShepherdStatusView', () => {
     expect(view.overallStatus).toBe('blocked');
   });
 
+  // DR-3 (#1595): escalation is driven by the COUNT of `shepherd.iteration`
+  // events reaching maxIterations (5), not by a single payload `iteration: 5`.
+  // Five events fold to `iteration === 5 >= maxIterations`. (Was a single event
+  // with `iteration: 5` — the OLD payload-value semantics.)
   it('Apply_MaxIterationsReached_SetsEscalate', () => {
     const events = [
       makeEvent(1, 'ci.status', { pr: 1, status: 'passing' }),
-      makeEvent(2, 'shepherd.iteration', {
-        prUrl: 'https://github.com/pr/1',
-        iteration: 5,
-        action: 'push-fix',
-        outcome: 'ci-passed',
-      }),
+      makeEvent(2, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-passed' }),
+      makeEvent(3, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-passed' }),
+      makeEvent(4, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-passed' }),
+      makeEvent(5, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-passed' }),
+      makeEvent(6, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-passed' }),
     ];
 
     const view = materializer.materialize<ShepherdStatusState>(
@@ -265,6 +319,7 @@ describe('ShepherdStatusView', () => {
       events,
     );
 
+    expect(view.iteration).toBe(5);
     expect(view.overallStatus).toBe('escalate');
   });
 
@@ -326,15 +381,16 @@ describe('ShepherdStatusView', () => {
   });
 
   it('Apply_EscalateTakesPriorityOverNeedsFixes', () => {
-    // escalate (iteration >= maxIterations) should override needs-fixes
+    // escalate (iteration >= maxIterations) should override needs-fixes.
+    // DR-3 (#1595): the count of five `shepherd.iteration` events drives
+    // escalation, not a payload `iteration: 5` (the OLD payload-value semantics).
     const events = [
       makeEvent(1, 'ci.status', { pr: 1, status: 'failing' }),
-      makeEvent(2, 'shepherd.iteration', {
-        prUrl: 'https://github.com/pr/1',
-        iteration: 5,
-        action: 'push-fix',
-        outcome: 'ci-failed',
-      }),
+      makeEvent(2, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-failed' }),
+      makeEvent(3, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-failed' }),
+      makeEvent(4, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-failed' }),
+      makeEvent(5, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-failed' }),
+      makeEvent(6, 'shepherd.iteration', { prUrl: 'https://github.com/pr/1', action: 'push-fix', outcome: 'ci-failed' }),
     ];
 
     const view = materializer.materialize<ShepherdStatusState>(

--- a/servers/exarchos-mcp/src/views/shepherd-status-view.ts
+++ b/servers/exarchos-mcp/src/views/shepherd-status-view.ts
@@ -29,6 +29,16 @@ export interface ShepherdStatusState {
   readonly approvalRequestedAt?: string;
   readonly completedAt?: string;
   readonly outcome?: string;
+  // DR-3 (#1595): the WHY behind an `escalate` status. `overallStatus` already
+  // derives `'escalate'` from the iteration count; this field carries the
+  // structured reason + counts from the `shepherd.escalated` event so
+  // shepherd_status/ps surface a human-readable escalation, not just a status.
+  readonly escalation?: {
+    readonly reason: string;
+    readonly iterationCount: number;
+    readonly maxIterations: number;
+    readonly escalatedAt: string;
+  };
 }
 
 // ─── Per-PR Update Helper ──────────────────────────────────────────────────
@@ -63,7 +73,12 @@ function updatePr(
 // ─── Overall Status Computation ────────────────────────────────────────────
 
 function isEscalated(state: ShepherdStatusState): boolean {
-  return state.iteration >= state.maxIterations;
+  // Escalated when the bound is hit (iteration count) OR when a structured
+  // `shepherd.escalated` event has been folded (DR-3, #1595). The explicit
+  // event is authoritative: it records that the loop terminated on the bound,
+  // so the status reflects escalation even if folded independently of the
+  // iteration events.
+  return state.escalation !== undefined || state.iteration >= state.maxIterations;
 }
 
 function hasBlockedPr(prs: ReadonlyArray<PrStatus>): boolean {
@@ -200,6 +215,28 @@ function handleShepherdApprovalRequested(state: ShepherdStatusState, event: Work
   return { ...state, approvalRequestedAt: event.timestamp };
 }
 
+function handleShepherdEscalated(state: ShepherdStatusState, event: WorkflowEvent): ShepherdStatusState {
+  // DR-3 (#1595): fold the structured bound-hit escalation into a surfaceable
+  // shape. `overallStatus` already reflects `'escalate'` via `isEscalated`; this
+  // adds the WHY (reason + counts) so a human/agent reading shepherd_status/ps
+  // sees why the loop terminated, not just that it did.
+  const data = event.data as
+    | { reason?: string; iterationCount?: number; maxIterations?: number }
+    | undefined;
+  if (!data) return state;
+
+  const next: ShepherdStatusState = {
+    ...state,
+    escalation: {
+      reason: data.reason ?? '',
+      iterationCount: data.iterationCount ?? state.iteration,
+      maxIterations: data.maxIterations ?? state.maxIterations,
+      escalatedAt: event.timestamp,
+    },
+  };
+  return { ...next, overallStatus: computeOverallStatus(next) };
+}
+
 function handleShepherdCompleted(state: ShepherdStatusState, event: WorkflowEvent): ShepherdStatusState {
   const data = event.data as { outcome?: string } | undefined;
   return {
@@ -244,6 +281,9 @@ export const shepherdStatusProjection: ViewProjection<ShepherdStatusState> = {
 
       case 'shepherd.approval_requested':
         return handleShepherdApprovalRequested(view, event);
+
+      case 'shepherd.escalated':
+        return handleShepherdEscalated(view, event);
 
       case 'shepherd.completed':
         return handleShepherdCompleted(view, event);

--- a/servers/exarchos-mcp/src/views/shepherd-status-view.ts
+++ b/servers/exarchos-mcp/src/views/shepherd-status-view.ts
@@ -180,10 +180,15 @@ function handleCommentResolved(state: ShepherdStatusState, event: WorkflowEvent)
 }
 
 function handleShepherdIteration(state: ShepherdStatusState, event: WorkflowEvent): ShepherdStatusState {
-  const data = event.data as { iteration?: number } | undefined;
-  if (!data || data.iteration === undefined) return state;
-
-  const next: ShepherdStatusState = { ...state, iteration: data.iteration };
+  // The COUNT of `shepherd.iteration` events is the single authority (DR-3,
+  // #1595) — increment by 1 per event rather than reading the `iteration` value
+  // in the payload. The payload may still carry an `iteration` field, but it is
+  // no longer the authority. This folds the SAME rule the loop's
+  // `countShepherdIterations` applies, so after N events `view.iteration === N`
+  // regardless of any payload value, and `shepherd_status`/`ps` can never
+  // disagree with the loop's count (INV-1: one event-sourced counter).
+  void event;
+  const next: ShepherdStatusState = { ...state, iteration: state.iteration + 1 };
   return { ...next, overallStatus: computeOverallStatus(next) };
 }
 

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -634,6 +634,7 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
       case 'shepherd.started':
       case 'shepherd.iteration':
       case 'shepherd.approval_requested':
+      case 'shepherd.escalated':
       case 'shepherd.completed':
       case 'remediation.attempted':
       case 'remediation.succeeded':

--- a/servers/exarchos-mcp/src/workflow/describe-config.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.ts
@@ -117,5 +117,25 @@ export function buildConfigDescription(config: ResolvedProjectConfig) {
       // `'normal'`; `'full'` fsyncs on every commit (power-loss durable).
       synchronous: annotate(config.storage.synchronous, DEFAULTS.storage.synchronous),
     },
+    synthesis: {
+      // DR-2 (#1594) — SYNTHESIZE-kind `document` readiness leg. `severity`
+      // gates whether an uncovered doc-bearing change blocks synthesis;
+      // `surfaceGlobs` declares doc-bearing paths (empty default ⇒ auto-waive);
+      // `docGlobs` declares what counts as a documentation change.
+      documentLeg: {
+        severity: annotate(
+          config.synthesis.documentLeg.severity,
+          DEFAULTS.synthesis.documentLeg.severity,
+        ),
+        surfaceGlobs: annotate(
+          config.synthesis.documentLeg.surfaceGlobs,
+          DEFAULTS.synthesis.documentLeg.surfaceGlobs,
+        ),
+        docGlobs: annotate(
+          config.synthesis.documentLeg.docGlobs,
+          DEFAULTS.synthesis.documentLeg.docGlobs,
+        ),
+      },
+    },
   };
 }

--- a/servers/exarchos-mcp/src/workflow/describe-config.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.ts
@@ -137,5 +137,11 @@ export function buildConfigDescription(config: ResolvedProjectConfig) {
         ),
       },
     },
+    escalation: {
+      // DR-3 (#1595) — shared escalation policy. `maxIterations` is the per-loop
+      // auto-fix bound for the spec-review, quality-review, and shepherd
+      // fix-loops; default `5` (DEFAULT_MAX_ITERATIONS).
+      maxIterations: annotate(config.escalation.maxIterations, DEFAULTS.escalation.maxIterations),
+    },
   };
 }

--- a/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
@@ -174,6 +174,12 @@ export function createFeatureHSM(): HSMDefinition {
       id: 'implementation',
       type: 'compound',
       initial: 'delegate',
+      // HSM circuit-breaker fix-cycle bound for the delegate↔review loop. This
+      // is the structural delegate-loop guard and is a DELIBERATE value, kept
+      // distinct from the shared escalation auto-fix bound
+      // (`DEFAULT_MAX_ITERATIONS` = 5 in orchestrate/escalation-policy.ts, DR-3
+      // #1595) that governs the spec/quality/shepherd fix-loops — do not fold
+      // the two together.
       maxFixCycles: 3,
       onEntry: ['log'],
       onExit: ['log'],

--- a/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.test.ts
@@ -364,7 +364,28 @@ describe('synthesis-readiness resolver (DR-9)', () => {
   it('ResolveGateSet_SynthesizeKind_ReturnsReadinessLegs', () => {
     const resolved = resolveGateSet('SYNTHESIZE', { riskTier: 'low', boundaryTouching: false });
     expect(resolved.every((g) => g.family === 'synthesis')).toBe(true);
-    expect(resolved.map((g) => g.gate)).toEqual(['task-completion', 'tests', 'typecheck', 'stack']);
+    expect(resolved.map((g) => g.gate)).toEqual([
+      'task-completion',
+      'tests',
+      'typecheck',
+      'document',
+      'stack',
+    ]);
+  });
+
+  // DR-2 (#1594): the `document` leg is pinned to sit immediately after
+  // `typecheck` and before `stack` — a docs gap surfaces alongside the build
+  // legs, not after them. This is the resolver-roster SoT pin; the leg's
+  // evaluation lives in prepare-synthesis.ts.
+  it('SynthesisReadinessResolver_Roster_PinsDocumentAfterTypecheck', () => {
+    const legs = resolveGateSet('SYNTHESIZE', { riskTier: 'low', boundaryTouching: false }).map(
+      (g) => g.gate,
+    );
+    const typecheckIdx = legs.indexOf('typecheck');
+    const documentIdx = legs.indexOf('document');
+    const stackIdx = legs.indexOf('stack');
+    expect(documentIdx).toBe(typecheckIdx + 1);
+    expect(stackIdx).toBe(documentIdx + 1);
   });
 });
 

--- a/servers/exarchos-mcp/src/workflow/phase-kind.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-kind.ts
@@ -72,8 +72,16 @@ export type GateResolverName =
  */
 export type PlanGateName = PlanDepthGateName;
 
-/** Synthesis-readiness legs (SYNTHESIZE kind). */
-export type SynthesisLeg = 'task-completion' | 'tests' | 'typecheck' | 'stack';
+/**
+ * Synthesis-readiness legs (SYNTHESIZE kind). The `'document'` leg (DR-2,
+ * #1594) is a structural docs-coverage obligation: when the changeset touches a
+ * doc-bearing surface, the relevant docs must have changed (or the leg
+ * auto-waives). It sits after `'typecheck'` and before `'stack'` so a docs gap
+ * surfaces alongside the build legs, not after them. Membership here is the
+ * *obligation order*; its evaluation (and config-resolved severity) is owned by
+ * `prepare-synthesis.ts`, exactly as the other legs are.
+ */
+export type SynthesisLeg = 'task-completion' | 'tests' | 'typecheck' | 'document' | 'stack';
 
 /**
  * One resolved gate, tagged by its family. `ReviewDimension` is re-exported
@@ -213,7 +221,7 @@ const GATE_RESOLVERS: Readonly<
   // stack). Readiness derivation (which source the task-completion leg folds) is
   // owned by `prepare-synthesis.ts`; this resolver names the obligation order.
   'synthesis-readiness': () =>
-    (['task-completion', 'tests', 'typecheck', 'stack'] as const).map(
+    (['task-completion', 'tests', 'typecheck', 'document', 'stack'] as const).map(
       (gate): ResolvedGate => ({ family: 'synthesis', gate }),
     ),
 });

--- a/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -274,12 +274,35 @@ export const SynthesisSchema = z.object({
   prFeedback: z.array(z.unknown()),
 }).passthrough();
 
+// ─── Workflow Intent Schema (DR-1 #1593) ─────────────────────────────────────
+//
+// A transcript/diff-derived intent captured once on the code-review path
+// (`extract-intent.ts`) and persisted to `artifacts.intent` via a single
+// `state.patched` event. REVIEW (task 005) and PR-body generation (task 006)
+// read it back. This is the single zod source of truth for the shape; the
+// `WorkflowIntent` TS type is `z.infer`-derived below and re-exported, so the
+// derivation and the persisted shape can never drift. `.passthrough()` keeps it
+// additive-tolerant for future enrichment fields.
+export const WorkflowIntentSchema = z.object({
+  source: z.enum(['diff', 'diff+transcript']),
+  changedFiles: z.array(z.string()),
+  surfaces: z.array(z.string()),
+  summary: z.string(),
+  transcriptSummary: z.string().optional(),
+}).passthrough();
+
+export type WorkflowIntent = z.infer<typeof WorkflowIntentSchema>;
+
 // ─── Artifacts Schema ───────────────────────────────────────────────────────
 
 export const ArtifactsSchema = z.object({
   design: z.string().nullable(),
   plan: z.string().nullable(),
   pr: z.union([z.string(), z.array(z.string())]).nullable(),
+  // DR-1 #1593: additive, optional — absent for workflows that never extracted
+  // an intent. `.passthrough()` (above and here) means an absent field is never
+  // a validation failure.
+  intent: WorkflowIntentSchema.optional(),
 }).passthrough();
 
 // ─── Feature ID Schema ──────────────────────────────────────────────────────

--- a/skills-src/quality-review/SKILL.md
+++ b/skills-src/quality-review/SKILL.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `{{COMMAND_PREFIX}}review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `{{COMMAND_PREFIX}}review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/skills-src/spec-review/SKILL.md
+++ b/skills-src/spec-review/SKILL.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/skills-src/spec-review/SKILL.md
+++ b/skills-src/spec-review/SKILL.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/skills/claude/quality-review/SKILL.md
+++ b/skills/claude/quality-review/SKILL.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `/exarchos:review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `/exarchos:review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/skills/claude/spec-review/SKILL.md
+++ b/skills/claude/spec-review/SKILL.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/skills/claude/spec-review/SKILL.md
+++ b/skills/claude/spec-review/SKILL.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/skills/codex/quality-review/SKILL.md
+++ b/skills/codex/quality-review/SKILL.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/skills/codex/spec-review/SKILL.md
+++ b/skills/codex/spec-review/SKILL.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/skills/codex/spec-review/SKILL.md
+++ b/skills/codex/spec-review/SKILL.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/skills/copilot/quality-review/SKILL.md
+++ b/skills/copilot/quality-review/SKILL.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `/review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `/review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/skills/copilot/spec-review/SKILL.md
+++ b/skills/copilot/spec-review/SKILL.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/skills/copilot/spec-review/SKILL.md
+++ b/skills/copilot/spec-review/SKILL.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/skills/cursor/quality-review/SKILL.md
+++ b/skills/cursor/quality-review/SKILL.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/skills/cursor/spec-review/SKILL.md
+++ b/skills/cursor/spec-review/SKILL.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/skills/cursor/spec-review/SKILL.md
+++ b/skills/cursor/spec-review/SKILL.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/skills/generic/quality-review/SKILL.md
+++ b/skills/generic/quality-review/SKILL.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/skills/generic/spec-review/SKILL.md
+++ b/skills/generic/spec-review/SKILL.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/skills/generic/spec-review/SKILL.md
+++ b/skills/generic/spec-review/SKILL.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/skills/opencode/quality-review/SKILL.md
+++ b/skills/opencode/quality-review/SKILL.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `/review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `/review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/skills/opencode/spec-review/SKILL.md
+++ b/skills/opencode/spec-review/SKILL.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/skills/opencode/spec-review/SKILL.md
+++ b/skills/opencode/spec-review/SKILL.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/test/migration/__fixtures__/batch-baselines/quality-review.md
+++ b/test/migration/__fixtures__/batch-baselines/quality-review.md
@@ -199,7 +199,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: `/exarchos:review --max-fix-iterations 5`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via `escalation.maxIterations` in `.exarchos.yml`, with a per-loop override still available: `/exarchos:review --max-fix-iterations <n>`. `check_review_verdict` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (`escalate: true` + `escalationReason`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — `escalate: true`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (`escalation.maxIterations`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/test/migration/__fixtures__/batch-baselines/spec-review.md
+++ b/test/migration/__fixtures__/batch-baselines/spec-review.md
@@ -138,15 +138,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable `escalation.maxIterations`, default **5**) — it does NOT loop unboundedly. `check_review_verdict` returns the escalate decision the loop MUST honor: on a `NEEDS_FIXES` verdict it carries `escalate: true` + `escalationReason` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — `escalate` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — `escalate: true`. Do NOT re-dispatch `/delegate --fixes`. Surface the findings and `escalationReason` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (`escalation.maxIterations`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a `spec`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior `review-verdict` NEEDS_FIXES gate events) — there is no separate counter to maintain, and `check_review_verdict` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — `check_review_verdict` re-evaluates the bound each pass
 
 ```typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/test/migration/__fixtures__/batch-baselines/spec-review.md
+++ b/test/migration/__fixtures__/batch-baselines/spec-review.md
@@ -98,12 +98,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils `artifacts.intent` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when `intentGrounding` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as `artifacts.intent` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an `intentGrounding` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a `spec` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a `spec` issue.
+
+When no `intentGrounding` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -4393,12 +4393,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils \`artifacts.intent\` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when \`intentGrounding\` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as \`artifacts.intent\` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an \`intentGrounding\` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a \`spec\` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a \`spec\` issue.
+
+When no \`intentGrounding\` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 
@@ -9490,12 +9500,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils \`artifacts.intent\` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when \`intentGrounding\` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as \`artifacts.intent\` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an \`intentGrounding\` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a \`spec\` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a \`spec\` issue.
+
+When no \`intentGrounding\` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 
@@ -14579,12 +14599,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils \`artifacts.intent\` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when \`intentGrounding\` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as \`artifacts.intent\` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an \`intentGrounding\` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a \`spec\` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a \`spec\` issue.
+
+When no \`intentGrounding\` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 
@@ -19678,12 +19708,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils \`artifacts.intent\` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when \`intentGrounding\` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as \`artifacts.intent\` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an \`intentGrounding\` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a \`spec\` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a \`spec\` issue.
+
+When no \`intentGrounding\` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 
@@ -24748,12 +24788,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils \`artifacts.intent\` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when \`intentGrounding\` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as \`artifacts.intent\` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an \`intentGrounding\` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a \`spec\` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a \`spec\` issue.
+
+When no \`intentGrounding\` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 
@@ -29845,12 +29895,22 @@ This enables catching:
 - Test adequacy (outcome-based, tier-scaled — not test-first ordering)
 - Specification alignment
 - Test coverage
+- Intended-vs-delivered: the delivered diff fulfils \`artifacts.intent\` — no intended-but-missing or delivered-but-unintended (scope-creep) work (when \`intentGrounding\` is supplied)
 
 **Does NOT cover (that's Quality Review):**
 - Code style
 - SOLID principles
 - Performance optimization
 - Error handling elegance
+
+### Intended-vs-Delivered Grounding
+
+The orchestrator captures the **intended** change as \`artifacts.intent\` (surfaces, a summary, and — when available — a one-line transcript summary) and threads it into your dispatch as an \`intentGrounding\` directive on the back-of-pipeline code-review path. When present, you MUST verify the delivered diff against the intended change:
+
+- **Intended-but-missing** — a surface or outcome the intent calls for that the diff does not deliver. Flag as a \`spec\` issue.
+- **Delivered-but-unintended (scope creep)** — changes outside the intended surfaces/summary with no spec justification. Flag as a \`spec\` issue.
+
+When no \`intentGrounding\` is supplied (an empty or un-resolvable diff), proceed against the diff alone — do NOT fabricate an intent. This grounding is additive to the spec-alignment checks below, not a replacement for them.
 
 ## Review Checklist
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -4433,15 +4433,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable \`escalation.maxIterations\`, default **5**) — it does NOT loop unboundedly. \`check_review_verdict\` returns the escalate decision the loop MUST honor: on a \`NEEDS_FIXES\` verdict it carries \`escalate: true\` + \`escalationReason\` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — \`escalate: true\`. Do NOT re-dispatch \`/delegate --fixes\`. Surface the findings and \`escalationReason\` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a \`spec\`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior \`review-verdict\` NEEDS_FIXES gate events) — there is no separate counter to maintain, and \`check_review_verdict\` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — \`check_review_verdict\` re-evaluates the bound each pass
 
 \`\`\`typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",
@@ -9540,15 +9550,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable \`escalation.maxIterations\`, default **5**) — it does NOT loop unboundedly. \`check_review_verdict\` returns the escalate decision the loop MUST honor: on a \`NEEDS_FIXES\` verdict it carries \`escalate: true\` + \`escalationReason\` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — \`escalate: true\`. Do NOT re-dispatch \`/delegate --fixes\`. Surface the findings and \`escalationReason\` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a \`spec\`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior \`review-verdict\` NEEDS_FIXES gate events) — there is no separate counter to maintain, and \`check_review_verdict\` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — \`check_review_verdict\` re-evaluates the bound each pass
 
 \`\`\`typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",
@@ -14639,15 +14659,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable \`escalation.maxIterations\`, default **5**) — it does NOT loop unboundedly. \`check_review_verdict\` returns the escalate decision the loop MUST honor: on a \`NEEDS_FIXES\` verdict it carries \`escalate: true\` + \`escalationReason\` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — \`escalate: true\`. Do NOT re-dispatch \`/delegate --fixes\`. Surface the findings and \`escalationReason\` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a \`spec\`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior \`review-verdict\` NEEDS_FIXES gate events) — there is no separate counter to maintain, and \`check_review_verdict\` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — \`check_review_verdict\` re-evaluates the bound each pass
 
 \`\`\`typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",
@@ -19748,15 +19778,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable \`escalation.maxIterations\`, default **5**) — it does NOT loop unboundedly. \`check_review_verdict\` returns the escalate decision the loop MUST honor: on a \`NEEDS_FIXES\` verdict it carries \`escalate: true\` + \`escalationReason\` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — \`escalate: true\`. Do NOT re-dispatch \`/delegate --fixes\`. Surface the findings and \`escalationReason\` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a \`spec\`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior \`review-verdict\` NEEDS_FIXES gate events) — there is no separate counter to maintain, and \`check_review_verdict\` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — \`check_review_verdict\` re-evaluates the bound each pass
 
 \`\`\`typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",
@@ -24828,15 +24868,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable \`escalation.maxIterations\`, default **5**) — it does NOT loop unboundedly. \`check_review_verdict\` returns the escalate decision the loop MUST honor: on a \`NEEDS_FIXES\` verdict it carries \`escalate: true\` + \`escalationReason\` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — \`escalate: true\`. Do NOT re-dispatch \`/delegate --fixes\`. Surface the findings and \`escalationReason\` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a \`spec\`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior \`review-verdict\` NEEDS_FIXES gate events) — there is no separate counter to maintain, and \`check_review_verdict\` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — \`check_review_verdict\` re-evaluates the bound each pass
 
 \`\`\`typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",
@@ -29935,15 +29985,25 @@ exarchos_orchestrate({
 
 ## Fix Loop
 
-If review FAILS:
+If review FAILS, the fix-loop is **bounded by the shared escalation policy** (config-resolvable \`escalation.maxIterations\`, default **5**) — it does NOT loop unboundedly. \`check_review_verdict\` returns the escalate decision the loop MUST honor: on a \`NEEDS_FIXES\` verdict it carries \`escalate: true\` + \`escalationReason\` when the loop must stop (the auto-fix bound was hit OR a finding is intent-touching), and the report's routing instruction reflects this.
+
+**Two outcomes:**
+
+1. **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Re-dispatch to the implementer and re-review, as below. The verdict report surfaces the remaining budget (e.g. "fix cycle N/maxIterations").
+2. **Escalate to the user (ask-user)** — \`escalate: true\`. Do NOT re-dispatch \`/delegate --fixes\`. Surface the findings and \`escalationReason\` to the user and ask how to proceed (accept, redesign, or adjust scope). This happens when EITHER:
+   - the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached — the loop has fixed-and-re-reviewed that many times without converging; OR
+   - a finding is **intent-touching** — a \`spec\`-category issue (intended-but-missing or scope-creep) that changes what was asked for, so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
+
+The fix-cycle count is event-sourced (prior \`review-verdict\` NEEDS_FIXES gate events) — there is no separate counter to maintain, and \`check_review_verdict\` reads it for you.
+
+**Auto-fix path — re-dispatch to implementer:**
 
 1. Create fix task with specific issues
 2. Dispatch to implementer (same or new)
-3. Re-review after fixes
-4. Repeat until PASS
+3. Re-review after fixes — \`check_review_verdict\` re-evaluates the bound each pass
 
 \`\`\`typescript
-// Return to implementer
+// Return to implementer (auto-fix path only — when escalate is falsy)
 Task({
   model: "opus",
   description: "Fix spec review issues",

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -3598,7 +3598,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: \`/exarchos:review --max-fix-iterations 5\`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via \`escalation.maxIterations\` in \`.exarchos.yml\`, with a per-loop override still available: \`/exarchos:review --max-fix-iterations <n>\`. \`check_review_verdict\` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (\`escalate: true\` + \`escalationReason\`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — \`escalate: true\`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 
@@ -8715,7 +8718,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: \`review --max-fix-iterations 5\`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via \`escalation.maxIterations\` in \`.exarchos.yml\`, with a per-loop override still available: \`review --max-fix-iterations <n>\`. \`check_review_verdict\` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (\`escalate: true\` + \`escalationReason\`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — \`escalate: true\`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 
@@ -13824,7 +13830,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: \`/review --max-fix-iterations 5\`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via \`escalation.maxIterations\` in \`.exarchos.yml\`, with a per-loop override still available: \`/review --max-fix-iterations <n>\`. \`check_review_verdict\` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (\`escalate: true\` + \`escalationReason\`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — \`escalate: true\`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 
@@ -18943,7 +18952,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: \`review --max-fix-iterations 5\`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via \`escalation.maxIterations\` in \`.exarchos.yml\`, with a per-loop override still available: \`review --max-fix-iterations <n>\`. \`check_review_verdict\` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (\`escalate: true\` + \`escalationReason\`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — \`escalate: true\`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 
@@ -24033,7 +24045,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: \`review --max-fix-iterations 5\`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via \`escalation.maxIterations\` in \`.exarchos.yml\`, with a per-loop override still available: \`review --max-fix-iterations <n>\`. \`check_review_verdict\` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (\`escalate: true\` + \`escalationReason\`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — \`escalate: true\`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 
@@ -29150,7 +29165,10 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
-**Fix loop iteration limit: max 3.** If HIGH-priority issues persist after 3 fix-review cycles, pause and escalate to the user with a summary of unresolved issues. The user can override: \`/review --max-fix-iterations 5\`
+The fix loop is **bounded by the shared escalation policy (DR-3)** — the same bound the spec-review and shepherd loops use, not an ad-hoc quality-review limit. The default is **5**, config-resolvable via \`escalation.maxIterations\` in \`.exarchos.yml\`, with a per-loop override still available: \`/review --max-fix-iterations <n>\`. \`check_review_verdict\` reads the event-sourced fix-cycle count and returns the escalate decision the loop MUST honor (\`escalate: true\` + \`escalationReason\`).
+
+- **Auto-fix (under the bound, MECHANICAL findings)** — \`escalate\` is absent/falsy. Mechanical style/quality findings (SOLID, DRY, naming, complexity) re-dispatch to the implementer and re-review, as above.
+- **Escalate to the user (ask-user)** — \`escalate: true\`. Pause and ask the user how to proceed, with a summary of unresolved issues, when EITHER the auto-fix bound (\`escalation.maxIterations\`, default 5) is reached without converging, OR a finding is **intent-touching** — one that changes what was asked for (e.g. API-contract break, spec regression) so a human decides rather than the loop silently "fixing" it. Intent-touching findings escalate immediately, regardless of how many cycles have run.
 
 ### Post-Fix Spec Compliance Check (MANDATORY after fix cycle)
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
             'src/**/*.test.ts',
             'benchmarks/**/*.test.ts',
             'scripts/**/*.test.ts',
+            // Black-box tests for top-level git-hook samples (e.g. the opt-in
+            // pre-push ship-gate hook). They drive the `.sample` script via
+            // `sh` and assert exit codes — no MCP-package deps, so they run in
+            // the root `unit` project rather than `servers/exarchos-mcp`.
+            'hooks/**/*.test.ts',
             'test/fixtures/**/*.test.ts',
             'test/setup/**/*.test.ts',
             'test/migration/**/*.test.ts',


### PR DESCRIPTION
## Summary

Implements the **ship-gate methodology** epic (#1592) — grounds the no-mistakes pipeline into the REVIEW→SYNTHESIZE phase-kinds. Seven independently-scoped requirements (DR-1..DR-7), all **additive** on the existing REVIEW/SYNTHESIZE kinds — no new `PhaseKind`, no workflow-typed branch (INV-6). Shipped here as one consolidated PR (23 commits over `main`).

Closes #1592. Implements #1593, #1594, #1595, #1596, #1597, #1598. Follow-ups filed: #1612 (GitLab harvest), #1613 (Azure DevOps harvest).

## Changes

| DR | Bundle | What |
|----|--------|------|
| DR-2 | A | **Document-readiness leg** in SYNTHESIZE — `SynthesisLeg` gains `'document'`, resolver pins it after `typecheck`/before `stack`; `prepare_synthesis` evaluates docs coverage + emits `gate.executed`; config-resolvable severity (advisory default, empty `surfaceGlobs` ⇒ auto-waive) wired schema→resolve via new `adaptWithEventStoreAndConfig` adapter. |
| DR-1 | B | **Intent grounding** — new `extract-intent.ts` derives a diff-floor `artifacts.intent` (+transcript enrichment) via a single `state.patched`; REVIEW dispatch grounds spec-review in intended-vs-delivered; `validate_pr_body` + `create_pr` body generation read the intent. Workflow-agnostic (no type branch). |
| DR-4 | C | **Harden single PR owner** — structural event-sourced `PR_ALREADY_OWNED` guard refuses `create_pr` when the workflow already owns a PR (by-construction, not prose; fires before side effects); double-create `listPrs` guard retained+pinned; explicit-SHA `--force-with-lease=<ref>:<sha>` push helper with fresh `ls-remote` anchoring. |
| DR-7 | D | **Platform-generic PR-feedback ingestion** — `PrComment` widened to a platform-neutral, thread-aware contract (`source`/`parentId`/tri-state `resolved`/`state`, no GitHub field leak); `github.getPrComments` aggregates issue + inline-review + review-summary surfaces (paginated) with fail-soft GraphQL `resolved` enrichment; `assess_stack` consumes the unified feed generically; gitlab/azure conform (still throw `UnsupportedOperationError`). |
| DR-3 | E | **Uniform bounded auto-fix + ask-user escalation** — shared config-resolvable `escalation-policy.ts` (default 5, per-loop override) replaces the ad-hoc `3`+pause; single event-sourced shepherd iteration counter (loop + view agree); bound-hit emits a structured escalation surfaced via `shepherd_status` (INV-10, no hang); applied to spec-review + quality-review loops. |
| DR-5 | F | **Opt-in pre-push ship-gate hook** — `hooks/pre-push.ship-gate.sample` POSIX-sh thin trigger, opt-in `.sample` (POLA), degrades-open, no daemon (INV-15), OS-neutral (INV-4); explicit-install guide. |
| DR-6 | G | **SDK combinator migration contract** — pattern↦combinator migration note cross-linked from #1258; `SDK_MIGRATION_CONTRACT` constant + divergence guard test pinning the live escalation policy against the documented `repeatUntil`/`awaitApproval` semantics. |

## Test Plan

- **MCP suite** (`cd servers/exarchos-mcp && npm run test:run`): 8024 passed / 21 skipped, +5 root pre-push hook tests. 234 tests across the new/changed files specifically (escalation-policy 19, push-with-lease 16, provider 7, github 38, review-verdict 38, assess-stack 41, prepare-synthesis 23, extract-intent 13, create-pr 18, prepare-review 21, pre-push 5).
- **Root suite** (`npm run test:run`): 866 passed / 6 skipped (102 files).
- **Static gates**: `npm run typecheck`, `npm run skills:guard`, `npm run hooks:guard`, MCP `check_static_analysis` — all green.
- **Two-stage review (`/exarchos:review`)**: spec-compliance **PASS** (DR-1..DR-7 obligations all met, every named test present); code-quality **APPROVED** (0 HIGH / 0 MEDIUM / 5 LOW advisory). Tests verified as genuine kill-probes (single-PR-owner guard asserts no side effect + no event append; divergence guard pins live policy vs SDK contract; GraphQL fail-soft distinguishes unknown from resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
