### PR TITLE
docs(upgrade): legacy JSONL state bridge for v2.10+

### DIFF
--- a/documentation/.vitepress/config.ts
+++ b/documentation/.vitepress/config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/guide/' },
             { text: 'Installation', link: '/guide/installation' },
+            { text: 'Legacy State Upgrade', link: '/guide/legacy-state-upgrade' },
             { text: 'First Workflow', link: '/guide/first-workflow' },
           ],
         },

--- a/documentation/architecture/design-rationale.md
+++ b/documentation/architecture/design-rationale.md
@@ -26,7 +26,7 @@ Early Exarchos releases used JSONL files because they were simple: one event per
 
 Events are the audit trail. With a traditional database, you'd need a separate record-keeping system to answer "what happened during this workflow?" With event sourcing, the events *are* the history. Every transition, guard failure, task assignment, and review result is recorded with timestamps and context.
 
-Because SQLite is local, the operational model is still file-based: back up or move the workflow store by copying the state directory while agents are stopped. If you have an old JSONL-only directory, bridge it through v2.9.0 before starting v2.11; see [Legacy State Upgrade](/guide/legacy-state-upgrade).
+Because SQLite is local, the operational model is still file-based: back up or move the workflow store by copying the state directory while agents are stopped. If you have a pre-v2.9.0 JSONL-only directory, bridge it through v2.9.x before starting v2.10.0 or later; see [Legacy State Upgrade](/guide/legacy-state-upgrade).
 
 Trade-off: Query flexibility is intentionally mediated. Even though events live in SQLite, callers should use CQRS (Command Query Responsibility Segregation) materialized views rather than coupling directly to tables. The `exarchos_view` tool provides pre-built projections like pipeline status, task details, and convergence metrics. This adds code complexity, but it cleanly separates the write path (append events) from the read path (query views).
 

--- a/documentation/architecture/design-rationale.md
+++ b/documentation/architecture/design-rationale.md
@@ -18,17 +18,17 @@ MCP also enables input validation. When an agent calls `exarchos_workflow({ acti
 
 Trade-off: MCP adds operational overhead. The server needs to start up, establish stdio communication, and initialize its state. This adds latency to the first tool call. For simple tasks that don't need structured workflows, a few markdown files in the context are lighter. The MCP approach pays off when workflows are complex enough that losing state mid-session would cost more than the server overhead.
 
-## Why event sourcing over a database
+## Why event sourcing
 
-Agent workflows have a specific access pattern: events happen in order, most writes are appends, and the most common query is "give me the current state." This is a good fit for event sourcing with JSONL files.
+Agent workflows have a specific access pattern: events happen in order, most writes are appends, and the most common query is "give me the current state." This is a good fit for event sourcing.
 
-JSONL is simple. Each event is a line of JSON appended to a file. No schema migrations, no connection pooling, no query language. You can debug a workflow by opening the file in a text editor. You can back it up by copying a file. You can move it to another machine by copying a directory.
+Early Exarchos releases used JSONL files because they were simple: one event per line, easy to copy, and easy to inspect in a text editor. Current releases use SQLite as the required local event-store substrate so concurrent agents, idempotency claims, stream queries, and projections share one durable source of truth.
 
 Events are the audit trail. With a traditional database, you'd need a separate record-keeping system to answer "what happened during this workflow?" With event sourcing, the events *are* the history. Every transition, guard failure, task assignment, and review result is recorded with timestamps and context.
 
-Exarchos does use SQLite as an optional acceleration layer. The SQLite backend caches queries and sequence lookups for better performance on large event streams. But JSONL is always the source of truth. If the SQLite database corrupts, the server deletes it and rebuilds from JSONL on the next startup. No data loss.
+Because SQLite is local, the operational model is still file-based: back up or move the workflow store by copying the state directory while agents are stopped. If you have an old JSONL-only directory, bridge it through v2.9.0 before starting v2.11; see [Legacy State Upgrade](/guide/legacy-state-upgrade).
 
-Trade-off: Query flexibility is limited. You can't write arbitrary SQL against a JSONL file. The solution is CQRS (Command Query Responsibility Segregation) materialized views, where the `exarchos_view` tool provides pre-built projections like pipeline status, task details, and convergence metrics. This adds code complexity, but it cleanly separates the write path (append events) from the read path (query views).
+Trade-off: Query flexibility is intentionally mediated. Even though events live in SQLite, callers should use CQRS (Command Query Responsibility Segregation) materialized views rather than coupling directly to tables. The `exarchos_view` tool provides pre-built projections like pipeline status, task details, and convergence metrics. This adds code complexity, but it cleanly separates the write path (append events) from the read path (query views).
 
 ## Why typed agents over a single general-purpose agent
 

--- a/documentation/architecture/event-sourcing.md
+++ b/documentation/architecture/event-sourcing.md
@@ -8,7 +8,7 @@ outline: deep
 
 Agent sessions are fragile. They end when context windows fill up and compact, when the user closes their laptop, when the process crashes, or when the network drops. Any of these can happen mid-operation.
 
-With mutable state, a crash mid-write can leave a half-updated JSON file. You can't tell what happened. Did the task complete? Did the review pass? The state says one thing, but the state might be wrong.
+With mutable state, a crash mid-write can leave a half-updated record. You can't tell what happened. Did the task complete? Did the review pass? The state says one thing, but the state might be wrong.
 
 Event sourcing sidesteps this. Every action is recorded as an immutable event, appended to a log. State is computed from events, not stored directly. If state gets corrupted, you replay the events and rebuild it. The events themselves are the truth.
 
@@ -16,7 +16,7 @@ This gives you crash recovery, a full audit trail, and reconciliation. If a sess
 
 ## How it works
 
-Each workflow gets its own JSONL file: `{featureId}.events.jsonl`. One event per line, append-only. A typical event looks like this:
+Each workflow gets its own stream in the local SQLite event store. A typical event looks like this:
 
 ```json
 {
@@ -36,9 +36,9 @@ Events have:
 - `timestamp` -- ISO 8601, used for time-based queries
 - `idempotencyKey` (optional) -- deduplication key for retry safety
 
-State is a projection: a JSON object computed by reading events from sequence 0. In practice, state is cached in a `{featureId}.json` file and only new events (those with sequence numbers higher than the state's `_eventSequence`) are applied. This means state reads are fast (just read the JSON file) while still being rebuildable from events.
+State is a projection computed by reading events from sequence 0. In practice, projected state and CQRS views are cached so reads are fast while remaining rebuildable from events.
 
-The event store uses a `.seq` cache file alongside each JSONL stream for O(1) sequence lookup. On startup, it cross-validates the cached sequence against the actual JSONL line count and falls through to a full scan if they disagree.
+The event store keeps stream metadata, high-water marks, idempotency claims, projected state, and materialized-view snapshots in SQLite. Older JSONL-only state directories need the [legacy state upgrade](/guide/legacy-state-upgrade) bridge before v2.11 can open them.
 
 ## Reconciliation
 
@@ -52,22 +52,22 @@ This reads the event store, compares sequence numbers against the state's `_even
 
 Reconciliation handles several real-world scenarios:
 
-- Crash recovery. Hook subprocesses write events directly to JSONL via sidecar files. On the next MCP server startup, sidecar events are merged into the main stream, and reconciliation brings state up to date.
-- State corruption. If the JSON state file is deleted or truncated, reconciliation rebuilds it entirely from events.
-- Sequence corruption. If events in the JSONL file have non-monotonic sequence numbers (from a bug or disk corruption), the event store detects this during initialization and re-sequences the entire stream.
+- Crash recovery. If a session ends after an event write but before a projected-state refresh, reconciliation brings state up to date on the next read.
+- State corruption. If projected state is missing or stale, reconciliation rebuilds it entirely from events.
+- Sequence conflicts. If another writer appends to a stream between read and write, optimistic concurrency reports the mismatch instead of losing an update.
 
 ## Concurrency control
 
 The event store uses optimistic concurrency via `expectedSequence`. A caller can pass the sequence number it last read; if another write happened in between, the append fails with a `SequenceConflictError`. This prevents lost updates when multiple processes try to write events to the same stream.
 
-Within a single process, a per-stream promise-chain lock serializes writes. Multiple event store instances sharing the same directory are prevented by a PID lock file that detects stale locks from crashed processes.
+Within a single process, a per-stream promise-chain lock serializes writes. Across processes, SQLite WAL and bounded busy handling coordinate concurrent access to the same state directory.
 
 ## Trade-offs vs. mutable state
 
 Event sourcing is not free:
 
-- Storage. Events accumulate, but JSONL is compact and workflows are finite. A complex feature workflow might produce a few hundred events over its lifetime, a few kilobytes of text.
-- Query complexity. You can't just read a field from the event log. You need projections (the cached state file) or materialized views (the CQRS views in `exarchos_view`). This adds code, but it also cleanly separates write and read concerns.
-- In-memory event log cap. The internal event log in state is capped at 100 entries (configurable via `EVENT_LOG_MAX`) to prevent unbounded memory growth. This means old events are still in JSONL but not in the in-memory state `_events` array. Materialized views query the store directly when they need historical data.
+- Storage. Events accumulate, but workflows are finite. A complex feature workflow usually produces a few hundred events.
+- Query complexity. You still should not treat the event table as mutable application state. Use projections or materialized views through `exarchos_workflow` and `exarchos_view`; this adds code, but it cleanly separates write and read concerns.
+- Operational dependency. Current releases require a working SQLite driver. If neither the bundled runtime nor the Node SQLite driver can load, the server fails fast instead of falling back to JSONL-only mode.
 
 The benefits (crash recovery, audit trails, reconciliation) matter more for agent workflows than for typical applications because agent sessions are inherently unreliable. When your process can vanish at any moment, immutable event logs are cheap insurance.

--- a/documentation/architecture/event-sourcing.md
+++ b/documentation/architecture/event-sourcing.md
@@ -38,7 +38,7 @@ Events have:
 
 State is a projection computed by reading events from sequence 0. In practice, projected state and CQRS views are cached so reads are fast while remaining rebuildable from events.
 
-The event store keeps stream metadata, high-water marks, idempotency claims, projected state, and materialized-view snapshots in SQLite. Older JSONL-only state directories need the [legacy state upgrade](/guide/legacy-state-upgrade) bridge before v2.11 can open them.
+The event store keeps stream metadata, high-water marks, idempotency claims, projected state, and materialized-view snapshots in SQLite. Pre-v2.9.0 JSONL-only state directories need the [legacy state upgrade](/guide/legacy-state-upgrade) bridge before v2.10.0 or later can open them.
 
 ## Reconciliation
 

--- a/documentation/architecture/index.md
+++ b/documentation/architecture/index.md
@@ -23,7 +23,7 @@ The MCP server (`servers/exarchos-mcp/`) handles all workflow logic. It exposes 
 
 A fifth tool (`exarchos_sync`) exists for future remote synchronization but is hidden from agents.
 
-The event store persists workflow events to a local SQLite database with projected workflow state derived from those events. Older JSONL-only state directories must be bridged through v2.9.0 before v2.11 can open them; see [Legacy State Upgrade](/guide/legacy-state-upgrade).
+The event store persists workflow events to a local SQLite database with projected workflow state derived from those events. Pre-v2.9.0 JSONL-only state directories must be bridged through v2.9.x before v2.10.0 or later can open them; see [Legacy State Upgrade](/guide/legacy-state-upgrade).
 
 Lifecycle hooks intercept Claude Code events (session start, pre-compact, task completion, teammate idle) and trigger MCP operations. Hooks run as lightweight CLI subcommands with tight timeouts (5-30 seconds), skipping heavy initialization to stay fast.
 

--- a/documentation/architecture/index.md
+++ b/documentation/architecture/index.md
@@ -23,7 +23,7 @@ The MCP server (`servers/exarchos-mcp/`) handles all workflow logic. It exposes 
 
 A fifth tool (`exarchos_sync`) exists for future remote synchronization but is hidden from agents.
 
-The event store persists everything to JSONL files (one per workflow) with JSON state files derived from events. JSONL is always the source of truth. An optional SQLite backend accelerates queries but self-heals from JSONL if the database corrupts.
+The event store persists workflow events to a local SQLite database with projected workflow state derived from those events. Older JSONL-only state directories must be bridged through v2.9.0 before v2.11 can open them; see [Legacy State Upgrade](/guide/legacy-state-upgrade).
 
 Lifecycle hooks intercept Claude Code events (session start, pre-compact, task completion, teammate idle) and trigger MCP operations. Hooks run as lightweight CLI subcommands with tight timeouts (5-30 seconds), skipping heavy initialization to stay fast.
 
@@ -35,7 +35,7 @@ Validation scripts are deterministic bash programs that replace prose checklists
 
 Agent-first. Every tool accepts structured JSON input, validates it with Zod schemas, and returns structured JSON output with clear error messages. When a guard blocks a transition, the error includes the expected state shape and a suggested fix (the exact tool call to resolve it). This is designed for LLM consumption, not human CLI usage.
 
-Event-sourced. Every workflow action produces an immutable event appended to a JSONL stream. State is derived from events, never mutated directly. If state and events diverge, `reconcile` rebuilds state from the event log. This matters because agent sessions end abruptly: context compaction, crashes, laptop lids closing. Mutable state can corrupt silently. Events don't.
+Event-sourced. Every workflow action produces an immutable event appended to a stream. State is derived from events, never mutated directly. If state and events diverge, `reconcile` rebuilds state from the event log. This matters because agent sessions end abruptly: context compaction, crashes, laptop lids closing. Mutable state can corrupt silently. Events don't.
 
 Token-efficient. LLM context windows are finite, and Exarchos is infrastructure. Every token it consumes is a token unavailable for actual coding. Lazy schema registration keeps MCP startup under 500 tokens. Field projection on state queries cuts response size by roughly 90%. Artifact references store file paths instead of inlining content. Every design choice accounts for context window cost.
 

--- a/documentation/architecture/platform-portability.md
+++ b/documentation/architecture/platform-portability.md
@@ -74,8 +74,8 @@ This split is the reason portability works:
 
 **Platform-agnostic (runtime):**
 - MCP server -- stdio JSON-RPC, works with any client
-- Event store -- JSONL append-only log on the filesystem
-- State store -- JSON files derived from events
+- Event store -- local SQLite append-only streams on the filesystem
+- State store -- projections derived from events
 - Dispatch engine -- TypeScript handlers, zero Claude Code dependency
 - CLI -- Commander-based, zero Claude Code dependency
 

--- a/documentation/guide/installation.md
+++ b/documentation/guide/installation.md
@@ -224,7 +224,7 @@ Workflow state at `~/.exarchos/state/` is forward-compatible — the v2.9 binary
 
 If the plugin update lands before the binary install, MCP server registration and the eight lifecycle hooks fail with `exarchos: command not found` until you complete step 2 and restart. Order matters here.
 
-Upgrading old JSONL-only state directly to v2.11 requires an extra bridge step through v2.9.0. See [Legacy State Upgrade](/guide/legacy-state-upgrade) before pointing v2.11 at a state directory that contains `*.events.jsonl` files and no `exarchos.db`.
+Upgrading pre-v2.9.0 JSONL-only state directly to v2.10.0 or later requires an extra bridge step through v2.9.x. See [Legacy State Upgrade](/guide/legacy-state-upgrade) before pointing v2.10.0+ at a state directory that contains `*.events.jsonl` files and no `exarchos.db`.
 
 ## Update
 

--- a/documentation/guide/installation.md
+++ b/documentation/guide/installation.md
@@ -224,6 +224,8 @@ Workflow state at `~/.exarchos/state/` is forward-compatible — the v2.9 binary
 
 If the plugin update lands before the binary install, MCP server registration and the eight lifecycle hooks fail with `exarchos: command not found` until you complete step 2 and restart. Order matters here.
 
+Upgrading old JSONL-only state directly to v2.11 requires an extra bridge step through v2.9.0. See [Legacy State Upgrade](/guide/legacy-state-upgrade) before pointing v2.11 at a state directory that contains `*.events.jsonl` files and no `exarchos.db`.
+
 ## Update
 
 The bootstrap installers are idempotent — re-run the same one-liner and the new binary atomically replaces the old one. SHA-512 verification guards against partial writes.

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -31,32 +31,34 @@ Do not wipe the directory if you want to keep old workflows. Use the bridge path
 
 ## Bridge through v2.9.0
 
-Install a temporary v2.9.0 binary into a scratch directory. This does not replace your current `exarchos` on PATH.
+The commands below use the common Claude Code state path, `~/.claude/workflow-state`. If your install uses a different `WORKFLOW_STATE_DIR`, replace that path in each command.
+
+First, copy the old state directory. Do not run the bridge against your only copy.
 
 ```bash
-set -euo pipefail
+cp -a "$HOME/.claude/workflow-state" "$HOME/.claude/workflow-state-v211"
+```
 
-OLD_STATE="${WORKFLOW_STATE_DIR:-$HOME/.claude/workflow-state}"
-NEW_STATE="${OLD_STATE}-v211"
-BRIDGE_BIN_DIR="$(mktemp -d)"
+Install a temporary v2.9.0 binary into its own directory. This does not replace your current `exarchos` on PATH.
 
-test ! -e "$NEW_STATE" || {
-  echo "$NEW_STATE already exists; choose a new NEW_STATE path" >&2
-  exit 1
-}
+```bash
+mkdir -p "$HOME/.local/exarchos-2.9.0"
+curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh -o /tmp/get-exarchos.sh
+EXARCHOS_INSTALL_DIR="$HOME/.local/exarchos-2.9.0" bash /tmp/get-exarchos.sh --version v2.9.0
+```
 
-cp -a "$OLD_STATE" "$NEW_STATE"
+Run the v2.9.0 binary once against the copied state directory:
 
-curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh \
-  -o "$BRIDGE_BIN_DIR/get-exarchos.sh"
-
-EXARCHOS_INSTALL_DIR="$BRIDGE_BIN_DIR" \
-  bash "$BRIDGE_BIN_DIR/get-exarchos.sh" --version v2.9.0
-
-WORKFLOW_STATE_DIR="$NEW_STATE" "$BRIDGE_BIN_DIR/exarchos" doctor
+```bash
+WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211" \
+  "$HOME/.local/exarchos-2.9.0/exarchos" doctor
 ```
 
 The v2.9.0 doctor run opens the copied state directory with the last runtime that still knows how to hydrate JSONL workflow events into SQLite. After it finishes, the copied directory should contain `exarchos.db`.
+
+```bash
+ls "$HOME/.claude/workflow-state-v211/exarchos.db"
+```
 
 If the temporary install fails because the `v2.9.0` tag is unavailable in your environment, use the newest available v2.9.x tag and run the same `doctor` command against the copied state directory.
 
@@ -67,13 +69,13 @@ Install or update to v2.11, then run `doctor` against the migrated copy:
 ```bash
 curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh | bash -s -- --version v2.11.0-preview.4
 
-WORKFLOW_STATE_DIR="$NEW_STATE" exarchos doctor
+WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211" exarchos doctor
 ```
 
 Then verify one known workflow:
 
 ```bash
-WORKFLOW_STATE_DIR="$NEW_STATE" exarchos workflow get --feature-id <feature-id>
+WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211" exarchos workflow get --feature-id <feature-id>
 ```
 
 Inside Claude Code, restart the session and run:

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -33,6 +33,31 @@ Do not wipe the directory if you want to keep old workflows. Use the bridge path
 
 Do not use v2.10.0 or later as the bridge runtime. Those versions expect SQLite state to already exist.
 
+## Agent prompt
+
+If you want a local coding agent to perform the migration for you, copy this prompt into that agent. Replace the paths or target version first if your setup differs.
+
+```text
+Migrate my legacy Exarchos workflow state safely.
+
+Context:
+- Exarchos v2.10.0 and later require SQLite-backed workflow state.
+- My current/old state directory may be JSONL-only: it may contain *.events.jsonl files but no exarchos.db or events.db.
+- Use v2.9.x as the bridge runtime. Do not use v2.10.0 or later as the bridge.
+- Preserve the original state directory unchanged.
+
+Please do this:
+1. Confirm there are no running Claude Code, Codex, opencode, Cursor, or other Exarchos MCP sessions using the state directory. If you cannot confirm that, stop and tell me what to close.
+2. Identify the current Exarchos state directory. Prefer WORKFLOW_STATE_DIR if it is set; otherwise check the common path ~/.claude/workflow-state. If the directory does not contain *.events.jsonl files, tell me what you found before continuing.
+3. Create a migrated copy at ~/.claude/workflow-state-v211, or choose a timestamped sibling if that path already exists. Do not modify or delete the original directory.
+4. Install a temporary v2.9.x Exarchos binary into ~/.local/exarchos-2.9.0 without replacing my current exarchos on PATH.
+5. Run the temporary v2.9.x binary with WORKFLOW_STATE_DIR pointing at the copied state directory, using `doctor` to hydrate legacy JSONL workflow events into exarchos.db.
+6. Verify the copied state directory now contains exarchos.db.
+7. Install or use my target Exarchos v2.10.0+ runtime, then run `exarchos doctor` with WORKFLOW_STATE_DIR pointing at the migrated copy.
+8. Verify at least one known workflow with `exarchos workflow get --feature-id <feature-id>` if a feature id is available; otherwise report how I should run /exarchos:rehydrate after restart.
+9. Tell me the original state path, migrated state path, bridge binary path, target Exarchos version, and every command you ran. Do not switch my agent config to the migrated state path unless I explicitly approve that final step.
+```
+
 ## Before you start
 
 1. Close Claude Code, Codex, opencode, and any other agent session using Exarchos.

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -44,24 +44,25 @@ If you would rather do it yourself, use the shorter terminal flow below the prom
 If you want a local coding agent to perform the migration for you, copy this prompt into that agent. Replace the paths or target version first if your setup differs.
 
 ```text
-Migrate my legacy Exarchos workflow state safely.
+Please migrate my legacy Exarchos workflow state safely.
 
 Context:
 - Exarchos v2.10.0 and later require SQLite-backed workflow state.
-- My current/old state directory may be JSONL-only: it may contain *.events.jsonl files but no exarchos.db or events.db.
+- A legacy state directory may contain `*.events.jsonl` files but no `exarchos.db` or `events.db`.
 - Use v2.9.x as the bridge runtime. Do not use v2.10.0 or later as the bridge.
-- Preserve the original state directory unchanged.
+- Preserve the original state directory unchanged. Work only on a copied state directory.
 
-Please do this:
-1. Confirm there are no running Claude Code, Codex, opencode, Cursor, or other Exarchos MCP sessions using the state directory. If you cannot confirm that, stop and tell me what to close.
-2. Identify the current Exarchos state directory. Prefer WORKFLOW_STATE_DIR if it is set; otherwise check the common path ~/.claude/workflow-state. If the directory does not contain *.events.jsonl files, tell me what you found before continuing.
-3. Create a migrated copy at ~/.claude/workflow-state-v211, or choose a timestamped sibling if that path already exists. Do not modify or delete the original directory.
-4. Install a temporary v2.9.x Exarchos binary into ~/.local/exarchos-2.9.0 without replacing my current exarchos on PATH.
-5. Run the temporary v2.9.x binary with WORKFLOW_STATE_DIR pointing at the copied state directory, using `doctor` to hydrate legacy JSONL workflow events into exarchos.db.
-6. Verify the copied state directory now contains exarchos.db.
-7. Install or use my target Exarchos v2.10.0+ runtime, then run `exarchos doctor` with WORKFLOW_STATE_DIR pointing at the migrated copy.
-8. Verify at least one known workflow with `exarchos workflow get --feature-id <feature-id>` if a feature id is available; otherwise report how I should run /exarchos:rehydrate after restart.
-9. Tell me the original state path, migrated state path, bridge binary path, target Exarchos version, and every command you ran. Do not switch my agent config to the migrated state path unless I explicitly approve that final step.
+Steps:
+1. Make sure Claude Code, Codex, opencode, Cursor, and any other Exarchos MCP clients are closed. If you cannot confirm that, stop and tell me what to close.
+2. Find the current Exarchos state directory. Prefer `WORKFLOW_STATE_DIR` if it is set; otherwise check `~/.claude/workflow-state`.
+3. Inspect the state directory. If it does not contain `*.events.jsonl`, or if it already contains `exarchos.db` or `events.db`, pause and tell me what you found before migrating anything.
+4. Copy the state directory to `~/.claude/workflow-state-v211`. If that path already exists, create a timestamped sibling instead. Do not modify, delete, or move the original.
+5. Install a temporary v2.9.x Exarchos binary into `~/.local/exarchos-2.9.0` without replacing the `exarchos` currently on PATH.
+6. Run the temporary v2.9.x binary with `WORKFLOW_STATE_DIR` pointed at the copied state directory, using `doctor` to hydrate the legacy JSONL events into `exarchos.db`.
+7. Verify the copied state directory now contains `exarchos.db`.
+8. Use the target Exarchos v2.10.0+ runtime, then run `exarchos doctor` with `WORKFLOW_STATE_DIR` pointed at the migrated copy.
+9. If a workflow id is available, verify it with `exarchos workflow get --feature-id <feature-id>`. If no workflow id is available, tell me to restart my agent and run `/exarchos:rehydrate`.
+10. Report the original state path, migrated state path, bridge binary path, target Exarchos version, and every command you ran. Do not switch my agent config to the migrated state path unless I explicitly approve that final step.
 ```
 
 ## Option 2: Run it yourself

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -48,28 +48,28 @@ The commands below use the common Claude Code state path, `~/.claude/workflow-st
 First, copy the old state directory. Do not run the bridge against your only copy.
 
 ```bash
-cp -a "$HOME/.claude/workflow-state" "$HOME/.claude/workflow-state-v211"
+cp -a ~/.claude/workflow-state ~/.claude/workflow-state-v211
 ```
 
 Install a temporary v2.9.0 binary into its own directory. This does not replace your current `exarchos` on PATH.
 
 ```bash
-mkdir -p "$HOME/.local/exarchos-2.9.0"
+mkdir -p ~/.local/exarchos-2.9.0
 curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh -o /tmp/get-exarchos.sh
-EXARCHOS_INSTALL_DIR="$HOME/.local/exarchos-2.9.0" bash /tmp/get-exarchos.sh --version v2.9.0
+EXARCHOS_INSTALL_DIR=~/.local/exarchos-2.9.0 bash /tmp/get-exarchos.sh --version v2.9.0
 ```
 
 Run the v2.9.0 binary once against the copied state directory:
 
 ```bash
-WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211" \
-  "$HOME/.local/exarchos-2.9.0/exarchos" doctor
+WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211 \
+  ~/.local/exarchos-2.9.0/exarchos doctor
 ```
 
 The v2.9.0 doctor run opens the copied state directory with a runtime that still knows how to hydrate JSONL workflow events into SQLite. After it finishes, the copied directory should contain `exarchos.db`.
 
 ```bash
-ls "$HOME/.claude/workflow-state-v211/exarchos.db"
+ls ~/.claude/workflow-state-v211/exarchos.db
 ```
 
 If the temporary install fails because the `v2.9.0` tag is unavailable in your environment, use the newest available v2.9.x tag and run the same `doctor` command against the copied state directory.
@@ -81,13 +81,13 @@ Install or update to your target v2.10.0+ release, then run `doctor` against the
 ```bash
 curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh | bash -s -- --version v2.11.0-preview.4
 
-WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211" exarchos doctor
+WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211 exarchos doctor
 ```
 
 Then verify one known workflow:
 
 ```bash
-WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211" exarchos workflow get --feature-id <feature-id>
+WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211 exarchos workflow get --feature-id <feature-id>
 ```
 
 Inside Claude Code, restart the session and run:
@@ -103,7 +103,7 @@ If the workflow appears in the pipeline view and `rehydrate` can load it, the mi
 Update the MCP server configuration or plugin environment so `WORKFLOW_STATE_DIR` points at the migrated copy:
 
 ```bash
-export WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211"
+export WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211
 ```
 
 For Claude Code plugin users, restart Claude Code after updating the plugin or environment. For Codex, Cursor, opencode, or another MCP client, update the client config that launches `exarchos mcp` and restart the client.

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -58,61 +58,49 @@ Please do this:
 9. Tell me the original state path, migrated state path, bridge binary path, target Exarchos version, and every command you ran. Do not switch my agent config to the migrated state path unless I explicitly approve that final step.
 ```
 
-## Before you start
+## Quick migration
 
-1. Close Claude Code, Codex, opencode, and any other agent session using Exarchos.
-2. Identify the state directory. If you set `WORKFLOW_STATE_DIR`, use that value. Claude Code plugin installs commonly use `~/.claude/workflow-state`; standalone and other harnesses may use `~/.exarchos/state`.
-3. Work on a copy. Keep the original JSONL directory unchanged until you have verified the migrated copy.
+Close Claude Code, Codex, opencode, Cursor, and any other agent session using Exarchos before you start.
 
-## Bridge through v2.9.0
-
-Use a v2.9.x binary as the bridge. v2.9.x is the last line that can hydrate legacy JSONL workflow events into `exarchos.db`; v2.10.0 and later expect the SQLite database to already exist.
-
-The commands below use the common Claude Code state path, `~/.claude/workflow-state`. If your install uses a different `WORKFLOW_STATE_DIR`, replace that path in each command.
-
-First, copy the old state directory. Do not run the bridge against your only copy.
+The commands below use the common Claude Code state path. Run them in the same terminal so the path variables stay set. If your install uses a different state directory, change `STATE` before running the rest.
 
 ```bash
-cp -a ~/.claude/workflow-state ~/.claude/workflow-state-v211
+STATE=~/.claude/workflow-state
+MIGRATED=~/.claude/workflow-state-v211
+BRIDGE=~/.local/exarchos-2.9.0
 ```
 
-Install a temporary v2.9.0 binary into its own directory. This does not replace your current `exarchos` on PATH.
+Copy the old state directory. Do not run the bridge against your only copy.
 
 ```bash
-mkdir -p ~/.local/exarchos-2.9.0
-curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh -o /tmp/get-exarchos.sh
-EXARCHOS_INSTALL_DIR=~/.local/exarchos-2.9.0 bash /tmp/get-exarchos.sh --version v2.9.0
+cp -a "$STATE" "$MIGRATED"
 ```
 
-Run the v2.9.0 binary once against the copied state directory:
+Install the v2.9.0 bridge binary and run it once against the copied state. This does not replace your current `exarchos` on PATH.
 
 ```bash
-WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211 \
-  ~/.local/exarchos-2.9.0/exarchos doctor
-```
+mkdir -p "$BRIDGE"
+curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh \
+  | EXARCHOS_INSTALL_DIR="$BRIDGE" bash -s -- --version v2.9.0
 
-The v2.9.0 doctor run opens the copied state directory with a runtime that still knows how to hydrate JSONL workflow events into SQLite. After it finishes, the copied directory should contain `exarchos.db`.
-
-```bash
-ls ~/.claude/workflow-state-v211/exarchos.db
+WORKFLOW_STATE_DIR="$MIGRATED" "$BRIDGE/exarchos" doctor
+ls "$MIGRATED/exarchos.db"
 ```
 
 If the temporary install fails because the `v2.9.0` tag is unavailable in your environment, use the newest available v2.9.x tag and run the same `doctor` command against the copied state directory.
 
-## Verify with v2.10 or later
-
-Install or update to your target v2.10.0+ release, then run `doctor` against the migrated copy. This example uses v2.11.0-preview.4:
+Install or use your target v2.10.0+ runtime, then verify the migrated copy. This example installs v2.11.0-preview.4:
 
 ```bash
 curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh | bash -s -- --version v2.11.0-preview.4
 
-WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211 exarchos doctor
+WORKFLOW_STATE_DIR="$MIGRATED" exarchos doctor
 ```
 
-Then verify one known workflow:
+If you know a workflow id, verify it directly:
 
 ```bash
-WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211 exarchos workflow get --feature-id <feature-id>
+WORKFLOW_STATE_DIR="$MIGRATED" exarchos workflow get --feature-id <feature-id>
 ```
 
 Inside Claude Code, restart the session and run:
@@ -128,7 +116,7 @@ If the workflow appears in the pipeline view and `rehydrate` can load it, the mi
 Update the MCP server configuration or plugin environment so `WORKFLOW_STATE_DIR` points at the migrated copy:
 
 ```bash
-export WORKFLOW_STATE_DIR=~/.claude/workflow-state-v211
+export WORKFLOW_STATE_DIR="$MIGRATED"
 ```
 
 For Claude Code plugin users, restart Claude Code after updating the plugin or environment. For Codex, Cursor, opencode, or another MCP client, update the client config that launches `exarchos mcp` and restart the client.

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -33,7 +33,13 @@ Do not wipe the directory if you want to keep old workflows. Use the bridge path
 
 Do not use v2.10.0 or later as the bridge runtime. Those versions expect SQLite state to already exist.
 
-## Agent prompt
+## Choose a path
+
+Most users should let their local coding agent do the migration. The agent can inspect your actual state path, avoid overwriting an existing migrated copy, and report exactly what it changed.
+
+If you would rather do it yourself, use the shorter terminal flow below the prompt. Both paths do the same thing: preserve the original JSONL state directory, bridge a copy through v2.9.x, then verify that the copy works with v2.10.0 or later.
+
+## Option 1: Ask an agent
 
 If you want a local coding agent to perform the migration for you, copy this prompt into that agent. Replace the paths or target version first if your setup differs.
 
@@ -58,7 +64,7 @@ Please do this:
 9. Tell me the original state path, migrated state path, bridge binary path, target Exarchos version, and every command you ran. Do not switch my agent config to the migrated state path unless I explicitly approve that final step.
 ```
 
-## Quick migration
+## Option 2: Run it yourself
 
 Close Claude Code, Codex, opencode, Cursor, and any other agent session using Exarchos before you start.
 
@@ -113,7 +119,7 @@ If the workflow appears in the pipeline view and `rehydrate` can load it, the mi
 
 ## Switch agents to the migrated copy
 
-Update the MCP server configuration or plugin environment so `WORKFLOW_STATE_DIR` points at the migrated copy:
+After either path succeeds, update the MCP server configuration or plugin environment so `WORKFLOW_STATE_DIR` points at the migrated copy:
 
 ```bash
 export WORKFLOW_STATE_DIR="$MIGRATED"

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -37,7 +37,7 @@ Do not use v2.10.0 or later as the bridge runtime. Those versions expect SQLite 
 
 Most users should let their local coding agent do the migration. The agent can inspect your actual state path, avoid overwriting an existing migrated copy, and report exactly what it changed.
 
-If you would rather do it yourself, use the shorter terminal flow below the prompt. Both paths do the same thing: preserve the original JSONL state directory, bridge a copy through v2.9.x, then verify that the copy works with v2.10.0 or later.
+If you would rather do it yourself, use the shorter terminal flow below the prompt. Both paths do the same thing: preserve the original JSONL state directory as a backup, bridge a copy through v2.9.x, put the migrated copy back at the original state path, then verify that the default path works with v2.10.0 or later.
 
 ## Option 1: Ask an agent
 
@@ -50,19 +50,20 @@ Context:
 - Exarchos v2.10.0 and later require SQLite-backed workflow state.
 - A legacy state directory may contain `*.events.jsonl` files but no `exarchos.db` or `events.db`.
 - Use v2.9.x as the bridge runtime. Do not use v2.10.0 or later as the bridge.
-- Preserve the original state directory unchanged. Work only on a copied state directory.
+- Preserve the original state directory as a backup. Run the bridge only on a copied state directory, then put the migrated copy back at the original state path so no new WORKFLOW_STATE_DIR override is needed.
 
 Steps:
 1. Make sure Claude Code, Codex, opencode, Cursor, and any other Exarchos MCP clients are closed. If you cannot confirm that, stop and tell me what to close.
 2. Find the current Exarchos state directory. Prefer `WORKFLOW_STATE_DIR` if it is set; otherwise check `~/.claude/workflow-state`.
 3. Inspect the state directory. If it does not contain `*.events.jsonl`, or if it already contains `exarchos.db` or `events.db`, pause and tell me what you found before migrating anything.
-4. Copy the state directory to `~/.claude/workflow-state-v211`. If that path already exists, create a timestamped sibling instead. Do not modify, delete, or move the original.
+4. Copy the state directory to `~/.claude/workflow-state-v211`. If that path already exists, create a timestamped sibling instead. Do not run the bridge against the original directory.
 5. Install a temporary v2.9.x Exarchos binary into `~/.local/exarchos-2.9.0` without replacing the `exarchos` currently on PATH.
 6. Run the temporary v2.9.x binary with `WORKFLOW_STATE_DIR` pointed at the copied state directory, using `doctor` to hydrate the legacy JSONL events into `exarchos.db`.
 7. Verify the copied state directory now contains `exarchos.db`.
-8. Use the target Exarchos v2.10.0+ runtime, then run `exarchos doctor` with `WORKFLOW_STATE_DIR` pointed at the migrated copy.
-9. If a workflow id is available, verify it with `exarchos workflow get --feature-id <feature-id>`. If no workflow id is available, tell me to restart my agent and run `/exarchos:rehydrate`.
-10. Report the original state path, migrated state path, bridge binary path, target Exarchos version, and every command you ran. Do not switch my agent config to the migrated state path unless I explicitly approve that final step.
+8. Move the original state directory to a timestamped backup path, then move the migrated copy back to the original state path. Do not leave my agent configured to a new migrated-only path.
+9. Use the target Exarchos v2.10.0+ runtime, then run `exarchos doctor` normally, without a special `WORKFLOW_STATE_DIR` override.
+10. If a workflow id is available, verify it with `exarchos workflow get --feature-id <feature-id>`. If no workflow id is available, tell me to restart my agent and run `/exarchos:rehydrate`.
+11. Report the original state path, backup path, temporary migrated path, bridge binary path, target Exarchos version, and every command you ran.
 ```
 
 ## Option 2: Run it yourself
@@ -74,10 +75,11 @@ The commands below use the common Claude Code state path. Run them in the same t
 ```bash
 STATE=~/.claude/workflow-state
 MIGRATED=~/.claude/workflow-state-v211
+BACKUP=~/.claude/workflow-state-jsonl-backup-$(date +%Y%m%d-%H%M%S)
 BRIDGE=~/.local/exarchos-2.9.0
 ```
 
-Copy the old state directory. Do not run the bridge against your only copy.
+Copy the old state directory. Do not run the bridge against the original.
 
 ```bash
 cp -a "$STATE" "$MIGRATED"
@@ -96,18 +98,25 @@ ls "$MIGRATED/exarchos.db"
 
 If the temporary install fails because the `v2.9.0` tag is unavailable in your environment, use the newest available v2.9.x tag and run the same `doctor` command against the copied state directory.
 
-Install or use your target v2.10.0+ runtime, then verify the migrated copy. This example installs v2.11.0-preview.4:
+Put the migrated state back at the original path and keep the JSONL directory as a timestamped backup:
+
+```bash
+mv "$STATE" "$BACKUP"
+mv "$MIGRATED" "$STATE"
+```
+
+Install or use your target v2.10.0+ runtime, then verify the default state path. This example installs v2.11.0-preview.4:
 
 ```bash
 curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh | bash -s -- --version v2.11.0-preview.4
 
-WORKFLOW_STATE_DIR="$MIGRATED" exarchos doctor
+exarchos doctor
 ```
 
 If you know a workflow id, verify it directly:
 
 ```bash
-WORKFLOW_STATE_DIR="$MIGRATED" exarchos workflow get --feature-id <feature-id>
+exarchos workflow get --feature-id <feature-id>
 ```
 
 Inside Claude Code, restart the session and run:
@@ -116,23 +125,17 @@ Inside Claude Code, restart the session and run:
 /exarchos:rehydrate
 ```
 
-If the workflow appears in the pipeline view and `rehydrate` can load it, the migration copy is ready.
+If the workflow appears in the pipeline view and `rehydrate` can load it, the default state path is ready.
 
-## Switch agents to the migrated copy
+## Restart agents
 
-After either path succeeds, update the MCP server configuration or plugin environment so `WORKFLOW_STATE_DIR` points at the migrated copy:
+After either path succeeds, restart Claude Code, Codex, opencode, Cursor, or whichever MCP client launches `exarchos mcp`. Because the migrated state was moved back to the original state path, you should not need a new `WORKFLOW_STATE_DIR` override.
 
-```bash
-export WORKFLOW_STATE_DIR="$MIGRATED"
-```
-
-For Claude Code plugin users, restart Claude Code after updating the plugin or environment. For Codex, Cursor, opencode, or another MCP client, update the client config that launches `exarchos mcp` and restart the client.
-
-Keep the original JSONL directory until you have completed at least one successful rehydrate and one normal workflow operation on your target v2.10.0+ release.
+Keep the timestamped JSONL backup until you have completed at least one successful rehydrate and one normal workflow operation on your target v2.10.0+ release.
 
 ## Troubleshooting
 
-If v2.10.0 or later still reports a legacy JSONL directory, the bridge ran against the wrong path or did not create `exarchos.db`. Re-check `WORKFLOW_STATE_DIR` and rerun the v2.9.0 `doctor` command against the copied directory.
+If v2.10.0 or later still reports a legacy JSONL directory, the bridge ran against the wrong path or did not create `exarchos.db`. Re-check the migrated copy, rerun the v2.9.0 `doctor` command against it if needed, then move it back to the original state path again.
 
 If `doctor` reports SQLite lock or busy errors, another agent process still has the state directory open. Close all agents and rerun the command.
 

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -1,6 +1,6 @@
 # Upgrade legacy workflow state
 
-Exarchos v2.11 requires the SQLite event store. If your state directory was created by a JSONL-only release and was never opened by a SQLite-capable v2.9.x runtime, v2.11 refuses to start instead of guessing how to import old events.
+Exarchos v2.10.0 and later require SQLite-backed workflow state. If your state directory was created by a pre-v2.9.0 JSONL-only release and was never opened by a v2.9.x runtime, v2.10.0+ cannot safely import it on startup.
 
 This affects older installs with workflow state files such as:
 
@@ -23,6 +23,16 @@ or an error that says the directory contains `*.events.jsonl` files without an e
 
 Do not wipe the directory if you want to keep old workflows. Use the bridge path below.
 
+## Version boundaries
+
+| Purpose | Version range |
+|---------|---------------|
+| Legacy JSONL-only state that needs this guide | Created before v2.9.0, or any state directory with `*.events.jsonl` files and no `exarchos.db` or `events.db` |
+| Bridge runtime | v2.9.x only; the examples use v2.9.0 |
+| Target runtime after the bridge | v2.10.0 or later |
+
+Do not use v2.10.0 or later as the bridge runtime. Those versions expect SQLite state to already exist.
+
 ## Before you start
 
 1. Close Claude Code, Codex, opencode, and any other agent session using Exarchos.
@@ -30,6 +40,8 @@ Do not wipe the directory if you want to keep old workflows. Use the bridge path
 3. Work on a copy. Keep the original JSONL directory unchanged until you have verified the migrated copy.
 
 ## Bridge through v2.9.0
+
+Use a v2.9.x binary as the bridge. v2.9.x is the last line that can hydrate legacy JSONL workflow events into `exarchos.db`; v2.10.0 and later expect the SQLite database to already exist.
 
 The commands below use the common Claude Code state path, `~/.claude/workflow-state`. If your install uses a different `WORKFLOW_STATE_DIR`, replace that path in each command.
 
@@ -54,7 +66,7 @@ WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211" \
   "$HOME/.local/exarchos-2.9.0/exarchos" doctor
 ```
 
-The v2.9.0 doctor run opens the copied state directory with the last runtime that still knows how to hydrate JSONL workflow events into SQLite. After it finishes, the copied directory should contain `exarchos.db`.
+The v2.9.0 doctor run opens the copied state directory with a runtime that still knows how to hydrate JSONL workflow events into SQLite. After it finishes, the copied directory should contain `exarchos.db`.
 
 ```bash
 ls "$HOME/.claude/workflow-state-v211/exarchos.db"
@@ -62,9 +74,9 @@ ls "$HOME/.claude/workflow-state-v211/exarchos.db"
 
 If the temporary install fails because the `v2.9.0` tag is unavailable in your environment, use the newest available v2.9.x tag and run the same `doctor` command against the copied state directory.
 
-## Verify with v2.11
+## Verify with v2.10 or later
 
-Install or update to v2.11, then run `doctor` against the migrated copy:
+Install or update to your target v2.10.0+ release, then run `doctor` against the migrated copy. This example uses v2.11.0-preview.4:
 
 ```bash
 curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh | bash -s -- --version v2.11.0-preview.4
@@ -96,11 +108,11 @@ export WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211"
 
 For Claude Code plugin users, restart Claude Code after updating the plugin or environment. For Codex, Cursor, opencode, or another MCP client, update the client config that launches `exarchos mcp` and restart the client.
 
-Keep the original JSONL directory until you have completed at least one successful rehydrate and one normal workflow operation on v2.11.
+Keep the original JSONL directory until you have completed at least one successful rehydrate and one normal workflow operation on your target v2.10.0+ release.
 
 ## Troubleshooting
 
-If v2.11 still reports a legacy JSONL directory, the bridge ran against the wrong path or did not create `exarchos.db`. Re-check `WORKFLOW_STATE_DIR` and rerun the v2.9.0 `doctor` command against the copied directory.
+If v2.10.0 or later still reports a legacy JSONL directory, the bridge ran against the wrong path or did not create `exarchos.db`. Re-check `WORKFLOW_STATE_DIR` and rerun the v2.9.0 `doctor` command against the copied directory.
 
 If `doctor` reports SQLite lock or busy errors, another agent process still has the state directory open. Close all agents and rerun the command.
 

--- a/documentation/guide/legacy-state-upgrade.md
+++ b/documentation/guide/legacy-state-upgrade.md
@@ -1,0 +1,105 @@
+# Upgrade legacy workflow state
+
+Exarchos v2.11 requires the SQLite event store. If your state directory was created by a JSONL-only release and was never opened by a SQLite-capable v2.9.x runtime, v2.11 refuses to start instead of guessing how to import old events.
+
+This affects older installs with workflow state files such as:
+
+```text
+<state-dir>/<featureId>.events.jsonl
+<state-dir>/<featureId>.state.json
+```
+
+and no SQLite database (`exarchos.db` or `events.db`) in the same directory.
+
+## Symptom
+
+The MCP server or `exarchos doctor` fails with a message like:
+
+```text
+Legacy v2.10 JSONL state directory detected
+```
+
+or an error that says the directory contains `*.events.jsonl` files without an event-store database.
+
+Do not wipe the directory if you want to keep old workflows. Use the bridge path below.
+
+## Before you start
+
+1. Close Claude Code, Codex, opencode, and any other agent session using Exarchos.
+2. Identify the state directory. If you set `WORKFLOW_STATE_DIR`, use that value. Claude Code plugin installs commonly use `~/.claude/workflow-state`; standalone and other harnesses may use `~/.exarchos/state`.
+3. Work on a copy. Keep the original JSONL directory unchanged until you have verified the migrated copy.
+
+## Bridge through v2.9.0
+
+Install a temporary v2.9.0 binary into a scratch directory. This does not replace your current `exarchos` on PATH.
+
+```bash
+set -euo pipefail
+
+OLD_STATE="${WORKFLOW_STATE_DIR:-$HOME/.claude/workflow-state}"
+NEW_STATE="${OLD_STATE}-v211"
+BRIDGE_BIN_DIR="$(mktemp -d)"
+
+test ! -e "$NEW_STATE" || {
+  echo "$NEW_STATE already exists; choose a new NEW_STATE path" >&2
+  exit 1
+}
+
+cp -a "$OLD_STATE" "$NEW_STATE"
+
+curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh \
+  -o "$BRIDGE_BIN_DIR/get-exarchos.sh"
+
+EXARCHOS_INSTALL_DIR="$BRIDGE_BIN_DIR" \
+  bash "$BRIDGE_BIN_DIR/get-exarchos.sh" --version v2.9.0
+
+WORKFLOW_STATE_DIR="$NEW_STATE" "$BRIDGE_BIN_DIR/exarchos" doctor
+```
+
+The v2.9.0 doctor run opens the copied state directory with the last runtime that still knows how to hydrate JSONL workflow events into SQLite. After it finishes, the copied directory should contain `exarchos.db`.
+
+If the temporary install fails because the `v2.9.0` tag is unavailable in your environment, use the newest available v2.9.x tag and run the same `doctor` command against the copied state directory.
+
+## Verify with v2.11
+
+Install or update to v2.11, then run `doctor` against the migrated copy:
+
+```bash
+curl -fsSL https://lvlup-sw.github.io/exarchos/get-exarchos.sh | bash -s -- --version v2.11.0-preview.4
+
+WORKFLOW_STATE_DIR="$NEW_STATE" exarchos doctor
+```
+
+Then verify one known workflow:
+
+```bash
+WORKFLOW_STATE_DIR="$NEW_STATE" exarchos workflow get --feature-id <feature-id>
+```
+
+Inside Claude Code, restart the session and run:
+
+```text
+/exarchos:rehydrate
+```
+
+If the workflow appears in the pipeline view and `rehydrate` can load it, the migration copy is ready.
+
+## Switch agents to the migrated copy
+
+Update the MCP server configuration or plugin environment so `WORKFLOW_STATE_DIR` points at the migrated copy:
+
+```bash
+export WORKFLOW_STATE_DIR="$HOME/.claude/workflow-state-v211"
+```
+
+For Claude Code plugin users, restart Claude Code after updating the plugin or environment. For Codex, Cursor, opencode, or another MCP client, update the client config that launches `exarchos mcp` and restart the client.
+
+Keep the original JSONL directory until you have completed at least one successful rehydrate and one normal workflow operation on v2.11.
+
+## Troubleshooting
+
+If v2.11 still reports a legacy JSONL directory, the bridge ran against the wrong path or did not create `exarchos.db`. Re-check `WORKFLOW_STATE_DIR` and rerun the v2.9.0 `doctor` command against the copied directory.
+
+If `doctor` reports SQLite lock or busy errors, another agent process still has the state directory open. Close all agents and rerun the command.
+
+If a workflow is missing after migration, confirm the copied directory contains the matching `<featureId>.events.jsonl` file before the bridge run. The bridge can only import workflow events that were present in the copied state directory.

--- a/documentation/learn/core-concepts.md
+++ b/documentation/learn/core-concepts.md
@@ -35,7 +35,7 @@ This gives you two things:
 1. Crash recovery. If state gets corrupted, the `reconcile` action rebuilds it from scratch by replaying the event history. No data is lost because events are never modified.
 2. Audit trail. You can trace every decision, transition, and gate result back to the event that recorded it. When a reviewer agent flags an issue, you can see exactly which gate produced the finding and what data it checked.
 
-The event store is local to your machine. Current releases use SQLite for workflow events and projections, with no network dependency. Older JSONL-only state directories need the [legacy state upgrade](/guide/legacy-state-upgrade) bridge before v2.11 can open them.
+The event store is local to your machine. Current releases use SQLite for workflow events and projections, with no network dependency. Pre-v2.9.0 JSONL-only state directories need the [legacy state upgrade](/guide/legacy-state-upgrade) bridge before v2.10.0 or later can open them.
 
 ## Convergence gates
 

--- a/documentation/learn/core-concepts.md
+++ b/documentation/learn/core-concepts.md
@@ -28,14 +28,14 @@ This isn't bureaucracy for its own sake. It prevents the common failure mode whe
 
 ## Events and state
 
-Every workflow action produces an immutable event. Events are stored in an append-only JSONL log. The current state of any workflow is a projection of its events, not a mutable record that gets updated in place.
+Every workflow action produces an immutable event. Events are stored in the local event store. The current state of any workflow is a projection of its events, not a mutable record that gets updated in place.
 
 This gives you two things:
 
 1. Crash recovery. If state gets corrupted, the `reconcile` action rebuilds it from scratch by replaying the event history. No data is lost because events are never modified.
 2. Audit trail. You can trace every decision, transition, and gate result back to the event that recorded it. When a reviewer agent flags an issue, you can see exactly which gate produced the finding and what data it checked.
 
-The event store uses JSONL files on the local filesystem. No database. No network dependency.
+The event store is local to your machine. Current releases use SQLite for workflow events and projections, with no network dependency. Older JSONL-only state directories need the [legacy state upgrade](/guide/legacy-state-upgrade) bridge before v2.11 can open them.
 
 ## Convergence gates
 

--- a/documentation/learn/how-it-works.md
+++ b/documentation/learn/how-it-works.md
@@ -6,7 +6,7 @@ outline: deep
 
 ## MCP server as state backend
 
-Exarchos ships as a single binary with an `mcp` subcommand. Claude Code spawns it as a stdio MCP server. No network listeners, no database, no external dependencies.
+Exarchos ships as a single binary with an `mcp` subcommand. Claude Code spawns it as a stdio MCP server. No network listeners and no external service dependency.
 
 Four composite tools cover the entire API surface:
 
@@ -21,11 +21,11 @@ Every tool input is a Zod-validated discriminated union keyed on `action`. The s
 
 ## Event-sourced append-only log
 
-Every action produces events stored in JSONL files on the local filesystem. State is a projection of events, not a mutable record.
+Every action produces events stored in the local SQLite event store. State is a projection of events, not a mutable record.
 
 When you call `exarchos_workflow({ action: "get", featureId: "my-feature" })`, the server replays events and returns the computed current state. CQRS view projections (pipeline, tasks, convergence) work the same way: fold events into a view, return the result.
 
-If the state file gets corrupted or deleted, `reconcile` rebuilds it by replaying the event log. The events are the source of truth. Everything else is derived.
+If projected state gets corrupted or deleted, `reconcile` rebuilds it by replaying the event log. The events are the source of truth. Everything else is derived.
 
 ## State machine enforcing phase transitions
 

--- a/documentation/reference/events.md
+++ b/documentation/reference/events.md
@@ -1,6 +1,6 @@
 # Events
 
-The event store is an append-only JSONL log per feature. Every state change in a workflow is captured as an event, forming an audit trail that can be queried, replayed, and used for state reconciliation.
+The event store is an append-only local SQLite store. Every state change in a workflow is captured as an event, forming an audit trail that can be queried, replayed, and used for state reconciliation.
 
 ## Event structure
 

--- a/documentation/reference/tools/event.md
+++ b/documentation/reference/tools/event.md
@@ -1,6 +1,6 @@
 # exarchos_event
 
-Event sourcing -- append and query events in streams. Each workflow has its own JSONL event stream identified by a stream ID (typically the feature ID). CLI alias: `ev`.
+Event sourcing -- append and query events in streams. Each workflow has its own event stream identified by a stream ID (typically the feature ID). CLI alias: `ev`.
 
 ## Actions
 


### PR DESCRIPTION
## Summary

- Adds a public Legacy State Upgrade guide for pre-v2.9.0 JSONL-only workflow state directories that v2.10.0+ cannot safely import on startup.
- Presents the migration as two clear paths: ask a local coding agent with a copyable prompt, or run a short manual terminal flow.
- Documents the safe bridge path: preserve the original state as a timestamped backup, bridge a copy through v2.9.x, move the migrated copy back to the original state path, then verify normally with the target v2.10.0+ release.
- Updates high-traffic learn, reference, and architecture pages so they describe the current SQLite event-store substrate instead of JSONL as the active runtime.

## Changes

- Adds `documentation/guide/legacy-state-upgrade.md` and links it from the Guide sidebar.
- Adds explicit version boundaries: source state created before v2.9.0, bridge runtime v2.9.x only, target runtime v2.10.0 or later.
- Adds an agent prompt section with guardrails: inspect the actual state directory, stop if the state is not JSONL-only, preserve the original directory as a backup, bridge only with v2.9.x, restore the migrated copy to the original state path, and report commands.
- Adds a shorter manual migration flow with reusable path variables to reduce repeated typing.
- Removes the need for a permanent `WORKFLOW_STATE_DIR` override by putting migrated state back at the original path.
- Adds a pointer from the installation guide for users upgrading old JSONL-only state directly to v2.10.0+.
- Refreshes storage wording in learn, reference, and architecture docs to match the current SQLite event-store substrate.

## Test Plan

- Local: `git diff --check`
- Local: `npm run docs:build` from `documentation/`
- GitHub Actions: PR Body Check / `validate-pr-body` passed
- GitHub Actions: CI matrix passed, including binary matrix, E2E Process, Outcome Tests, Grep Gates, Validate No Legacy, benchmark, and CI Gate

## Operational Validation

- Successfully upgraded local legacy Exarchos/Codex workflow state in a similar fashion: copied the JSONL state directory, used v2.9.0 as the bridge to create `exarchos.db`, then verified the migrated state with v2.11.0-preview.4 `doctor` and an MCP workflow read.

## Context

The v2.10 line moved workflow state to the SQLite substrate, and v2.11 removes the remaining JSONL runtime/import shims. A state directory with `*.events.jsonl` but no `exarchos.db` or `events.db` needs a v2.9.x bridge pass before it can be used by v2.10.0 or later.
