### PR TITLE
feat(wlm-operational-core): event-sourced liveness + integration-merge serializer (#1577 #1578)

### DIFF
--- a/docs/specs/2026-06-26-wlm-operational-core.md
+++ b/docs/specs/2026-06-26-wlm-operational-core.md
@@ -1,0 +1,286 @@
+# Spec: WLM Operational Core — event-sourced liveness + integration-merge serializer
+
+**Date:** 2026-06-26 · **Feature:** `wlm-operational-core` · **Depth:** standard
+**Inputs:**
+- Epic `#1574` — holistic worktree lifecycle manager + integration-branch merge serializer
+- Source design: [`docs/designs/2026-06-21-worktree-lifecycle-manager.md`](../designs/2026-06-21-worktree-lifecycle-manager.md) (DR-4, DR-5, DR-7, DR-8, DR-12)
+- Foundation already shipped (PR #1628, v2.12.0): [`docs/specs/2026-06-25-wlm-foundation.md`](2026-06-25-wlm-foundation.md) — WLM-1 (`#1575`) + WLM-2 (`#1576`)
+- Bundle issues: WLM-3 `#1577` (DR-4/5) · WLM-4 `#1578` (DR-7/8)
+- Roadmap: `#1599` Z2 (runtime supervision), coordination rules 2 & 3
+
+> One unified artifact: `## Design & Rationale` is the DR-N source; `## Decomposition` maps tasks → DR-N within this same document.
+>
+> **Scope note.** This spec carries the **operational-core** slice of epic `#1574`, preserving the source design's DR numbering (DR-4/5/7/8 + a liveness/merge-scoped DR-12) so the bundle traces 1:1 to the epic design and the issues. Shipped: DR-1/2/3 + DR-6 (PR #1628). Deferred behind the `#1603` launcher fork: DR-9 (boundary), DR-11 (Windows-CI) → `#1579`; the **full** DR-10 agent-first surface (parity-harness across all actions, ergonomic "do NOT use for", dry-run UX) → `#1580`. The DR-10 **registration floor** (a registered Zod `outputSchema` + the three core per-action annotations, which the MCP registry requires *fail-closed at module load*) and the **dispatch wiring** for the new verbs are **NOT deferrable** and are included here (Tasks 004/006/007).
+
+## Design & Rationale
+
+### Problem Statement
+
+The WLM foundation (PR #1628) landed the durable substrate — the `worktree.*` family (`adopted`/`reserved`/`released`/`orphan_detected`), the singleton-stream `worktrees@v1` projection, crash-safe ownership, and state-based GC — but two operational capabilities are missing:
+
+1. **No liveness observability.** The foundation registered `worktree.orphan_detected` (type + fold) but **deliberately did not add** any `worktree.merge_*` liveness events, and there is **no ground-truth probe**. So `worktrees@v1` has no in-flight signal to fold (`ps`/`wait` can't answer "what worktree work is in flight?"), and the `orphan_detected` *emitter* (the probe → event path) is unbuilt. This is the substrate the v2.12 `ps`/`wait`/`describe` verbs (`#1090`) read; until it lands, `#1090` is blocked (roadmap `#1599`, rule 2).
+
+2. **No integration-branch write serialization.** `merge_orchestrate` serializes on the *per-`featureId`* stream, so two different feature workflows merging onto the **same integration branch** share no ordering and can corrupt the shared `.git/` — Claude Code #55724 (*13 agents, 8 lost work to `index.lock`*), auto-worktree #174/#176 (*git is single-process; serialize ref updates/gc*). We feel this as stash collisions and `index.lock` flakiness under burst.
+
+Both are the **launcher-stable operational core**: the liveness schema and the merge single-writer guarantee are required no matter who owns worktree creation (the reconciling manager today, or the `exarchos <harness>` launcher in `#1603`).
+
+### Chosen Approach
+
+Implements the operational-core requirements of the epic's selected **Approach A** (full alternatives in the source design; not re-litigated).
+
+**Liveness rides the singleton `worktrees` stream (DR-4/5).** The manager's long-running ops emit a `requested`→`executed` pair on the `worktrees` stream — for merge, the new `worktree.merge_requested` (intent, carrying `{integrationRef, sourceBranch, holderPid, holderStartedAt, operationId}`) and `worktree.merge_executed` (result). This single pair is the INV-10 started/terminal signal, the INV-13 intent/result split, **and** the lease record the serializer uses (below). `worktrees@v1` folds the pair into an **integration-ref-keyed `inFlightMerges` sub-structure** (distinct from the worktreeId-keyed entries — an integration-branch merge maps to no adopted worktree). `exarchos_view{ps|wait|worktrees}` answers liveness **from that fold** (an open `worktree.merge_requested` with no paired `worktree.merge_executed` = in flight). `merge_orchestrate`'s own `merge.*` events stay on the per-`featureId` stream, **untouched** — the worktrees-stream pair is purely additive. A ground-truth probe (process-cwd + fs scan) is **pulled on demand only** (GC, orphan-detection, `ps --probe`), folding findings into `orphan_detected`/`released` — no interval/loop/daemon (INV-10/15). The probe excludes the manager's **own process ancestry** (DR-5).
+
+**Merge serialization is an optimistic lease, not a held lock (DR-7/8).** The event-store gate serializes *appends* (short transactions); it cannot hold a lock across `merge_orchestrate`'s multi-second git work, and it must not. So single-writer is enforced **logically** by a lease in the `inFlightMerges` projection:
+1. `serialize_merge` folds `inFlightMerges`. If `integrationRef` already has an unpaired in-flight merge, it **bounded-waits** via the injected sleep seam (Task 005) under an explicit timeout and re-folds (caller-bounded, not a daemon — INV-15); on expiry it returns a structured `merge-slot-timeout`. **Each wait iteration probes the current holder's `holderPid`/`holderStartedAt` (the DR-5 probe) and reclaims a provably-dead holder inline** (emits the terminal once) rather than waiting out the timeout — so a crashed holder never forces same-branch merges to eat a full timeout.
+2. Otherwise it claims the slot by appending `worktree.merge_requested` via `decide` with **OCC** (`expectedSequence` = current worktrees-stream tail). **The slot-emptiness check runs INSIDE the `decide` closure** (mirroring the shipped `WorktreeManager.reserve` single-writer pattern, manager.ts:622-651), so the OCC commit is gated on the exact folded tail: a racing claimant that folded the same empty state loses with `ConcurrencyError`, re-folds (now seeing the holder), and waits, and an unrelated event bumping the tail yields a conservative conflict — never a double-claim. At most one holder per `integrationRef`.
+3. The winner re-reads fresh integration HEAD, calls **unchanged** `merge_orchestrate`, then appends `worktree.merge_executed` to release the lease. **The release is a plain keyed append — NOT CAS-pinned to the claim's returned sequence** (other worktree events advance the stream meanwhile; CAS-pinning a follow-on event to a prior append's seq is the documented idempotency trap).
+4. A stale lease whose `holderPid`/`holderStartedAt` is provably dead (DR-5 probe) is reclaimed via reconcile (emits the terminal once, INV-8/13).
+
+This gives true cross-process single-writer (the lease invariant lives in the log + projection; the OCC claim serializes check-then-act) within INV-7/13/15, with `merge_orchestrate` composed unchanged. Worktree-mutating git the manager itself performs is wrapped with retry-on-`index.lock` (exp backoff + jitter) and burst-creation jitter, seam **injected** for deterministic tests.
+
+**`#1316` Q6 resolved inline.** This slice defines and lands the worktrees-stream liveness schema (DR-4), grounded in INV-10; the generic `#1090` verbs only *read* these events. Coordination rule 2 permits `#1577` to land the schema.
+
+### Requirements (DR-N)
+
+Numbering inherited from the epic design. The DR-N below are the single source the decomposition traces against.
+
+#### DR-4: Liveness protocol (worktrees-stream merge pair) + on-demand ground-truth probe
+
+Long-running ops emit a `requested`/`executed` pair on the singleton `worktrees` stream (merge: `worktree.merge_requested` + `worktree.merge_executed`). `worktrees@v1` folds them into an **integration-ref-keyed `inFlightMerges`** map; `exarchos_view{ps|wait|worktrees}` answers from that fold, never a scan. A ground-truth probe is pulled **on demand only** and folds findings into events. This slice also builds the `worktree.orphan_detected` **emitter** (the type + reducer fold already exist).
+
+**Acceptance criteria:**
+- Given a merge in flight (`worktree.merge_requested` with no paired `worktree.merge_executed`), when `exarchos_view{action:'ps'}` is dispatched (through `handleView`), then the in-flight op is listed from the `inFlightMerges` fold **without a process scan**.
+- `wait --worktree=<id>|--integration=<ref> --until=idle --timeout=<t>` resolves when the paired terminal is folded. The wait is **caller-bounded**: folds current events, and if not yet terminal bounded-polls via the **injected sleep seam** (Task 005) under `--timeout`, returning a **structured timeout** on expiry — never a hang.
+- **No background interval/daemon exists** in the manager: a `setInterval`/`setTimeout`-spy assertion confirms zero background timers are created during manager ops (a caller-invoked, timeout-bounded `wait` poll is not a background loop — INV-15).
+- Given a reserved worktree whose backing process is provably gone, when the probe runs on demand, then it emits `worktree.orphan_detected`/`worktree.released` and `worktrees@v1` reflects it — closing the unbuilt-emitter gap.
+
+#### DR-5: Protected-ancestry process probe
+
+The on-demand process-cwd probe **must** exclude the manager's own process ancestry — the orchestrator's shell can drift its cwd into an agent worktree (recurring hazard). Walk the current PID's parent chain and protect the whole ancestry before reporting in-use.
+
+**Acceptance criteria:**
+- Given the orchestrator's own shell cwd is inside worktree W, when the probe evaluates W, then the orchestrator's PID **and its full parent chain** are excluded from the in-use set; a self-rooted cwd never marks W in-use.
+- Containment is symlink-canonicalized so a process cwd matches a symlinked worktree path (unix path; cross-platform portability is DR-11 → `#1579`, behind an injected process-source shim so the Windows path is not foreclosed).
+- A unit test asserts a self-rooted cwd does not mark a worktree in-use.
+- **No process-termination path is introduced in this slice** — the probe is read-only (in-use reporting). The protected-ancestry filter is the same filter a future termination path (DR-12/`#1580`) would reuse; termination itself is out of scope here.
+
+#### DR-7: Integration-branch merge serializer (optimistic lease; composes `merge_orchestrate`)
+
+`serialize_merge` guarantees **one writer to a given integration branch at a time** via an optimistic lease over `inFlightMerges` (claim by OCC append + caller-bounded wait-for-slot), delegating the merge to **unchanged** `merge_orchestrate`. No flock/PID lock (INV-7).
+
+**Acceptance criteria:**
+- Given two task branches (possibly different `featureId`s) request merge onto the **same** integration branch concurrently, when `serialize_merge` handles them, then at most one holds the lease at a time; the second bounded-waits for the first's `worktree.merge_executed` before claiming, and **neither runs `merge_orchestrate` concurrently against the branch**. The claim race is resolved by OCC on the worktrees-stream tail, so the guarantee holds **cross-process**.
+- `serialize_merge` delegates to `merge_orchestrate` **unchanged**: the `merge.*` events it emits on the per-`featureId` stream match a direct call in **event-type sequence and non-volatile structural fields**, excluding all volatile/content-derived fields (event id, timestamp, sequence, and commit-derived `mergeSha`/`rollbackSha`/`recoveryPointSha`). The serializer's only additions are the two `worktrees`-stream lease events. INV-13 split and INV-14 `--abort`→`--keep` recovery pass through.
+- No flock/PID/`.lock` file is introduced (the serializer writes no lock file and imports no advisory-lock library); no speculative/remote-CI behavior (Non-Goals, INV-3).
+- The `worktree.merge_executed` release is a **plain keyed append**, not CAS-pinned to the claim's returned sequence (avoids the documented idempotency trap).
+
+#### DR-8: Git-mutation lock-contention resilience
+
+Worktree-mutating git the manager performs is wrapped with retry-on-`index.lock` (exp backoff ~200/400/800ms ±jitter); creation/adoption staggered 100–500ms under burst (#55724). Backoff/jitter/sleep seam **injectable**.
+
+**Acceptance criteria:**
+- Given a transient `Unable to create '.git/index.lock'`, when the manager performs the mutation, then it retries N times with backoff+jitter and **succeeds** without surfacing the error.
+- Backoff/jitter/sleep are **injected** — a test asserts the retry sequence deterministically; burst-creation jitter is likewise injected and asserted.
+- Exhausted retries return a **structured error**, never a silent no-op.
+
+#### DR-12 (operational-core scope): Error handling & failure modes for liveness + merge
+
+**Acceptance criteria:**
+- **Crash mid-merge:** Given `worktree.merge_requested` with no paired `worktree.merge_executed`, when reconcile runs, then an **idempotent precheck** (integration HEAD / merge state) determines resume-vs-skip and emits the terminal **exactly once** (INV-8/13); no duplicate merge.
+- **Stale lease reclaim:** Given an in-flight merge whose `holderPid`/`holderStartedAt` is provably dead, when **either** `serialize_merge`'s own wait loop probes the holder (inline, the live path) **or** an on-demand `reconcile` runs, then the lease is released (terminal emitted once) so a waiting `serialize_merge` can claim — no permanent deadlock and no full-timeout penalty on the live path.
+- **Concurrent prune + merge on the same worktree:** `prune_worktrees` folds `inFlightMerges` and **skips** any worktree/branch holding an unpaired in-flight merge lease (re-verified under its own claim); no double-free.
+- **Preserve-uncommitted on recovery:** `serialize_merge` introduces **no** `git reset --hard`; reversal passes INV-14 `--abort`→`--keep` through `merge_orchestrate` and surfaces `recoveryError` on indeterminate state.
+- **cwd-drift false positive:** the orchestrator's own drifted shell never marks/teardowns a worktree (DR-5).
+- **Exhausted `index.lock` retry:** surfaces the DR-8 structured error; no half-merge.
+
+### Technical Design
+
+**Module layout** (extend `servers/exarchos-mcp/src/orchestrate/worktree/`, created by the foundation):
+- `event-store/schemas.ts` — add `worktree.merge_requested`/`worktree.merge_executed` to the `EventType` union, `EventDataSchemas`, `EventDataMap`, the `EVENT_*` classification maps, **and the total-record `EVENT_EMISSION_REGISTRY` (`Record<EventType, …>`, schemas.ts:378, which compile-breaks on a missing key)**. Keys: the **claim** append goes through `decide`, which derives `${streamId}:${reducerId}:${operationId}` (= `worktrees:worktrees@v1:<operationId>`, atomic-appender.ts:544); the **release** is a plain keyed append `<eventType>:<operationId>` per the worktree-family convention (schemas.ts:1951). Both are operationId-discriminated, so two merges onto one branch never collide — the Task 001 test asserts that **no-collision property**, not a literal key string. The integrationRef is the *lease key in the projection*, not an idempotency key.
+- `views/workflow-state-projection.ts` — add `case 'worktree.merge_requested'`/`'worktree.merge_executed'` arms to the worktree case block (the `never`-exhaustive guard compile-breaks otherwise — a consumer beyond `worktrees@v1`).
+- `orchestrate/worktree/projections/worktrees.ts` — extend `worktrees@v1` with the integration-ref-keyed `inFlightMerges` map folding the merge pair, plus folding probe-emitted `orphan_detected`/`released`.
+- `orchestrate/worktree/pure/probe.ts` — process+fs scan behind an **injected process source**; symlink-canonicalized containment; protected-ancestry subtraction (DR-5).
+- `orchestrate/worktree/git-retry.ts` — injected backoff/jitter/sleep seam + `index.lock` retry wrapper + burst jitter (DR-8); the sleep seam is reused by Task 004's bounded `wait`.
+- `orchestrate/worktree/merge-serializer.ts` — the optimistic-lease loop (fold → wait-for-slot → OCC claim → fresh-HEAD re-read → unchanged `merge_orchestrate` → plain release).
+- **Dispatch wiring (DOA-class guard):** `orchestrate/worktree/handlers.ts` gains `handleSerializeMerge`, `handleViewPs`, `handleViewWait`; `orchestrate/composite.ts` `ACTION_HANDLERS` gains `serialize_merge`; `views/composite.ts` `handleView` switch gains `case 'ps'`/`case 'wait'`. The orchestrate side is guarded by `OrchestrateActions_MatchCompositeHandlers_InSync` (registry.test.ts:801); the view side currently has only a *superset* guard (`views/describe.coverage.test.ts`), so this slice adds the missing `ViewActions_MatchCompositeHandlers_InSync` equality twin (Task 007). All new-verb tests run **through `handleView`/`handleOrchestrate`**, not the module in isolation.
+
+**State & serialization.** Liveness + lease live only in `worktree.*` events + `worktrees@v1` over `WORKTREES_STREAM` (`'worktrees'`, manager.ts:98). Cross-process ordering = SQLite WAL `BEGIN IMMEDIATE` + per-stream version gate via `decide`/`appendComputed` `expectedSequence` (the only cross-process guard, INV-7; throws `ConcurrencyError`, retried by `withStateRetry`). Idempotency keys (INV-8) make the claim append crash-collapse. The lease (not a held DB lock) is what serializes the *merge execution*.
+
+**MCP-server typecheck.** Per the separate-typecheck gotcha, the schema-union and projection edits must be verified by `cd servers/exarchos-mcp && npm run typecheck` (root typecheck does not cover it).
+
+### Integration Points
+
+- `merge-orchestrate.ts` / `execute-merge.ts` — **unchanged**; `serialize_merge` is a caller (DR-7).
+- `event-store/schemas.ts` + both count-pin tests (`event-store/schemas.test.ts`, `__tests__/event-store/schemas.test.ts`) — EventTypes 136 → 138 (DR-4/7).
+- `views/workflow-state-projection.ts` — exhaustive worktree case arms (DR-4).
+- `orchestrate/worktree/{projections/worktrees.ts,pure/probe.ts,git-retry.ts,merge-serializer.ts,manager.ts,handlers.ts}` (DR-4/5/7/8).
+- `orchestrate/composite.ts` + `views/composite.ts` — dispatch wiring (DR-4/7).
+- `registry.ts` — register `serialize_merge`/`ps`/`wait` with `outputSchema` + 3 core annotations (fail-closed at load); full DR-10 polish → `#1580`.
+- v2.12 verbs (`#1090`) — first consumers of this liveness substrate.
+
+### Alternatives considered
+
+- **Gate-by-append (hold the worktrees-stream lock across the merge).** Rejected: the WAL write-lock + in-process mutex release when the append commits; `merge_orchestrate` runs outside any lock, so two processes could both claim then merge concurrently. The lease + bounded-wait enforces single-writer logically without holding a DB lock across an external side effect.
+- **Emit merge liveness on the per-`featureId` stream and cross-fold it.** Rejected: `worktrees@v1` is stream-scoped over the singleton stream; cross-folding breaks the single-projection model.
+- **flock/PID file keyed on the branch.** Rejected: violates INV-7 and isn't crash-safe.
+- **Bundle `#1578` with `#1579` (boundary + Windows-CI).** Rejected: `#1579` is launcher-exposed (`#1603`); liveness + merge are launcher-stable.
+
+### Open Questions
+
+- **`#1603` launcher fork (deferral, not a blocker).** If launcher-owns-creation is adopted, it becomes the event **producer** — schema + fold + lease are unchanged; the DR-5 probe is still needed (crash-orphans + cwd-drift survive a launcher). `#1579`/`#1580` deferred until `#1603`.
+- **Serialization granularity.** Single-writer is per-`integrationRef` (the lease key). Worktree-mutating ops still append to the singleton `worktrees` stream, so the OCC claim is per-stream but the *invariant* is per-branch; finer per-branch streams are a future optimization — out of scope.
+- **`wait` push vs bounded-poll.** Bounded-poll via the injected sleep seam under timeout (no daemon). The `#1315` subscription primitive is the future push replacement.
+- **`ps`/`wait` verb home.** This slice lands the events + a manager-scoped read path; the generic verbs ship under `#1090` (resolves source-design OQ-1).
+
+## Decomposition
+
+Maps every task to DR-N from `## Design & Rationale`. All work extends `servers/exarchos-mcp/src/orchestrate/worktree/` (PR #1628).
+
+### Scope
+
+**Target:** Partial — operational-core: DR-4 (liveness), DR-5 (probe), DR-7 (merge lease), DR-8 (lock resilience), DR-12 (liveness/merge subset).
+**Excluded:** DR-1/2/3 + DR-6 shipped (PR #1628). DR-9 + DR-11 → `#1579`. Full DR-10 surface polish → `#1580`. The DR-10 **registration floor** + the **dispatch wiring** are **included** (Tasks 004/006/007) — both are fail-closed/DOA hazards, not deferrable.
+
+### Traceability matrix (DR-N → tasks)
+
+| DR | Requirement | Tasks |
+|----|-------------|-------|
+| DR-4 | Liveness (worktrees-stream merge pair + `inFlightMerges`) + on-demand probe + ps/wait dispatch | 001, 003, 004, 007 |
+| DR-5 | Protected-ancestry process probe (read-only) | 002 |
+| DR-7 | Integration-branch merge serializer (optimistic lease; composes `merge_orchestrate`) | 001, 006, 007 |
+| DR-8 | Git-mutation lock-contention resilience | 005 |
+| DR-12 | Error handling & failure modes (liveness + merge subset) | 008 |
+
+### Tasks
+
+`riskTier` selects verification depth (ladder in `@skills/_shared/references/verification.md`). Tests judged **test-after by adequacy**.
+
+#### Task 001: Add `worktree.merge_requested`/`worktree.merge_executed` to the event-store union
+
+**Risk Tier:** high
+**Boundary Touching:** false
+**Implements:** DR-4, DR-7
+
+Extend the central discriminated union (`EventType`, `EventDataSchemas`, `EventDataMap`, `EVENT_*` maps, and the total-record `EVENT_EMISSION_REGISTRY` at schemas.ts:378). Update **both** EventTypes count pins (136 → 138) and the `never`-exhaustive consumer in `views/workflow-state-projection.ts`. The claim event is appended through `decide` (key derived as `${streamId}:${reducerId}:${operationId}`), the release through a plain keyed append (`<eventType>:<operationId>`); both are operationId-discriminated. Broad blast (every reducer/exhaustive switch + total record) → high. Verify via `cd servers/exarchos-mcp && npm run typecheck` (separate gate).
+
+**Verification (high):** medium set + union-exhaustiveness/integration check (both count pins + classification-map completeness + MCP-server typecheck).
+**Files:** `servers/exarchos-mcp/src/event-store/schemas.ts`, `servers/exarchos-mcp/src/event-store/schemas.test.ts`, `servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts`, `servers/exarchos-mcp/src/views/workflow-state-projection.ts`
+**Expected tests:** `EventTypes_IncludesWorktreeMergeRequestedAndExecuted`, `EventTypes_CountIs138_BothPinsUpdated`, `WorktreeMergeEvents_ClassificationMaps_Exhaustive`, `WorktreeMergeEvents_IdempotencyKey_PerOperationId_NoCollisionAcrossMergesOnSameBranch`, `WorkflowStateProjection_HandlesNewWorktreeMergeTypes_Exhaustive`
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 002: Protected-ancestry process probe (`pure/probe.ts`)
+
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** DR-5
+
+Process enumeration behind an **injected process source**; symlink-canonicalized cwd→worktree containment; subtract the current PID's full parent chain before reporting in-use. Read-only — returns event payloads; no termination path. Process source shimmed so the unix path is correct and Windows (DR-11 → `#1579`) is not foreclosed.
+
+**Verification (medium):** scoped tests + `check_test_adequacy` kill-probe (test-after).
+**Files:** `servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.test.ts`
+**Expected tests:** `Probe_SelfRootedCwd_ExcludedFromInUseSet`, `Probe_OwnerAncestryChain_FullyProtected`, `Probe_SymlinkedWorktreePath_ContainmentMatches`, `Probe_DeadOwner_ReportedReleasable`
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 003: Fold merge pair into `inFlightMerges` + probe emissions in `worktrees@v1`; orphan emitter
+
+**Risk Tier:** high
+**Boundary Touching:** false
+**Implements:** DR-4
+
+Extend `worktrees@v1` (at `orchestrate/worktree/projections/worktrees.ts`) with an **integration-ref-keyed `inFlightMerges`** map folding `worktree.merge_requested`/`worktree.merge_executed` (an integration merge maps to no worktreeId entry, so it needs its own sub-structure); fold probe-emitted `orphan_detected`/`released`; wire the probe → `worktree.orphan_detected` emitter. Broad blast → high.
+
+**Verification (high):** medium set + integration suite (cold-rebuild equals live state; `assertReducerImmutable`).
+**Files:** `servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.test.ts`
+**Expected tests:** `WorktreesProjection_MergeRequestedNoExecuted_AppearsInInFlightMerges`, `WorktreesProjection_MergeRequestedThenExecuted_ClearsInFlightMerges`, `WorktreesProjection_IntegrationMergeWithNoWorktreeEntry_HasHomeInInFlightMerges`, `WorktreesProjection_ProbeFinding_EmitsAndFoldsOrphanDetected`, `WorktreesProjection_ColdRebuild_EqualsLiveState`, `WorktreesReducer_AssertReducerImmutable_Passes`
+**Dependencies:** 001, 002
+**Parallelizable:** No
+
+#### Task 004: Liveness emission + `exarchos_view{ps|wait|worktrees}` read path **through `handleView`**
+
+**Risk Tier:** high
+**Boundary Touching:** false
+**Implements:** DR-4
+
+**Read-only** view path (the merge-pair *emission* is owned solely by Task 006; this task does not append liveness events). Add `case 'ps'`/`case 'wait'` to the `handleView` switch + `handleViewPs`/`handleViewWait` in `handlers.ts`, folding `inFlightMerges`. `wait` bounded-polls via the injected sleep seam (Task 005) under an explicit timeout → structured timeout, never hangs. Tests dispatch **through `handleView`** (DOA-class lesson). Include the no-background-timer spy assertion.
+
+**Verification (high):** medium set + integration suite across the view dispatch seam.
+**Files:** `servers/exarchos-mcp/src/views/composite.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/handlers.test.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/manager.ts`
+**Expected tests:** `HandleView_Ps_ListsInFlightFromInFlightMerges_NoProcessScan`, `HandleView_Ps_Probe_PullsOnDemandAndEmits`, `HandleView_Wait_AlreadyTerminal_ResolvesImmediately`, `HandleView_Wait_InFlightThenTerminal_ResolvesWithinTimeout`, `HandleView_Wait_Timeout_ReturnsStructuredTimeoutNotHang`, `Manager_NoBackgroundTimer_SetIntervalSpyZeroCalls`
+**Dependencies:** 001, 003, 005
+**Parallelizable:** No
+
+#### Task 005: Injectable backoff/jitter/sleep seam + `index.lock` retry wrapper
+
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** DR-8
+
+Retry-on-`index.lock` (exp backoff ±jitter) + burst-creation jitter; backoff/jitter/sleep injected (mirrors `merge_orchestrate`'s seam). Exposes the sleep seam reused by Task 004's bounded `wait` and Task 006's wait-for-slot.
+
+**Verification (medium):** scoped tests + `check_test_adequacy` kill-probe (test-after).
+**Files:** `servers/exarchos-mcp/src/orchestrate/worktree/git-retry.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/git-retry.test.ts`
+**Expected tests:** `GitRetry_TransientIndexLock_RetriesWithBackoffAndSucceeds`, `GitRetry_InjectedSeam_AssertsDeterministicRetrySequence`, `GitRetry_BurstCreationJitter_AssertedDeterministically`, `GitRetry_ExhaustedRetries_ReturnsStructuredErrorNotSilentNoOp`
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 006: `serialize_merge` optimistic-lease funnel **through `handleOrchestrate`** (composes `merge_orchestrate`)
+
+**Risk Tier:** high
+**Boundary Touching:** false
+**Implements:** DR-7
+
+Lease loop in `merge-serializer.ts`: fold `inFlightMerges` → bounded wait-for-slot (Task 005 seam) → OCC claim `worktree.merge_requested` (`expectedSequence`, `ConcurrencyError`→`withStateRetry`) → re-read fresh integration HEAD → **unchanged** `merge_orchestrate` → **plain** `worktree.merge_executed` release (not CAS-pinned). Wire `serialize_merge` into `ACTION_HANDLERS` + `handleSerializeMerge`; tests dispatch **through `handleOrchestrate`**.
+
+**Verification (high):** medium set + integration suite (real-SQLite two-featureId concurrent merge onto one integration branch; `merge.*` featureId-stream events compared to a direct call excluding volatile + commit-derived sha fields).
+**Files:** `servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts`, `servers/exarchos-mcp/src/orchestrate/composite.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts`
+**Expected tests:** `SerializeMerge_TwoFeatureIdsSameBranch_SecondWaitsForFirstExecutedBeforeClaiming`, `SerializeMerge_ConcurrentClaims_OccResolvesSingleHolderCrossProcess`, `SerializeMerge_MergeOrchestrateComposedUnchanged_FeatureStreamEventsMatchModuloVolatileAndShas`, `SerializeMerge_ReleaseIsPlainKeyedAppend_NotCasPinnedToClaimSeq`, `SerializeMerge_WritesNoLockFile_ImportsNoFlockLib`, `HandleOrchestrate_SerializeMerge_RoutesToHandler_NotUnknownAction`
+**Dependencies:** 001, 003, 005
+**Parallelizable:** No
+
+#### Task 007: Register `serialize_merge`/`ps`/`wait` (outputSchema + annotations) + close the view-side parity hole
+
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Implements:** DR-4, DR-7
+
+Register the three new actions, **each with a Zod `outputSchema` + the three core annotations** (destructive/readOnly/idempotent) — `validateAction` throws fail-closed at module load otherwise. Add the missing `ViewActions_MatchCompositeHandlers_InSync` equality guard (the existing view guard is superset-only, letting a registered-but-unrouted verb ship DOA). Visible composite-tool count stays at 4.
+
+**Verification (medium):** scoped tests + `check_test_adequacy` kill-probe (test-after).
+**Files:** `servers/exarchos-mcp/src/registry.ts`, `servers/exarchos-mcp/src/registry.test.ts`, `servers/exarchos-mcp/src/views/describe.coverage.test.ts`
+**Expected tests:** `Registry_NewActions_DeclareOutputSchemaAndCoreAnnotations`, `Registry_ModuleLoad_DoesNotThrowOnNewActions`, `ViewActions_MatchCompositeHandlers_InSync`, `Registry_VisibleCompositeToolCount_StaysFour`
+**Dependencies:** 004, 006
+**Parallelizable:** No
+
+#### Task 008: Error handling & failure modes (crash-resume, stale-lease, concurrent prune+merge, retry exhaustion)
+
+**Risk Tier:** high
+**Boundary Touching:** false
+**Implements:** DR-12
+
+Crash-mid-merge → idempotent precheck → **exactly one** terminal (INV-8/13). Stale lease (dead `holderPid`/`holderStartedAt` per DR-5) reclaimed **inline by `serialize_merge`'s wait loop** (live path) or by an on-demand reconcile → no deadlock, no full-timeout penalty. Concurrent prune+merge: `prune_worktrees` folds `inFlightMerges` and **skips** a worktree/branch with an unpaired in-flight merge (re-verified under its claim; no double-free). Exhausted `index.lock` retry → DR-8 structured error, no half-merge. `serialize_merge` introduces no `reset --hard`; reversal surfaces `recoveryError` from the composed-unchanged `merge_orchestrate` (INV-14).
+
+**Verification (high):** medium set + integration suite (real-SQLite crash/concurrency).
+**Files:** `servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts`, `servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts`
+**Expected tests:** `Recovery_MergeRequestedNoExecuted_ResumeEmitsSingleExecuted`, `Recovery_StaleLeaseDeadHolder_WaitLoopReclaimsInlineNoFullTimeout`, `Recovery_StaleLeaseDeadHolder_ReconcilePathAlsoReclaims`, `Recovery_ConcurrentPruneAndMerge_PruneSkipsBranchWithInFlightLease`, `Recovery_ExhaustedIndexLockRetry_SurfacesStructuredErrorNoHalfMerge`, `Recovery_SerializerIntroducesNoResetHard_SurfacesRecoveryErrorFromMergeOrchestrate`
+**Dependencies:** 003, 004, 006
+**Parallelizable:** No
+
+### Parallelization
+
+- **Wave 1 (parallel):** Task 001 (event union), Task 002 (probe), Task 005 (git-retry seam) — no shared files.
+- **Wave 2:** Task 003 (reducer + `inFlightMerges`; needs 001+002).
+- **Wave 3 (parallel):** Task 004 (view dispatch; needs 001+003+005), Task 006 (lease serializer; needs 001+003+005). **Coordination:** both edit `orchestrate/worktree/handlers.ts` (004 adds `handleViewPs`/`handleViewWait`; 006 adds `handleSerializeMerge`) — additive, non-overlapping functions; if run in separate worktrees, rebase/merge `handlers.ts` carefully (or sequence 006 → 004).
+- **Wave 4 (parallel):** Task 007 (registry + parity guard; needs 004+006), Task 008 (error/edge; needs 003+004+006).
+- **Critical path:** 001 → 003 → {004 | 006} → 008.
+
+### Completion checklist
+
+- [x] Every DR-N maps to ≥1 task (DR-4/5/7/8/12 covered)
+- [x] Every task `Implements:` a DR-N that exists here (no forward-dangling references)
+- [x] Every task carries a `riskTier` (001/003/004/006/008 high; 002/005/007 medium)
+- [x] Medium/high tasks carry adequacy-judged tests (test-after); new verbs tested **through dispatch** (`handleView`/`handleOrchestrate`) per the DOA-action lesson
+- [x] Round-1 HIGH (H1–H4) + round-2 HIGH (lease-not-gate, idempotency-key collision, DOA dispatch wiring) + MEDIUM (worktreeId-keyed projection home, modulo-volatile sha set, missed schema consumers) all closed
+- [x] Open questions resolved or explicitly deferred (`#1316` Q6 inline; `#1603`/`#1579`/`#1580` deferred; serialization granularity, `wait` mechanism, termination-out-of-scope stated)
+- [ ] Ready for `plan-review`

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -502,8 +502,11 @@ describe('EventTypes', () => {
     // WLM foundation: bumped 132 → 136 to include the worktree lifecycle
     // (lease/ownership) family — `worktree.adopted` / `worktree.reserved` /
     // `worktree.released` / `worktree.orphan_detected`. The GC half reuses the
-    // existing `worktree.remove.*` pair (no `worktree.pruned` / `worktree.merge_*`).
-    expect(EventTypes).toHaveLength(136);
+    // existing `worktree.remove.*` pair (no `worktree.pruned`).
+    // WLM operational-core: bumped 136 → 138 to include the serialized-merge
+    // lease pair — `worktree.merge_requested` / `worktree.merge_executed`
+    // (DR-4 / DR-7), the CLAIM + RELEASE on the singleton `worktrees` stream.
+    expect(EventTypes).toHaveLength(138);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('merge.executing_started');

--- a/servers/exarchos-mcp/src/event-store/atomic-appender-consumers.test.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender-consumers.test.ts
@@ -35,6 +35,9 @@ import { fileURLToPath } from 'node:url';
 
 const FROZEN_IMPORT_BASELINE = [
   'src/event-store/store.ts',
+  // WLM operational-core (#1578): the serialize_merge optimistic lease claims
+  // the worktrees stream via the AtomicAppender decide seam.
+  'src/orchestrate/worktree/merge-serializer.ts',
 ] as const;
 
 /**
@@ -90,7 +93,7 @@ async function listProductionTsFiles(srcRoot: string): Promise<string[]> {
 const IMPORT_REGEX = /^\s*import\b[^;]*\bAtomicAppender\b/m;
 
 describe('AtomicAppender_ConsumerCount_MatchesBaselineEnumeration', () => {
-  it('exactly 3 production .ts files import AtomicAppender (frozen baseline)', async () => {
+  it('exactly the frozen-baseline production .ts files import AtomicAppender', async () => {
     const srcRoot = resolveSrcRoot();
     const repoRoot = path.dirname(srcRoot);
     const candidates = await listProductionTsFiles(srcRoot);

--- a/servers/exarchos-mcp/src/event-store/poc.acceptance.test.ts
+++ b/servers/exarchos-mcp/src/event-store/poc.acceptance.test.ts
@@ -67,6 +67,7 @@ const EXPECTED_CONSUMERS = [
   'src/orchestrate/execute-merge.ts',
   'src/orchestrate/merge-orchestrate.ts',
   'src/orchestrate/worktree/manager.ts',
+  'src/orchestrate/worktree/merge-serializer.ts',
   'src/storage/sqlite-backend.ts',
 ] as const;
 

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -79,7 +79,12 @@ import {
   WorktreeReservedData,
   WorktreeReleasedData,
   WorktreeOrphanDetectedData,
+  // WLM operational-core — serialized-merge lease pair (DR-4 / DR-7).
+  WorktreeMergeRequestedData,
+  WorktreeMergeExecutedData,
+  type WorkflowEvent,
 } from './schemas.js';
+import { workflowStateProjection } from '../views/workflow-state-projection.js';
 import { randomUUID } from 'node:crypto';
 
 // ─── T1: EventEmissionSource + EVENT_EMISSION_REGISTRY ──────────────────────
@@ -583,8 +588,11 @@ describe('EventTypes', () => {
     // Bumped 132 → 136: WLM foundation — worktree.adopted / worktree.reserved /
     //   worktree.released / worktree.orphan_detected (the lease/ownership half of
     //   worktree lifecycle management; the GC half reuses the worktree.remove.*
-    //   pair, so no worktree.pruned / worktree.merge_* types are added).
-    expect(EventTypes).toHaveLength(136);
+    //   pair, so no worktree.pruned type is added).
+    // Bumped 136 → 138: WLM operational-core — worktree.merge_requested /
+    //   worktree.merge_executed (DR-4 / DR-7 — the serialized-merge lease pair on
+    //   the singleton `worktrees` stream; CLAIM + RELEASE correlated by operationId).
+    expect(EventTypes).toHaveLength(138);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('merge.executing_started');
@@ -3863,13 +3871,10 @@ describe('WLM worktree lifecycle schemas', () => {
   });
 
   it('WorktreeSchemas_ReuseExistingRemoveRequestedExecuted_NotDuplicated', () => {
-    // GC deletion REUSES the remove pair — no `worktree.pruned`, and no
-    // `worktree.merge_*` types are introduced.
-    for (const forbidden of [
-      'worktree.pruned',
-      'worktree.merge_requested',
-      'worktree.merge_executed',
-    ]) {
+    // GC deletion REUSES the remove pair — no `worktree.pruned` type is
+    // introduced. (The `worktree.merge_*` pair IS introduced separately by the
+    // WLM operational-core layer — DR-4 / DR-7 — and is asserted elsewhere.)
+    for (const forbidden of ['worktree.pruned']) {
       expect(EventTypes as readonly string[]).not.toContain(forbidden);
       expect(EVENT_DATA_SCHEMAS as Record<string, unknown>).not.toHaveProperty(forbidden);
     }
@@ -3990,5 +3995,152 @@ describe('WLM worktree lifecycle schemas', () => {
         operationId: 'not-a-uuid',
       }),
     ).toThrow();
+  });
+});
+
+// ─── WLM operational-core: serialized-merge lease pair (DR-4 / DR-7) ─────────
+//
+// `worktree.merge_requested` (CLAIM + lease record) / `worktree.merge_executed`
+// (RELEASE + outcome) ride the singleton `worktrees` stream alongside the
+// lifecycle family. They are correlated by `operationId`, which is the SOLE
+// per-merge discriminator: two merges onto the SAME integrationRef mint two
+// operationIds and therefore two distinct idempotency keys, so they never
+// collide. The CLAIM key is derived by the event-store `decide` seam
+// (`${streamId}:${reducerId}:${operationId}`); the RELEASE is a plain keyed
+// append `<eventType>:<operationId>`.
+
+describe('WLM operational-core merge lease schemas', () => {
+  const MERGE_TYPES = ['worktree.merge_requested', 'worktree.merge_executed'] as const;
+
+  const wellFormedRequested = (operationId: string, integrationRef = 'integration/wlm'): Record<string, unknown> => ({
+    integrationRef,
+    sourceBranch: 'task/wlm-oc-001',
+    operationId,
+    holderPid: 4242,
+    holderStartedAt: '2026-06-25T00:00:00.000Z',
+  });
+
+  const wellFormedExecuted = (operationId: string, integrationRef = 'integration/wlm'): Record<string, unknown> => ({
+    integrationRef,
+    operationId,
+    status: 'merged',
+    mergeSha: 'a'.repeat(40),
+  });
+
+  it('EventTypes_IncludesWorktreeMergeRequestedAndExecuted', () => {
+    // Both new types must be members of the closed EventTypes union.
+    expect(EventTypes).toContain('worktree.merge_requested');
+    expect(EventTypes).toContain('worktree.merge_executed');
+  });
+
+  it('EventTypes_CountIs138_BothPinsUpdated', () => {
+    // The single canonical count after adding the two operational-core merge
+    // types (136 foundation → 138). The pinned literal in BOTH schemas.test.ts
+    // files must agree with this — a divergence means one pin was missed.
+    expect(EventTypes).toHaveLength(138);
+    // No duplicate slipped in while bumping the count.
+    expect(new Set(EventTypes).size).toBe(EventTypes.length);
+  });
+
+  it('WorktreeMergeEvents_ClassificationMaps_Exhaustive', () => {
+    // Each merge type must be wired into EVERY map the worktree family appears
+    // in: the emission registry (classified 'auto' — deterministic plumbing,
+    // not model-authored) and the data-schema map (with a parseable payload).
+    for (const type of MERGE_TYPES) {
+      expect(EVENT_EMISSION_REGISTRY[type], `${type} should be classified 'auto'`).toBe('auto');
+      const schema = EVENT_DATA_SCHEMAS[type];
+      expect(schema, `${type} missing from EVENT_DATA_SCHEMAS`).toBeDefined();
+    }
+
+    const requested = WorktreeMergeRequestedData.parse(wellFormedRequested(randomUUID()));
+    expect(requested).toMatchObject({
+      integrationRef: 'integration/wlm',
+      sourceBranch: 'task/wlm-oc-001',
+      holderPid: 4242,
+      holderStartedAt: '2026-06-25T00:00:00.000Z',
+    });
+    // `worktreeId` is optional — absent ⇒ not injected onto the parsed object.
+    expect(requested as Record<string, unknown>).not.toHaveProperty('worktreeId');
+    expect(
+      (WorktreeMergeRequestedData.parse({ ...wellFormedRequested(randomUUID()), worktreeId: '/repo/.worktrees/x' }))
+        .worktreeId,
+    ).toBe('/repo/.worktrees/x');
+
+    const executed = WorktreeMergeExecutedData.parse(wellFormedExecuted(randomUUID()));
+    expect(executed.status).toBe('merged');
+    expect(executed.mergeSha).toBe('a'.repeat(40));
+    // status is a closed enum; an out-of-set value is rejected.
+    expect(() =>
+      WorktreeMergeExecutedData.parse({ ...wellFormedExecuted(randomUUID()), status: 'bogus' }),
+    ).toThrow();
+    // `recoveryError` is the optional dead-holder-recovery diagnostic.
+    expect(
+      (WorktreeMergeExecutedData.parse({ ...wellFormedExecuted(randomUUID()), recoveryError: 'holder pid dead' }))
+        .recoveryError,
+    ).toBe('holder pid dead');
+  });
+
+  it('WorktreeMergeEvents_IdempotencyKey_PerOperationId_NoCollisionAcrossMergesOnSameBranch', () => {
+    // PROPERTY under test: two DISTINCT merges targeting the SAME integrationRef
+    // must never collapse onto one idempotency key. operationId is the sole
+    // discriminator, so each merge mints its own key regardless of the shared
+    // integrationRef — that is what serializes merges per branch without a
+    // literal `<integrationRef>:…` key.
+    const integrationRef = 'integration/wlm';
+    const opA = randomUUID();
+    const opB = randomUUID();
+
+    // CLAIM keys (decide seam): `${streamId}:${reducerId}:${operationId}`. Two
+    // merges on the same branch share streamId + reducerId but differ by opId.
+    const streamId = 'worktrees';
+    const reducerId = 'worktrees@v1';
+    const claimA = WorktreeMergeRequestedData.parse(wellFormedRequested(opA, integrationRef));
+    const claimB = WorktreeMergeRequestedData.parse(wellFormedRequested(opB, integrationRef));
+    const claimKeyA = `${streamId}:${reducerId}:${claimA.operationId}`;
+    const claimKeyB = `${streamId}:${reducerId}:${claimB.operationId}`;
+    expect(claimKeyA).not.toBe(claimKeyB);
+    expect(claimA.integrationRef).toBe(claimB.integrationRef); // same branch…
+    expect(claimA.operationId).not.toBe(claimB.operationId); // …distinct operations.
+
+    // RELEASE keys (plain keyed append): `<eventType>:<operationId>`.
+    const relA = WorktreeMergeExecutedData.parse(wellFormedExecuted(opA, integrationRef));
+    const relB = WorktreeMergeExecutedData.parse(wellFormedExecuted(opB, integrationRef));
+    const relKeyA = `worktree.merge_executed:${relA.operationId}`;
+    const relKeyB = `worktree.merge_executed:${relB.operationId}`;
+    expect(relKeyA.split(':')).toHaveLength(2);
+    expect(relKeyA).not.toBe(relKeyB);
+
+    // The RELEASE correlates back to its CLAIM by operationId, so the four keys
+    // form two non-colliding (claim, release) pairs.
+    expect(new Set([claimKeyA, claimKeyB, relKeyA, relKeyB]).size).toBe(4);
+    expect(relA.operationId).toBe(claimA.operationId);
+  });
+
+  it('WorkflowStateProjection_HandlesNewWorktreeMergeTypes_Exhaustive', () => {
+    // The workflow-state projection is NOT the worktrees projection: these merge
+    // events carry no workflow_state-affecting fields, so the reducer must fold
+    // them to identity. Critically, both must be HANDLED — the `never`-exhaustive
+    // default throws on any unhandled built-in type, so a missing case arm would
+    // throw here instead of returning the view unchanged.
+    const baseView = workflowStateProjection.init();
+    for (const type of MERGE_TYPES) {
+      const data = type === 'worktree.merge_requested' ? wellFormedRequested(randomUUID()) : wellFormedExecuted(randomUUID());
+      const event = {
+        streamId: 'worktrees',
+        sequence: 1,
+        timestamp: '2026-06-25T00:00:00.000Z',
+        type,
+        schemaVersion: '1.0',
+        data,
+      } as unknown as WorkflowEvent;
+
+      expect(isBuiltInEventType(type)).toBe(true); // exercises the switch, not the early custom-type return.
+      let next: typeof baseView | undefined;
+      expect(() => {
+        next = workflowStateProjection.apply(baseView, event);
+      }, `${type} must be handled by the projection switch, not the never-default`).not.toThrow();
+      // Identity fold — no workflow_state field is mutated.
+      expect(next).toEqual(baseView);
+    }
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -4037,11 +4037,12 @@ describe('WLM operational-core merge lease schemas', () => {
     expect(EventTypes).toContain('worktree.merge_executed');
   });
 
-  it('EventTypes_CountIs138_BothPinsUpdated', () => {
+  it('EventTypes_CountIs139_BothPinsUpdated', () => {
     // The single canonical count after adding the two operational-core merge
-    // types (136 foundation → 138). The pinned literal in BOTH schemas.test.ts
-    // files must agree with this — a divergence means one pin was missed.
-    expect(EventTypes).toHaveLength(138);
+    // types (136 foundation → 138) and main's `workflow.plan-revision` merged in
+    // (138 → 139). The pinned literal in BOTH schemas.test.ts files must agree
+    // with this — a divergence means one pin was missed.
+    expect(EventTypes).toHaveLength(139);
     // No duplicate slipped in while bumping the count.
     expect(new Set(EventTypes).size).toBe(EventTypes.length);
   });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -2087,6 +2087,11 @@ export const WorktreeMergeExecutedData = z.object({
     .min(1)
     .optional()
     .describe('Diagnostic captured when the lease was released during dead-holder recovery'),
+  worktreeId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Canonical worktrees@v1 key the released lease was attributable to, when known'),
 });
 
 // ─── Command Resolver Event Data (#1199 T15) ────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -213,13 +213,26 @@ export const EventTypes = [
   // `ownerPid`, `ownerStartedAt`, `operationId`). They are the lease/ownership
   // half of worktree lifecycle management; the GC/deletion half REUSES the
   // `worktree.remove.requested`/`worktree.remove.executed` pair above (there is
-  // deliberately no `worktree.pruned` / `worktree.merge_*` type). Like the
-  // remove pair, they are `auto` (deterministic plumbing) and keyed on the
-  // existing two-component `<eventType>:<operationId>` idempotency convention.
+  // deliberately no `worktree.pruned` type). Like the remove pair, they are
+  // `auto` (deterministic plumbing) and keyed on the existing two-component
+  // `<eventType>:<operationId>` idempotency convention.
   'worktree.adopted',
   'worktree.reserved',
   'worktree.released',
   'worktree.orphan_detected',
+  // WLM operational-core (DR-4 / DR-7) — the serialized-merge lease pair that
+  // rides the singleton `worktrees` stream alongside the lifecycle family above.
+  // `worktree.merge_requested` is the CLAIM (intent + lease record: which
+  // operation holds the right to merge `sourceBranch` into `integrationRef`,
+  // and which live process holds it). `worktree.merge_executed` is the RELEASE
+  // (terminal outcome: merged / aborted / failed). `operationId` is the sole
+  // discriminator so two concurrent merges onto one `integrationRef` mint
+  // distinct keys and never collide. The CLAIM is appended via the event-store
+  // `decide` seam (its own `${streamId}:${reducerId}:${operationId}` key); the
+  // RELEASE is a plain keyed append `<eventType>:<operationId>` per the
+  // worktree-family convention.
+  'worktree.merge_requested',
+  'worktree.merge_executed',
   // #1290 — emitted by `resolveWorkspace` (servers/exarchos-mcp/src/workspace/
   // discovery.ts) when the dispatch boundary resolves a missing `featureId`
   // from MCP roots or via the cwd-walk fallback. Records the source so audit
@@ -619,6 +632,13 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'worktree.reserved': 'auto',
   'worktree.released': 'auto',
   'worktree.orphan_detected': 'auto',
+
+  // WLM operational-core (DR-4 / DR-7) — serialized-merge lease pair. Both are
+  // `auto`: the CLAIM is appended deterministically by the merge orchestrator
+  // via the event-store `decide` seam, and the RELEASE is a deterministic
+  // keyed append on the terminal outcome — neither is model-authored.
+  'worktree.merge_requested': 'auto',
+  'worktree.merge_executed': 'auto',
 
   // #1290 — auto-emitted by the workspace discovery resolver on the
   // dispatch boundary. See EventTypes registration above.
@@ -1946,7 +1966,9 @@ export const WorktreeRemoveExecutedData = z.object({
  * as the canonical (symlink-resolved) worktree path: it is the stable identity
  * a later reducer canonicalizes the remove pair's `worktreePath` onto, which is
  * why GC deletion REUSES `worktree.remove.requested`/`worktree.remove.executed`
- * (no `worktree.pruned` and no `worktree.merge_*` types are introduced).
+ * (no `worktree.pruned` type is introduced; the serialized-merge lease pair
+ * `worktree.merge_requested`/`worktree.merge_executed` is defined separately
+ * below as the WLM operational-core layer — DR-4 / DR-7).
  *
  * Idempotency: these events use the existing two-component
  * `<eventType>:<operationId>` key — exactly like `worktree.remove.requested:${operationId}`
@@ -1985,6 +2007,64 @@ export const WorktreeReleasedData = WorktreeLifecycleBaseData.extend({
 export const WorktreeOrphanDetectedData = WorktreeLifecycleBaseData.extend({
   ownerPid: z.number().int().nullable().describe('PID recorded on the orphaned reservation, or null'),
   ownerStartedAt: z.string().nullable().describe('Start time recorded on the orphaned reservation, or null'),
+});
+
+/**
+ * WLM operational-core — serialized-merge lease event data (DR-4 / DR-7).
+ *
+ * `worktree.merge_requested` is the CLAIM half: an intent-to-merge record that
+ * doubles as a lease (which live process is currently authorized to merge
+ * `sourceBranch` into `integrationRef`). `worktree.merge_executed` is the
+ * RELEASE half: the terminal outcome of that operation.
+ *
+ * Both ride the singleton `worktrees` stream alongside the lifecycle family and
+ * are correlated by `operationId`. `operationId` is the SOLE discriminator, so
+ * two distinct merge attempts onto the SAME `integrationRef` mint two distinct
+ * operationIds and therefore two distinct idempotency keys — they never collapse
+ * into one another, which is what serializes merges per branch without a literal
+ * `<integrationRef>:…` key. The CLAIM is appended via the event-store `decide`
+ * seam, which derives its own `${streamId}:${reducerId}:${operationId}` key; the
+ * RELEASE is a plain keyed append `<eventType>:<operationId>` per the
+ * worktree-family convention. The schema's only contract is that both payloads
+ * carry `operationId` so callers can build those keys.
+ *
+ * `holderPid` / `holderStartedAt` identify the live process that holds the merge
+ * lease (liveness ground truth for orphan reclamation). `worktreeId` is the
+ * OPTIONAL canonical worktrees@v1 key, stamped when the merge is attributable to
+ * a specific tracked worktree.
+ */
+export const WorktreeMergeRequestedData = z.object({
+  integrationRef: z.string().min(1).describe('Integration ref the merge targets (the per-branch serialization key)'),
+  sourceBranch: z.string().min(1).describe('Branch being merged into integrationRef'),
+  operationId: z.string().min(1).describe('Idempotency key / lease correlator — the sole per-merge discriminator'),
+  holderPid: z.number().int().describe('PID of the live process holding the merge lease (liveness ground truth)'),
+  holderStartedAt: z.string().min(1).describe('Lease-holder process start time (ISO 8601) — disambiguates PID reuse'),
+  worktreeId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Canonical worktrees@v1 key, when the merge is attributable to a specific tracked worktree'),
+});
+
+/**
+ * worktree.merge_executed — RELEASE half of the serialized-merge lease.
+ *
+ * Correlates back to its `worktree.merge_requested` via `operationId` and
+ * records the terminal `status`. `mergeSha` is present only on `status: 'merged'`
+ * (the resulting integration commit). `recoveryError` is an OPTIONAL diagnostic
+ * captured when the lease was released during recovery of a dead holder rather
+ * than by the original operation completing.
+ */
+export const WorktreeMergeExecutedData = z.object({
+  integrationRef: z.string().min(1).describe('Integration ref the merge targeted (matches the requested event)'),
+  operationId: z.string().min(1).describe('Correlates to the worktree.merge_requested event'),
+  status: z.enum(['merged', 'aborted', 'failed']).describe('Terminal outcome of the merge operation'),
+  mergeSha: z.string().min(1).optional().describe('Resulting integration commit SHA — present only on status "merged"'),
+  recoveryError: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Diagnostic captured when the lease was released during dead-holder recovery'),
 });
 
 // ─── Command Resolver Event Data (#1199 T15) ────────────────────────────────
@@ -2764,6 +2844,10 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'worktree.released': WorktreeReleasedData,
   'worktree.orphan_detected': WorktreeOrphanDetectedData,
 
+  // WLM operational-core — serialized-merge lease pair (DR-4 / DR-7).
+  'worktree.merge_requested': WorktreeMergeRequestedData,
+  'worktree.merge_executed': WorktreeMergeExecutedData,
+
   // #1290 — workspace discovery resolution
   'workspace.resolved': WorkspaceResolvedData,
 
@@ -2901,6 +2985,10 @@ export type WorktreeReserved = z.infer<typeof WorktreeReservedData>;
 export type WorktreeReleased = z.infer<typeof WorktreeReleasedData>;
 export type WorktreeOrphanDetected = z.infer<typeof WorktreeOrphanDetectedData>;
 
+// WLM operational-core — serialized-merge lease pair (DR-4 / DR-7).
+export type WorktreeMergeRequested = z.infer<typeof WorktreeMergeRequestedData>;
+export type WorktreeMergeExecuted = z.infer<typeof WorktreeMergeExecutedData>;
+
 // #1290 — workspace discovery
 export type WorkspaceResolved = z.infer<typeof WorkspaceResolvedData>;
 
@@ -3034,6 +3122,9 @@ export type EventDataMap = {
   'worktree.reserved': WorktreeReserved;
   'worktree.released': WorktreeReleased;
   'worktree.orphan_detected': WorktreeOrphanDetected;
+  // WLM operational-core — serialized-merge lease pair (DR-4 / DR-7).
+  'worktree.merge_requested': WorktreeMergeRequested;
+  'worktree.merge_executed': WorktreeMergeExecuted;
   // #1290 — workspace discovery
   'workspace.resolved': WorkspaceResolved;
   // #1274 — dispatch elicitation hand-off

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -2056,7 +2056,11 @@ export const WorktreeMergeRequestedData = z.object({
   sourceBranch: z.string().min(1).describe('Branch being merged into integrationRef'),
   operationId: z.string().min(1).describe('Idempotency key / lease correlator — the sole per-merge discriminator'),
   holderPid: z.number().int().describe('PID of the live process holding the merge lease (liveness ground truth)'),
-  holderStartedAt: z.string().min(1).describe('Lease-holder process start time (ISO 8601) — disambiguates PID reuse'),
+  holderStartedAt: z
+    .string()
+    .min(1)
+    .nullable()
+    .describe('Lease-holder process start time (ISO 8601) — disambiguates PID reuse; null when the platform cannot resolve it'),
   worktreeId: z
     .string()
     .min(1)

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -92,6 +92,7 @@ import {
   handleAcquireWorktree,
   handleReleaseWorktree,
   handlePruneWorktrees,
+  handleSerializeMerge,
 } from './worktree/handlers.js';
 import { handleScaffold } from './invariants/scaffold.js';
 import type { HandleScaffoldArgs } from './invariants/scaffold.js';
@@ -506,6 +507,12 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   acquire_worktree: adaptCtx(handleAcquireWorktree),
   release_worktree: adaptCtx(handleReleaseWorktree),
   prune_worktrees: adaptCtx(handlePruneWorktrees),
+  // Integration-branch merge serializer (WLM operational core, DR-7) — the
+  // optimistic per-`integrationRef` lease that composes `merge_orchestrate`
+  // UNCHANGED. Rides exarchos_orchestrate (INV-5d — no new visible tool); the
+  // `(args, ctx) => ToolResult` shape matches `adaptCtx`, with the third (deps)
+  // parameter left at its production default here.
+  serialize_merge: adaptCtx(handleSerializeMerge),
 };
 
 /** Exported for sync test — ensures registry.ts stays in sync with handler keys. */

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.characterization.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.characterization.test.ts
@@ -71,9 +71,9 @@ describe('mutation-adequacy roster characterization (PIN)', () => {
     const orchestrate = TOOL_REGISTRY.find((t) => t.name === 'exarchos_orchestrate');
     const actionNames = (orchestrate?.actions ?? []).map((a) => a.name);
 
-    it('exposes exactly 75 actions (WLM foundation task 008 added acquire_worktree, release_worktree, prune_worktrees; #1587 retired check_tdd_compliance; #1581 task 018 added discover_bridge)', () => {
+    it('exposes exactly 76 actions (WLM operational-core #1578 added serialize_merge; WLM foundation task 008 added acquire_worktree, release_worktree, prune_worktrees; #1587 retired check_tdd_compliance; #1581 task 018 added discover_bridge)', () => {
       expect(orchestrate).toBeDefined();
-      expect(actionNames).toHaveLength(75);
+      expect(actionNames).toHaveLength(76);
     });
 
     it('carries the mutation-adequacy action (R5 / task 003)', () => {
@@ -145,6 +145,7 @@ describe('mutation-adequacy roster characterization (PIN)', () => {
         'review_triage',
         'runbook',
         'select_debug_track',
+        'serialize_merge',
         'setup_worktree',
         'spec_coverage_check',
         'task_claim',

--- a/servers/exarchos-mcp/src/orchestrate/worktree/git-retry.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/git-retry.test.ts
@@ -1,0 +1,183 @@
+// ─── git-retry tests (DR-8) ─────────────────────────────────────────────────
+//
+// MEDIUM-tier unit suite over the fully-injected backoff/jitter/sleep seam.
+// Every timing seam is replaced with a deterministic fake (no real timers, no
+// real `Math.random()`), so the retry sequence is asserted EXACTLY. The four
+// named tests pin DR-8's acceptance criteria:
+//   • transient lock → retries → succeeds without surfacing the error
+//   • injected seam → exact backoff sequence [200,400,800] (modulo jitter)
+//   • burst-creation jitter → bounded + deterministic under injection
+//   • exhausted retries → structured error (lock path + attempts), not a no-op
+// ───────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  withIndexLockRetry,
+  burstStaggerDelayMs,
+  burstStagger,
+  IndexLockContentionError,
+  extractLockPath,
+  isIndexLockError,
+  MAX_INDEX_LOCK_RETRIES,
+  INDEX_LOCK_BASE_DELAY_MS,
+  BURST_STAGGER_MIN_MS,
+  BURST_STAGGER_MAX_MS,
+} from './git-retry.js';
+
+// A realistic git lock-creation failure for a given lock path.
+function lockError(lockPath: string): Error {
+  return new Error(`fatal: Unable to create '${lockPath}': File exists.`);
+}
+
+const LOCK_PATH = '/tmp/repo/.git/index.lock';
+
+// Deterministic seams: zero jitter → delay == base; recording sleep → no wait.
+const zeroJitter = () => 0;
+function recordingSleep(): { sleep: (ms: number) => Promise<void>; calls: number[] } {
+  const calls: number[] = [];
+  return {
+    calls,
+    sleep: async (ms: number) => {
+      calls.push(ms);
+    },
+  };
+}
+
+describe('git-retry — index.lock contention resilience (DR-8)', () => {
+  it('GitRetry_TransientIndexLock_RetriesWithBackoffAndSucceeds', async () => {
+    // One transient index.lock failure, then success. The wrapper must retry
+    // and return the operation's value WITHOUT surfacing the lock error.
+    let calls = 0;
+    const { sleep, calls: slept } = recordingSleep();
+    const op = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw lockError(LOCK_PATH);
+      return 'merged-sha';
+    });
+
+    const result = await withIndexLockRetry(op, { sleep, jitter: zeroJitter });
+
+    expect(result).toBe('merged-sha');
+    expect(op).toHaveBeenCalledTimes(2); // initial fail + one successful retry
+    expect(slept).toEqual([INDEX_LOCK_BASE_DELAY_MS]); // exactly one backoff: 200ms
+  });
+
+  it('GitRetry_InjectedSeam_AssertsDeterministicRetrySequence', async () => {
+    // With injected sleep/jitter the exact backoff sequence is asserted. Fail
+    // on the first three attempts (the lock clears on the fourth) so all three
+    // configured retries fire and their delays are observed in order.
+    const { sleep, calls: slept } = recordingSleep();
+    const onRetryInfo: Array<{ attempt: number; delayMs: number; lockPath: string }> = [];
+    let calls = 0;
+    const op = async () => {
+      calls += 1;
+      if (calls <= 3) throw lockError(LOCK_PATH);
+      return 'ok';
+    };
+
+    const result = await withIndexLockRetry(op, {
+      sleep,
+      jitter: zeroJitter,
+      onRetry: (info) => {
+        onRetryInfo.push(info);
+      },
+    });
+
+    expect(result).toBe('ok');
+    // Default budget is 3 retries → zero-jitter backoff sequence [200,400,800].
+    expect(MAX_INDEX_LOCK_RETRIES).toBe(3);
+    expect(slept).toEqual([200, 400, 800]);
+    // The audit hook sees the same sequence with 1-based ordinals + lock path.
+    expect(onRetryInfo).toEqual([
+      { attempt: 1, delayMs: 200, lockPath: LOCK_PATH },
+      { attempt: 2, delayMs: 400, lockPath: LOCK_PATH },
+      { attempt: 3, delayMs: 800, lockPath: LOCK_PATH },
+    ]);
+
+    // "modulo injected jitter": a non-zero signed jitter feeds the multiplier
+    // `base * (1 + 0.25 * jitter())`. jitter = +1 → ×1.25 → [250,500,1000].
+    const persistent = async () => {
+      throw lockError(LOCK_PATH);
+    };
+    const { sleep: jitterSleep, calls: jitterSlept } = recordingSleep();
+    await expect(
+      withIndexLockRetry(persistent, { sleep: jitterSleep, jitter: () => 1 }),
+    ).rejects.toBeInstanceOf(IndexLockContentionError);
+    expect(jitterSlept).toEqual([250, 500, 1000]);
+  });
+
+  it('GitRetry_BurstCreationJitter_AssertedDeterministically', async () => {
+    // Burst-creation jitter is bounded to [100,500] and deterministic under an
+    // injected jitter source: midpoint at 0, the band edges at ±1, clamped
+    // beyond ±1 so a misbehaving source can never escape the band.
+    expect(burstStaggerDelayMs(() => 0)).toBe(300); // midpoint of [100,500]
+    expect(burstStaggerDelayMs(() => 1)).toBe(BURST_STAGGER_MAX_MS); // 500
+    expect(burstStaggerDelayMs(() => -1)).toBe(BURST_STAGGER_MIN_MS); // 100
+    expect(burstStaggerDelayMs(() => 0.5)).toBe(400);
+    // Out-of-band jitter is clamped, never surfaced.
+    expect(burstStaggerDelayMs(() => 5)).toBe(BURST_STAGGER_MAX_MS);
+    expect(burstStaggerDelayMs(() => -5)).toBe(BURST_STAGGER_MIN_MS);
+
+    // burstStagger sleeps the computed (injected, deterministic) delay and
+    // returns it — both jitter and sleep are injected, no real timer fires.
+    const { sleep, calls: slept } = recordingSleep();
+    const applied = await burstStagger({ sleep, jitter: () => 0 });
+    expect(applied).toBe(300);
+    expect(slept).toEqual([300]);
+  });
+
+  it('GitRetry_ExhaustedRetries_ReturnsStructuredErrorNotSilentNoOp', async () => {
+    // A persistent index.lock contention exhausts the budget. The wrapper MUST
+    // surface a structured error carrying the lock path + attempt count — never
+    // a silent no-op (which would return undefined and swallow the failure).
+    const { sleep, calls: slept } = recordingSleep();
+    const op = vi.fn(async () => {
+      throw lockError(LOCK_PATH);
+    });
+
+    const caught = await withIndexLockRetry(op, { sleep, jitter: zeroJitter }).then(
+      () => {
+        throw new Error('expected withIndexLockRetry to throw, but it resolved');
+      },
+      (err: unknown) => err,
+    );
+
+    expect(caught).toBeInstanceOf(IndexLockContentionError);
+    const structured = caught as IndexLockContentionError;
+    expect(structured.code).toBe('INDEX_LOCK_CONTENTION');
+    expect(structured.lockPath).toBe(LOCK_PATH);
+    expect(structured.attempts).toBe(MAX_INDEX_LOCK_RETRIES + 1); // 4 total
+    expect(structured.maxRetries).toBe(MAX_INDEX_LOCK_RETRIES);
+    expect(structured.delaysMs).toEqual([200, 400, 800]);
+    expect(structured.lastError).toBeInstanceOf(Error);
+    // Not a no-op: the op was actually attempted 1 + N times, and every retry
+    // backed off.
+    expect(op).toHaveBeenCalledTimes(MAX_INDEX_LOCK_RETRIES + 1);
+    expect(slept).toEqual([200, 400, 800]);
+  });
+
+  it('GitRetry_NonLockError_RethrowsImmediatelyWithoutRetry', async () => {
+    // A non-lock failure is NOT our concern: rethrow on the first attempt with
+    // zero retries / zero sleeps, surfacing the original error unchanged.
+    const { sleep, calls: slept } = recordingSleep();
+    const original = new Error('fatal: merge conflict in src/foo.ts');
+    const op = vi.fn(async () => {
+      throw original;
+    });
+
+    await expect(
+      withIndexLockRetry(op, { sleep, jitter: zeroJitter }),
+    ).rejects.toBe(original);
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(slept).toEqual([]);
+  });
+
+  it('extractLockPath / isIndexLockError recognize the git signature', () => {
+    expect(extractLockPath(lockError(LOCK_PATH))).toBe(LOCK_PATH);
+    expect(isIndexLockError(lockError(LOCK_PATH))).toBe(true);
+    // Non-throwing git-runner result shape ({ stderr }) is also recognized.
+    expect(isIndexLockError({ status: 128, stderr: `Unable to create '${LOCK_PATH}': File exists.` })).toBe(true);
+    expect(extractLockPath(new Error('some other failure'))).toBeUndefined();
+    expect(isIndexLockError('plain string, no lock')).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/worktree/git-retry.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/git-retry.ts
@@ -1,0 +1,307 @@
+// ─── git-retry — index.lock contention resilience + burst stagger (DR-8) ────
+//
+// DR-8 (git-mutation lock-contention resilience). Worktree-mutating git
+// operations the manager performs (e.g. `git worktree add`, `git merge`,
+// `git checkout`) can transiently lose a race for `.git/index.lock` under
+// burst dispatch — git surfaces this as
+// `fatal: Unable to create '<path>/index.lock': File exists.`. That contention
+// is *transient*: the holder releases the lock within milliseconds, so a
+// bounded retry-with-backoff resolves it without surfacing the error.
+//
+// The whole seam — backoff base, jitter source, AND the sleep delay — is
+// INJECTED (mirroring the bounded timeout-retry seam in
+// `orchestrate/pure/execute-merge.ts`, the canonical reference for this shape).
+// The testable core (`withIndexLockRetry`, `burstStaggerDelayMs`) calls NO real
+// `Math.random()` and NO real timers when the seams are injected, so the retry
+// sequence is asserted deterministically (workflow-determinism invariant). The
+// real `Math.random()` jitter and `setTimeout` sleep live ONLY in the exported
+// defaults, which production leaves in place and tests replace.
+//
+// The `SleepFn` seam (and `defaultSleep`) is exported deliberately so the
+// bounded `wait` (Task 004) and the merge wait-for-slot loop (Task 006) reuse
+// ONE timing seam rather than each re-deriving a `setTimeout` promise.
+// ───────────────────────────────────────────────────────────────────────────
+
+// ─── Injected seams (exported for reuse across the WLM operational core) ─────
+
+/**
+ * Injected delay seam — invoked with a computed delay (ms). Injected so tests
+ * skip the real wall-clock wait and so other WLM tasks (004 bounded `wait`,
+ * 006 merge wait-for-slot) reuse a single timing seam. Defaults to a real
+ * `setTimeout`-based sleep.
+ */
+export type SleepFn = (ms: number) => Promise<void>;
+
+/**
+ * Default real sleep over `setTimeout`. The ONLY place a real timer is
+ * created in this module — every testable code path accepts an injected
+ * `SleepFn` and never reaches this default under test.
+ */
+export const defaultSleep: SleepFn = (ms) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Injected jitter source. Returns a signed fraction in `[-1, 1]`; the effective
+ * backoff delay is `base * (1 + jitterFraction * jitter())`. Injected rather
+ * than an inline `Math.random()` so the retry path stays deterministic under
+ * test.
+ */
+export type JitterFn = () => number;
+
+/**
+ * Default real jitter over `Math.random()` mapped to a uniform signed fraction
+ * in `[-1, 1]`. The ONLY place real randomness is read in this module — every
+ * testable code path accepts an injected `JitterFn`.
+ */
+export const defaultJitter: JitterFn = () => Math.random() * 2 - 1;
+
+// ─── index.lock retry tuning ────────────────────────────────────────────────
+
+/** Base backoff delay (ms) before the first retry. */
+export const INDEX_LOCK_BASE_DELAY_MS = 200;
+/** Exponential growth factor applied per retry: `base * factor^attempt`. */
+export const INDEX_LOCK_BACKOFF_FACTOR = 2.0;
+/** Symmetric jitter band as a fraction of the computed delay (±25%). */
+export const INDEX_LOCK_JITTER_FRACTION = 0.25;
+/**
+ * Max retries after the initial attempt → `MAX_INDEX_LOCK_RETRIES + 1` total
+ * attempts. With the defaults above the zero-jitter backoff sequence is
+ * `[200, 400, 800]` ms (DR-8 "~200/400/800ms ±jitter").
+ */
+export const MAX_INDEX_LOCK_RETRIES = 3;
+
+// ─── Burst-creation stagger tuning ──────────────────────────────────────────
+
+/** Lower bound (ms) of the burst-creation stagger band. */
+export const BURST_STAGGER_MIN_MS = 100;
+/** Upper bound (ms) of the burst-creation stagger band. */
+export const BURST_STAGGER_MAX_MS = 500;
+
+// ─── git lock-error signature ───────────────────────────────────────────────
+
+/**
+ * git's lock-creation failure message:
+ *   `fatal: Unable to create '<path>.lock': File exists.`
+ * Capture the lock-file path so the structured error can report exactly which
+ * lock could not be acquired. Matches `index.lock` (DR-8's named case) and any
+ * sibling `*.lock` (HEAD.lock, packed-refs.lock, …) so the same wrapper covers
+ * every worktree-mutating git lock contention.
+ */
+const INDEX_LOCK_SIGNATURE = /unable to create '([^']*\.lock)'/i;
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  // A git-runner result object surfacing `{ status, stdout, stderr }` — fold
+  // any string-bearing fields so the signature still matches a non-throwing
+  // runner that returns its diagnostics rather than throwing.
+  if (err !== null && typeof err === 'object') {
+    const rec = err as Record<string, unknown>;
+    const parts = [rec.message, rec.stderr, rec.stdout].filter(
+      (v): v is string => typeof v === 'string',
+    );
+    if (parts.length > 0) return parts.join('\n');
+  }
+  return String(err);
+}
+
+/**
+ * Extract the contended lock-file path from a git lock-creation failure, or
+ * `undefined` when `err` is not a recognizable lock-contention error.
+ */
+export function extractLockPath(err: unknown): string | undefined {
+  const match = INDEX_LOCK_SIGNATURE.exec(errorMessage(err));
+  return match?.[1];
+}
+
+/** True when `err` is a transient git `index.lock`-family contention error. */
+export function isIndexLockError(err: unknown): boolean {
+  return extractLockPath(err) !== undefined;
+}
+
+// ─── Structured exhaustion error ────────────────────────────────────────────
+
+/** Diagnostics carried by {@link IndexLockContentionError}. */
+export interface IndexLockRetryDiagnostics {
+  /** The contended lock-file path git refused to create. */
+  readonly lockPath: string;
+  /** Total attempts made (initial + retries). */
+  readonly attempts: number;
+  /** The configured retry budget (`attempts === maxRetries + 1` on exhaustion). */
+  readonly maxRetries: number;
+  /** The actual backoff delays slept, in order (post-jitter, rounded ms). */
+  readonly delaysMs: readonly number[];
+}
+
+/**
+ * Thrown when the bounded retry budget is exhausted and the `index.lock`
+ * contention never cleared. Carries the lock path + attempt count so the
+ * failure is a *structured* surface, never a silent no-op (DR-8 AC). The
+ * underlying last error is preserved on `lastError`.
+ */
+export class IndexLockContentionError extends Error {
+  readonly code = 'INDEX_LOCK_CONTENTION' as const;
+  readonly lockPath: string;
+  readonly attempts: number;
+  readonly maxRetries: number;
+  readonly delaysMs: readonly number[];
+  readonly lastError: unknown;
+
+  constructor(diagnostics: IndexLockRetryDiagnostics, lastError: unknown) {
+    super(
+      `git index lock contention unresolved after ${diagnostics.attempts} attempt(s): ${diagnostics.lockPath}`,
+    );
+    this.name = 'IndexLockContentionError';
+    this.lockPath = diagnostics.lockPath;
+    this.attempts = diagnostics.attempts;
+    this.maxRetries = diagnostics.maxRetries;
+    this.delaysMs = diagnostics.delaysMs;
+    this.lastError = lastError;
+  }
+}
+
+// ─── Retry wrapper ──────────────────────────────────────────────────────────
+
+/** Options for {@link withIndexLockRetry}. All timing seams are injectable. */
+export interface IndexLockRetryOptions {
+  /** Injected sleep seam. Defaults to {@link defaultSleep}. */
+  readonly sleep?: SleepFn;
+  /** Injected signed-jitter source in `[-1, 1]`. Defaults to {@link defaultJitter}. */
+  readonly jitter?: JitterFn;
+  /** Retries after the initial attempt. Defaults to {@link MAX_INDEX_LOCK_RETRIES}. */
+  readonly maxRetries?: number;
+  /** Base backoff (ms). Defaults to {@link INDEX_LOCK_BASE_DELAY_MS}. */
+  readonly baseDelayMs?: number;
+  /** Exponential factor. Defaults to {@link INDEX_LOCK_BACKOFF_FACTOR}. */
+  readonly backoffFactor?: number;
+  /** Symmetric jitter fraction. Defaults to {@link INDEX_LOCK_JITTER_FRACTION}. */
+  readonly jitterFraction?: number;
+  /**
+   * Invoked once per retry, BEFORE the backoff sleep, so a caller can emit an
+   * audit record. `attempt` is the 1-based retry ordinal; `delayMs` is the
+   * backoff about to be applied; `lockPath` is the contended lock file.
+   */
+  readonly onRetry?: (info: {
+    attempt: number;
+    delayMs: number;
+    lockPath: string;
+  }) => void | Promise<void>;
+}
+
+/**
+ * Run a (possibly async) git operation, retrying ONLY on a transient
+ * `index.lock`-family contention error with exponential backoff + bounded
+ * jitter. A non-lock failure is rethrown immediately (never retried). On
+ * success the operation's value is returned and no error is surfaced. When the
+ * retry budget is exhausted, throws a structured {@link IndexLockContentionError}
+ * carrying the lock path and attempt count — never a silent no-op (DR-8).
+ *
+ * Backoff, jitter, and sleep are all injected; with deterministic fakes the
+ * exact retry sequence is assertable.
+ */
+export async function withIndexLockRetry<T>(
+  op: () => Promise<T> | T,
+  options: IndexLockRetryOptions = {},
+): Promise<T> {
+  const sleep = options.sleep ?? defaultSleep;
+  const jitter = options.jitter ?? defaultJitter;
+  const maxRetries = options.maxRetries ?? MAX_INDEX_LOCK_RETRIES;
+  const baseDelayMs = options.baseDelayMs ?? INDEX_LOCK_BASE_DELAY_MS;
+  const backoffFactor = options.backoffFactor ?? INDEX_LOCK_BACKOFF_FACTOR;
+  const jitterFraction = options.jitterFraction ?? INDEX_LOCK_JITTER_FRACTION;
+
+  let lastError: unknown;
+  let lastLockPath = '';
+  const delaysMs: number[] = [];
+
+  // attempt index: 0 = initial, 1..maxRetries = retries.
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      return await op();
+    } catch (err) {
+      lastError = err;
+      const lockPath = extractLockPath(err);
+      if (lockPath === undefined) {
+        // Non-transient (not an index.lock contention) → not our concern.
+        // Rethrow unchanged so the caller's own error handling runs.
+        throw err;
+      }
+      lastLockPath = lockPath;
+
+      const retriesRemain = attempt < maxRetries;
+      if (!retriesRemain) {
+        // Out of retry budget → exit the loop and surface the structured error.
+        break;
+      }
+
+      // Exponential backoff with bounded symmetric jitter. The failed attempt's
+      // base delay is `baseDelayMs * backoffFactor^attempt`; the jitter source
+      // is signed in `[-1, 1]`, so the effective multiplier stays in
+      // `[1 - jitterFraction, 1 + jitterFraction]` (> 0 for the default 0.25).
+      const baseDelay = baseDelayMs * backoffFactor ** attempt;
+      const delayMs = Math.max(
+        0,
+        Math.round(baseDelay * (1 + jitterFraction * jitter())),
+      );
+      delaysMs.push(delayMs);
+      if (options.onRetry) {
+        await options.onRetry({ attempt: attempt + 1, delayMs, lockPath });
+      }
+      await sleep(delayMs);
+    }
+  }
+
+  throw new IndexLockContentionError(
+    {
+      lockPath: lastLockPath,
+      attempts: maxRetries + 1,
+      maxRetries,
+      delaysMs,
+    },
+    lastError,
+  );
+}
+
+// ─── Burst-creation stagger ─────────────────────────────────────────────────
+
+/**
+ * Compute a bounded stagger delay in `[minMs, maxMs]` from an injected signed
+ * jitter source in `[-1, 1]`. Pure (no sleep) so the bound is unit-assertable.
+ * `jitter() === 0` → band midpoint; `+1` → `maxMs`; `-1` → `minMs`; values
+ * outside `[-1, 1]` are clamped to the band so a misbehaving source can never
+ * produce an out-of-band stagger.
+ */
+export function burstStaggerDelayMs(
+  jitter: JitterFn = defaultJitter,
+  minMs: number = BURST_STAGGER_MIN_MS,
+  maxMs: number = BURST_STAGGER_MAX_MS,
+): number {
+  const mid = (minMs + maxMs) / 2;
+  const halfBand = (maxMs - minMs) / 2;
+  const raw = mid + halfBand * jitter();
+  return Math.max(minMs, Math.min(maxMs, Math.round(raw)));
+}
+
+/**
+ * Stagger a burst-dispatched worktree creation/adoption by sleeping a bounded
+ * jittered delay (DR-8 "creation/adoption staggered 100–500ms under burst").
+ * Both the jitter source and the sleep seam are injected; returns the delay
+ * actually applied so a caller (or test) can observe it.
+ */
+export async function burstStagger(
+  options: {
+    readonly sleep?: SleepFn;
+    readonly jitter?: JitterFn;
+    readonly minMs?: number;
+    readonly maxMs?: number;
+  } = {},
+): Promise<number> {
+  const sleep = options.sleep ?? defaultSleep;
+  const delayMs = burstStaggerDelayMs(
+    options.jitter ?? defaultJitter,
+    options.minMs ?? BURST_STAGGER_MIN_MS,
+    options.maxMs ?? BURST_STAGGER_MAX_MS,
+  );
+  await sleep(delayMs);
+  return delayMs;
+}

--- a/servers/exarchos-mcp/src/orchestrate/worktree/handlers.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/handlers.test.ts
@@ -6,7 +6,7 @@
 // over a real EventStore with deterministic injected deps (no git spawn, no OS
 // process probe), so the assertions are platform-free.
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -14,12 +14,15 @@ import * as path from 'node:path';
 import { EventStore } from '../../event-store/store.js';
 import type { DispatchContext } from '../../core/dispatch.js';
 import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import { handleView } from '../../views/composite.js';
 import {
   handleAcquireWorktree,
   handleReleaseWorktree,
 } from './handlers.js';
-import type { GitWorktreeProbe } from './manager.js';
+import { WORKTREES_STREAM, type GitWorktreeProbe } from './manager.js';
 import type { ProcessSource, StartTimeProbe } from './pure/process-identity.js';
+import type { ProcessTableSource, ProcessRecord } from './pure/probe.js';
+import type { InFlightMerge } from './projections/worktrees.js';
 
 // ─── Deterministic injected deps ─────────────────────────────────────────────
 
@@ -61,6 +64,7 @@ async function createArm(): Promise<Arm> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   while (arms.length > 0) {
     const arm = arms.pop();
     if (arm) await rmrfAsync(arm.stateDir);
@@ -172,5 +176,273 @@ describe('exclusive ownership (acquire/release handlers)', () => {
     );
     expect(release.success).toBe(false);
     expect(release.error?.code).toBe('WORKTREE_OWNED_BY_OTHER');
+  });
+});
+
+// ─── ps / wait — read-only liveness surface (DR-4), dispatched via handleView ──
+//
+// Every assertion drives the PUBLIC composite entry (`handleView`), not the
+// handler in isolation, so a missing `case 'ps'`/`'wait'` routing arm (or an
+// unregistered action) goes red. Deterministic injected seams only — a fake
+// process-table source / identity realpath / injected sleep+clock — so there is
+// no OS process scan and no real timer.
+
+/** Seed a CLAIM (`worktree.merge_requested`) directly on the singleton stream. */
+async function seedMergeRequested(
+  arm: Arm,
+  holder: {
+    integrationRef: string;
+    operationId: string;
+    sourceBranch: string;
+    holderPid: number;
+    holderStartedAt: string;
+  },
+): Promise<void> {
+  await arm.ctx.eventStore.append(
+    WORKTREES_STREAM,
+    { type: 'worktree.merge_requested', data: { ...holder } },
+    { idempotencyKey: `worktree.merge_requested:${holder.operationId}` },
+  );
+}
+
+/** Seed a RELEASE (`worktree.merge_executed`) clearing the slot for `op`. */
+async function seedMergeExecuted(
+  arm: Arm,
+  ref: { integrationRef: string; operationId: string; sourceBranch: string },
+): Promise<void> {
+  await arm.ctx.eventStore.append(
+    WORKTREES_STREAM,
+    { type: 'worktree.merge_executed', data: { ...ref } },
+    { idempotencyKey: `worktree.merge_executed:${ref.operationId}` },
+  );
+}
+
+/** Seed a reservation (`worktree.reserved`) for a worktree owned by a PID. */
+async function seedReserved(
+  arm: Arm,
+  r: {
+    worktreeId: string;
+    path: string;
+    ownerPid: number;
+    ownerStartedAt: string;
+    operationId: string;
+  },
+): Promise<void> {
+  await arm.ctx.eventStore.append(
+    WORKTREES_STREAM,
+    {
+      type: 'worktree.reserved',
+      data: {
+        worktreeId: r.worktreeId,
+        path: r.path,
+        featureId: null,
+        ownerPid: r.ownerPid,
+        ownerStartedAt: r.ownerStartedAt,
+        operationId: r.operationId,
+      },
+    },
+    { idempotencyKey: `worktree.reserved:${r.operationId}` },
+  );
+}
+
+describe('ps — in-flight liveness read (DR-4)', () => {
+  it('HandleView_Ps_ListsInFlightFromInFlightMerges_NoProcessScan', async () => {
+    const arm = await createArm();
+    await seedMergeRequested(arm, {
+      integrationRef: 'main',
+      operationId: 'op-ps',
+      sourceBranch: 'feat/x',
+      holderPid: 4242,
+      holderStartedAt: 'boot-4242',
+    });
+
+    // The process table is a spy; without `probe` it must NEVER be enumerated.
+    const listSpy = vi.fn((): readonly ProcessRecord[] => []);
+    const table: ProcessTableSource = { list: listSpy };
+
+    const result = await handleView({ action: 'ps' }, arm.ctx, {
+      processTableSource: table,
+      realpath: (p) => p,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { inFlight: InFlightMerge[]; count: number };
+    expect(data.count).toBe(1);
+    expect(data.inFlight[0].integrationRef).toBe('main');
+    expect(data.inFlight[0].sourceBranch).toBe('feat/x');
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it('HandleView_Ps_Probe_PullsOnDemandAndEmits', async () => {
+    const arm = await createArm();
+    // released-wt: owner 555 DEAD (absent), not occupied   → worktree.released
+    // orphan-wt:   owner 666 DEAD (absent), occupied by 777 → worktree.orphan_detected
+    await seedReserved(arm, {
+      worktreeId: '/wlm/released-wt',
+      path: '/wlm/released-wt',
+      ownerPid: 555,
+      ownerStartedAt: 'b555',
+      operationId: 'op-rel',
+    });
+    await seedReserved(arm, {
+      worktreeId: '/wlm/orphan-wt',
+      path: '/wlm/orphan-wt',
+      ownerPid: 666,
+      ownerStartedAt: 'b666',
+      operationId: 'op-orph',
+    });
+
+    // Only PID 777 is alive, cwd inside the orphan worktree; 555/666 are absent
+    // (provably dead). selfPid (999999) is not in the table, so its ancestry is
+    // just itself and the foreign occupant 777 counts.
+    const table: ProcessTableSource = {
+      list: () => [{ pid: 777, ppid: 1, cwd: '/wlm/orphan-wt/sub', startTime: 'b777' }],
+    };
+
+    const result = await handleView({ action: 'ps', probe: true }, arm.ctx, {
+      processTableSource: table,
+      realpath: (p) => p,
+      selfPid: 999999,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      probe: { released: string[]; orphaned: string[]; probed: number };
+    };
+    expect(data.probe.probed).toBe(2);
+    expect(data.probe.released).toContain('/wlm/released-wt');
+    expect(data.probe.orphaned).toContain('/wlm/orphan-wt');
+
+    // The on-demand write path landed both terminal events on the stream.
+    const events = await arm.ctx.eventStore.query(WORKTREES_STREAM);
+    const types = events.map((e) => e.type);
+    expect(types).toContain('worktree.released');
+    expect(types).toContain('worktree.orphan_detected');
+  });
+});
+
+describe('wait — caller-bounded merge-terminal poll (DR-4)', () => {
+  it('HandleView_Wait_AlreadyTerminal_ResolvesImmediately', async () => {
+    const arm = await createArm();
+    // No holder seeded → the slot is already terminal: resolve on the first fold.
+    const sleep = vi.fn(async () => {});
+
+    const result = await handleView(
+      { action: 'wait', integrationRef: 'main', timeoutMs: 5_000 },
+      arm.ctx,
+      { sleep },
+    );
+
+    expect(result.success).toBe(true);
+    expect((result.data as { resolved: boolean }).resolved).toBe(true);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('HandleView_Wait_InFlightThenTerminal_ResolvesWithinTimeout', async () => {
+    const arm = await createArm();
+    await seedMergeRequested(arm, {
+      integrationRef: 'main',
+      operationId: 'op-wait',
+      sourceBranch: 'feat/x',
+      holderPid: 100,
+      holderStartedAt: 'boot-100',
+    });
+
+    // The injected sleep clears the slot on its first call, so the next re-fold
+    // resolves — within the bounded budget, using NO real timer.
+    let sleeps = 0;
+    const sleep = vi.fn(async () => {
+      sleeps += 1;
+      if (sleeps === 1) {
+        await seedMergeExecuted(arm, {
+          integrationRef: 'main',
+          operationId: 'op-wait',
+          sourceBranch: 'feat/x',
+        });
+      }
+    });
+
+    const result = await handleView(
+      { action: 'wait', integrationRef: 'main', timeoutMs: 10_000 },
+      arm.ctx,
+      { sleep },
+    );
+
+    expect(result.success).toBe(true);
+    expect((result.data as { resolved: boolean }).resolved).toBe(true);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('HandleView_Wait_Timeout_ReturnsStructuredTimeoutNotHang', async () => {
+    const arm = await createArm();
+    await seedMergeRequested(arm, {
+      integrationRef: 'main',
+      operationId: 'op-stuck',
+      sourceBranch: 'feat/x',
+      holderPid: 100,
+      holderStartedAt: 'boot-100',
+    });
+
+    // Controllable clock: each (instant) sleep advances it past the deadline so
+    // the bounded poll terminates with a STRUCTURED timeout, never hanging.
+    let t = 0;
+    const now = (): number => t;
+    const sleep = vi.fn(async (ms: number) => {
+      t += ms;
+    });
+
+    const result = await handleView(
+      { action: 'wait', integrationRef: 'main', timeoutMs: 100 },
+      arm.ctx,
+      { now, sleep, pollIntervalMs: 200 },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('WAIT_TIMEOUT');
+    const data = result.data as {
+      reason: string;
+      integrationRef: string;
+      timeoutMs: number;
+    };
+    expect(data.reason).toBe('wait-timeout');
+    expect(data.integrationRef).toBe('main');
+    expect(data.timeoutMs).toBe(100);
+  });
+
+  it('Manager_NoBackgroundTimer_SetIntervalSpyZeroCalls', async () => {
+    const arm = await createArm();
+    await seedMergeRequested(arm, {
+      integrationRef: 'main',
+      operationId: 'op-timer',
+      sourceBranch: 'feat/x',
+      holderPid: 100,
+      holderStartedAt: 'boot-100',
+    });
+
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const beforeInterval = setIntervalSpy.mock.calls.length;
+    const beforeTimeout = setTimeoutSpy.mock.calls.length;
+
+    // The bounded poll uses the INJECTED sleep seam (which clears the slot on the
+    // first poll), so neither a real setTimeout nor a background setInterval is
+    // ever created during the manager wait op.
+    const sleep = vi.fn(async () => {
+      await seedMergeExecuted(arm, {
+        integrationRef: 'main',
+        operationId: 'op-timer',
+        sourceBranch: 'feat/x',
+      });
+    });
+
+    const result = await handleView(
+      { action: 'wait', integrationRef: 'main', timeoutMs: 10_000 },
+      arm.ctx,
+      { sleep },
+    );
+    expect(result.success).toBe(true);
+
+    expect(setIntervalSpy.mock.calls.length - beforeInterval).toBe(0);
+    expect(setTimeoutSpy.mock.calls.length - beforeTimeout).toBe(0);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
@@ -477,7 +477,9 @@ export async function handleViewWait(
       ? args.timeoutMs
       : DEFAULT_WAIT_TIMEOUT_MS;
 
-  const manager = buildManager(ctx);
+  // Pass `deps` through so injected DI seams (processTableSource / realpath) are
+  // honored, matching handleViewPs — see the width-subtyping note there.
+  const manager = buildManager(ctx, deps);
   const result = await manager.waitForMergeTerminal(integrationRef, {
     timeoutMs,
     ...(deps?.sleep !== undefined ? { sleep: deps.sleep } : {}),

--- a/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
@@ -19,6 +19,7 @@ import type { DispatchContext } from '../../core/dispatch.js';
 import type { ToolResult } from '../../format.js';
 import {
   WorktreeManager,
+  DEFAULT_WAIT_TIMEOUT_MS,
   type WorktreeManagerDeps,
   type ReserveInput,
 } from './manager.js';
@@ -31,6 +32,8 @@ import {
   type SerializeMergeInput,
   type SerializeMergeDeps,
 } from './merge-serializer.js';
+import type { SleepFn } from './git-retry.js';
+import type { InFlightMerge } from './projections/worktrees.js';
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -364,4 +367,129 @@ export async function handleSerializeMerge(
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
   };
   return serializeMerge(input, ctx, deps);
+}
+
+// ─── ps / wait (WLM operational core, DR-4 — read-only liveness surface) ──────
+
+/**
+ * Test/DI seam for the worktree-lifecycle VIEW handlers (`ps` / `wait`),
+ * threaded by {@link handleView} as its optional third argument. Extends the
+ * manager-construction {@link InjectableDeps} (fake process-table source /
+ * realpath) with the probe self-PID and the bounded-wait timing seams. Kept OUT
+ * of the registry input schema — these are never user-facing flags; production
+ * dispatch omits every field so the manager wires the real OS-backed defaults.
+ */
+export interface WorktreeViewDeps extends InjectableDeps {
+  /** Probe self-PID whose FULL ancestry is excluded from occupancy. Defaults to `process.pid`. */
+  readonly selfPid?: number;
+  /** Bounded-wait sleep seam (shared with `git-retry.ts`). Defaults to the real `setTimeout` sleep. */
+  readonly sleep?: SleepFn;
+  /** Monotone clock for the wait deadline. Defaults to `Date.now`. */
+  readonly now?: () => number;
+  /** Wait poll interval (ms). Defaults to the manager's `DEFAULT_WAIT_POLL_INTERVAL_MS`. */
+  readonly pollIntervalMs?: number;
+}
+
+/**
+ * `ps` — list the live serialized-merge set from `inFlightMerges` (an open
+ * `worktree.merge_requested` with no paired `worktree.merge_executed`) WITHOUT a
+ * process scan: a pure fold of the `worktrees@v1` projection.
+ *
+ * `probe: true` additionally pulls the DR-5 ground-truth process probe on demand
+ * and emits `worktree.released` (owner dead, not in use) / `worktree.orphan_detected`
+ * (owner dead, still occupied) from the finding — the ONLY write path on this
+ * otherwise read-only view surface (the deferred orphan emitter). Without
+ * `probe`, no table is enumerated at all.
+ */
+export async function handleViewPs(
+  args: Record<string, unknown>,
+  ctx: DispatchContext,
+  deps?: WorktreeViewDeps,
+): Promise<ToolResult> {
+  // `buildManager` takes the manager-construction subset; the extra view-only
+  // seams (`selfPid` / timing) ride through by width subtyping and the manager
+  // ignores them — only `processTableSource` / `realpath` are consumed here.
+  const manager = buildManager(ctx, deps);
+  const inFlight = await manager.listInFlightMerges();
+
+  if (optionalBoolean(args.probe) !== true) {
+    return { success: true, data: { inFlight, count: inFlight.length } };
+  }
+
+  // --probe: pull the DR-5 probe on demand and emit released / orphan_detected.
+  const reclaim = await manager.probeAndReclaim(deps?.selfPid);
+  return {
+    success: true,
+    data: { inFlight, count: inFlight.length, probe: reclaim },
+  };
+}
+
+/** Structured (never-hang) bounded-wait timeout for {@link handleViewWait}. */
+function waitTimeout(
+  integrationRef: string,
+  timeoutMs: number,
+  holder: InFlightMerge,
+): ToolResult {
+  return {
+    success: false,
+    error: {
+      code: 'WAIT_TIMEOUT',
+      message: `merge slot for integration ref '${integrationRef}' did not reach a terminal worktree.merge_executed within ${timeoutMs}ms`,
+    },
+    // The error envelope has a fixed field set; the structured payload rides
+    // `data`, with `reason` the stable kebab discriminator callers match on.
+    data: {
+      reason: 'wait-timeout' as const,
+      integrationRef,
+      timeoutMs,
+      holder: {
+        operationId: holder.operationId,
+        sourceBranch: holder.sourceBranch,
+        holderPid: holder.holderPid,
+      },
+    },
+  };
+}
+
+/**
+ * `wait` — block until the serialized merge on `integrationRef` reaches its
+ * terminal `worktree.merge_executed` (DR-4). Caller-bounded: folds the current
+ * events and, if not yet terminal, bounded-polls the injected `sleep` seam under
+ * an explicit `--timeout`, re-folding each iteration; returns a STRUCTURED
+ * timeout on expiry. Pure read — appends nothing, spins up NO background
+ * interval/daemon, and NEVER hangs.
+ */
+export async function handleViewWait(
+  args: Record<string, unknown>,
+  ctx: DispatchContext,
+  deps?: WorktreeViewDeps,
+): Promise<ToolResult> {
+  const integrationRef = optionalString(args.integrationRef);
+  if (!integrationRef) {
+    return invalidInput('wait requires integrationRef: string', {
+      integrationRef: 'string',
+    });
+  }
+  const timeoutMs =
+    typeof args.timeoutMs === 'number' &&
+    Number.isInteger(args.timeoutMs) &&
+    args.timeoutMs > 0
+      ? args.timeoutMs
+      : DEFAULT_WAIT_TIMEOUT_MS;
+
+  const manager = buildManager(ctx);
+  const result = await manager.waitForMergeTerminal(integrationRef, {
+    timeoutMs,
+    ...(deps?.sleep !== undefined ? { sleep: deps.sleep } : {}),
+    ...(deps?.now !== undefined ? { now: deps.now } : {}),
+    ...(deps?.pollIntervalMs !== undefined ? { pollIntervalMs: deps.pollIntervalMs } : {}),
+  });
+
+  if (result.resolved) {
+    return {
+      success: true,
+      data: { integrationRef, resolved: true, waitedMs: result.waitedMs },
+    };
+  }
+  return waitTimeout(integrationRef, timeoutMs, result.holder);
 }

--- a/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
@@ -26,6 +26,11 @@ import {
   defaultProcessSource,
   type ProcessSource,
 } from './pure/process-identity.js';
+import {
+  serializeMerge,
+  type SerializeMergeInput,
+  type SerializeMergeDeps,
+} from './merge-serializer.js';
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -295,4 +300,68 @@ export async function handleViewWorktrees(
     success: true,
     data: { worktrees, count: worktrees.length },
   };
+}
+
+// ─── serialize_merge (WLM operational core, DR-7) ─────────────────────────────
+
+/**
+ * Serialize an integration-branch merge behind the optimistic per-`integrationRef`
+ * lease, then compose `merge_orchestrate` UNCHANGED. The lease (a
+ * `worktree.merge_requested` / `worktree.merge_executed` pair on the singleton
+ * `worktrees` stream) is the ONLY serialization — no flock, no `.lock` file. The
+ * `deps` parameter is the test-only DI seam (injected sleep / process-table
+ * probe / composed merge); production callers omit it so the serializer wires the
+ * real OS-backed defaults. Validates the four required fields up front so a
+ * malformed dispatch returns a structured `INVALID_INPUT` rather than reaching
+ * the lease loop.
+ */
+export async function handleSerializeMerge(
+  args: Record<string, unknown>,
+  ctx: DispatchContext,
+  deps?: SerializeMergeDeps,
+): Promise<ToolResult> {
+  const featureId = optionalString(args.featureId);
+  if (!featureId) {
+    return invalidInput('serialize_merge requires featureId: string', {
+      featureId: 'string',
+    });
+  }
+  const integrationRef = optionalString(args.integrationRef);
+  if (!integrationRef) {
+    return invalidInput('serialize_merge requires integrationRef: string', {
+      integrationRef: 'string',
+    });
+  }
+  const sourceBranch = optionalString(args.sourceBranch);
+  if (!sourceBranch) {
+    return invalidInput('serialize_merge requires sourceBranch: string', {
+      sourceBranch: 'string',
+    });
+  }
+  const strategy = optionalString(args.strategy);
+  if (strategy !== 'squash' && strategy !== 'rebase' && strategy !== 'merge') {
+    return invalidInput(
+      "serialize_merge requires strategy: 'squash' | 'rebase' | 'merge'",
+      { strategy: "'squash' | 'rebase' | 'merge'" },
+    );
+  }
+  const taskId = optionalString(args.taskId);
+  const repoRoot = optionalString(args.repoRoot);
+  const timeoutMs =
+    typeof args.timeoutMs === 'number' &&
+    Number.isInteger(args.timeoutMs) &&
+    args.timeoutMs > 0
+      ? args.timeoutMs
+      : undefined;
+
+  const input: SerializeMergeInput = {
+    featureId,
+    integrationRef,
+    sourceBranch,
+    strategy,
+    ...(taskId !== undefined ? { taskId } : {}),
+    ...(repoRoot !== undefined ? { repoRoot } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  };
+  return serializeMerge(input, ctx, deps);
 }

--- a/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
@@ -77,6 +77,12 @@ import {
   defaultRealpath,
   type RealpathResolver,
 } from './pure/path-containment.js';
+import {
+  probeWorktrees,
+  defaultProcessTableSource,
+  type ProcessTableSource,
+} from './pure/probe.js';
+import { defaultSleep, type SleepFn } from './git-retry.js';
 import { reservationLiveness, selectDeadReservations } from './pure/ownership.js';
 import {
   classifyPruneCandidate,
@@ -87,6 +93,7 @@ import {
 import type {
   WorktreeEntry,
   WorktreesProjection,
+  InFlightMerge,
 } from './projections/worktrees.js';
 // Side-effect import: registers the `worktrees@v1` reducer with the
 // process-wide `defaultRegistry` so the appender's `aggregateStream` / `decide`
@@ -99,6 +106,12 @@ export const WORKTREES_STREAM = 'worktrees';
 
 /** Reducer id used to fold {@link WORKTREES_STREAM} into the live worktree set. */
 export const WORKTREES_REDUCER = 'worktrees@v1';
+
+/** Default bounded-wait budget (ms) for {@link WorktreeManager.waitForMergeTerminal}. */
+export const DEFAULT_WAIT_TIMEOUT_MS = 30_000;
+
+/** Default poll interval (ms) between bounded-wait re-folds. */
+export const DEFAULT_WAIT_POLL_INTERVAL_MS = 200;
 
 // ─── Real git ground-truth probe (Task 005 owns it) ─────────────────────────
 
@@ -495,6 +508,16 @@ export interface WorktreeManagerDeps {
    * path never `git reset --hard`s); defaults to {@link defaultGitRunner}.
    */
   readonly gitRunner?: GitRunner;
+  /**
+   * Ground-truth process-table source used by the on-demand orphan probe
+   * ({@link WorktreeManager.probeAndReclaim}, DR-5). Injected so the probe is
+   * testable with a fake table and zero OS access; defaults to the real
+   * {@link defaultProcessTableSource} (`/proc` on Linux, empty/fail-closed
+   * elsewhere). NOTE: distinct from {@link processSource} — that is the per-PID
+   * create-time probe for reservation liveness; this enumerates the FULL table
+   * for cwd-occupancy + protected-ancestry subtraction.
+   */
+  readonly processTableSource?: ProcessTableSource;
 }
 
 /** Arguments for {@link WorktreeManager.reserve}. */
@@ -557,6 +580,21 @@ export interface ReconcileResult {
   readonly released: readonly string[];
 }
 
+/** Outcome of a {@link WorktreeManager.probeAndReclaim} pass (DR-5 + orphan emitter). */
+export interface ProbeReclaimResult {
+  /** `worktreeId`s for which a `worktree.released` was emitted (owner dead, not in use). */
+  readonly released: readonly string[];
+  /** `worktreeId`s for which a `worktree.orphan_detected` was emitted (owner dead, still in use). */
+  readonly orphaned: readonly string[];
+  /** Total governed worktrees the probe classified this pass. */
+  readonly probed: number;
+}
+
+/** Outcome of a {@link WorktreeManager.waitForMergeTerminal} bounded poll. */
+export type WaitForMergeTerminalResult =
+  | { readonly resolved: true; readonly waitedMs: number }
+  | { readonly resolved: false; readonly holder: InFlightMerge; readonly waitedMs: number };
+
 /**
  * The in-process worktree-lifecycle facade. Construct one per
  * {@link EventStore}; it is cheap and holds no mutable state.
@@ -568,6 +606,7 @@ export class WorktreeManager {
   private readonly featureIdResolver: FeatureIdResolver;
   private readonly realpath: RealpathResolver;
   private readonly gitRunner: GitRunner;
+  private readonly processTableSource: ProcessTableSource;
 
   constructor(deps: WorktreeManagerDeps) {
     this.eventStore = deps.eventStore;
@@ -576,6 +615,7 @@ export class WorktreeManager {
     this.featureIdResolver = deps.featureIdResolver ?? unattachedFeatureIdResolver;
     this.realpath = deps.realpath ?? defaultRealpath;
     this.gitRunner = deps.gitRunner ?? defaultGitRunner;
+    this.processTableSource = deps.processTableSource ?? defaultProcessTableSource;
   }
 
   /**
@@ -1014,6 +1054,151 @@ export class WorktreeManager {
   async list(): Promise<readonly WorktreeEntry[]> {
     const projection = await this.loadProjection();
     return Object.values(projection.worktrees);
+  }
+
+  /**
+   * Read-only listing of the live serialized-merge set (DR-4): fold the
+   * `worktrees` stream and return every {@link InFlightMerge} — an open
+   * `worktree.merge_requested` with no paired `worktree.merge_executed`. Backs
+   * the `ps` view action's in-flight column. Appends nothing and runs NO process
+   * scan — it is a pure fold of the event log.
+   */
+  async listInFlightMerges(): Promise<readonly InFlightMerge[]> {
+    const projection = await this.loadProjection();
+    return Object.values(projection.inFlightMerges);
+  }
+
+  /**
+   * On-demand orphan / stale-reservation probe + emit — the deferred orphan
+   * emitter (DR-5). Folds the `worktrees@v1` projection, runs the ground-truth
+   * {@link probeWorktrees} process probe over every governed worktree, and emits
+   * exactly ONE terminal lifecycle event per finding:
+   *
+   *   - recorded owner provably DEAD and NOT occupied by a live process →
+   *     `worktree.released` (heal the stale reservation, exactly as `reconcile`
+   *     does — but cross-checked against ground-truth cwd occupancy).
+   *   - recorded owner provably DEAD but the worktree IS still occupied by a
+   *     live, non-ancestry process → `worktree.orphan_detected` (the recorded
+   *     owner is gone yet work may be live; flag as orphan, do NOT free).
+   *
+   * A live / unprovable (`unknown`) owner, and any unreserved entry, emit
+   * NOTHING — the probe never reclaims what it cannot prove gone. `selfPid` (and
+   * its FULL parent-PID ancestry) is excluded from occupancy so the
+   * orchestrator's own drifted cwd never marks a worktree in-use. This is the
+   * ONLY write path on the otherwise read-only `ps`/`wait` view surface, and it
+   * runs only when the caller passes `--probe`. Idempotent across runs: once
+   * released/orphaned the entry is no longer `reserved`, so a re-probe finds no
+   * dead owner and emits nothing.
+   */
+  async probeAndReclaim(selfPid: number = process.pid): Promise<ProbeReclaimResult> {
+    const projection = await this.loadProjection();
+    const entries = Object.values(projection.worktrees);
+    const targets = entries.map((entry) => ({
+      worktreePath: entry.path,
+      owner:
+        entry.state === 'reserved' &&
+        entry.ownerPid !== null &&
+        entry.ownerStartedAt !== null
+          ? { ownerPid: entry.ownerPid, ownerStartedAt: entry.ownerStartedAt }
+          : null,
+    }));
+    // Findings come back in target order; zip with `entries` by index so the
+    // canonical `worktreeId` (the projection key) — not just the probe's `path`
+    // — is what we stamp on the emitted event.
+    const findings = probeWorktrees(
+      { targets, selfPid },
+      this.processTableSource,
+      this.realpath,
+    );
+
+    const released: string[] = [];
+    const orphaned: string[] = [];
+    for (let i = 0; i < entries.length; i += 1) {
+      const entry = entries[i];
+      const finding = findings[i];
+      if (finding === undefined) continue;
+      if (finding.releasable) {
+        // Owner provably dead AND no live occupant → free the stale reservation.
+        await this.appendLifecycle('worktree.released', entry);
+        released.push(entry.worktreeId);
+      } else if (finding.ownerLiveness === 'dead' && finding.inUse) {
+        // Owner provably dead BUT a live foreign process occupies it → orphan.
+        await this.appendLifecycle('worktree.orphan_detected', entry);
+        orphaned.push(entry.worktreeId);
+      }
+    }
+    return { released, orphaned, probed: entries.length };
+  }
+
+  /**
+   * Append one terminal lifecycle event (`worktree.released` /
+   * `worktree.orphan_detected`) for `entry`, clearing the owner fields. Keyed by
+   * `<eventType>:<operationId>` for idempotency (matching the rest of the
+   * worktree family); the `worktrees@v1` reducer flips the entry's state and
+   * nulls the owner on fold. A plain keyed append — no OCC pin — because the
+   * probe already established the owner is provably dead (no live claim to race).
+   */
+  private async appendLifecycle(
+    type: 'worktree.released' | 'worktree.orphan_detected',
+    entry: WorktreeEntry,
+  ): Promise<void> {
+    const operationId = randomUUID();
+    await withStateRetry(() =>
+      this.eventStore.append(
+        WORKTREES_STREAM,
+        {
+          type,
+          data: {
+            worktreeId: entry.worktreeId,
+            path: entry.path,
+            featureId: entry.featureId,
+            ownerPid: null,
+            ownerStartedAt: null,
+            operationId,
+          },
+        },
+        { idempotencyKey: `${type}:${operationId}` },
+      ),
+    );
+  }
+
+  /**
+   * Caller-bounded poll until the serialized merge on `integrationRef` reaches
+   * its terminal `worktree.merge_executed` (DR-4). Folds `worktrees@v1` each
+   * iteration: when `inFlightMerges[integrationRef]` is clear the wait RESOLVES;
+   * otherwise it sleeps `pollIntervalMs` via the INJECTED {@link SleepFn} seam
+   * (shared with `git-retry.ts`) and re-folds, until the explicit `timeoutMs`
+   * deadline — then returns `{ resolved: false }` with the still-live holder so
+   * the caller can surface a STRUCTURED timeout. Pure read: appends NOTHING and
+   * creates NO background interval/timer (the only timer is the injected sleep's
+   * own, which production wires to `setTimeout` and tests replace). NEVER hangs.
+   */
+  async waitForMergeTerminal(
+    integrationRef: string,
+    opts: {
+      readonly timeoutMs?: number;
+      readonly sleep?: SleepFn;
+      readonly now?: () => number;
+      readonly pollIntervalMs?: number;
+    } = {},
+  ): Promise<WaitForMergeTerminalResult> {
+    const sleep = opts.sleep ?? defaultSleep;
+    const now = opts.now ?? Date.now;
+    const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_WAIT_POLL_INTERVAL_MS;
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+    const start = now();
+    const deadline = start + timeoutMs;
+    while (true) {
+      const projection = await this.loadProjection();
+      const holder = projection.inFlightMerges[integrationRef];
+      if (holder === undefined) {
+        return { resolved: true, waitedMs: now() - start };
+      }
+      if (now() >= deadline) {
+        return { resolved: false, holder, waitedMs: now() - start };
+      }
+      await sleep(pollIntervalMs);
+    }
   }
 
   /**

--- a/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
@@ -1161,14 +1161,24 @@ export class WorktreeManager {
       const entry = entries[i];
       const finding = findings[i];
       if (finding === undefined) continue;
-      if (finding.releasable) {
-        // Owner provably dead AND no live occupant → free the stale reservation.
-        await this.appendLifecycle('worktree.released', entry);
-        released.push(entry.worktreeId);
-      } else if (finding.ownerLiveness === 'dead' && finding.inUse) {
-        // Owner provably dead BUT a live foreign process occupies it → orphan.
-        await this.appendLifecycle('worktree.orphan_detected', entry);
-        orphaned.push(entry.worktreeId);
+      // Per-entry isolation: a transient append failure on ONE reclaim must not
+      // abort the whole batch. An entry is counted as released/orphaned ONLY
+      // after its event provably lands (INV-1) — never report a reclaim that
+      // failed to persist. A skipped entry stays `reserved`, so the next probe
+      // pass retries it at-most-once (INV-8); the reclaim self-heals across runs.
+      try {
+        if (finding.releasable) {
+          // Owner provably dead AND no live occupant → free the stale reservation.
+          await this.appendLifecycle('worktree.released', entry);
+          released.push(entry.worktreeId);
+        } else if (finding.ownerLiveness === 'dead' && finding.inUse) {
+          // Owner provably dead BUT a live foreign process occupies it → orphan.
+          await this.appendLifecycle('worktree.orphan_detected', entry);
+          orphaned.push(entry.worktreeId);
+        }
+      } catch {
+        // Reclaim is self-healing across passes — skip this entry, keep going.
+        continue;
       }
     }
     return { released, orphaned, probed: entries.length };

--- a/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
@@ -473,6 +473,35 @@ function eventStringField(event: WorkflowEvent, key: string): string | null {
   return typeof value === 'string' ? value : null;
 }
 
+/**
+ * Whether a prune candidate is covered by an unpaired in-flight merge lease
+ * (DR-12, no double-free). Pure over a folded `inFlightMerges` map so it is
+ * shared by both the classification pass (over the planning fold) AND the
+ * under-lock re-verification inside `executeDeletion` (over the fold INSIDE the
+ * `decide` closure — "re-verified under its claim").
+ *
+ * A lease covers the candidate when EITHER:
+ *   - the lease is attributed to this exact worktree (`merge.worktreeId === worktreeId`); or
+ *   - the lease targets the candidate's resolved integration ref
+ *     (`merge.integrationRef === integrationRef`) — the serializer leaves
+ *     `worktreeId` null, so the integration-ref match is what catches a
+ *     `serialize_merge` racing the GC for the same branch.
+ *
+ * Both arms are conservative (fail-closed): a held lease keeps the worktree, so
+ * the GC never deletes a worktree whose branch a live merge is mid-applying.
+ */
+function mergeLeaseHeld(
+  worktreeId: string,
+  integrationRef: string | null,
+  inFlightMerges: Readonly<Record<string, InFlightMerge>>,
+): boolean {
+  for (const merge of Object.values(inFlightMerges)) {
+    if (merge.worktreeId !== null && merge.worktreeId === worktreeId) return true;
+    if (integrationRef !== null && merge.integrationRef === integrationRef) return true;
+  }
+  return false;
+}
+
 /** Constructor dependencies for {@link WorktreeManager}. */
 export interface WorktreeManagerDeps {
   /** The shared event store — the manager's ONLY persistence path. */
@@ -984,7 +1013,20 @@ export class WorktreeManager {
     const reports: PruneCandidateReport[] = [];
     for (const entry of candidates) {
       const facts = await this.gatherFacts(entry, branchCache);
-      const classification = classifyPruneCandidate(facts);
+      let classification = classifyPruneCandidate(facts);
+      // No double-free (DR-12): a worktree (or its integration branch) that
+      // holds an unpaired in-flight merge lease is never deletion-eligible while
+      // the merge runs — override an otherwise-deletable classification to a
+      // scannable `in-flight-merge` skip. The under-lock re-verify in
+      // `executeDeletion` enforces the same guard against a lease that appears
+      // AFTER this planning fold, so the report and the commit gate agree.
+      if (
+        (classification.action === 'delete-eligible' ||
+          classification.action === 'orphan-unverifiable') &&
+        mergeLeaseHeld(entry.worktreeId, facts.integrationRef, projection.inFlightMerges)
+      ) {
+        classification = { action: 'skip', reason: 'in-flight-merge' };
+      }
       const reclaimable =
         classification.action === 'delete-eligible' ||
         classification.action === 'orphan-unverifiable'
@@ -1422,6 +1464,14 @@ export class WorktreeManager {
           // A worktree that became dirty / unmerged / in-use between the planning
           // pass and now is no longer safe — abort rather than commit the delete.
           const facts = await this.gatherFacts(entry, branchCache);
+          // No double-free (DR-12), re-verified UNDER the claim: a merge lease
+          // that landed on this worktree (or its integration branch) AFTER the
+          // planning fold is visible in THIS in-closure fold of `inFlightMerges`,
+          // so a `serialize_merge` that won the slot concurrently aborts the
+          // delete intent — the GC never removes a worktree mid-merge.
+          if (mergeLeaseHeld(worktreeId, facts.integrationRef, state.inFlightMerges)) {
+            return [];
+          }
           const classification = classifyPruneCandidate(facts);
           const stillEligible =
             classification.action === 'delete-eligible' ||

--- a/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
@@ -541,8 +541,10 @@ export interface WorktreeManagerDeps {
    * Ground-truth process-table source used by the on-demand orphan probe
    * ({@link WorktreeManager.probeAndReclaim}, DR-5). Injected so the probe is
    * testable with a fake table and zero OS access; defaults to the real
-   * {@link defaultProcessTableSource} (`/proc` on Linux, empty/fail-closed
-   * elsewhere). NOTE: distinct from {@link processSource} — that is the per-PID
+   * {@link defaultProcessTableSource} (`/proc` on Linux; off-Linux the source
+   * reports `isSupported() === false` so every owner reads `'unknown'` and the
+   * probe releases / orphans NOTHING — fail closed, never a spurious heal).
+   * NOTE: distinct from {@link processSource} — that is the per-PID
    * create-time probe for reservation liveness; this enumerates the FULL table
    * for cwd-occupancy + protected-ancestry subtraction.
    */

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
@@ -580,6 +580,34 @@ describe('serialize_merge — unresolvable create-time (Sentry #15023070/1)', ()
     expect(() => schema.parse(claim!.data)).not.toThrow();
     expect(() => schema.parse({ ...claim!.data, holderStartedAt: '' })).toThrow();
   });
+
+  it('SerializeMerge_Release_EmitsSchemaValidStatus_NoStraySourceBranch', async () => {
+    // Sentry #15023037/0: the RELEASE event must carry the required `status` and
+    // must NOT carry the CLAIM-only `sourceBranch`, so the raw stored event
+    // conforms to WorktreeMergeExecutedData.
+    const arm = await createArm();
+    const merged: string[] = [];
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef: 'integration/release', sourceBranch: 'feat/y', strategy: 'merge', timeoutMs: 10_000 },
+      arm.ctx,
+      {
+        selfPid: 777,
+        selfStartedAt: 'self-777',
+        mergeOrchestrate: recordingMerge(merged),
+        readIntegrationHead: () => null,
+      },
+    );
+    expect(result.success).toBe(true);
+
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    const release = events.find((e) => e.type === 'worktree.merge_executed');
+    expect(release).toBeDefined();
+    const data = release!.data as Record<string, unknown>;
+    expect(data.status).toBe('merged'); // truthful terminal for a successful merge
+    expect('sourceBranch' in data).toBe(false); // CLAIM-only field, not on the release
+    // The raw stored event validates against the canonical release schema.
+    expect(() => EVENT_DATA_SCHEMAS['worktree.merge_executed'].parse(data)).not.toThrow();
+  });
 });
 
 // ─── Test 6: handleOrchestrate routes serialize_merge to the handler ──────────

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
@@ -19,6 +19,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { EventStore } from '../../event-store/store.js';
+import { EVENT_DATA_SCHEMAS } from '../../event-store/schemas.js';
 import type { DispatchContext } from '../../core/dispatch.js';
 import { rmrfAsync } from '../../test-helpers/temp-dir.js';
 import { writeStateFile } from '../../workflow/state-store.js';
@@ -543,6 +544,41 @@ describe('serialize_merge — the lease IS the serialization', () => {
       entry.toString().endsWith('.lock'),
     );
     expect(lockFiles).toEqual([]);
+  });
+});
+
+// ─── Test 5b: unresolved create-time emits schema-valid null holderStartedAt ───
+
+describe('serialize_merge — unresolvable create-time (Sentry #15023070/1)', () => {
+  it('SerializeMerge_UnresolvedStartTime_EmitsNullHolderStartedAt_SchemaValid', async () => {
+    const arm = await createArm();
+    const merged: string[] = [];
+    // A process source that can't resolve the caller's create-time (the off-Linux
+    // shape). Do NOT inject selfStartedAt, so resolveSelfStartedAt runs and must
+    // yield null — NOT '' — keeping the emitted event schema-valid.
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef: 'integration/nostart', sourceBranch: 'feat/x', strategy: 'merge', timeoutMs: 10_000 },
+      arm.ctx,
+      {
+        processSource: { getStartTime: () => ({ status: 'absent' as const }) },
+        selfPid: 555,
+        mergeOrchestrate: recordingMerge(merged),
+        readIntegrationHead: () => null,
+      },
+    );
+    expect(result.success).toBe(true);
+
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    const claim = events.find((e) => e.type === 'worktree.merge_requested');
+    expect(claim).toBeDefined();
+    // Modeled as null (absence), never an out-of-contract empty string.
+    expect((claim!.data as { holderStartedAt?: unknown }).holderStartedAt).toBeNull();
+
+    // The stored raw event validates against the canonical data schema — null is
+    // in-contract now (z.string().min(1).nullable()); '' would still be rejected.
+    const schema = EVENT_DATA_SCHEMAS['worktree.merge_requested'];
+    expect(() => schema.parse(claim!.data)).not.toThrow();
+    expect(() => schema.parse({ ...claim!.data, holderStartedAt: '' })).toThrow();
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
@@ -1,0 +1,590 @@
+// ─── serialize_merge — integration-branch merge lease tests (DR-7) ────────────
+//
+// The optimistic lease: at most one in-flight merge per `integrationRef`,
+// composing `merge_orchestrate` UNCHANGED. Concurrency tests run against a real
+// SQLite EventStore (the substrate's in-transaction stream-version gate is the
+// cross-process guard); the composition test runs the REAL merge over two real
+// temp git repos so the per-featureId `merge.*` events are compared modulo the
+// commit-derived SHAs. Every behavioral test drives the handler / lease with
+// deterministic injected seams (no real timers, no OS process probe); the
+// routing test drives `handleOrchestrate` so a missing dispatch wiring goes red.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { EventStore } from '../../event-store/store.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import { writeStateFile } from '../../workflow/state-store.js';
+import type { ToolResult } from '../../format.js';
+
+import { handleOrchestrate } from '../composite.js';
+import { handleMergeOrchestrate } from '../merge-orchestrate.js';
+import { serializeMerge } from './merge-serializer.js';
+import { handleSerializeMerge } from './handlers.js';
+import { WORKTREES_STREAM, WORKTREES_REDUCER } from './manager.js';
+import type { WorktreesProjection } from './projections/worktrees.js';
+import type { ProcessTableSource, ProcessRecord } from './pure/probe.js';
+import type { SleepFn } from './git-retry.js';
+
+// ─── Arm: one stateDir + EventStore + ctx ────────────────────────────────────
+
+interface Arm {
+  readonly stateDir: string;
+  readonly eventStore: EventStore;
+  readonly ctx: DispatchContext;
+}
+
+const arms: Arm[] = [];
+const repoDirs: string[] = [];
+
+async function createArm(stateDirOverride?: string): Promise<Arm> {
+  const stateDir = stateDirOverride ?? (await mkdtemp(path.join(tmpdir(), 'wlm-serialize-')));
+  const eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+  const ctx: DispatchContext = { stateDir, eventStore, enableTelemetry: false };
+  const arm = { stateDir, eventStore, ctx };
+  arms.push(arm);
+  return arm;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  while (arms.length > 0) {
+    const arm = arms.pop();
+    if (arm) {
+      arm.eventStore.close();
+      await rmrfAsync(arm.stateDir);
+    }
+  }
+  while (repoDirs.length > 0) {
+    const dir = repoDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Live process table reporting exactly the listed (pid, startTime) pairs alive. */
+function liveTable(pairs: ReadonlyArray<{ pid: number; startTime: string }>): ProcessTableSource {
+  const records: ProcessRecord[] = pairs.map(({ pid, startTime }) => ({
+    pid,
+    ppid: 1,
+    cwd: `/proc-fixture/${pid}`,
+    startTime,
+  }));
+  return { list: () => records };
+}
+
+/** Empty process table — every probed pid reads as absent (provably dead). */
+const EMPTY_TABLE: ProcessTableSource = { list: () => [] };
+
+/** A merge_orchestrate stub that records the featureIds it ran for. */
+function recordingMerge(into: string[]): (input: { featureId: string }) => Promise<ToolResult> {
+  return async (input) => {
+    into.push(input.featureId);
+    return { success: true, data: { phase: 'completed' } };
+  };
+}
+
+/** Directly seed a held lease (CLAIM) on the worktrees stream. */
+async function seedHolder(
+  arm: Arm,
+  holder: {
+    integrationRef: string;
+    operationId: string;
+    sourceBranch: string;
+    holderPid: number;
+    holderStartedAt: string;
+  },
+): Promise<void> {
+  await arm.eventStore.getAppender().append(
+    WORKTREES_STREAM,
+    [{ type: 'worktree.merge_requested', data: { ...holder } }],
+    `worktree.merge_requested:${holder.operationId}`,
+  );
+}
+
+async function foldWorktrees(arm: Arm): Promise<WorktreesProjection> {
+  const { aggregate } = await arm.eventStore
+    .getAppender()
+    .aggregateStream<WorktreesProjection>(WORKTREES_STREAM, WORKTREES_REDUCER);
+  return aggregate;
+}
+
+// ─── Real-git helpers (composition test) ─────────────────────────────────────
+
+function git(repoRoot: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+/**
+ * A repo where `main` (the integration ref) IS an ancestor of `feat` (the
+ * source): main@A, feat@A→C. HEAD is left on `feat` (a non-protected branch) so
+ * merge-preflight passes — ancestry, current-branch, main-worktree, drift all
+ * clean — and `git merge --no-ff feat` lands a clean merge commit on main.
+ */
+function setupMergeableRepo(): string {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), 'wlm-serialize-repo-'));
+  repoDirs.push(repoRoot);
+  git(repoRoot, ['init', '--initial-branch=main', '-q']);
+  git(repoRoot, ['config', 'user.email', 'test@example.com']);
+  git(repoRoot, ['config', 'user.name', 'Test']);
+  git(repoRoot, ['config', 'commit.gpgsign', 'false']);
+  writeFileSync(path.join(repoRoot, 'a.txt'), 'A\n');
+  git(repoRoot, ['add', 'a.txt']);
+  git(repoRoot, ['commit', '-m', 'A', '-q']);
+  git(repoRoot, ['checkout', '-b', 'feat', '-q']);
+  writeFileSync(path.join(repoRoot, 'c.txt'), 'C\n');
+  git(repoRoot, ['add', 'c.txt']);
+  git(repoRoot, ['commit', '-m', 'C', '-q']);
+  return repoRoot;
+}
+
+async function seedFeatureState(stateDir: string, featureId: string): Promise<void> {
+  const now = new Date().toISOString();
+  await writeStateFile(
+    path.join(stateDir, `${featureId}.state.json`),
+    {
+      version: '1.1',
+      workflowType: 'feature',
+      featureId,
+      phase: 'delegate',
+      createdAt: now,
+      updatedAt: now,
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      integration: null,
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      mergeOrchestrator: { phase: 'pending', sourceBranch: 'feat', targetBranch: 'main' },
+    } as never,
+  );
+}
+
+/** Normalize a `merge.*` event to its stable (non-volatile, non-SHA) projection. */
+function normalizeMergeEvent(e: { type: string; data?: Record<string, unknown> }): Record<string, unknown> {
+  const d = e.data ?? {};
+  return {
+    type: e.type,
+    sourceBranch: d.sourceBranch,
+    targetBranch: d.targetBranch,
+    ...(d.strategy !== undefined ? { strategy: d.strategy } : {}),
+    ...(d.passed !== undefined ? { passed: d.passed } : {}),
+  };
+}
+
+// ─── Test 1: second claimant waits for the first's release before claiming ────
+
+describe('serialize_merge — single-writer ordering', () => {
+  it('SerializeMerge_TwoFeatureIdsSameBranch_SecondWaitsForFirstExecutedBeforeClaiming', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/main';
+    const f1OpId = 'f1-holder-op';
+
+    // F1 holds the lease under a LIVE pid (999).
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: f1OpId,
+      sourceBranch: 'feat/1',
+      holderPid: 999,
+      holderStartedAt: 'alive-999',
+    });
+
+    // The injected sleep releases F1 on its FIRST call, so F2 must wait at least
+    // one poll iteration and can only claim AFTER F1's worktree.merge_executed.
+    let sleepCalls = 0;
+    let released = false;
+    const sleep: SleepFn = async () => {
+      sleepCalls += 1;
+      if (!released) {
+        released = true;
+        await arm.eventStore.getAppender().append(
+          WORKTREES_STREAM,
+          [{ type: 'worktree.merge_executed', data: { integrationRef, operationId: f1OpId, sourceBranch: 'feat/1' } }],
+          `worktree.merge_executed:${f1OpId}`,
+        );
+      }
+    };
+
+    const merged: string[] = [];
+    const result = await serializeMerge(
+      { featureId: 'F2', integrationRef, sourceBranch: 'feat/2', strategy: 'merge', timeoutMs: 10_000 },
+      arm.ctx,
+      {
+        sleep,
+        processTableSource: liveTable([{ pid: 999, startTime: 'alive-999' }]),
+        selfPid: 222,
+        selfStartedAt: 'self-222',
+        mergeOrchestrate: recordingMerge(merged),
+        readIntegrationHead: () => 'head-sha',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(merged).toEqual(['F2']);
+    expect(sleepCalls).toBeGreaterThanOrEqual(1); // F2 blocked at least once.
+
+    // Ordering: F2's CLAIM lands strictly AFTER F1's RELEASE.
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    const f1ExecIdx = events.findIndex(
+      (e) => e.type === 'worktree.merge_executed' && e.data?.operationId === f1OpId,
+    );
+    const f2ReqIdx = events.findIndex(
+      (e) => e.type === 'worktree.merge_requested' && e.data?.operationId !== f1OpId,
+    );
+    expect(f1ExecIdx).toBeGreaterThanOrEqual(0);
+    expect(f2ReqIdx).toBeGreaterThan(f1ExecIdx);
+
+    // The lease is released at the end — no in-flight merge remains.
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+  });
+});
+
+// ─── Test 2: concurrent claims resolve to a single holder (real-SQLite, x-proc)─
+
+describe('serialize_merge — cross-process OCC', () => {
+  it('SerializeMerge_ConcurrentClaims_OccResolvesSingleHolderCrossProcess', async () => {
+    // TWO EventStores over the SAME db file = two appenders / two SQLite handles
+    // = a genuine cross-process race resolved by the in-txn stream-version gate.
+    const armA = await createArm();
+    const armB = await createArm(armA.stateDir);
+    const integrationRef = 'integration/shared';
+
+    // The composed merge asserts non-overlap: if serialization broke and both
+    // claims won, two merges would run concurrently and maxActive would reach 2.
+    let active = 0;
+    let maxActive = 0;
+    const merged: string[] = [];
+    const mergeOrchestrate = async (input: { featureId: string }): Promise<ToolResult> => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      // Hold the lease across the loser's OCC-conflict retry window (its
+      // withStateRetry backoff is ~50ms): a winner that releases too fast would
+      // let the loser re-claim a FREE slot, masking a broken in-closure guard.
+      // Holding makes the loser's retry fold the LIVE holder, so a removed guard
+      // commits a second claim (active-claim counter → 2) and the log invariant
+      // below goes red.
+      await new Promise((r) => setTimeout(r, 120));
+      active -= 1;
+      merged.push(input.featureId);
+      return { success: true, data: { phase: 'completed' } };
+    };
+
+    // The loser polls a MACROTASK so it never starves the winner's setImmediate.
+    const sleep: SleepFn = () => new Promise((r) => setImmediate(r));
+    // Both claimants' pids read alive, so neither reclaims the other's live lease.
+    const table = liveTable([
+      { pid: 5001, startTime: 'start-A' },
+      { pid: 5002, startTime: 'start-B' },
+    ]);
+
+    const [rA, rB] = await Promise.all([
+      serializeMerge(
+        { featureId: 'F-A', integrationRef, sourceBranch: 'feat/a', strategy: 'merge', timeoutMs: 15_000 },
+        armA.ctx,
+        { sleep, processTableSource: table, selfPid: 5001, selfStartedAt: 'start-A', mergeOrchestrate, readIntegrationHead: () => 'head-a' },
+      ),
+      serializeMerge(
+        { featureId: 'F-B', integrationRef, sourceBranch: 'feat/b', strategy: 'merge', timeoutMs: 15_000 },
+        armB.ctx,
+        { sleep, processTableSource: table, selfPid: 5002, selfStartedAt: 'start-B', mergeOrchestrate, readIntegrationHead: () => 'head-b' },
+      ),
+    ]);
+
+    expect(rA.success).toBe(true);
+    expect(rB.success).toBe(true);
+    expect(maxActive).toBe(1); // never two in-flight merges at once (wall-clock).
+    expect([...merged].sort()).toEqual(['F-A', 'F-B']);
+
+    // Exactly one CLAIM + one RELEASE per featureId, slot ends clear.
+    const events = await armA.eventStore.query(WORKTREES_STREAM);
+    const claims = events.filter((e) => e.type === 'worktree.merge_requested');
+    const releases = events.filter((e) => e.type === 'worktree.merge_executed');
+    expect(claims).toHaveLength(2);
+    expect(releases).toHaveLength(2);
+    expect((await foldWorktrees(armA)).inFlightMerges[integrationRef]).toBeUndefined();
+
+    // DETERMINISTIC single-writer invariant on the COMMITTED log order: walk the
+    // worktrees stream maintaining an active-claim counter (+1 on a claim, -1 on
+    // a release). It must NEVER exceed 1 — two adjacent claims with no intervening
+    // release for the same ref is exactly the double-claim a broken in-closure OCC
+    // guard would produce (and is independent of wall-clock interleaving).
+    let activeClaims = 0;
+    let maxActiveClaims = 0;
+    for (const e of events) {
+      if (e.type === 'worktree.merge_requested' && e.data?.integrationRef === integrationRef) {
+        activeClaims += 1;
+        maxActiveClaims = Math.max(maxActiveClaims, activeClaims);
+      } else if (e.type === 'worktree.merge_executed' && e.data?.integrationRef === integrationRef) {
+        activeClaims -= 1;
+      }
+    }
+    expect(maxActiveClaims).toBe(1);
+  });
+});
+
+// ─── Test 3: merge_orchestrate composed UNCHANGED (real git, modulo SHAs) ─────
+
+describe('serialize_merge — composition', () => {
+  it('SerializeMerge_MergeOrchestrateComposedUnchanged_FeatureStreamEventsMatchModuloVolatileAndShas', async () => {
+    const featureId = 'feat-compose';
+
+    // (1) Serialized path — through handleOrchestrate, production defaults.
+    const repoSerial = setupMergeableRepo();
+    const armSerial = await createArm();
+    await seedFeatureState(armSerial.stateDir, featureId);
+    const serialResult = await handleOrchestrate(
+      {
+        action: 'serialize_merge',
+        featureId,
+        integrationRef: 'main',
+        sourceBranch: 'feat',
+        strategy: 'merge',
+        repoRoot: repoSerial,
+      },
+      armSerial.ctx,
+    );
+    expect(serialResult.success).toBe(true);
+
+    // (2) Direct path — handleMergeOrchestrate on an EQUIVALENT independent repo.
+    const repoDirect = setupMergeableRepo();
+    const armDirect = await createArm();
+    await seedFeatureState(armDirect.stateDir, featureId);
+    const directResult = await handleMergeOrchestrate(
+      { featureId, sourceBranch: 'feat', targetBranch: 'main', strategy: 'merge', repoRoot: repoDirect },
+      armDirect.ctx,
+    );
+    expect(directResult.success).toBe(true);
+
+    // The per-featureId `merge.*` timeline matches modulo id/timestamp/sequence
+    // AND the commit-derived SHAs (independent repos → different SHAs/paths).
+    const serialMerge = (await armSerial.eventStore.query(featureId))
+      .filter((e) => e.type.startsWith('merge.'))
+      .map(normalizeMergeEvent);
+    const directMerge = (await armDirect.eventStore.query(featureId))
+      .filter((e) => e.type.startsWith('merge.'))
+      .map(normalizeMergeEvent);
+
+    expect(serialMerge.length).toBeGreaterThan(0);
+    expect(serialMerge).toEqual(directMerge);
+    // The serializer adds NO events to the feature stream (only worktrees stream).
+    expect(serialMerge.map((e) => e.type)).toContain('merge.executed');
+  });
+});
+
+// ─── Test 4: release is a plain keyed append, NOT CAS-pinned to the claim seq ─
+
+describe('serialize_merge — release semantics', () => {
+  it('SerializeMerge_ReleaseIsPlainKeyedAppend_NotCasPinnedToClaimSeq', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/release';
+    const appender = arm.eventStore.getAppender();
+    const appendSpy = vi.spyOn(appender, 'append');
+
+    // The composed merge ADVANCES the worktrees stream with an unrelated event,
+    // so the tail moves PAST the claim seq before the release append runs. A
+    // CAS-pin to the claim seq would conflict here; a plain keyed append does not.
+    const mergeOrchestrate = async (): Promise<ToolResult> => {
+      await appender.append(
+        WORKTREES_STREAM,
+        [{ type: 'worktree.adopted', data: { worktreeId: '/tmp/unrelated-wt', path: '/tmp/unrelated-wt', featureId: null } }],
+        'worktree.adopted:unrelated-advance',
+      );
+      return { success: true, data: { phase: 'completed' } };
+    };
+
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef, sourceBranch: 'feat/x', strategy: 'merge', timeoutMs: 10_000 },
+      arm.ctx,
+      { mergeOrchestrate, readIntegrationHead: () => null, selfPid: 333, selfStartedAt: 'self-333' },
+    );
+    expect(result.success).toBe(true);
+
+    // The RELEASE append carried NO AppendOptions (no expectedSequence pin).
+    const releaseCall = appendSpy.mock.calls.find((c) => {
+      const events = c[1] as Array<{ type: string }>;
+      return events[0]?.type === 'worktree.merge_executed';
+    });
+    expect(releaseCall).toBeDefined();
+    expect(releaseCall![3]).toBeUndefined(); // 4th arg = AppendOptions → absent.
+
+    // Behavioral proof: the release CLEARED the slot despite the advanced tail.
+    const fold = await foldWorktrees(arm);
+    expect(fold.inFlightMerges[integrationRef]).toBeUndefined();
+    // The unrelated event really did advance the stream between claim and release.
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    const adoptIdx = events.findIndex((e) => e.type === 'worktree.adopted');
+    const releaseIdx = events.findIndex((e) => e.type === 'worktree.merge_executed');
+    expect(adoptIdx).toBeGreaterThanOrEqual(0);
+    expect(releaseIdx).toBeGreaterThan(adoptIdx);
+  });
+});
+
+// ─── Test 5: no lock file written, no flock library imported ──────────────────
+
+describe('serialize_merge — the lease IS the serialization', () => {
+  it('SerializeMerge_WritesNoLockFile_ImportsNoFlockLib', async () => {
+    // (a) Static: the serializer imports NO advisory-lock library and uses NO
+    // flock / .lock filesystem API. Strip comments first so the module's own
+    // prose ("no flock / .lock") cannot false-positive.
+    const sourcePath = fileURLToPath(new URL('./merge-serializer.ts', import.meta.url));
+    const source = readFileSync(sourcePath, 'utf-8');
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+      .replace(/(^|[^:])\/\/.*$/gm, '$1'); // line comments (keep "://" in URLs)
+    const importSpecifiers = [...code.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((m) => m[1]);
+    for (const spec of importSpecifiers) {
+      expect(spec.toLowerCase()).not.toContain('lock');
+    }
+    expect(code).not.toMatch(/flockSync|O_EXLOCK|proper-lockfile|lockfile|\.lock\b/i);
+
+    // (b) Behavioral: a full lease cycle writes NO `*.lock` file under stateDir.
+    const arm = await createArm();
+    const merged: string[] = [];
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef: 'integration/nolock', sourceBranch: 'feat/x', strategy: 'merge', timeoutMs: 10_000 },
+      arm.ctx,
+      { mergeOrchestrate: recordingMerge(merged), readIntegrationHead: () => null, selfPid: 444, selfStartedAt: 'self-444' },
+    );
+    expect(result.success).toBe(true);
+
+    const lockFiles = execFileSync('find', [arm.stateDir, '-name', '*.lock'], { encoding: 'utf-8' }).trim();
+    expect(lockFiles).toBe('');
+  });
+});
+
+// ─── Test 6: handleOrchestrate routes serialize_merge to the handler ──────────
+
+describe('serialize_merge — dispatch wiring', () => {
+  it('HandleOrchestrate_SerializeMerge_RoutesToHandler_NotUnknownAction', async () => {
+    const arm = await createArm();
+    // Dispatch with a MISSING required field: routing to the handler surfaces a
+    // structured INVALID_INPUT (the handler's own validation), NOT UNKNOWN_ACTION
+    // (which would mean the action fell through the dispatch table — the DOA class).
+    const result = await handleOrchestrate(
+      { action: 'serialize_merge', featureId: 'F' }, // integrationRef/sourceBranch/strategy missing
+      arm.ctx,
+    );
+    expect(result.error?.code).not.toBe('UNKNOWN_ACTION');
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+});
+
+// ─── Bonus: bounded-wait timeout + dead-holder inline reclamation ─────────────
+
+describe('serialize_merge — bounded wait + reclamation', () => {
+  it('SerializeMerge_LiveHolderPastDeadline_ReturnsMergeSlotTimeout', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/timeout';
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: 'live-holder-op',
+      sourceBranch: 'feat/held',
+      holderPid: 777,
+      holderStartedAt: 'alive-777',
+    });
+
+    // A fake clock advanced by the injected sleep makes the deadline deterministic.
+    let clock = 0;
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef, sourceBranch: 'feat/x', strategy: 'merge', timeoutMs: 1000 },
+      arm.ctx,
+      {
+        now: () => clock,
+        sleep: async (ms) => {
+          clock += ms;
+        },
+        pollIntervalMs: 200,
+        processTableSource: liveTable([{ pid: 777, startTime: 'alive-777' }]), // holder stays alive.
+        mergeOrchestrate: async () => {
+          throw new Error('merge_orchestrate must NOT run on a timed-out slot');
+        },
+        readIntegrationHead: () => null,
+        selfPid: 111,
+        selfStartedAt: 'self-111',
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('MERGE_SLOT_TIMEOUT');
+    expect((result.data as { reason?: string }).reason).toBe('merge-slot-timeout');
+    // The live holder still holds the slot (we never reclaimed it).
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]?.operationId).toBe('live-holder-op');
+  });
+
+  it('SerializeMerge_DeadHolder_ReclaimedInline_ThenClaimsAndMerges', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/dead';
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: 'dead-holder-op',
+      sourceBranch: 'feat/dead',
+      holderPid: 4242,
+      holderStartedAt: 'gone',
+    });
+
+    const merged: string[] = [];
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef, sourceBranch: 'feat/live', strategy: 'merge', timeoutMs: 5000 },
+      arm.ctx,
+      {
+        processTableSource: EMPTY_TABLE, // pid 4242 absent → provably dead.
+        sleep: async () => {
+          throw new Error('reclamation should clear the slot without waiting');
+        },
+        mergeOrchestrate: recordingMerge(merged),
+        readIntegrationHead: () => null,
+        selfPid: 111,
+        selfStartedAt: 'self-111',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(merged).toEqual(['F']);
+
+    // The dead holder was reclaimed inline — its terminal release rode its OWN
+    // operationId (the documented correlation, even for recovery releases).
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    const deadRelease = events.find(
+      (e) => e.type === 'worktree.merge_executed' && e.data?.operationId === 'dead-holder-op',
+    );
+    expect(deadRelease).toBeDefined();
+    // Slot ends clear (our own claim released too).
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+  });
+});
+
+// ─── Handler-level input validation ───────────────────────────────────────────
+
+describe('handleSerializeMerge — input guards', () => {
+  it('HandleSerializeMerge_MissingStrategy_RejectsInvalidInput', async () => {
+    const arm = await createArm();
+    const result = await handleSerializeMerge(
+      { featureId: 'F', integrationRef: 'main', sourceBranch: 'feat/x' }, // strategy missing
+      arm.ctx,
+      { mergeOrchestrate: recordingMerge([]), readIntegrationHead: () => null, selfPid: 1, selfStartedAt: 's' },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toMatch(/strategy/i);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
@@ -82,8 +82,20 @@ function liveTable(pairs: ReadonlyArray<{ pid: number; startTime: string }>): Pr
   return { list: () => records };
 }
 
-/** Empty process table — every probed pid reads as absent (provably dead). */
+/** Empty but SUPPORTED process table — every probed pid reads as absent (provably dead). */
 const EMPTY_TABLE: ProcessTableSource = { list: () => [] };
+
+/**
+ * UNSUPPORTED process table — the off-Linux shape (no enumerator). `list()` is
+ * `[]` but `isSupported()` is `false`, so a probed pid reads as `'unknown'`,
+ * NEVER provably dead. A holder probed against this table must be HELD, not
+ * reclaimed (DR-7 fail-closed). Mirrors the real `defaultProcessTableSource`
+ * off-Linux.
+ */
+const UNSUPPORTED_TABLE: ProcessTableSource = {
+  list: () => [],
+  isSupported: () => false,
+};
 
 /** A merge_orchestrate stub that records the featureIds it ran for. */
 function recordingMerge(into: string[]): (input: { featureId: string }) => Promise<ToolResult> {
@@ -256,6 +268,64 @@ describe('serialize_merge — single-writer ordering', () => {
 
     // The lease is released at the end — no in-flight merge remains.
     expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+  });
+});
+
+// ─── Test 1b: off-Linux unsupported table NEVER reclaims a live holder (REV-H1)─
+
+describe('serialize_merge — unsupported process table (DR-7 fail-closed)', () => {
+  it('SerializeMerge_UnsupportedProcessTable_DoesNotReclaimLiveHolder', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/unsupported';
+    const holderOpId = 'live-holder-op';
+
+    // A holder whose pid is absent from the UNSUPPORTED table's empty list. On a
+    // SUPPORTED-empty table this pid would read as provably dead and be reclaimed
+    // inline; on the UNSUPPORTED table it reads 'unknown', so it must be HELD —
+    // the off-Linux path must never steal what could be a LIVE merge holder.
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: holderOpId,
+      sourceBranch: 'feat/held',
+      holderPid: 9090,
+      holderStartedAt: 'boot-9090',
+    });
+
+    // A fake clock that the injected sleep advances, so the bounded wait expires
+    // deterministically (no real timer, no hang) INSTEAD of reclaiming the holder.
+    let clock = 0;
+    const sleep: SleepFn = async (ms) => {
+      clock += ms;
+    };
+    const merged: string[] = [];
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef, sourceBranch: 'feat/new', strategy: 'merge', timeoutMs: 1_000 },
+      arm.ctx,
+      {
+        now: () => clock,
+        sleep,
+        processTableSource: UNSUPPORTED_TABLE, // pid 9090 → 'unknown', NOT dead.
+        selfPid: 222,
+        selfStartedAt: 'self-222',
+        mergeOrchestrate: recordingMerge(merged),
+        readIntegrationHead: () => 'head-sha',
+      },
+    );
+
+    // The slot was NEVER stolen: the wait timed out structurally instead.
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('MERGE_SLOT_TIMEOUT');
+    expect((result.data as { reason?: string }).reason).toBe('merge-slot-timeout');
+    // The merge NEVER ran — no live holder was reclaimed.
+    expect(merged).toEqual([]);
+    // The holder's lease is STILL in flight (no merge_executed reclaimed it).
+    const projection = await foldWorktrees(arm);
+    expect(projection.inFlightMerges[integrationRef]?.operationId).toBe(holderOpId);
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    const reclaims = events.filter(
+      (e) => e.type === 'worktree.merge_executed' && e.data?.operationId === holderOpId,
+    );
+    expect(reclaims).toHaveLength(0); // the holder was held, never reclaimed.
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtemp } from 'node:fs/promises';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import * as os from 'node:os';
@@ -537,8 +537,12 @@ describe('serialize_merge — the lease IS the serialization', () => {
     );
     expect(result.success).toBe(true);
 
-    const lockFiles = execFileSync('find', [arm.stateDir, '-name', '*.lock'], { encoding: 'utf-8' }).trim();
-    expect(lockFiles).toBe('');
+    // Cross-platform recursive walk — never shell out to `find` (on Windows that
+    // resolves to C:\Windows\System32\find.exe, whose syntax differs entirely).
+    const lockFiles = readdirSync(arm.stateDir, { recursive: true }).filter((entry) =>
+      entry.toString().endsWith('.lock'),
+    );
+    expect(lockFiles).toEqual([]);
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
@@ -473,3 +473,219 @@ function resolveSelfStartedAt(pid: number, source: ProcessSource): string {
   const probe = source.getStartTime(pid);
   return probe.status === 'present' ? probe.startedAt : '';
 }
+
+// ─── Crash-mid-merge resume (DR-12) ──────────────────────────────────────────
+//
+// `serializeMerge`'s `finally` releases the lease, and its wait-for-slot loop
+// reclaims a provably-DEAD holder inline (Task 006). Two edges remain on the
+// recovery surface that the lease loop alone does NOT cover:
+//
+//   1. SAME-PROCESS stuck lease — the merge ran, but the best-effort RELEASE
+//      append failed (the `finally` swallows it). The slot now reads as held by
+//      a LIVE process (us), so the inline dead-holder probe will NOT reclaim it
+//      and a fresh claimant waits out the full budget. This process can safely
+//      finish its OWN lease.
+//   2. A crashed holder whose slot is reclaimed through an explicit
+//      reconcile/recovery pass rather than incidentally during another merge's
+//      wait loop.
+//
+// `resumeCrashedMerge` handles both: it folds the unpaired CLAIM, confirms the
+// lease is ours OR provably dead (never a different live merge), runs an
+// IDEMPOTENT precheck against the integration ref (`git merge-base
+// --is-ancestor <sourceBranch> <integrationRef>` — is the merge already
+// applied?), and emits the terminal `worktree.merge_executed` EXACTLY ONCE
+// (INV-8/13) under the holder's ORIGINAL `operationId`. The terminal is a keyed
+// append, so a double resume — or a race with the inline reclaim — converges on
+// one release. It NEVER `git reset --hard`s: a resumed merge composes
+// `merge_orchestrate` UNCHANGED, whose own INV-14 reversal is `--abort` →
+// `--keep`.
+
+/** Caller-facing arguments for {@link resumeCrashedMerge}. */
+export interface ResumeCrashedMergeInput {
+  /** Owning feature workflow id — threaded UNCHANGED to a resumed `merge_orchestrate`. */
+  readonly featureId: string;
+  /** Integration ref whose unpaired lease to resume (the per-branch serialization key). */
+  readonly integrationRef: string;
+  /** Merge strategy for a resumed `merge_orchestrate`. */
+  readonly strategy: 'squash' | 'rebase' | 'merge';
+  /** Optional task id, threaded UNCHANGED to a resumed `merge_orchestrate`. */
+  readonly taskId?: string;
+  /** Optional repository root for the precheck + a resumed `merge_orchestrate`. */
+  readonly repoRoot?: string;
+}
+
+/**
+ * Injected seams for {@link resumeCrashedMerge} — every external effect (process
+ * table, git ancestry probe, the composed merge) is reachable so the resume is
+ * deterministically testable with zero OS / git access. Production omits every field.
+ */
+export interface ResumeCrashedMergeDeps {
+  /** Process-table probe for dead-holder detection. Defaults to {@link defaultProcessTableSource}. */
+  readonly processTableSource?: ProcessTableSource;
+  /** Per-PID source for the resuming process's own create-time. Defaults to {@link defaultProcessSource}. */
+  readonly processSource?: ProcessSource;
+  /** PID of the resuming process (own-lease identity). Defaults to `process.pid`. */
+  readonly selfPid?: number;
+  /** Create-time fingerprint of the resuming process. Defaults to the resolved create-time of `selfPid`. */
+  readonly selfStartedAt?: string;
+  /** The merge COMPOSED UNCHANGED for a resume. Defaults to the real {@link handleMergeOrchestrate}. */
+  readonly mergeOrchestrate?: (
+    input: HandleMergeOrchestrateInput,
+    ctx: DispatchContext,
+  ) => Promise<ToolResult>;
+  /**
+   * Idempotent precheck: is `sourceBranch` already an ancestor of
+   * `integrationRef` (the merge already applied)? Defaults to a
+   * `git merge-base --is-ancestor` over {@link defaultGitExec}.
+   */
+  readonly isMergeApplied?: (
+    input: ResumeCrashedMergeInput,
+    sourceBranch: string,
+  ) => boolean;
+}
+
+/** Outcome of a {@link resumeCrashedMerge} pass. */
+export type ResumeCrashedMergeOutcome =
+  /** No unpaired CLAIM for the ref (nothing to resume), OR a DIFFERENT live process owns it. */
+  | { readonly resumed: false; readonly reason: 'no-lease' | 'foreign-live-holder' }
+  /** A resume re-merge ran and FAILED — the lease is left intact (no terminal), the failure surfaced. */
+  | {
+      readonly resumed: false;
+      readonly reason: 'resume-merge-failed';
+      readonly operationId: string;
+      readonly mergeResult: ToolResult;
+    }
+  /** The lease was terminated exactly once. `reMerged` ⇒ the precheck said "not applied" so the merge re-ran. */
+  | {
+      readonly resumed: true;
+      readonly operationId: string;
+      readonly reMerged: boolean;
+      readonly holderKind: 'self' | 'dead';
+      readonly mergeResult?: ToolResult;
+    };
+
+/** Default `git merge-base --is-ancestor <sourceBranch> <integrationRef>` precheck. */
+function buildDefaultIsMergeApplied(
+  gitExec: GitExec,
+): (input: ResumeCrashedMergeInput, sourceBranch: string) => boolean {
+  return (input, sourceBranch) => {
+    const repoRoot = input.repoRoot ?? process.cwd();
+    // exit 0 ⇒ sourceBranch is an ancestor of integrationRef (already merged).
+    return (
+      gitExec(repoRoot, [
+        'merge-base',
+        '--is-ancestor',
+        sourceBranch,
+        input.integrationRef,
+      ]).exitCode === 0
+    );
+  };
+}
+
+/**
+ * Resume a crash-interrupted serialized merge: an unpaired
+ * `worktree.merge_requested` (CLAIM) on `integrationRef` with no
+ * `worktree.merge_executed` (RELEASE), whose holder is THIS process or provably
+ * dead. Idempotently terminates the lease exactly once — re-running
+ * `merge_orchestrate` only when the precheck proves the merge was NOT applied
+ * before the crash.
+ *
+ * Resolves to `{ resumed: false, reason: 'no-lease' }` when there is no lease to
+ * resume (idempotent across repeated calls — once terminated, the next fold sees
+ * an empty slot), and `{ resumed: false, reason: 'foreign-live-holder' }` when a
+ * DIFFERENT live process still owns the merge (we never steal an active merge).
+ */
+export async function resumeCrashedMerge(
+  input: ResumeCrashedMergeInput,
+  ctx: DispatchContext,
+  deps: ResumeCrashedMergeDeps = {},
+): Promise<ResumeCrashedMergeOutcome> {
+  const processTableSource = deps.processTableSource ?? defaultProcessTableSource;
+  const processSource = deps.processSource ?? defaultProcessSource;
+  const mergeOrchestrate = deps.mergeOrchestrate ?? handleMergeOrchestrate;
+  const isMergeApplied = deps.isMergeApplied ?? buildDefaultIsMergeApplied(defaultGitExec);
+  const selfPid = deps.selfPid ?? process.pid;
+  const selfStartedAt =
+    deps.selfStartedAt ?? resolveSelfStartedAt(selfPid, processSource);
+
+  const appender = ctx.eventStore.getAppender();
+  const { aggregate } = await appender.aggregateStream<WorktreesProjection>(
+    WORKTREES_STREAM,
+    WORKTREES_REDUCER,
+  );
+  const holder = aggregate.inFlightMerges[input.integrationRef];
+  if (holder === undefined) {
+    // No unpaired CLAIM for this ref — nothing to resume (idempotent: a prior
+    // resume already terminated it, or the lease was never held).
+    return { resumed: false, reason: 'no-lease' };
+  }
+
+  // Only terminate a lease we MAY safely finish: our OWN (a failed best-effort
+  // release that wedged our slot — the holder is alive and is us) OR a provably
+  // dead holder (a crashed process). A DIFFERENT LIVE holder owns an ACTIVE
+  // merge; leave it untouched so we never steal a live merge's lease.
+  const sameProcess =
+    holder.holderPid === selfPid &&
+    holder.holderStartedAt !== null &&
+    holder.holderStartedAt !== '' &&
+    holder.holderStartedAt === selfStartedAt;
+  const dead = isHolderProvablyDead(holder, processTableSource);
+  if (!sameProcess && !dead) {
+    return { resumed: false, reason: 'foreign-live-holder' };
+  }
+  const holderKind: 'self' | 'dead' = sameProcess ? 'self' : 'dead';
+
+  // Idempotent precheck: is the merge already applied to the integration ref?
+  // `git merge-base --is-ancestor <sourceBranch> <integrationRef>` exit 0 ⇒ the
+  // source tip is already contained → the pre-crash merge SUCCEEDED → skip the
+  // re-merge and just release. Otherwise RESUME by re-running merge_orchestrate.
+  let reMerged = false;
+  let mergeResult: ToolResult | undefined;
+  if (!isMergeApplied(input, holder.sourceBranch)) {
+    mergeResult = await mergeOrchestrate(
+      {
+        featureId: input.featureId,
+        sourceBranch: holder.sourceBranch,
+        // `merge_orchestrate` calls the integration ref `targetBranch`.
+        targetBranch: input.integrationRef,
+        strategy: input.strategy,
+        ...(input.taskId !== undefined ? { taskId: input.taskId } : {}),
+        ...(input.repoRoot !== undefined ? { repoRoot: input.repoRoot } : {}),
+      },
+      ctx,
+    );
+    reMerged = true;
+    // A FAILED resume merge must NOT emit the terminal — leave the lease intact
+    // so a later resume / dead-holder reclaim can retry, and surface the
+    // failure. `merge_orchestrate`'s own INV-14 reversal has already rewound any
+    // partial merge (`--abort` → `--keep`, never `--hard`), so nothing is
+    // half-applied.
+    if (!mergeResult.success) {
+      return {
+        resumed: false,
+        reason: 'resume-merge-failed',
+        operationId: holder.operationId,
+        mergeResult,
+      };
+    }
+  }
+
+  // Emit the terminal EXACTLY ONCE under the holder's ORIGINAL operationId. The
+  // keyed append (`worktree.merge_executed:<operationId>`) dedups, so a double
+  // resume — or a race with the inline dead-holder reclaim — converges on ONE
+  // release (INV-8/13); the reducer's operationId guard correlates it to exactly
+  // the CLAIM it terminates.
+  await appendMergeExecuted(appender, {
+    integrationRef: holder.integrationRef,
+    operationId: holder.operationId,
+    sourceBranch: holder.sourceBranch,
+    worktreeId: holder.worktreeId,
+  });
+  return {
+    resumed: true,
+    operationId: holder.operationId,
+    reMerged,
+    holderKind,
+    ...(mergeResult !== undefined ? { mergeResult } : {}),
+  };
+}

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
@@ -144,7 +144,11 @@ function buildDefaultReadIntegrationHead(gitExec: GitExec): (input: SerializeMer
  * probe — the SAME ground-truth liveness lens the manager uses for reservation
  * reaping. A holder with a null pid/create-time cannot be proven dead (the lease
  * pre-dates a holder fingerprint), so it is held, not reclaimed. Provably dead
- * means PID absent OR present-with-mismatched create-time (PID reuse).
+ * means PID absent from a SUPPORTED process table OR present-with-mismatched
+ * create-time (PID reuse). On an UNSUPPORTED table (off-Linux, no enumerator)
+ * the probe yields `'unknown'` → `releasable === false`, so this returns `false`
+ * and the holder is HELD, never reclaimed — fail closed (DR-7): the off-Linux
+ * path must never steal a live holder's merge lease.
  */
 function isHolderProvablyDead(
   holder: InFlightMerge,
@@ -583,6 +587,92 @@ function buildDefaultIsMergeApplied(
 }
 
 /**
+ * Re-claim a crash-interrupted merge lease under OCC so a RESUMED
+ * `merge_orchestrate` runs AT MOST ONCE across concurrent recovery passes (DR-7
+ * / DR-12 no-double-merge).
+ *
+ * The `resumeCrashedMerge` precheck (`isMergeApplied`) is a read-only git probe:
+ * two concurrent resumes can BOTH observe "not applied" and BOTH re-run the
+ * merge, double-applying it. This re-claim is the serialization point — the SAME
+ * claim-inside-`decide` OCC the live `serializeMerge` path uses. It re-folds
+ * `inFlightMerges` inside the closure and commits a re-claim ONLY when the slot
+ * is STILL the lease being resumed (`operationId` unchanged) AND still
+ * ours-or-provably-dead under the now-fail-closed liveness (an `'unknown'`
+ * holder on an unsupported table is NOT reclaimable). The re-claim keeps the
+ * holder's ORIGINAL `operationId` (so the eventual terminal still correlates via
+ * the reducer's operationId guard) but stamps OUR LIVE identity, so a racing
+ * resumer re-folds, sees a live foreign holder, and backs off.
+ *
+ * Returns `true` iff this call WON the slot; `false` (closure no-op, OCC
+ * `ConcurrencyError`, or transient `StorageBusyError`) means a concurrent
+ * claimant holds it — the caller MUST abort the resume rather than re-merge. We
+ * never retry-and-steal: re-running the merge is the exact hazard guarded here.
+ *
+ * The `decide` idempotency key is a FRESH uuid (NOT the holder's operationId,
+ * which already keys the original CLAIM via `serializeMerge`) so the re-claim is
+ * a genuine new commit, never a cache-hit of the pre-crash claim.
+ */
+async function tryReclaimLeaseForResume(
+  appender: AtomicAppender,
+  holder: InFlightMerge,
+  selfPid: number,
+  selfStartedAt: string,
+  processTableSource: ProcessTableSource,
+): Promise<boolean> {
+  try {
+    const result = await appender.decide<WorktreesProjection>(
+      WORKTREES_STREAM,
+      WORKTREES_REDUCER,
+      (state) => {
+        const current = state.inFlightMerges[holder.integrationRef];
+        // The lease vanished (a concurrent resume already terminated it) OR a
+        // concurrent resumer re-claimed under a different lease — either way it
+        // is no longer ours to take over.
+        if (current === undefined || current.operationId !== holder.operationId) {
+          return [];
+        }
+        // Re-verify against the FRESH fold (fail-closed): the slot is takeable
+        // only when it is STILL us (a wedged self-release) or STILL provably
+        // dead. A holder that became a live foreign process is left untouched.
+        const stillSelf =
+          current.holderPid === selfPid &&
+          current.holderStartedAt !== null &&
+          current.holderStartedAt !== '' &&
+          current.holderStartedAt === selfStartedAt;
+        const stillDead = isHolderProvablyDead(current, processTableSource);
+        if (!stillSelf && !stillDead) {
+          return [];
+        }
+        // Win the slot: re-claim the SAME lease (operationId unchanged) under OUR
+        // live identity so a racing resumer re-folds and backs off as foreign-live.
+        return [
+          {
+            type: 'worktree.merge_requested',
+            data: {
+              integrationRef: holder.integrationRef,
+              operationId: holder.operationId,
+              sourceBranch: holder.sourceBranch,
+              holderPid: selfPid,
+              holderStartedAt: selfStartedAt,
+              ...(holder.worktreeId != null ? { worktreeId: holder.worktreeId } : {}),
+            },
+          },
+        ];
+      },
+      { operationId: randomUUID(), alwaysEnforceConsistency: false },
+    );
+    return result.kind === 'committed';
+  } catch (err) {
+    // Lost the OCC (a concurrent resumer committed first) or transient substrate
+    // contention — treat as "did not win" so the caller aborts the resume.
+    if (err instanceof ConcurrencyError || err instanceof StorageBusyError) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
  * Resume a crash-interrupted serialized merge: an unpaired
  * `worktree.merge_requested` (CLAIM) on `integrationRef` with no
  * `worktree.merge_executed` (RELEASE), whose holder is THIS process or provably
@@ -642,6 +732,24 @@ export async function resumeCrashedMerge(
   let reMerged = false;
   let mergeResult: ToolResult | undefined;
   if (!isMergeApplied(input, holder.sourceBranch)) {
+    // ─── OCC re-claim BEFORE the re-merge (DR-7 / DR-12 no-double-merge) ──
+    // The `isMergeApplied` precheck is a read-only git probe — two concurrent
+    // resumes can BOTH see "not applied" and BOTH re-run the merge. Serialize
+    // the re-merge behind the SAME claim-inside-`decide` OCC `serializeMerge`
+    // uses: only the resumer that WINS the re-claim re-runs `merge_orchestrate`;
+    // a loser aborts rather than double-applying. (When the merge is ALREADY
+    // applied no merge runs, so the keyed terminal alone is safe without a claim.)
+    const reclaimed = await tryReclaimLeaseForResume(
+      appender,
+      holder,
+      selfPid,
+      selfStartedAt,
+      processTableSource,
+    );
+    if (!reclaimed) {
+      // A concurrent claimant holds the slot — never double-run the merge.
+      return { resumed: false, reason: 'foreign-live-holder' };
+    }
     mergeResult = await mergeOrchestrate(
       {
         featureId: input.featureId,

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
@@ -113,8 +113,8 @@ export interface SerializeMergeDeps {
   readonly processSource?: ProcessSource;
   /** PID stamped on the claim (lease holder identity). Defaults to `process.pid`. */
   readonly selfPid?: number;
-  /** Create-time fingerprint stamped on the claim. Defaults to the resolved create-time of `selfPid`. */
-  readonly selfStartedAt?: string;
+  /** Create-time fingerprint stamped on the claim. Defaults to the resolved create-time of `selfPid`, or `null` when the platform cannot resolve it. */
+  readonly selfStartedAt?: string | null;
   /** The merge COMPOSED UNCHANGED. Defaults to the real {@link handleMergeOrchestrate}. */
   readonly mergeOrchestrate?: (
     input: HandleMergeOrchestrateInput,
@@ -218,7 +218,7 @@ async function tryClaim(
   input: SerializeMergeInput,
   operationId: string,
   holderPid: number,
-  holderStartedAt: string,
+  holderStartedAt: string | null,
 ): Promise<boolean> {
   let claimed = false;
   try {
@@ -469,13 +469,15 @@ async function waitForFreeSlot(args: WaitForFreeSlotArgs): Promise<WaitOutcome> 
 
 /**
  * Resolve the claiming process's create-time fingerprint via the injected
- * {@link ProcessSource}. A platform that cannot resolve it yields `''` — still a
- * well-formed claim; it just cannot defeat PID reuse for dead-holder probing
- * (mirrors {@link resolveOwner} in `handlers.ts`).
+ * {@link ProcessSource}. A platform that cannot resolve it yields `null` — still
+ * a well-formed claim; it just cannot defeat PID reuse for dead-holder probing.
+ * Modeled as `null` (not `''`) so the emitted `holderStartedAt` stays schema-
+ * valid (`z.string().min(1).nullable()`) rather than an out-of-contract empty
+ * string that only the projection defensively normalized.
  */
-function resolveSelfStartedAt(pid: number, source: ProcessSource): string {
+function resolveSelfStartedAt(pid: number, source: ProcessSource): string | null {
   const probe = source.getStartTime(pid);
-  return probe.status === 'present' ? probe.startedAt : '';
+  return probe.status === 'present' ? probe.startedAt : null;
 }
 
 // ─── Crash-mid-merge resume (DR-12) ──────────────────────────────────────────
@@ -616,7 +618,7 @@ async function tryReclaimLeaseForResume(
   appender: AtomicAppender,
   holder: InFlightMerge,
   selfPid: number,
-  selfStartedAt: string,
+  selfStartedAt: string | null,
   processTableSource: ProcessTableSource,
 ): Promise<boolean> {
   try {
@@ -661,7 +663,12 @@ async function tryReclaimLeaseForResume(
       },
       { operationId: randomUUID(), alwaysEnforceConsistency: false },
     );
-    return result.kind === 'committed';
+    // A cache-hit (the same keyed append already landed) is a WIN, same as a
+    // fresh commit — only a no-op (the decide closure emitted nothing: lease
+    // vanished or turned foreign-live) means we did not take the slot. Mirrors
+    // tryClaim's `!== 'no-op'` check; `=== 'committed'` would wrongly fail on a
+    // cache-hit (improbable under randomUUID, but a latent semantic inconsistency).
+    return result.kind !== 'no-op';
   } catch (err) {
     // Lost the OCC (a concurrent resumer committed first) or transient substrate
     // contention — treat as "did not win" so the caller aborts the resume.

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
@@ -182,17 +182,27 @@ function isHolderProvablyDead(
  */
 async function appendMergeExecuted(
   appender: AtomicAppender,
-  merge: { integrationRef: string; operationId: string; sourceBranch: string; worktreeId?: string | null },
+  merge: { integrationRef: string; operationId: string; worktreeId?: string | null },
+  outcome: {
+    status: 'merged' | 'aborted' | 'failed';
+    mergeSha?: string;
+    recoveryError?: string;
+  },
 ): Promise<void> {
   await appender.append(
     WORKTREES_STREAM,
     [
       {
         type: 'worktree.merge_executed',
+        // Schema-conformant payload (WorktreeMergeExecutedData): `status` is
+        // REQUIRED; `sourceBranch` is NOT part of the release contract (it lives
+        // on the CLAIM) and the reducer correlates by integrationRef+operationId.
         data: {
           integrationRef: merge.integrationRef,
           operationId: merge.operationId,
-          sourceBranch: merge.sourceBranch,
+          status: outcome.status,
+          ...(outcome.mergeSha != null ? { mergeSha: outcome.mergeSha } : {}),
+          ...(outcome.recoveryError != null ? { recoveryError: outcome.recoveryError } : {}),
           ...(merge.worktreeId != null ? { worktreeId: merge.worktreeId } : {}),
         },
       },
@@ -359,6 +369,9 @@ export async function serializeMerge(
   //
   // We hold the lease. RELEASE in `finally` so a thrown / failed merge never
   // wedges the slot (the dead-holder reclaim is only a crash safety net).
+  // `terminalStatus` records the truthful release disposition; it stays 'failed'
+  // if the merge throws (the honest terminal for a wedged-then-reclaimed slot).
+  let terminalStatus: 'merged' | 'failed' = 'failed';
   try {
     const integrationHead = readIntegrationHead(input);
     const mergeResult = await mergeOrchestrate(
@@ -378,6 +391,7 @@ export async function serializeMerge(
     // serializer's own lease metadata under a dedicated key so the composed
     // per-featureId `merge.*` events are byte-identical to a direct call.
     if (mergeResult.success) {
+      terminalStatus = 'merged';
       return {
         ...mergeResult,
         data: {
@@ -397,11 +411,11 @@ export async function serializeMerge(
     // reclaim path clears once this process exits; surfacing it here would
     // mask the merge's own result/error.
     try {
-      await appendMergeExecuted(appender, {
-        integrationRef: input.integrationRef,
-        operationId,
-        sourceBranch: input.sourceBranch,
-      });
+      await appendMergeExecuted(
+        appender,
+        { integrationRef: input.integrationRef, operationId },
+        { status: terminalStatus },
+      );
     } catch {
       /* best-effort release — see note above */
     }
@@ -448,12 +462,15 @@ async function waitForFreeSlot(args: WaitForFreeSlotArgs): Promise<WaitOutcome> 
     // provably gone, emit its terminal release under its OWN operationId, then
     // re-fold (the slot should now be clear).
     if (isHolderProvablyDead(holder, processTableSource)) {
-      await appendMergeExecuted(appender, {
-        integrationRef: holder.integrationRef,
-        operationId: holder.operationId,
-        sourceBranch: holder.sourceBranch,
-        worktreeId: holder.worktreeId,
-      });
+      await appendMergeExecuted(
+        appender,
+        {
+          integrationRef: holder.integrationRef,
+          operationId: holder.operationId,
+          worktreeId: holder.worktreeId,
+        },
+        { status: 'aborted', recoveryError: 'dead-holder-reclaimed' },
+      );
       continue;
     }
 
@@ -790,12 +807,17 @@ export async function resumeCrashedMerge(
   // resume — or a race with the inline dead-holder reclaim — converges on ONE
   // release (INV-8/13); the reducer's operationId guard correlates it to exactly
   // the CLAIM it terminates.
-  await appendMergeExecuted(appender, {
-    integrationRef: holder.integrationRef,
-    operationId: holder.operationId,
-    sourceBranch: holder.sourceBranch,
-    worktreeId: holder.worktreeId,
-  });
+  // Reached only when the merge succeeded or was already applied (a failed
+  // resume returns early WITHOUT emitting) → the terminal status is 'merged'.
+  await appendMergeExecuted(
+    appender,
+    {
+      integrationRef: holder.integrationRef,
+      operationId: holder.operationId,
+      worktreeId: holder.worktreeId,
+    },
+    { status: 'merged' },
+  );
   return {
     resumed: true,
     operationId: holder.operationId,

--- a/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/merge-serializer.ts
@@ -1,0 +1,475 @@
+// ─── Integration-branch merge serializer (WLM operational core, DR-7) ────────
+//
+// `serialize_merge` is an OPTIMISTIC LEASE over the integration ref: it grants
+// at most ONE in-flight merge per `integrationRef` at a time, then composes
+// `merge_orchestrate` UNCHANGED for the actual git work. The lease itself IS the
+// serialization — there is NO flock, NO PID/`.lock` file, and NO advisory-lock
+// library (INV-1/INV-7): the right to merge lives EXCLUSIVELY in the event log,
+// folded by `worktrees@v1` into `inFlightMerges[integrationRef]`.
+//
+// The lease lifecycle is a two-event pair on the singleton `worktrees` stream
+// (DR-4), exactly mirroring the single-writer `reserve` pattern in `manager.ts`:
+//
+//   1. CLAIM (`worktree.merge_requested`) — committed through `decide` over
+//      `worktrees@v1` under `withStateRetry`. The slot-emptiness check lives
+//      INSIDE the decide closure so the OCC commit is gated on the exact folded
+//      tail: a racing claimant loses with `ConcurrencyError`, re-folds, sees the
+//      holder, and falls back to waiting. At most one claimant wins per ref.
+//
+//   2. RELEASE (`worktree.merge_executed`) — a PLAIN keyed append
+//      (`worktree.merge_executed:<operationId>`), NOT CAS-pinned to the claim's
+//      returned sequence. Other worktree events advance the stream while the
+//      merge runs, so pinning the release to the claim seq would be the
+//      idempotency trap that wedges every retry forever.
+//
+// Bounded-wait: when the slot is held, the lease waits under an explicit timeout
+// using the SHARED injected `sleep` seam from `git-retry.ts`, re-folding each
+// iteration. On expiry it returns a structured `merge-slot-timeout` error rather
+// than hanging. Each wait iteration probes the CURRENT holder's liveness via the
+// DR-5 process probe (`pure/probe.ts`): a holder whose `holderPid` /
+// `holderStartedAt` is provably dead is reclaimed inline — the lease emits the
+// terminal `worktree.merge_executed` ONCE under the holder's ORIGINAL
+// `operationId` — so a crashed holder never wastes the full timeout budget.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { randomUUID } from 'node:crypto';
+
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { ToolResult } from '../../format.js';
+import type { AtomicAppender } from '../../event-store/atomic-appender.js';
+import { ConcurrencyError, StorageBusyError } from '../../event-store/index.js';
+import { withStateRetry } from '../../workflow/state-retry.js';
+import {
+  handleMergeOrchestrate,
+  type HandleMergeOrchestrateInput,
+} from '../merge-orchestrate.js';
+import { defaultGitExec } from '../git-exec-default.js';
+import type { GitExec } from '../pure/merge-preflight.js';
+// WORKTREES_STREAM / WORKTREES_REDUCER are the singleton-stream + reducer ids
+// the manager's `reserve` writes through; importing them keeps the serializer
+// on the SAME stream and fold (and pulls in the DR-1 reducer self-registration).
+import { WORKTREES_STREAM, WORKTREES_REDUCER } from './manager.js';
+// Side-effect import: ensures the `worktrees@v1` reducer is registered with the
+// process-wide `defaultRegistry` so `decide` / `aggregateStream` can resolve it.
+import './projections/index.js';
+import type {
+  WorktreesProjection,
+  InFlightMerge,
+} from './projections/worktrees.js';
+import { defaultSleep, type SleepFn } from './git-retry.js';
+import {
+  probeReservations,
+  defaultProcessTableSource,
+  type ProcessTableSource,
+} from './pure/probe.js';
+import {
+  defaultProcessSource,
+  type ProcessSource,
+} from './pure/process-identity.js';
+
+// ─── Tuning ──────────────────────────────────────────────────────────────────
+
+/** Default bounded-wait budget (ms) before a held slot yields `merge-slot-timeout`. */
+export const DEFAULT_MERGE_SLOT_TIMEOUT_MS = 30_000;
+
+/** Default poll interval (ms) between wait-for-slot re-folds. */
+export const DEFAULT_MERGE_SLOT_POLL_INTERVAL_MS = 200;
+
+// ─── Public input / dependency shapes ────────────────────────────────────────
+
+/** Caller-facing arguments for {@link serializeMerge}. */
+export interface SerializeMergeInput {
+  /** Owning feature workflow id — the per-featureId stream `merge_orchestrate` writes to. */
+  readonly featureId: string;
+  /** Integration ref the merge targets — the per-branch serialization key (= `targetBranch`). */
+  readonly integrationRef: string;
+  /** Branch being merged into `integrationRef`. */
+  readonly sourceBranch: string;
+  /** Merge strategy, threaded UNCHANGED to `merge_orchestrate`. */
+  readonly strategy: 'squash' | 'rebase' | 'merge';
+  /** Optional task id, threaded UNCHANGED to `merge_orchestrate`. */
+  readonly taskId?: string;
+  /** Optional repository root for the fresh-HEAD read + `merge_orchestrate`. */
+  readonly repoRoot?: string;
+  /** Bounded-wait budget (ms). Defaults to {@link DEFAULT_MERGE_SLOT_TIMEOUT_MS}. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Injected seams — every external effect (timing, process table, git, the
+ * composed merge) is reachable here so the lease is deterministically testable
+ * with zero OS / git access. Production callers omit every field.
+ */
+export interface SerializeMergeDeps {
+  /** Bounded-wait sleep seam (SHARED with `git-retry.ts`). Defaults to {@link defaultSleep}. */
+  readonly sleep?: SleepFn;
+  /** Monotone clock for the deadline. Defaults to `Date.now`. */
+  readonly now?: () => number;
+  /** Wait-for-slot poll interval (ms). Defaults to {@link DEFAULT_MERGE_SLOT_POLL_INTERVAL_MS}. */
+  readonly pollIntervalMs?: number;
+  /** Process-table probe for dead-holder reclamation. Defaults to {@link defaultProcessTableSource}. */
+  readonly processTableSource?: ProcessTableSource;
+  /** Per-PID source for the claiming process's own create-time. Defaults to {@link defaultProcessSource}. */
+  readonly processSource?: ProcessSource;
+  /** PID stamped on the claim (lease holder identity). Defaults to `process.pid`. */
+  readonly selfPid?: number;
+  /** Create-time fingerprint stamped on the claim. Defaults to the resolved create-time of `selfPid`. */
+  readonly selfStartedAt?: string;
+  /** The merge COMPOSED UNCHANGED. Defaults to the real {@link handleMergeOrchestrate}. */
+  readonly mergeOrchestrate?: (
+    input: HandleMergeOrchestrateInput,
+    ctx: DispatchContext,
+  ) => Promise<ToolResult>;
+  /** Reads the fresh integration HEAD just before the merge. Defaults to a `git rev-parse` over {@link defaultGitExec}. */
+  readonly readIntegrationHead?: (input: SerializeMergeInput) => string | null;
+}
+
+// ─── Default fresh-HEAD reader ───────────────────────────────────────────────
+
+function buildDefaultReadIntegrationHead(gitExec: GitExec): (input: SerializeMergeInput) => string | null {
+  return (input) => {
+    const repoRoot = input.repoRoot ?? process.cwd();
+    const result = gitExec(repoRoot, ['rev-parse', '--verify', input.integrationRef]);
+    if (result.exitCode !== 0) return null;
+    const sha = result.stdout.trim();
+    return sha.length > 0 ? sha : null;
+  };
+}
+
+// ─── Holder liveness (DR-5 probe reuse) ──────────────────────────────────────
+
+/**
+ * Is the current lease holder provably dead? Routes the holder's recorded
+ * `holderPid` / `holderStartedAt` through the DR-5 {@link probeReservations}
+ * probe — the SAME ground-truth liveness lens the manager uses for reservation
+ * reaping. A holder with a null pid/create-time cannot be proven dead (the lease
+ * pre-dates a holder fingerprint), so it is held, not reclaimed. Provably dead
+ * means PID absent OR present-with-mismatched create-time (PID reuse).
+ */
+function isHolderProvablyDead(
+  holder: InFlightMerge,
+  source: ProcessTableSource,
+): boolean {
+  if (holder.holderPid === null || holder.holderStartedAt === null) {
+    return false; // no fingerprint to probe → fail closed (do not reclaim).
+  }
+  const [finding] = probeReservations(
+    [
+      {
+        worktreePath: holder.integrationRef,
+        ownerPid: holder.holderPid,
+        ownerStartedAt: holder.holderStartedAt,
+      },
+    ],
+    source,
+  );
+  return finding?.releasable === true;
+}
+
+// ─── Lease appends (CLAIM / RELEASE / dead-holder reclaim) ───────────────────
+
+/**
+ * Terminal `worktree.merge_executed` as a PLAIN keyed append — keyed by
+ * `<eventType>:<operationId>` for idempotency, but NOT CAS-pinned to any prior
+ * sequence. Used for BOTH the normal release (caller's own `operationId`) and
+ * dead-holder reclamation (the holder's ORIGINAL `operationId`), so two racing
+ * reclaimers converge on ONE release and the reducer's `operationId` guard
+ * correlates the release to exactly the claim it terminates.
+ */
+async function appendMergeExecuted(
+  appender: AtomicAppender,
+  merge: { integrationRef: string; operationId: string; sourceBranch: string; worktreeId?: string | null },
+): Promise<void> {
+  await appender.append(
+    WORKTREES_STREAM,
+    [
+      {
+        type: 'worktree.merge_executed',
+        data: {
+          integrationRef: merge.integrationRef,
+          operationId: merge.operationId,
+          sourceBranch: merge.sourceBranch,
+          ...(merge.worktreeId != null ? { worktreeId: merge.worktreeId } : {}),
+        },
+      },
+    ],
+    `worktree.merge_executed:${merge.operationId}`,
+    // NOTE: no `options.expectedSequence` — a plain keyed append. The stream
+    // advances (other worktree events) between CLAIM and RELEASE, so pinning to
+    // the claim seq would wedge every retry forever (the idempotency trap).
+  );
+}
+
+/**
+ * Attempt the CLAIM under OCC. Returns `true` iff this call committed the
+ * `worktree.merge_requested` event (won the slot). The slot-emptiness check is
+ * INSIDE the decide closure, so the commit is gated on the exact folded tail: a
+ * racing claimant loses the OCC commit, `withStateRetry` re-folds, the closure
+ * now sees the holder and emits nothing (no-op). On persistent contention the
+ * typed OCC/storage errors surface; the caller treats them as "not claimed" and
+ * re-enters the wait loop.
+ */
+async function tryClaim(
+  appender: AtomicAppender,
+  input: SerializeMergeInput,
+  operationId: string,
+  holderPid: number,
+  holderStartedAt: string,
+): Promise<boolean> {
+  let claimed = false;
+  try {
+    await withStateRetry(async () => {
+      claimed = false;
+      const result = await appender.decide<WorktreesProjection>(
+        WORKTREES_STREAM,
+        WORKTREES_REDUCER,
+        (state) => {
+          // Re-check slot emptiness INSIDE the closure (mirrors `reserve`). A
+          // holder present in THIS fold means a concurrent winner already
+          // claimed → emit nothing so the loser re-waits rather than double-claims.
+          if (state.inFlightMerges[input.integrationRef] !== undefined) {
+            return [];
+          }
+          return [
+            {
+              type: 'worktree.merge_requested',
+              data: {
+                integrationRef: input.integrationRef,
+                operationId,
+                sourceBranch: input.sourceBranch,
+                holderPid,
+                holderStartedAt,
+              },
+            },
+          ];
+        },
+        // alwaysEnforceConsistency=false: a no-op (slot already held) must NOT
+        // throw on an unrelated concurrent worktree append; the emit path still
+        // commits under expectedSequence OCC — the single-writer guard.
+        { operationId, alwaysEnforceConsistency: false },
+      );
+      claimed = result.kind !== 'no-op';
+    });
+  } catch (err) {
+    // Persistent OCC / substrate contention after the retry budget — treat as
+    // "did not claim" and let the outer loop re-fold + wait (respecting the
+    // deadline). Any other error is a genuine fault and propagates.
+    if (err instanceof ConcurrencyError || err instanceof StorageBusyError) {
+      return false;
+    }
+    throw err;
+  }
+  return claimed;
+}
+
+// ─── Structured timeout ──────────────────────────────────────────────────────
+
+function mergeSlotTimeout(
+  input: SerializeMergeInput,
+  timeoutMs: number,
+  holder: InFlightMerge | undefined,
+): ToolResult {
+  return {
+    success: false,
+    error: {
+      code: 'MERGE_SLOT_TIMEOUT',
+      message: `merge slot for integration ref '${input.integrationRef}' is held by a live process after ${timeoutMs}ms`,
+    },
+    // Structured payload rides `data` (the error envelope has a fixed field
+    // set); `reason` is the stable kebab discriminator callers match on.
+    data: {
+      reason: 'merge-slot-timeout' as const,
+      integrationRef: input.integrationRef,
+      timeoutMs,
+      ...(holder !== undefined
+        ? {
+            holder: {
+              operationId: holder.operationId,
+              sourceBranch: holder.sourceBranch,
+              holderPid: holder.holderPid,
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+// ─── The lease ───────────────────────────────────────────────────────────────
+
+/**
+ * Serialize a `sourceBranch → integrationRef` merge behind a single-writer
+ * optimistic lease, then compose `merge_orchestrate` UNCHANGED. Returns the
+ * merge result (pass-through, annotated with the lease metadata) on success, or
+ * a structured `merge-slot-timeout` error if the slot stays held by a live
+ * process past the bounded-wait budget.
+ */
+export async function serializeMerge(
+  input: SerializeMergeInput,
+  ctx: DispatchContext,
+  deps: SerializeMergeDeps = {},
+): Promise<ToolResult> {
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? Date.now;
+  const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_MERGE_SLOT_POLL_INTERVAL_MS;
+  const processTableSource = deps.processTableSource ?? defaultProcessTableSource;
+  const processSource = deps.processSource ?? defaultProcessSource;
+  const mergeOrchestrate = deps.mergeOrchestrate ?? handleMergeOrchestrate;
+  const readIntegrationHead =
+    deps.readIntegrationHead ?? buildDefaultReadIntegrationHead(defaultGitExec);
+
+  const selfPid = deps.selfPid ?? process.pid;
+  const selfStartedAt =
+    deps.selfStartedAt ?? resolveSelfStartedAt(selfPid, processSource);
+
+  const appender = ctx.eventStore.getAppender();
+  const operationId = randomUUID();
+  const timeoutMs = input.timeoutMs ?? DEFAULT_MERGE_SLOT_TIMEOUT_MS;
+  const deadline = now() + timeoutMs;
+
+  // ─── 1+2. Wait for a free slot, then CLAIM it (loop until won or timeout) ──
+  while (true) {
+    const slot = await waitForFreeSlot({
+      appender,
+      input,
+      deadline,
+      now,
+      sleep,
+      pollIntervalMs,
+      processTableSource,
+    });
+    if (!slot.free) {
+      return mergeSlotTimeout(input, timeoutMs, slot.holder);
+    }
+
+    const claimed = await tryClaim(appender, input, operationId, selfPid, selfStartedAt);
+    if (claimed) break;
+
+    // Lost the claim race (a concurrent winner took the slot) — re-enter the
+    // wait loop so we block on the new holder, unless the budget is spent.
+    if (now() >= deadline) {
+      return mergeSlotTimeout(input, timeoutMs, undefined);
+    }
+  }
+
+  // ─── 3+4. Re-read fresh integration HEAD, then compose merge_orchestrate ──
+  //
+  // We hold the lease. RELEASE in `finally` so a thrown / failed merge never
+  // wedges the slot (the dead-holder reclaim is only a crash safety net).
+  try {
+    const integrationHead = readIntegrationHead(input);
+    const mergeResult = await mergeOrchestrate(
+      {
+        featureId: input.featureId,
+        sourceBranch: input.sourceBranch,
+        // `merge_orchestrate` calls the integration ref `targetBranch`.
+        targetBranch: input.integrationRef,
+        strategy: input.strategy,
+        ...(input.taskId !== undefined ? { taskId: input.taskId } : {}),
+        ...(input.repoRoot !== undefined ? { repoRoot: input.repoRoot } : {}),
+      },
+      ctx,
+    );
+
+    // Pass the merge result through UNCHANGED in shape; annotate ONLY the
+    // serializer's own lease metadata under a dedicated key so the composed
+    // per-featureId `merge.*` events are byte-identical to a direct call.
+    if (mergeResult.success) {
+      return {
+        ...mergeResult,
+        data: {
+          ...((mergeResult.data as Record<string, unknown> | undefined) ?? {}),
+          serializedMerge: {
+            integrationRef: input.integrationRef,
+            operationId,
+            integrationHead,
+          },
+        },
+      };
+    }
+    return mergeResult;
+  } finally {
+    // ─── 5. RELEASE — plain keyed append (NOT CAS-pinned to the claim seq) ──
+    // Best-effort: a failed release leaves a stuck slot the dead-holder
+    // reclaim path clears once this process exits; surfacing it here would
+    // mask the merge's own result/error.
+    try {
+      await appendMergeExecuted(appender, {
+        integrationRef: input.integrationRef,
+        operationId,
+        sourceBranch: input.sourceBranch,
+      });
+    } catch {
+      /* best-effort release — see note above */
+    }
+  }
+}
+
+// ─── Wait-for-slot (with inline dead-holder reclamation) ─────────────────────
+
+interface WaitForFreeSlotArgs {
+  readonly appender: AtomicAppender;
+  readonly input: SerializeMergeInput;
+  readonly deadline: number;
+  readonly now: () => number;
+  readonly sleep: SleepFn;
+  readonly pollIntervalMs: number;
+  readonly processTableSource: ProcessTableSource;
+}
+
+type WaitOutcome =
+  | { readonly free: true }
+  | { readonly free: false; readonly holder: InFlightMerge };
+
+/**
+ * Block until `inFlightMerges[integrationRef]` is clear, re-folding the
+ * `worktrees@v1` projection each iteration. A provably-dead holder is reclaimed
+ * inline (emit the terminal release under the holder's ORIGINAL operationId) and
+ * the loop re-folds — so a crashed holder is freed without waiting out the
+ * budget. A live (or unprovable) holder is waited on via the injected `sleep`
+ * seam until the deadline, then surfaced for a structured timeout.
+ */
+async function waitForFreeSlot(args: WaitForFreeSlotArgs): Promise<WaitOutcome> {
+  const { appender, input, deadline, now, sleep, pollIntervalMs, processTableSource } = args;
+  while (true) {
+    const { aggregate } = await appender.aggregateStream<WorktreesProjection>(
+      WORKTREES_STREAM,
+      WORKTREES_REDUCER,
+    );
+    const holder = aggregate.inFlightMerges[input.integrationRef];
+    if (holder === undefined) {
+      return { free: true };
+    }
+
+    // Dead-holder reclamation: probe the CURRENT holder's liveness and, if
+    // provably gone, emit its terminal release under its OWN operationId, then
+    // re-fold (the slot should now be clear).
+    if (isHolderProvablyDead(holder, processTableSource)) {
+      await appendMergeExecuted(appender, {
+        integrationRef: holder.integrationRef,
+        operationId: holder.operationId,
+        sourceBranch: holder.sourceBranch,
+        worktreeId: holder.worktreeId,
+      });
+      continue;
+    }
+
+    // Live / unprovable holder — wait under the deadline.
+    if (now() >= deadline) {
+      return { free: false, holder };
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+// ─── Self create-time resolution ─────────────────────────────────────────────
+
+/**
+ * Resolve the claiming process's create-time fingerprint via the injected
+ * {@link ProcessSource}. A platform that cannot resolve it yields `''` — still a
+ * well-formed claim; it just cannot defeat PID reuse for dead-holder probing
+ * (mirrors {@link resolveOwner} in `handlers.ts`).
+ */
+function resolveSelfStartedAt(pid: number, source: ProcessSource): string {
+  const probe = source.getStartTime(pid);
+  return probe.status === 'present' ? probe.startedAt : '';
+}

--- a/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.test.ts
@@ -565,6 +565,42 @@ describe('worktreesReducer.apply — in-flight merges + orphan folding (DR-4)', 
     expect(stale.inFlightMerges[INT_REF].operationId).toBe('op-current');
   });
 
+  it('WorktreesProjection_MergeExecuted_MissingOperationId_DoesNotClearLease', () => {
+    // Fail-closed guard (Sentry #15015231/1): a `worktree.merge_executed` with NO
+    // operationId cannot prove lease ownership, so it must clear NOTHING —
+    // symmetric with upsertInFlightMerge. Production always stamps an operationId;
+    // this guards the reducer against a malformed/legacy event clobbering a live
+    // lease and violating the DR-7 serialization guarantee.
+    const reducer = createWorktreesReducer(identityRealpath);
+
+    const requested = reducer.apply(
+      reducer.initial,
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 1,
+        data: {
+          integrationRef: INT_REF,
+          sourceBranch: 'task/current',
+          operationId: 'op-current',
+          holderPid: 33,
+          holderStartedAt: '2026-06-25T10:00:00.000Z',
+        },
+      }),
+    );
+
+    const noOp = reducer.apply(
+      requested,
+      buildEvent({
+        type: 'worktree.merge_executed',
+        sequence: 2,
+        data: { integrationRef: INT_REF }, // operationId ABSENT
+      }),
+    );
+    // Identity return (no sequence bump), lease untouched.
+    expect(noOp).toBe(requested);
+    expect(noOp.inFlightMerges[INT_REF].operationId).toBe('op-current');
+  });
+
   it('WorktreesProjection_ProbeFinding_EmitsAndFoldsOrphanDetected', () => {
     const reducer = createWorktreesReducer(identityRealpath);
 

--- a/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.test.ts
@@ -61,6 +61,13 @@ const identityRealpath: RealpathResolver = (p) => p;
 const WT_A = toPosix(path.resolve('/srv/wt/feature-a'));
 const WT_B = toPosix(path.resolve('/srv/wt/feature-b'));
 
+// Integration refs used by the in-flight-merge (DR-4) suite. These are branch
+// refs, NOT filesystem paths — `inFlightMerges` is keyed by `integrationRef`,
+// which typically maps to no adopted worktree entry (the integration branch is
+// the main worktree).
+const INT_REF = 'feat/wlm-operational-core';
+const INT_REF_OTHER = 'feat/other-integration';
+
 describe('worktreesReducer.apply (WLM foundation)', () => {
   it('WorktreesReducer_FoldEvents_ReproducesStateFromLogAlone', () => {
     const reducer = createWorktreesReducer(identityRealpath);
@@ -115,6 +122,7 @@ describe('worktreesReducer.apply (WLM foundation)', () => {
           ownerStartedAt: null,
         },
       },
+      inFlightMerges: {},
     } satisfies WorktreesProjection);
   });
 
@@ -395,6 +403,353 @@ describe('worktreesReducer.apply (WLM foundation)', () => {
     // Dropped by the stored key — no throw, entry gone.
     expect(WT_A in removed.worktrees).toBe(false);
     expect(removed.projectionSequence).toBe(2);
+  });
+});
+
+describe('worktreesReducer.apply — in-flight merges + orphan folding (DR-4)', () => {
+  it('WorktreesProjection_MergeRequestedNoExecuted_AppearsInInFlightMerges', () => {
+    const reducer = createWorktreesReducer(identityRealpath);
+
+    const state = reducer.apply(
+      reducer.initial,
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 1,
+        data: {
+          integrationRef: INT_REF,
+          sourceBranch: 'task/wlm-oc-003-reducer',
+          operationId: 'op-merge-1',
+          holderPid: 5151,
+          holderStartedAt: '2026-06-25T04:00:00.000Z',
+        },
+      }),
+    );
+
+    // A requested-but-not-yet-executed merge is live in `inFlightMerges`, keyed
+    // by its integrationRef and carrying the lease-holder fields verbatim.
+    expect(state.inFlightMerges[INT_REF]).toEqual({
+      integrationRef: INT_REF,
+      operationId: 'op-merge-1',
+      sourceBranch: 'task/wlm-oc-003-reducer',
+      holderPid: 5151,
+      holderStartedAt: '2026-06-25T04:00:00.000Z',
+      worktreeId: null,
+    });
+    // It does NOT leak into the worktreeId-keyed entries map.
+    expect(state.worktrees).toEqual({});
+    expect(state.projectionSequence).toBe(1);
+  });
+
+  it('WorktreesProjection_MergeRequestedThenExecuted_ClearsInFlightMerges', () => {
+    const reducer = createWorktreesReducer(identityRealpath);
+
+    const requested = reducer.apply(
+      reducer.initial,
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 1,
+        data: {
+          integrationRef: INT_REF,
+          sourceBranch: 'task/x',
+          operationId: 'op-merge-1',
+          holderPid: 6262,
+          holderStartedAt: '2026-06-25T05:00:00.000Z',
+        },
+      }),
+    );
+    expect(requested.inFlightMerges[INT_REF]).toBeDefined();
+
+    const executed = reducer.apply(
+      requested,
+      buildEvent({
+        type: 'worktree.merge_executed',
+        sequence: 2,
+        data: {
+          integrationRef: INT_REF,
+          operationId: 'op-merge-1',
+          status: 'merged',
+          mergeSha: 'abc1234',
+        },
+      }),
+    );
+    // The RELEASE half clears the in-flight entry for that integrationRef.
+    expect(INT_REF in executed.inFlightMerges).toBe(false);
+    expect(executed.inFlightMerges).toEqual({});
+    expect(executed.projectionSequence).toBe(2);
+
+    // Idempotent: a release for an already-cleared merge is a no-op (identity).
+    const executedAgain = reducer.apply(
+      executed,
+      buildEvent({
+        type: 'worktree.merge_executed',
+        sequence: 3,
+        data: { integrationRef: INT_REF, operationId: 'op-merge-1', status: 'merged' },
+      }),
+    );
+    expect(executedAgain).toBe(executed);
+  });
+
+  it('WorktreesProjection_IntegrationMergeWithNoWorktreeEntry_HasHomeInInFlightMerges', () => {
+    const reducer = createWorktreesReducer(identityRealpath);
+
+    // Adopt a worktree whose worktreeId is unrelated to the integration ref.
+    const adopted = reducer.apply(
+      reducer.initial,
+      buildEvent({
+        type: 'worktree.adopted',
+        sequence: 1,
+        data: { worktreeId: WT_A, path: WT_A, featureId: 'feat-a', operationId: 'op-1' },
+      }),
+    );
+
+    // A merge targeting the integration BRANCH — there is NO adopted worktree
+    // entry keyed under `integrationRef` (the integration branch IS the main
+    // worktree, not an adopted feature worktree).
+    const merged = reducer.apply(
+      adopted,
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 2,
+        data: {
+          integrationRef: INT_REF,
+          sourceBranch: 'task/x',
+          operationId: 'op-merge-1',
+          holderPid: 7373,
+          holderStartedAt: '2026-06-25T06:00:00.000Z',
+        },
+      }),
+    );
+
+    // No worktree entry is keyed under the integrationRef...
+    expect(INT_REF in merged.worktrees).toBe(false);
+    // ...yet the merge still has a home in `inFlightMerges`.
+    expect(merged.inFlightMerges[INT_REF]).toMatchObject({
+      integrationRef: INT_REF,
+      sourceBranch: 'task/x',
+      holderPid: 7373,
+      worktreeId: null,
+    });
+    // The pre-existing, unrelated worktree entry is left untouched.
+    expect(merged.worktrees[WT_A].state).toBe('adopted');
+  });
+
+  it('WorktreesProjection_MergeExecuted_MismatchedOperationId_DoesNotClobberClaim', () => {
+    const reducer = createWorktreesReducer(identityRealpath);
+
+    const requested = reducer.apply(
+      reducer.initial,
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 1,
+        data: {
+          integrationRef: INT_REF,
+          sourceBranch: 'task/current',
+          operationId: 'op-current',
+          holderPid: 33,
+          holderStartedAt: '2026-06-25T10:00:00.000Z',
+        },
+      }),
+    );
+
+    // A stale release correlating to a DIFFERENT operationId must not clear the
+    // current claim under the same integrationRef — identity, no sequence bump.
+    const stale = reducer.apply(
+      requested,
+      buildEvent({
+        type: 'worktree.merge_executed',
+        sequence: 2,
+        data: { integrationRef: INT_REF, operationId: 'op-stale', status: 'aborted' },
+      }),
+    );
+    expect(stale).toBe(requested);
+    expect(stale.inFlightMerges[INT_REF].operationId).toBe('op-current');
+  });
+
+  it('WorktreesProjection_ProbeFinding_EmitsAndFoldsOrphanDetected', () => {
+    const reducer = createWorktreesReducer(identityRealpath);
+
+    // A live reservation: a process holds the worktree.
+    const reserved = reducer.apply(
+      reducer.initial,
+      buildEvent({
+        type: 'worktree.reserved',
+        sequence: 1,
+        data: {
+          worktreeId: WT_A,
+          path: WT_A,
+          featureId: 'feat-a',
+          ownerPid: 8484,
+          ownerStartedAt: '2026-06-25T07:00:00.000Z',
+          operationId: 'op-res',
+        },
+      }),
+    );
+    expect(reserved.worktrees[WT_A].state).toBe('reserved');
+    expect(reserved.worktrees[WT_A].ownerPid).toBe(8484);
+
+    // A probe finds the holder dead → `worktree.orphan_detected`. Folding the
+    // finding flips the entry's liveness: state becomes `orphan`, owner cleared.
+    const orphaned = reducer.apply(
+      reserved,
+      buildEvent({
+        type: 'worktree.orphan_detected',
+        sequence: 2,
+        data: {
+          worktreeId: WT_A,
+          path: WT_A,
+          featureId: 'feat-a',
+          ownerPid: null,
+          ownerStartedAt: null,
+          operationId: 'op-orphan',
+        },
+      }),
+    );
+    expect(orphaned.worktrees[WT_A].state).toBe('orphan');
+    expect(orphaned.worktrees[WT_A].ownerPid).toBeNull();
+    expect(orphaned.worktrees[WT_A].ownerStartedAt).toBeNull();
+    expect(orphaned.projectionSequence).toBe(2);
+
+    // A subsequent release folds liveness to `released` (owner stays cleared).
+    const released = reducer.apply(
+      orphaned,
+      buildEvent({
+        type: 'worktree.released',
+        sequence: 3,
+        data: { worktreeId: WT_A, path: WT_A, featureId: 'feat-a', operationId: 'op-rel' },
+      }),
+    );
+    expect(released.worktrees[WT_A].state).toBe('released');
+    expect(released.worktrees[WT_A].ownerPid).toBeNull();
+  });
+
+  it('WorktreesProjection_ColdRebuild_EqualsLiveState', () => {
+    const reducer = createWorktreesReducer(identityRealpath);
+    // A log interleaving the lifecycle family with the merge-lease pair on the
+    // singleton stream — cold replay must reproduce both maps byte-for-byte.
+    const log: readonly WorkflowEvent[] = [
+      buildEvent({
+        type: 'worktree.adopted',
+        sequence: 1,
+        data: { worktreeId: WT_A, path: WT_A, featureId: 'feat-a', operationId: 'op-1' },
+      }),
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 2,
+        data: {
+          integrationRef: INT_REF,
+          sourceBranch: 'task/a',
+          operationId: 'op-m-1',
+          holderPid: 11,
+          holderStartedAt: '2026-06-25T08:00:00.000Z',
+        },
+      }),
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 3,
+        data: {
+          integrationRef: INT_REF_OTHER,
+          sourceBranch: 'task/b',
+          operationId: 'op-m-2',
+          holderPid: 22,
+          holderStartedAt: '2026-06-25T09:00:00.000Z',
+          worktreeId: WT_A,
+        },
+      }),
+      buildEvent({
+        type: 'worktree.merge_executed',
+        sequence: 4,
+        data: { integrationRef: INT_REF, operationId: 'op-m-1', status: 'merged', mergeSha: 'sha-1' },
+      }),
+      buildEvent({
+        type: 'worktree.orphan_detected',
+        sequence: 5,
+        data: {
+          worktreeId: WT_A,
+          path: WT_A,
+          featureId: 'feat-a',
+          ownerPid: null,
+          ownerStartedAt: null,
+          operationId: 'op-orphan',
+        },
+      }),
+    ];
+
+    // "Live" — fold each event as it arrives, threading the accumulator.
+    let live = reducer.initial;
+    for (const ev of log) {
+      live = reducer.apply(live, ev);
+    }
+
+    // "Cold rebuild" — replay the same persisted log from the seed.
+    const cold = log.reduce((acc, ev) => reducer.apply(acc, ev), reducer.initial);
+
+    expect(cold).toEqual(live);
+    // INT_REF was requested then executed → cleared; INT_REF_OTHER still live.
+    expect(Object.keys(cold.inFlightMerges)).toEqual([INT_REF_OTHER]);
+    expect(cold.inFlightMerges[INT_REF_OTHER].worktreeId).toBe(WT_A);
+    // WT_A's liveness folded to orphan.
+    expect(cold.worktrees[WT_A].state).toBe('orphan');
+  });
+
+  it('WorktreesReducer_AssertReducerImmutable_Passes', () => {
+    const reducer = createWorktreesReducer(identityRealpath);
+    const events: readonly WorkflowEvent[] = [
+      buildEvent({
+        type: 'worktree.adopted',
+        sequence: 1,
+        data: { worktreeId: WT_A, path: WT_A, featureId: 'feat-a', operationId: 'op-1' },
+      }),
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 2,
+        data: {
+          integrationRef: INT_REF,
+          sourceBranch: 'task/a',
+          operationId: 'op-m-1',
+          holderPid: 11,
+          holderStartedAt: '2026-06-25T08:00:00.000Z',
+        },
+      }),
+      buildEvent({
+        type: 'worktree.merge_requested',
+        sequence: 3,
+        data: {
+          integrationRef: INT_REF_OTHER,
+          sourceBranch: 'task/b',
+          operationId: 'op-m-2',
+          holderPid: 22,
+          holderStartedAt: '2026-06-25T09:00:00.000Z',
+        },
+      }),
+      buildEvent({
+        type: 'worktree.merge_executed',
+        sequence: 4,
+        data: { integrationRef: INT_REF, operationId: 'op-m-1', status: 'merged', mergeSha: 'sha-1' },
+      }),
+      buildEvent({
+        type: 'worktree.orphan_detected',
+        sequence: 5,
+        data: {
+          worktreeId: WT_A,
+          path: WT_A,
+          featureId: 'feat-a',
+          ownerPid: null,
+          ownerStartedAt: null,
+          operationId: 'op-orphan',
+        },
+      }),
+      buildEvent({
+        type: 'worktree.released',
+        sequence: 6,
+        data: { worktreeId: WT_A, path: WT_A, featureId: 'feat-a', operationId: 'op-rel' },
+      }),
+    ];
+
+    // Deep-freezes the seed + every intermediate; the merge + lifecycle folds
+    // must never mutate the frozen `state` argument in place.
+    expect(() => assertReducerImmutable(reducer, events)).not.toThrow();
+    // Order-independence of the purity property.
+    expect(() => assertReducerImmutable(reducer, [...events].reverse())).not.toThrow();
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.ts
@@ -4,8 +4,10 @@
  * Folds the worktree-lifecycle event family on the dedicated singleton
  * `worktrees` stream into a {@link WorktreesProjection} — a map of
  * {@link WorktreeEntry} records keyed by `worktreeId` (the canonical,
- * symlink-resolved worktree path). This is the single canonical left-fold that
- * derives the live set of governed worktrees from the event log alone (INV-1).
+ * symlink-resolved worktree path) PLUS an `inFlightMerges` map keyed by
+ * `integrationRef`. This is the single canonical left-fold that derives the live
+ * set of governed worktrees AND the live set of in-flight serialized merges from
+ * the event log alone (INV-1).
  *
  * ## Fold rules
  *
@@ -15,11 +17,28 @@
  *   - `worktree.orphan_detected`→ upsert, state `orphan`,   owner cleared
  *   - `worktree.remove.executed`→ DROP the entry from the map (absence is the
  *                                 terminal state — there is NO `removed` state)
+ *   - `worktree.merge_requested`→ upsert an {@link InFlightMerge} under its
+ *                                 `integrationRef` (the CLAIM half of the lease)
+ *   - `worktree.merge_executed` → CLEAR the in-flight merge for that
+ *                                 `integrationRef` (the RELEASE half)
  *
  * `worktree.remove.requested` is durable intent only and is a no-op here; the
  * entry is dropped on `worktree.remove.executed`. Every lifecycle event carries
  * the full payload (`worktreeId`, `path`, `featureId`, owner fields), so each
  * upsert is self-describing and the fold reproduces state from the log alone.
+ *
+ * ## In-flight merges (DR-4)
+ *
+ * The serialized-merge lease pair rides the SAME singleton `worktrees` stream as
+ * the lifecycle family but folds into a SEPARATE `inFlightMerges` map keyed by
+ * `integrationRef`, NOT by `worktreeId`. An integration-branch merge typically
+ * maps to NO adopted worktree entry (the integration branch is the main
+ * worktree), so it must have a home keyed by the branch it targets. The CLAIM
+ * (`worktree.merge_requested`) records which live process holds the right to
+ * merge `sourceBranch` into `integrationRef`; the RELEASE
+ * (`worktree.merge_executed`) clears it. The `ps` / `wait` read paths read
+ * `inFlightMerges` to surface and block on live merges. Per-branch serialization
+ * means at most one in-flight merge exists per `integrationRef` at a time.
  *
  * ## Owner discipline
  *
@@ -88,20 +107,50 @@ export interface WorktreeEntry {
 }
 
 /**
+ * A single in-flight serialized merge — the CLAIM half of the
+ * `worktree.merge_requested` / `worktree.merge_executed` lease pair (DR-4).
+ *
+ * Keyed in {@link WorktreesProjection.inFlightMerges} by `integrationRef` (the
+ * per-branch serialization key), NOT by `worktreeId`: an integration-branch
+ * merge typically maps to no adopted worktree entry. `holderPid` /
+ * `holderStartedAt` identify the live process holding the merge lease (liveness
+ * ground truth for orphan reclamation); `worktreeId` is the optional canonical
+ * `worktrees@v1` key when the merge is attributable to a specific worktree.
+ */
+export interface InFlightMerge {
+  /** Integration ref the merge targets — the map key / per-branch serialization key. */
+  readonly integrationRef: string;
+  /** Idempotency key / lease correlator — the sole per-merge discriminator. */
+  readonly operationId: string;
+  /** Branch being merged into `integrationRef`. */
+  readonly sourceBranch: string;
+  /** PID of the live process holding the merge lease, or `null` when absent. */
+  readonly holderPid: number | null;
+  /** Lease-holder process start time (ISO 8601), or `null` — disambiguates PID reuse. */
+  readonly holderStartedAt: string | null;
+  /** Canonical `worktrees@v1` key when attributable to a tracked worktree, else `null`. */
+  readonly worktreeId: string | null;
+}
+
+/**
  * The full projected state: a map of {@link WorktreeEntry} keyed by
- * `worktreeId`, plus the monotone `projectionSequence` stale-snapshot detector
- * (bumped only on handled, state-changing events — matching the sibling
- * `task-store@v1` convention).
+ * `worktreeId`, a map of {@link InFlightMerge} keyed by `integrationRef`, plus
+ * the monotone `projectionSequence` stale-snapshot detector (bumped only on
+ * handled, state-changing events — matching the sibling `task-store@v1`
+ * convention).
  */
 export interface WorktreesProjection {
   readonly projectionSequence: number;
   readonly worktrees: Readonly<Record<string, WorktreeEntry>>;
+  /** Live serialized merges keyed by `integrationRef` (DR-4). */
+  readonly inFlightMerges: Readonly<Record<string, InFlightMerge>>;
 }
 
 /** Shared initial seed. Safe to share across folds because `apply` is pure. */
 export const initialWorktreesProjection: WorktreesProjection = {
   projectionSequence: 0,
   worktrees: {},
+  inFlightMerges: {},
 };
 
 // ─── Typed field extractors over the opaque event payload ───────────────────
@@ -164,6 +213,8 @@ function upsertLifecycle(
   return {
     projectionSequence: state.projectionSequence + 1,
     worktrees: { ...state.worktrees, [worktreeId]: entry },
+    // Lifecycle events never touch the merge map — structural-share it through.
+    inFlightMerges: state.inFlightMerges,
   };
 }
 
@@ -207,6 +258,75 @@ function dropRemoved(
   return {
     projectionSequence: state.projectionSequence + 1,
     worktrees: nextWorktrees,
+    // Removal never touches the merge map — structural-share it through.
+    inFlightMerges: state.inFlightMerges,
+  };
+}
+
+// ─── In-flight merge fold helpers (DR-4) ────────────────────────────────────
+
+/**
+ * Upsert the {@link InFlightMerge} for a `worktree.merge_requested` event under
+ * its `integrationRef`. Returns `state` by identity when the event is missing a
+ * usable `integrationRef`, `operationId`, or `sourceBranch` (lax replay
+ * tolerance, mirroring {@link upsertLifecycle}). The worktree-entry map is left
+ * untouched — a merge claim folds ONLY into `inFlightMerges`.
+ */
+function upsertInFlightMerge(
+  state: WorktreesProjection,
+  event: WorkflowEvent,
+): WorktreesProjection {
+  const integrationRef = extractString(event.data, 'integrationRef');
+  const operationId = extractString(event.data, 'operationId');
+  const sourceBranch = extractString(event.data, 'sourceBranch');
+  if (!integrationRef || !operationId || !sourceBranch) return state;
+  const merge: InFlightMerge = {
+    integrationRef,
+    operationId,
+    sourceBranch,
+    holderPid: extractNumber(event.data, 'holderPid') ?? null,
+    holderStartedAt: extractString(event.data, 'holderStartedAt') ?? null,
+    worktreeId: extractString(event.data, 'worktreeId') ?? null,
+  };
+  return {
+    projectionSequence: state.projectionSequence + 1,
+    worktrees: state.worktrees,
+    inFlightMerges: { ...state.inFlightMerges, [integrationRef]: merge },
+  };
+}
+
+/**
+ * Clear the in-flight merge targeted by a `worktree.merge_executed` event.
+ *
+ * Removes the entry keyed under the event's `integrationRef`. Returns `state` by
+ * identity when no `integrationRef` is present, no entry is keyed under it
+ * (idempotent — a release for an already-cleared merge is a no-op), or the
+ * stored claim's `operationId` does not match this release's `operationId`. The
+ * `operationId` guard correlates the RELEASE to the exact CLAIM it terminates
+ * (the documented correlation, even for dead-holder recovery releases) so a
+ * stale release can never clobber a newer concurrent claim under the same
+ * `integrationRef`.
+ */
+function clearInFlightMerge(
+  state: WorktreesProjection,
+  event: WorkflowEvent,
+): WorktreesProjection {
+  const integrationRef = extractString(event.data, 'integrationRef');
+  if (!integrationRef) return state;
+  if (!Object.prototype.hasOwnProperty.call(state.inFlightMerges, integrationRef)) {
+    return state;
+  }
+  const operationId = extractString(event.data, 'operationId');
+  const existing = state.inFlightMerges[integrationRef];
+  if (operationId && existing.operationId !== operationId) return state;
+  const nextInFlight: Record<string, InFlightMerge> = {};
+  for (const [key, value] of Object.entries(state.inFlightMerges)) {
+    if (key !== integrationRef) nextInFlight[key] = value;
+  }
+  return {
+    projectionSequence: state.projectionSequence + 1,
+    worktrees: state.worktrees,
+    inFlightMerges: nextInFlight,
   };
 }
 
@@ -240,6 +360,10 @@ export function createWorktreesReducer(
           return upsertLifecycle(state, event, 'orphan');
         case 'worktree.remove.executed':
           return dropRemoved(state, event, realpath);
+        case 'worktree.merge_requested':
+          return upsertInFlightMerge(state, event);
+        case 'worktree.merge_executed':
+          return clearInFlightMerge(state, event);
         default:
           // Unknown / intent-only event (e.g. `worktree.remove.requested`) —
           // return identity to preserve structural-sharing semantics.

--- a/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/projections/worktrees.ts
@@ -316,9 +316,15 @@ function clearInFlightMerge(
   if (!Object.prototype.hasOwnProperty.call(state.inFlightMerges, integrationRef)) {
     return state;
   }
+  // Fail closed: only the lease holder — proven by a MATCHING operationId — may
+  // clear it. A missing operationId cannot establish ownership, so it clears
+  // nothing (symmetric with upsertInFlightMerge, which no-ops without one),
+  // upholding the DR-7 merge-serialization guarantee even against a malformed
+  // `worktree.merge_executed` event a future change might introduce.
   const operationId = extractString(event.data, 'operationId');
+  if (!operationId) return state;
   const existing = state.inFlightMerges[integrationRef];
-  if (operationId && existing.operationId !== operationId) return state;
+  if (existing.operationId !== operationId) return state;
   const nextInFlight: Record<string, InFlightMerge> = {};
   for (const [key, value] of Object.entries(state.inFlightMerges)) {
     if (key !== integrationRef) nextInFlight[key] = value;

--- a/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  protectedAncestry,
+  probeWorktreeUsage,
+  probeReservations,
+  probeWorktrees,
+  type ProcessRecord,
+  type ProcessTableSource,
+} from './probe.js';
+import type { RealpathResolver } from './path-containment.js';
+
+/** A fixed-snapshot ProcessTableSource over an in-memory process table. */
+function tableSource(records: readonly ProcessRecord[]): ProcessTableSource {
+  return { list: () => records };
+}
+
+/** Identity resolver: no symlinks, paths pass through unchanged. */
+const identity: RealpathResolver = (p) => p;
+
+describe('protectedAncestry', () => {
+  it('walks the full pid -> ppid chain and terminates at a cycle', () => {
+    // 100 -> 90 -> 80 -> (ppid 0). A self-referential ppid (200 -> 200) must not
+    // loop forever — the visited-set guard makes the walk total.
+    const records: ProcessRecord[] = [
+      { pid: 100, ppid: 90, cwd: '/x', startTime: 'a' },
+      { pid: 90, ppid: 80, cwd: '/x', startTime: 'b' },
+      { pid: 80, ppid: 0, cwd: '/x', startTime: 'c' },
+      { pid: 200, ppid: 200, cwd: '/x', startTime: 'd' },
+    ];
+    const byPid = new Map(records.map((r) => [r.pid, r]));
+
+    expect([...protectedAncestry(100, byPid)]).toEqual([100, 90, 80]);
+    expect([...protectedAncestry(200, byPid)]).toEqual([200]); // cycle terminates.
+    // selfPid absent from the table is still protected (just can't walk further).
+    expect([...protectedAncestry(999, byPid)]).toEqual([999]);
+  });
+});
+
+describe('probeWorktreeUsage', () => {
+  it('Probe_SelfRootedCwd_ExcludedFromInUseSet', () => {
+    // The orchestrator's OWN shell (selfPid) has drifted its cwd into worktree W.
+    // A self-rooted cwd must NEVER mark a worktree in-use, or the orchestrator
+    // would forever see its own worktrees as occupied and never reclaim them.
+    const W = '/repo/.worktrees/W';
+    const records: ProcessRecord[] = [
+      { pid: 4242, ppid: 1, cwd: `${W}/src`, startTime: 'self-ct' }, // self, inside W
+    ];
+
+    const [usage] = probeWorktreeUsage(
+      { worktreePaths: [W], selfPid: 4242 },
+      tableSource(records),
+      identity,
+    );
+
+    expect(usage.inUse).toBe(false);
+    expect(usage.occupantPids).toEqual([]);
+  });
+
+  it('Probe_OwnerAncestryChain_FullyProtected', () => {
+    // The WHOLE parent chain of selfPid is excluded, not just the leaf. Here the
+    // self process (300) sits outside W, but its grandparent (100) — the
+    // orchestrator shell whose cwd drifted into W — is in the ancestry chain and
+    // must also be subtracted. An unrelated process (500) inside W still counts.
+    const W = '/repo/.worktrees/W';
+    const records: ProcessRecord[] = [
+      { pid: 300, ppid: 200, cwd: '/elsewhere', startTime: 's' }, // self, outside W
+      { pid: 200, ppid: 100, cwd: `${W}/a`, startTime: 'p' }, // parent, inside W
+      { pid: 100, ppid: 0, cwd: `${W}/b`, startTime: 'g' }, // grandparent, inside W
+      { pid: 500, ppid: 1, cwd: `${W}/c`, startTime: 'u' }, // unrelated, inside W
+    ];
+
+    const [usage] = probeWorktreeUsage(
+      { worktreePaths: [W], selfPid: 300 },
+      tableSource(records),
+      identity,
+    );
+
+    // Parent (200) and grandparent (100) are protected; only the unrelated 500
+    // marks W in-use.
+    expect(usage.occupantPids).toEqual([500]);
+    expect(usage.inUse).toBe(true);
+  });
+
+  it('Probe_SymlinkedWorktreePath_ContainmentMatches', () => {
+    // A process cwd reported under the macOS `/var` symlink must match a worktree
+    // recorded under its canonical `/private/var` realpath (and vice versa).
+    // Resolving symlinks on BOTH sides canonicalizes them to the same root.
+    const symlinkMap: Record<string, string> = {
+      '/var/folders/abc/W': '/private/var/folders/abc/W',
+      '/var/folders/abc/W/agent': '/private/var/folders/abc/W/agent',
+      '/private/var/folders/abc/W': '/private/var/folders/abc/W',
+    };
+    const symlinkRealpath: RealpathResolver = (p) => symlinkMap[p] ?? p;
+
+    const records: ProcessRecord[] = [
+      { pid: 700, ppid: 1, cwd: '/var/folders/abc/W/agent', startTime: 'x' }, // via /var
+    ];
+
+    // Worktree recorded under the canonical /private/var form; process cwd under
+    // the /var symlink form — both-sides realpath resolution still contains it.
+    const [usage] = probeWorktreeUsage(
+      { worktreePaths: ['/private/var/folders/abc/W'], selfPid: 1 },
+      tableSource(records),
+      symlinkRealpath,
+    );
+
+    expect(usage.inUse).toBe(true);
+    expect(usage.occupantPids).toEqual([700]);
+  });
+});
+
+describe('probeReservations', () => {
+  it('Probe_DeadOwner_ReportedReleasable', () => {
+    // A reservation is releasable iff its owner is provably gone: PID absent from
+    // the table, OR present but with a mismatched create-time (PID reuse). A live
+    // owner (PID present AND create-time matches) is NEVER releasable.
+    const records: ProcessRecord[] = [
+      { pid: 11, ppid: 1, cwd: '/x', startTime: 'live-ct' }, // live owner of W-live
+      { pid: 22, ppid: 1, cwd: '/x', startTime: 'reused-ct' }, // PID 22 REUSED by newer proc
+    ];
+
+    const findings = probeReservations(
+      [
+        { worktreePath: '/wt/live', ownerPid: 11, ownerStartedAt: 'live-ct' }, // alive
+        { worktreePath: '/wt/reused', ownerPid: 22, ownerStartedAt: 'orig-ct' }, // reuse -> dead
+        { worktreePath: '/wt/gone', ownerPid: 33, ownerStartedAt: 'gone-ct' }, // absent -> dead
+      ],
+      tableSource(records),
+    );
+
+    const byPath = Object.fromEntries(findings.map((f) => [f.worktreePath, f]));
+
+    // Live owner: present AND create-time matches -> never releasable.
+    expect(byPath['/wt/live'].liveness).toBe('alive');
+    expect(byPath['/wt/live'].releasable).toBe(false);
+
+    // PID present but create-time differs (reuse) -> dead -> releasable.
+    expect(byPath['/wt/reused'].liveness).toBe('dead');
+    expect(byPath['/wt/reused'].releasable).toBe(true);
+
+    // PID absent from the table (owner exited) -> dead -> releasable.
+    expect(byPath['/wt/gone'].liveness).toBe('dead');
+    expect(byPath['/wt/gone'].releasable).toBe(true);
+  });
+});
+
+describe('probeWorktrees (composite)', () => {
+  it('live occupancy vetoes a dead-owner release (orphan-candidate only when truly free)', () => {
+    // The recorded owner of W is gone (dead), but an UNRELATED live process has
+    // re-entered W. Ground-truth occupancy must veto the stale "owner dead"
+    // verdict: W is NOT releasable while a live non-ancestry process occupies it.
+    const W = '/repo/.worktrees/W';
+    const records: ProcessRecord[] = [
+      { pid: 4242, ppid: 1, cwd: '/elsewhere', startTime: 'self' }, // self, outside W
+      { pid: 808, ppid: 1, cwd: `${W}/x`, startTime: 'intruder' }, // live, inside W
+    ];
+
+    const [occupied] = probeWorktrees(
+      {
+        targets: [{ worktreePath: W, owner: { ownerPid: 99, ownerStartedAt: 'long-gone' } }],
+        selfPid: 4242,
+      },
+      tableSource(records),
+      identity,
+    );
+
+    expect(occupied.ownerLiveness).toBe('dead'); // owner PID 99 absent -> dead
+    expect(occupied.inUse).toBe(true); // but 808 is rooted inside
+    expect(occupied.releasable).toBe(false); // occupancy vetoes release
+
+    // With no live occupant, the same dead-owner worktree IS an orphan candidate.
+    const [free] = probeWorktrees(
+      {
+        targets: [{ worktreePath: W, owner: { ownerPid: 99, ownerStartedAt: 'long-gone' } }],
+        selfPid: 4242,
+      },
+      tableSource([records[0]]), // only self remains
+      identity,
+    );
+    expect(free.inUse).toBe(false);
+    expect(free.releasable).toBe(true);
+  });
+
+  it('reports ownerLiveness "none" for an unreserved worktree', () => {
+    const [finding] = probeWorktrees(
+      { targets: [{ worktreePath: '/wt/free', owner: null }], selfPid: 1 },
+      tableSource([]),
+      identity,
+    );
+    expect(finding.ownerLiveness).toBe('none');
+    expect(finding.inUse).toBe(false);
+    expect(finding.releasable).toBe(false); // 'none' is not 'dead' -> not releasable
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.test.ts
@@ -9,10 +9,25 @@ import {
 } from './probe.js';
 import type { RealpathResolver } from './path-containment.js';
 
-/** A fixed-snapshot ProcessTableSource over an in-memory process table. */
+/**
+ * A fixed-snapshot, SUPPORTED ProcessTableSource over an in-memory process
+ * table — `list()` is authoritative, so a PID absent from it is provably gone.
+ * (No `isSupported`; the probe reads an absent predicate as supported.)
+ */
 function tableSource(records: readonly ProcessRecord[]): ProcessTableSource {
   return { list: () => records };
 }
+
+/**
+ * An UNSUPPORTED ProcessTableSource — the off-Linux shape where enumeration is
+ * not implemented (DR-11/#1579). `list()` returns `[]` but `isSupported()` is
+ * `false`, so an absent PID is `'unknown'`, NEVER provably dead. Mirrors the
+ * real `defaultProcessTableSource` off-Linux.
+ */
+const UNSUPPORTED_TABLE: ProcessTableSource = {
+  list: () => [],
+  isSupported: () => false,
+};
 
 /** Identity resolver: no symlinks, paths pass through unchanged. */
 const identity: RealpathResolver = (p) => p;
@@ -138,9 +153,30 @@ describe('probeReservations', () => {
     expect(byPath['/wt/reused'].liveness).toBe('dead');
     expect(byPath['/wt/reused'].releasable).toBe(true);
 
-    // PID absent from the table (owner exited) -> dead -> releasable.
+    // PID absent from a SUPPORTED table (owner exited) -> dead -> releasable.
+    // (The table is non-empty / enumerated, so absence is authoritative.)
     expect(byPath['/wt/gone'].liveness).toBe('dead');
     expect(byPath['/wt/gone'].releasable).toBe(true);
+  });
+
+  it('Probe_UnsupportedPlatformTable_FailsClosed_NeverReleasable', () => {
+    // The off-Linux hole (REV-H1): an UNSUPPORTED table cannot prove a PID
+    // absent, so an owner that LOOKS gone (its pid is not in the empty list) must
+    // read as 'unknown', NOT 'dead' — and therefore is NEVER releasable. The old
+    // two-valued mapping classified this owner 'dead' and let `waitForFreeSlot`
+    // reclaim a LIVE merge holder; this pins the fail-closed contract.
+    const findings = probeReservations(
+      [
+        { worktreePath: '/wt/a', ownerPid: 4242, ownerStartedAt: 'boot-4242' },
+        { worktreePath: '/wt/b', ownerPid: 7, ownerStartedAt: 'boot-7' },
+      ],
+      UNSUPPORTED_TABLE,
+    );
+
+    for (const finding of findings) {
+      expect(finding.liveness).toBe('unknown'); // cannot prove dead off-Linux.
+      expect(finding.releasable).toBe(false); // fail closed — never reclaim.
+    }
   });
 });
 
@@ -179,6 +215,29 @@ describe('probeWorktrees (composite)', () => {
     );
     expect(free.inUse).toBe(false);
     expect(free.releasable).toBe(true);
+  });
+
+  it('Probe_UnsupportedTable_OwnerUnknown_NotReleasableNorOrphan', () => {
+    // On an UNSUPPORTED table the composite probe must classify a reserved
+    // worktree as neither releasable NOR an orphan candidate: ownerLiveness is
+    // 'unknown' (not 'dead'), so manager.probeAndReclaim — which emits
+    // worktree.released only when `releasable` and worktree.orphan_detected only
+    // when `ownerLiveness === 'dead' && inUse` — emits NOTHING. Fail closed.
+    const W = '/repo/.worktrees/W';
+    const [finding] = probeWorktrees(
+      {
+        targets: [{ worktreePath: W, owner: { ownerPid: 555, ownerStartedAt: 'boot-555' } }],
+        selfPid: 999999,
+      },
+      UNSUPPORTED_TABLE,
+      identity,
+    );
+
+    expect(finding.ownerLiveness).toBe('unknown'); // cannot prove dead off-Linux.
+    expect(finding.releasable).toBe(false); // no worktree.released.
+    expect(finding.inUse).toBe(false); // empty list → no occupant either.
+    // Neither emit branch fires: not releasable, and ownerLiveness !== 'dead'.
+    expect(finding.ownerLiveness === 'dead' && finding.inUse).toBe(false);
   });
 
   it('reports ownerLiveness "none" for an unreserved worktree', () => {

--- a/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.ts
@@ -82,6 +82,25 @@ export interface ProcessRecord {
 export interface ProcessTableSource {
   /** Snapshot every visible process. A point-in-time read, never a live stream. */
   list(): readonly ProcessRecord[];
+  /**
+   * Whether this platform's process enumeration is actually SUPPORTED — i.e.
+   * whether an empty `list()` means "no processes" (provably) or "could not
+   * enumerate" (unknown). This is the load-bearing distinction the off-Linux
+   * fail-closed contract rests on: on a platform without a real enumerator
+   * (macOS / Windows before DR-11, #1579) `list()` returns `[]`, and treating
+   * that `[]` as "every PID is absent → every owner is provably dead" would
+   * reclaim LIVE holders (DR-7 corruption). When `isSupported()` is `false`,
+   * a PID lookup is `'unknown'` (NOT `'dead'`), so every reclaim consumer fails
+   * closed — mirroring the `unknown` three-state contract of
+   * {@link ProcessSource} in `process-identity.ts`.
+   *
+   * OPTIONAL purely for backward-compatibility with in-memory test doubles that
+   * supply a concrete records list: an absent predicate is read as `true`
+   * (supported) by {@link isTableSupported}, because such a double IS asserting
+   * a real enumerated table. The real {@link defaultProcessTableSource} always
+   * declares it explicitly (`true` only on Linux).
+   */
+  isSupported?(): boolean;
 }
 
 /** A worktree path plus the current PID whose entire ancestry is protected. */
@@ -210,18 +229,46 @@ function occupantsOf(
 }
 
 /**
- * Adapt a point-in-time {@link ProcessTableSource} snapshot into the per-PID
- * {@link ProcessSource} that {@link ownerLiveness} consumes.
- *
- * A full ground-truth snapshot resolves to `present` / `absent` only — never the
- * per-PID probe's `unknown`: there is no separate create-time probe that could
- * fail to run, the process is simply in the enumerated table or it is not. So
- * owner liveness over a snapshot is two-valued (`alive` / `dead`); the `unknown`
- * fail-closed branch belongs to the live per-PID `defaultProcessSource`, not here.
+ * Whether a {@link ProcessTableSource}'s enumeration is supported. An absent
+ * `isSupported` predicate is read as supported (`true`) — see the field doc:
+ * an in-memory double that supplies a concrete records list IS a real table, so
+ * "PID absent → provably dead" still holds for it. Only a source that explicitly
+ * reports `false` (the real off-Linux {@link defaultProcessTableSource}) flips
+ * lookups to `'unknown'`.
  */
-function tableAsProcessSource(byPid: ReadonlyMap<number, ProcessRecord>): ProcessSource {
+function isTableSupported(source: ProcessTableSource): boolean {
+  return source.isSupported?.() ?? true;
+}
+
+/**
+ * Adapt a point-in-time {@link ProcessTableSource} snapshot into the per-PID
+ * {@link ProcessSource} that {@link ownerLiveness} consumes — THREE-valued.
+ *
+ * When the table is SUPPORTED (`supported === true`), a PID present in the
+ * enumerated snapshot resolves to `present` and an absent one to `absent`: the
+ * absence is authoritative (the process is provably gone), so owner liveness is
+ * two-valued (`alive` / `dead`) over a real enumeration.
+ *
+ * When the table is UNSUPPORTED (`supported === false` — e.g. macOS / Windows
+ * before DR-11, where `list()` returns `[]` because there is no enumerator),
+ * a PID lookup CANNOT distinguish "absent" from "unenumerated", so it resolves
+ * to `'unknown'` for EVERY pid. That propagates through {@link ownerLiveness} to
+ * an `'unknown'` verdict, and every reclaim consumer fails closed (never treats
+ * the holder as provably dead) — mirroring the `unknown` fail-closed branch of
+ * the live per-PID `defaultProcessSource`. This is the fix for the off-Linux
+ * dead-holder-reclaim hole that would otherwise free a LIVE merge holder.
+ */
+function tableAsProcessSource(
+  byPid: ReadonlyMap<number, ProcessRecord>,
+  supported: boolean,
+): ProcessSource {
   return {
     getStartTime(pid: number): StartTimeProbe {
+      if (!supported) {
+        // Unsupported enumeration: an empty/partial table cannot prove a PID
+        // absent, so every lookup is `unknown` → callers fail closed.
+        return { status: 'unknown' };
+      }
       const record = byPid.get(pid);
       return record === undefined
         ? { status: 'absent' }
@@ -257,15 +304,20 @@ export function probeWorktreeUsage(
  * Probe each recorded reservation owner's liveness against the process table.
  *
  * An owner is `releasable` only when {@link ownerLiveness} reports `'dead'` — the
- * PID is absent, or present but with a mismatched create-time (PID reuse). A live
- * owner (PID present AND create-time matches) is never releasable. Pure over the
- * injected {@link ProcessTableSource}.
+ * PID is absent from a SUPPORTED table, or present but with a mismatched
+ * create-time (PID reuse). A live owner (PID present AND create-time matches) is
+ * never releasable, and on an UNSUPPORTED table every owner is `'unknown'` (NOT
+ * `'dead'`) so nothing is releasable — fail closed. Pure over the injected
+ * {@link ProcessTableSource}.
  */
 export function probeReservations(
   reservations: readonly ReservationOwner[],
   source: ProcessTableSource,
 ): ReservationFinding[] {
-  const processSource = tableAsProcessSource(indexByPid(source.list()));
+  const processSource = tableAsProcessSource(
+    indexByPid(source.list()),
+    isTableSupported(source),
+  );
   return reservations.map((reservation) => {
     const liveness = ownerLiveness(
       { ownerPid: reservation.ownerPid, ownerStartedAt: reservation.ownerStartedAt },
@@ -287,8 +339,10 @@ export function probeReservations(
  * liveness lens ({@link probeReservations}) over a single process snapshot. A
  * worktree is releasable only when its recorded owner is provably `'dead'` AND it
  * is NOT in use by any live non-ancestry process — live occupancy is the ground
- * truth that vetoes a stale "owner dead" ledger verdict. Pure over the injected
- * {@link ProcessTableSource} and {@link RealpathResolver}.
+ * truth that vetoes a stale "owner dead" ledger verdict. On an UNSUPPORTED
+ * process table the owner verdict is `'unknown'` (never `'dead'`), so nothing is
+ * releasable and nothing is an orphan candidate — fail closed. Pure over the
+ * injected {@link ProcessTableSource} and {@link RealpathResolver}.
  */
 export function probeWorktrees(
   query: WorktreeProbeQuery,
@@ -298,7 +352,7 @@ export function probeWorktrees(
   const records = source.list();
   const byPid = indexByPid(records);
   const protectedPids = protectedAncestry(query.selfPid, byPid);
-  const processSource = tableAsProcessSource(byPid);
+  const processSource = tableAsProcessSource(byPid, isTableSupported(source));
 
   return query.targets.map((target) => {
     const occupantPids = occupantsOf(target.worktreePath, records, protectedPids, realpath);
@@ -373,14 +427,21 @@ function enumerateProcLinux(): ProcessRecord[] {
  *
  * Linux ground truth is read from `/proc`. macOS / Windows enumeration is
  * deferred to DR-11 (#1579); the injected-source seam keeps those platforms open
- * without foreclosing here. A consumer that receives an empty table on an
- * unsupported platform MUST fail closed — treat "cannot enumerate" as "cannot
- * prove free" and never release — mirroring the `unknown` fail-closed contract of
- * the per-PID `defaultProcessSource`. Never exercised by the unit tests (those
- * inject a fake table), so the probe core stays free of real OS calls.
+ * without foreclosing here. On those unsupported platforms `list()` returns `[]`
+ * AND `isSupported()` returns `false`, so the empty table is read as "cannot
+ * enumerate" (every PID `'unknown'`) — NOT as "every owner provably dead". That
+ * is the fail-closed contract that prevents reclaiming a LIVE merge holder
+ * off-Linux (DR-7), mirroring the `unknown` branch of the per-PID
+ * `defaultProcessSource`. Never exercised by the unit tests (those inject a fake
+ * table), so the probe core stays free of real OS calls.
  */
 export const defaultProcessTableSource: ProcessTableSource = {
   list(): readonly ProcessRecord[] {
     return process.platform === 'linux' ? enumerateProcLinux() : [];
+  },
+  isSupported(): boolean {
+    // Only Linux `/proc` enumeration is implemented today (DR-11 / #1579). On
+    // every other platform the empty `list()` is "unenumerated", not "empty".
+    return process.platform === 'linux';
   },
 };

--- a/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/pure/probe.ts
@@ -1,0 +1,386 @@
+/**
+ * DR-5 — protected-ancestry, read-only ground-truth process probe for the
+ * worktree-lifecycle manager.
+ *
+ * The reservation bookkeeping (`worktrees@v1`) records WHICH process claimed a
+ * worktree, but the only authoritative answer to "is this worktree actually in
+ * use right now?" is the live process table: a process whose cwd resolves inside
+ * the worktree is using it, regardless of what the ledger says. This module is
+ * that ground-truth probe. It is strictly **read-only** — it enumerates, it
+ * resolves, it RETURNS findings; it NEVER terminates a process and NEVER mutates
+ * state. There is no background loop, interval, or daemon: every function runs
+ * only when called (INV-15).
+ *
+ * Three properties make the probe safe to act on:
+ *
+ *   1. **Injected enumeration.** The host process table is reached only through
+ *      an injected {@link ProcessTableSource}, so the decision logic is fully
+ *      unit-testable with a fake table and zero OS calls — and the macOS /
+ *      Windows enumeration paths (DR-11, deferred to #1579) stay open behind the
+ *      same seam instead of being foreclosed by a hard-coded `ps`/native call.
+ *
+ *   2. **Symlink-canonicalized containment.** Whether a process cwd lives inside
+ *      a worktree is decided by {@link isPathWithin}, which realpath-resolves
+ *      BOTH sides — so a cwd reported under `/private/var/...` still matches a
+ *      worktree recorded under the `/var/...` symlink (and vice versa), and a
+ *      partial-segment sibling like `/a/bc` is never mistaken for inside `/a/b`.
+ *
+ *   3. **Protected-ancestry subtraction (the load-bearing requirement).** The
+ *      orchestrator's own shell can drift its cwd into an agent worktree; if that
+ *      self-rooted cwd counted, the orchestrator would forever see its own
+ *      worktrees as in-use and never reclaim them. So the current process's FULL
+ *      parent-PID chain (`pid -> ppid -> ...`) is computed and excluded from the
+ *      occupant set — not just the leaf PID, the entire ancestry.
+ *
+ * Owner liveness reuses the {@link ownerLiveness} primitive (PID presence paired
+ * with a create-time fingerprint, so a recycled PID reads as a *different* — and
+ * therefore dead — owner). A worktree is a release / orphan candidate only when
+ * its recorded owner is provably gone AND no live, non-ancestry process occupies
+ * it: ground-truth occupancy vetoes a stale "owner dead" ledger verdict.
+ */
+
+import * as fs from 'node:fs';
+import {
+  isPathWithin,
+  defaultRealpath,
+  type RealpathResolver,
+} from './path-containment.js';
+import {
+  ownerLiveness,
+  type OwnerLiveness,
+  type ProcessSource,
+  type StartTimeProbe,
+} from './process-identity.js';
+
+// ============================================================
+// Types
+// ============================================================
+
+/**
+ * A single process as seen by the host. `startTime` is an opaque, platform-
+ * defined create-time fingerprint (Linux jiffies-since-boot, macOS `lstart`,
+ * Windows FILETIME) — compared only for equality, never parsed — so a PID reused
+ * by a newer process is distinguishable from the original holder.
+ */
+export interface ProcessRecord {
+  /** The process id. */
+  readonly pid: number;
+  /** The parent process id (used to walk the protected ancestry chain). */
+  readonly ppid: number;
+  /** The process's current working directory (resolved against worktree roots). */
+  readonly cwd: string;
+  /** Opaque create-time fingerprint; equality-compared to defeat PID reuse. */
+  readonly startTime: string;
+}
+
+/**
+ * Abstraction over the host process table. Injected so the probe logic is
+ * testable without touching the real OS, and so non-Linux enumeration (DR-11,
+ * #1579) can be supplied later without changing the core. The signature is
+ * deliberately platform-agnostic — no syscall shape leaks through it.
+ */
+export interface ProcessTableSource {
+  /** Snapshot every visible process. A point-in-time read, never a live stream. */
+  list(): readonly ProcessRecord[];
+}
+
+/** A worktree path plus the current PID whose entire ancestry is protected. */
+export interface WorktreeUsageQuery {
+  /** Worktree roots to test for live, non-ancestry occupancy. */
+  readonly worktreePaths: readonly string[];
+  /**
+   * The current ("self") process whose FULL parent-PID chain is excluded from
+   * the in-use set, so a self-rooted cwd never marks a worktree in-use.
+   */
+  readonly selfPid: number;
+}
+
+/** Per-worktree occupancy finding from {@link probeWorktreeUsage}. */
+export interface WorktreeUsage {
+  readonly worktreePath: string;
+  /** True iff at least one non-ancestry process has its cwd inside the worktree. */
+  readonly inUse: boolean;
+  /** The PIDs (excluding the protected ancestry) rooted inside the worktree. */
+  readonly occupantPids: readonly number[];
+}
+
+/** A recorded reservation owner to probe for liveness against the process table. */
+export interface ReservationOwner {
+  readonly worktreePath: string;
+  /** PID recorded when the worktree was reserved. */
+  readonly ownerPid: number;
+  /** Create-time fingerprint recorded at reservation time (equality-compared). */
+  readonly ownerStartedAt: string;
+}
+
+/** Per-reservation liveness finding from {@link probeReservations}. */
+export interface ReservationFinding {
+  readonly worktreePath: string;
+  /** Owner liveness: `'dead'` (gone or PID-reused) is the only releasable state. */
+  readonly liveness: OwnerLiveness;
+  /** True iff the owner is provably `'dead'`; `'alive'`/`'unknown'` are held. */
+  readonly releasable: boolean;
+}
+
+/** A worktree plus its recorded reservation owner (null when unreserved). */
+export interface WorktreeReservationTarget {
+  readonly worktreePath: string;
+  readonly owner: { readonly ownerPid: number; readonly ownerStartedAt: string } | null;
+}
+
+/** Inputs to the composite {@link probeWorktrees} finding. */
+export interface WorktreeProbeQuery {
+  readonly targets: readonly WorktreeReservationTarget[];
+  readonly selfPid: number;
+}
+
+/** Composite per-worktree finding combining occupancy and owner liveness. */
+export interface WorktreeProbeFinding {
+  readonly worktreePath: string;
+  /** A live, non-ancestry process is rooted inside this worktree right now. */
+  readonly inUse: boolean;
+  readonly occupantPids: readonly number[];
+  /** Liveness of the recorded reservation owner; `'none'` when unreserved. */
+  readonly ownerLiveness: OwnerLiveness | 'none';
+  /**
+   * Releasable / orphan-candidate: the recorded owner is provably gone AND no
+   * live non-ancestry process occupies the worktree. Ground-truth occupancy
+   * VETOES a stale "owner dead" verdict, so a worktree a live process has
+   * re-entered is never reclaimed.
+   */
+  readonly releasable: boolean;
+}
+
+// ============================================================
+// Pure decisions
+// ============================================================
+
+/** Index a process snapshot by PID for O(1) parent/owner lookups. */
+function indexByPid(records: readonly ProcessRecord[]): Map<number, ProcessRecord> {
+  const byPid = new Map<number, ProcessRecord>();
+  for (const record of records) byPid.set(record.pid, record);
+  return byPid;
+}
+
+/**
+ * Compute the protected ancestry: the FULL parent-PID chain of `selfPid`
+ * (`selfPid -> ppid -> ppid' -> ...`), which must be excluded from every
+ * worktree's occupant set.
+ *
+ * `selfPid` is always included even when absent from the table (so a self-rooted
+ * cwd is protected regardless). The walk then follows each record's `ppid` until
+ * it leaves the table, reaches PID 0 (no parent / the kernel), or revisits a PID
+ * — the visited-set guard makes a malformed or cyclic `ppid` graph terminate
+ * instead of looping forever. Pure over its inputs; performs no OS access.
+ */
+export function protectedAncestry(
+  selfPid: number,
+  byPid: ReadonlyMap<number, ProcessRecord>,
+): ReadonlySet<number> {
+  const chain = new Set<number>();
+  let cursor = selfPid;
+  while (cursor > 0 && !chain.has(cursor)) {
+    chain.add(cursor);
+    const record = byPid.get(cursor);
+    if (record === undefined) break; // selfPid stays protected even if unlisted.
+    cursor = record.ppid;
+  }
+  return chain;
+}
+
+/**
+ * The PIDs whose cwd resolves inside `worktreePath`, excluding the protected
+ * ancestry. Containment is symlink-canonicalized on both sides via
+ * {@link isPathWithin}. Pure over the injected {@link RealpathResolver}.
+ */
+function occupantsOf(
+  worktreePath: string,
+  records: readonly ProcessRecord[],
+  protectedPids: ReadonlySet<number>,
+  realpath: RealpathResolver,
+): number[] {
+  const occupants: number[] = [];
+  for (const record of records) {
+    if (protectedPids.has(record.pid)) continue; // self + ancestry never count.
+    if (isPathWithin(record.cwd, worktreePath, realpath)) {
+      occupants.push(record.pid);
+    }
+  }
+  return occupants;
+}
+
+/**
+ * Adapt a point-in-time {@link ProcessTableSource} snapshot into the per-PID
+ * {@link ProcessSource} that {@link ownerLiveness} consumes.
+ *
+ * A full ground-truth snapshot resolves to `present` / `absent` only — never the
+ * per-PID probe's `unknown`: there is no separate create-time probe that could
+ * fail to run, the process is simply in the enumerated table or it is not. So
+ * owner liveness over a snapshot is two-valued (`alive` / `dead`); the `unknown`
+ * fail-closed branch belongs to the live per-PID `defaultProcessSource`, not here.
+ */
+function tableAsProcessSource(byPid: ReadonlyMap<number, ProcessRecord>): ProcessSource {
+  return {
+    getStartTime(pid: number): StartTimeProbe {
+      const record = byPid.get(pid);
+      return record === undefined
+        ? { status: 'absent' }
+        : { status: 'present', startedAt: record.startTime };
+    },
+  };
+}
+
+/**
+ * Probe which worktrees are in use by a live, non-ancestry process.
+ *
+ * For each requested worktree, returns the occupant PIDs (cwd resolves inside,
+ * after symlink canonicalization on both sides) with the current process's
+ * entire ancestry chain subtracted. `inUse` is true iff that occupant set is
+ * non-empty. Pure over the injected {@link ProcessTableSource} and
+ * {@link RealpathResolver}; performs no OS access of its own.
+ */
+export function probeWorktreeUsage(
+  query: WorktreeUsageQuery,
+  source: ProcessTableSource,
+  realpath: RealpathResolver = defaultRealpath,
+): WorktreeUsage[] {
+  const records = source.list();
+  const protectedPids = protectedAncestry(query.selfPid, indexByPid(records));
+
+  return query.worktreePaths.map((worktreePath) => {
+    const occupantPids = occupantsOf(worktreePath, records, protectedPids, realpath);
+    return { worktreePath, inUse: occupantPids.length > 0, occupantPids };
+  });
+}
+
+/**
+ * Probe each recorded reservation owner's liveness against the process table.
+ *
+ * An owner is `releasable` only when {@link ownerLiveness} reports `'dead'` — the
+ * PID is absent, or present but with a mismatched create-time (PID reuse). A live
+ * owner (PID present AND create-time matches) is never releasable. Pure over the
+ * injected {@link ProcessTableSource}.
+ */
+export function probeReservations(
+  reservations: readonly ReservationOwner[],
+  source: ProcessTableSource,
+): ReservationFinding[] {
+  const processSource = tableAsProcessSource(indexByPid(source.list()));
+  return reservations.map((reservation) => {
+    const liveness = ownerLiveness(
+      { ownerPid: reservation.ownerPid, ownerStartedAt: reservation.ownerStartedAt },
+      processSource,
+    );
+    return {
+      worktreePath: reservation.worktreePath,
+      liveness,
+      releasable: liveness === 'dead',
+    };
+  });
+}
+
+/**
+ * Composite probe: classify each worktree as in-use, owner-live, or
+ * releasable / orphan-candidate.
+ *
+ * Combines the occupancy lens ({@link probeWorktreeUsage}) with the owner-
+ * liveness lens ({@link probeReservations}) over a single process snapshot. A
+ * worktree is releasable only when its recorded owner is provably `'dead'` AND it
+ * is NOT in use by any live non-ancestry process — live occupancy is the ground
+ * truth that vetoes a stale "owner dead" ledger verdict. Pure over the injected
+ * {@link ProcessTableSource} and {@link RealpathResolver}.
+ */
+export function probeWorktrees(
+  query: WorktreeProbeQuery,
+  source: ProcessTableSource,
+  realpath: RealpathResolver = defaultRealpath,
+): WorktreeProbeFinding[] {
+  const records = source.list();
+  const byPid = indexByPid(records);
+  const protectedPids = protectedAncestry(query.selfPid, byPid);
+  const processSource = tableAsProcessSource(byPid);
+
+  return query.targets.map((target) => {
+    const occupantPids = occupantsOf(target.worktreePath, records, protectedPids, realpath);
+    const inUse = occupantPids.length > 0;
+    const ownerVerdict: OwnerLiveness | 'none' =
+      target.owner === null
+        ? 'none'
+        : ownerLiveness(
+            { ownerPid: target.owner.ownerPid, ownerStartedAt: target.owner.ownerStartedAt },
+            processSource,
+          );
+    return {
+      worktreePath: target.worktreePath,
+      inUse,
+      occupantPids,
+      ownerLiveness: ownerVerdict,
+      releasable: !inUse && ownerVerdict === 'dead',
+    };
+  });
+}
+
+// ============================================================
+// Default real source (thin; unix)
+// ============================================================
+
+/** A `/proc` entry that is a numeric PID directory. */
+const PID_DIR = /^\d+$/;
+
+/**
+ * Read one Linux process from `/proc/<pid>`: `ppid` and `starttime` from the
+ * `stat` line, `cwd` from the `cwd` symlink. Field parsing matches
+ * `process-identity.ts` — the `comm` field (2) is parenthesized and may itself
+ * contain spaces/parens, so the tail is split AFTER the final `')'`; in that tail
+ * index 0 is `state` (field 3), index 1 is `ppid` (field 4), index 19 is
+ * `starttime` (field 22). Returns `null` when the process vanished mid-scan or is
+ * unreadable (EACCES) so the enumerator simply skips it.
+ */
+function readProcRecord(pid: number): ProcessRecord | null {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const tail = stat.slice(stat.lastIndexOf(')') + 1).trim().split(/\s+/);
+    const ppidRaw = tail[1];
+    const startRaw = tail[19];
+    if (ppidRaw === undefined || startRaw === undefined) return null;
+    if (!/^\d+$/.test(ppidRaw) || !/^\d+$/.test(startRaw)) return null;
+    const cwd = fs.readlinkSync(`/proc/${pid}/cwd`);
+    return { pid, ppid: Number(ppidRaw), cwd, startTime: startRaw };
+  } catch {
+    return null;
+  }
+}
+
+/** Enumerate every readable process via `/proc` (Linux ground truth). */
+function enumerateProcLinux(): ProcessRecord[] {
+  const records: ProcessRecord[] = [];
+  let entries: string[];
+  try {
+    entries = fs.readdirSync('/proc');
+  } catch {
+    return records;
+  }
+  for (const entry of entries) {
+    if (!PID_DIR.test(entry)) continue;
+    const record = readProcRecord(Number(entry));
+    if (record !== null) records.push(record);
+  }
+  return records;
+}
+
+/**
+ * Default {@link ProcessTableSource} backed by the real OS.
+ *
+ * Linux ground truth is read from `/proc`. macOS / Windows enumeration is
+ * deferred to DR-11 (#1579); the injected-source seam keeps those platforms open
+ * without foreclosing here. A consumer that receives an empty table on an
+ * unsupported platform MUST fail closed — treat "cannot enumerate" as "cannot
+ * prove free" and never release — mirroring the `unknown` fail-closed contract of
+ * the per-PID `defaultProcessSource`. Never exercised by the unit tests (those
+ * inject a fake table), so the probe core stays free of real OS calls.
+ */
+export const defaultProcessTableSource: ProcessTableSource = {
+  list(): readonly ProcessRecord[] {
+    return process.platform === 'linux' ? enumerateProcLinux() : [];
+  },
+};

--- a/servers/exarchos-mcp/src/orchestrate/worktree/pure/prune-ladder.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/pure/prune-ladder.ts
@@ -91,6 +91,13 @@ export interface PruneCandidate {
 /**
  * Why a candidate was skipped. A small, stable enum so the handler can **group**
  * skips by reason in its dry-run report (the "scannable skip reason" contract).
+ *
+ * `in-flight-merge` is NOT produced by {@link classifyPruneCandidate} — the pure
+ * ladder classifies over per-worktree facts and has no view of the serialized
+ * merge lease. It is produced by the manager's prune ladder, which folds
+ * `inFlightMerges` and overrides an otherwise-deletable candidate that (or whose
+ * integration branch) holds an unpaired merge lease, so a concurrent
+ * `serialize_merge` is never double-freed (DR-12).
  */
 export type PruneSkipReason =
   | 'no-adoption-record'
@@ -100,7 +107,8 @@ export type PruneSkipReason =
   | 'unverifiable-integration-ref'
   | 'unmerged'
   | 'cannot-verify-merge'
-  | 'origin-unreachable';
+  | 'origin-unreachable'
+  | 'in-flight-merge';
 
 /**
  * Classification of a single prune candidate.

--- a/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
@@ -533,6 +533,55 @@ describe('DR-12 — unsupported process table fails closed (REV-H1)', () => {
   });
 });
 
+// ─── Test 6b: one failed reclaim never aborts the batch (CodeRabbit #4621186637) ─
+
+describe('probeAndReclaim — per-entry fault isolation', () => {
+  it('ProbeAndReclaim_OneReleaseAppendThrows_RemainingStillReclaimed', async () => {
+    const arm = await createArm();
+    // EMPTY but SUPPORTED table → both reserved owners read provably dead, so
+    // both are releasable. Reserve two so the batch has more than one target.
+    const manager = new WorktreeManager({
+      eventStore: arm.eventStore,
+      processTableSource: EMPTY_TABLE,
+    });
+    const wtFail = '/wlm/reclaim-fails';
+    const wtOk = '/wlm/reclaim-succeeds';
+    await manager.reserve({ worktreeId: wtFail, path: wtFail, featureId: 'F', ownerPid: 4242, ownerStartedAt: 'boot-4242' });
+    await manager.reserve({ worktreeId: wtOk, path: wtOk, featureId: 'F', ownerPid: 4343, ownerStartedAt: 'boot-4343' });
+
+    // Inject a transient persistence failure for ONLY the first worktree's
+    // release append; every other append delegates to the real store. A generic
+    // Error is not in withStateRetry's retryable set, so it propagates at once.
+    const realAppend = arm.eventStore.append.bind(arm.eventStore);
+    const appendSpy = vi
+      .spyOn(arm.eventStore, 'append')
+      .mockImplementation((streamId, event, options) => {
+        const worktreeId = (event as { data?: { worktreeId?: string } }).data?.worktreeId;
+        if (event.type === 'worktree.released' && worktreeId === wtFail) {
+          throw new Error('injected append failure');
+        }
+        return realAppend(streamId, event, options);
+      });
+
+    // Must NOT throw despite the first entry failing.
+    const result = await manager.probeAndReclaim(999999);
+    appendSpy.mockRestore();
+
+    expect(result.probed).toBe(2);
+    // Truthful counts (INV-1): only the entry whose event provably landed is
+    // reported released — the failed one is NOT (no phantom reclaim).
+    expect(result.released).toContain(wtOk);
+    expect(result.released).not.toContain(wtFail);
+    expect(result.orphaned).toEqual([]);
+
+    // The failed entry stays `reserved` (retried next pass, INV-8); the other
+    // folded to `released`.
+    const projection = await foldWorktrees(arm);
+    expect(projection.worktrees[wtFail]?.state).toBe('reserved');
+    expect(projection.worktrees[wtOk]?.state).toBe('released');
+  });
+});
+
 // ─── Test 7: two concurrent resumes never double-merge (REV-M1 OCC) ───────────
 
 describe('DR-12 — concurrent resume does not double-merge (REV-M1)', () => {

--- a/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
@@ -95,8 +95,19 @@ function liveTable(pairs: ReadonlyArray<{ pid: number; startTime: string }>): Pr
   return { list: () => records };
 }
 
-/** Empty process table — every probed pid reads as absent (provably dead). */
+/** Empty but SUPPORTED process table — every probed pid reads as absent (provably dead). */
 const EMPTY_TABLE: ProcessTableSource = { list: () => [] };
+
+/**
+ * UNSUPPORTED process table — the off-Linux shape (no enumerator, DR-11/#1579).
+ * `list()` is `[]` but `isSupported()` is `false`, so a probed pid reads as
+ * `'unknown'`, NEVER provably dead. Reclaim consumers must fail closed against
+ * it (REV-H1). Mirrors the real `defaultProcessTableSource` off-Linux.
+ */
+const UNSUPPORTED_TABLE: ProcessTableSource = {
+  list: () => [],
+  isSupported: () => false,
+};
 
 /** A per-PID create-time source backed by a map (absent pid ⇒ exited). */
 function startTimeSource(table: Record<number, string>): ProcessSource {
@@ -480,6 +491,131 @@ describe('DR-12 — no reset --hard, INV-14 pass-through', () => {
     expect(data.recoveryError).toBe('reset-keep-blocked');
     expect(data.recoveryErrorDetail).toBe('git reset --keep refused to discard local work');
     // The lease was released despite the reversal — no wedged slot.
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+  });
+});
+
+// ─── Test 6: off-Linux unsupported table reclaims/orphans NOTHING (REV-H1) ────
+
+describe('DR-12 — unsupported process table fails closed (REV-H1)', () => {
+  it('ProbeAndReclaim_UnsupportedTable_EmitsNoEvents', async () => {
+    const arm = await createArm();
+    const manager = new WorktreeManager({
+      eventStore: arm.eventStore,
+      processTableSource: UNSUPPORTED_TABLE,
+    });
+
+    // A reserved worktree whose owner pid (4242) is absent from the empty table.
+    // On a SUPPORTED table this owner reads provably dead and the probe emits
+    // worktree.released; on the UNSUPPORTED table it reads 'unknown', so the
+    // probe must emit NOTHING — fail closed, never a spurious heal off-Linux.
+    const wtId = '/wlm/unsupported-wt';
+    await manager.reserve({
+      worktreeId: wtId,
+      path: wtId,
+      featureId: 'F',
+      ownerPid: 4242,
+      ownerStartedAt: 'boot-4242',
+    });
+
+    const before = (await arm.eventStore.query(WORKTREES_STREAM)).length;
+    const result = await manager.probeAndReclaim(999999); // selfPid not in table.
+
+    expect(result.released).toEqual([]);
+    expect(result.orphaned).toEqual([]);
+    expect(result.probed).toBe(1);
+    // No terminal lifecycle event was appended — the reservation stands.
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    expect(events.length).toBe(before);
+    expect(events.some((e) => e.type === 'worktree.released')).toBe(false);
+    expect(events.some((e) => e.type === 'worktree.orphan_detected')).toBe(false);
+    expect((await foldWorktrees(arm)).worktrees[wtId]?.state).toBe('reserved');
+  });
+});
+
+// ─── Test 7: two concurrent resumes never double-merge (REV-M1 OCC) ───────────
+
+describe('DR-12 — concurrent resume does not double-merge (REV-M1)', () => {
+  it('Recovery_TwoConcurrentResumes_OccPreventsDoubleMerge', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/concurrent-resume';
+    const opId = 'crashed-op';
+
+    // A CRASHED holder (pid 9999, absent → provably dead). Two DIFFERENT live
+    // processes (101, 102) both attempt to resume it concurrently. Without the
+    // OCC re-claim both pass the read-only `isMergeApplied` precheck and both
+    // re-run merge_orchestrate — a DOUBLE merge. The re-claim must serialize them
+    // so the merge runs AT MOST once.
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: opId,
+      sourceBranch: 'feat/crashed',
+      holderPid: 9999,
+      holderStartedAt: 'gone-9999',
+    });
+
+    // 9999 absent (dead); BOTH resumers (101, 102) read alive, so once one
+    // re-claims the slot the other sees a LIVE foreign holder and backs off.
+    const table = liveTable([
+      { pid: 101, startTime: 'live-101' },
+      { pid: 102, startTime: 'live-102' },
+    ]);
+
+    let mergeCount = 0;
+    const mergeOrchestrate = async (): Promise<ToolResult> => {
+      mergeCount += 1;
+      // Hold briefly so the loser's OCC attempt overlaps the winner's merge.
+      await new Promise((r) => setTimeout(r, 40));
+      return { success: true, data: { phase: 'completed' } };
+    };
+
+    const resumeDeps = (selfPid: number, selfStartedAt: string) => ({
+      selfPid,
+      selfStartedAt,
+      processTableSource: table,
+      isMergeApplied: () => false, // not applied → both WANT to re-merge.
+      mergeOrchestrate,
+    });
+
+    const [a, b] = await Promise.all([
+      resumeCrashedMerge(
+        { featureId: 'F', integrationRef, strategy: 'merge', repoRoot: '/unused' },
+        arm.ctx,
+        resumeDeps(101, 'live-101'),
+      ),
+      resumeCrashedMerge(
+        { featureId: 'F', integrationRef, strategy: 'merge', repoRoot: '/unused' },
+        arm.ctx,
+        resumeDeps(102, 'live-102'),
+      ),
+    ]);
+
+    // THE invariant: the merge ran AT MOST once across the two concurrent resumes.
+    expect(mergeCount).toBe(1);
+
+    // Exactly one resume won; the other backed off without re-merging.
+    const outcomes = [a, b];
+    const winners = outcomes.filter((o) => o.resumed === true);
+    const losers = outcomes.filter((o) => o.resumed === false);
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+
+    const winner = winners[0];
+    if (winner.resumed) {
+      expect(winner.operationId).toBe(opId);
+      expect(winner.reMerged).toBe(true);
+    }
+    const loser = losers[0];
+    if (!loser.resumed) {
+      // The loser either saw a live foreign holder (our re-claim) or an
+      // already-terminated slot — both are correct "did not re-merge" outcomes.
+      expect(['foreign-live-holder', 'no-lease']).toContain(loser.reason);
+    }
+
+    // Exactly ONE terminal landed under the holder's ORIGINAL operationId; the
+    // slot ends clear.
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    expect(executedFor(events, opId)).toHaveLength(1);
     expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
@@ -1,0 +1,485 @@
+// ─── DR-12 — error handling & failure modes for the liveness + merge surface ──
+//
+// The crash / concurrency recovery edges that the Task-006 lease loop and the
+// Task-007 prune ladder do NOT cover on their own:
+//
+//   1. Crash-mid-merge resume — an unpaired `worktree.merge_requested` whose
+//      holder is THIS process (a failed best-effort release) or provably dead,
+//      idempotently terminated EXACTLY ONCE behind a `merge-base --is-ancestor`
+//      precheck (INV-8/13).
+//   2. Concurrent prune + merge — the GC must SKIP a worktree (or its
+//      integration branch) holding an unpaired in-flight merge lease, re-folded
+//      under the claim — no double-free.
+//   3. Exhausted index.lock retry — the structured `IndexLockContentionError`
+//      surfaces to the caller and the slot is released (no half-merge).
+//   4. No `git reset --hard` — the serializer introduces none of its own; the
+//      INV-14 `--abort` → `--keep` + `recoveryError` pass through from the
+//      UNCHANGED `merge_orchestrate`.
+//
+// The crash / concurrency assertions run against a REAL SQLite EventStore (the
+// substrate's in-transaction stream-version gate is the cross-process guard);
+// the prune assertion additionally drives a REAL git repo so the skip is pinned
+// against ground-truth `git` ancestry, not a mock.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { readFileSync, realpathSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { EventStore } from '../../event-store/store.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { ToolResult } from '../../format.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+
+import { serializeMerge, resumeCrashedMerge } from './merge-serializer.js';
+import {
+  WorktreeManager,
+  WORKTREES_STREAM,
+  WORKTREES_REDUCER,
+} from './manager.js';
+import type { WorktreesProjection } from './projections/worktrees.js';
+import type { ProcessTableSource, ProcessRecord } from './pure/probe.js';
+import type { ProcessSource, StartTimeProbe } from './pure/process-identity.js';
+import { IndexLockContentionError, type SleepFn } from './git-retry.js';
+import { canonicalWorktreeId } from './pure/path-containment.js';
+
+// ─── Arm: one stateDir + EventStore + ctx (real SQLite) ──────────────────────
+
+interface Arm {
+  readonly stateDir: string;
+  readonly eventStore: EventStore;
+  readonly ctx: DispatchContext;
+}
+
+const arms: Arm[] = [];
+const repoDirs: string[] = [];
+
+async function createArm(): Promise<Arm> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), 'wlm-recovery-'));
+  const eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+  const ctx: DispatchContext = { stateDir, eventStore, enableTelemetry: false };
+  const arm = { stateDir, eventStore, ctx };
+  arms.push(arm);
+  return arm;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  while (arms.length > 0) {
+    const arm = arms.pop();
+    if (arm) {
+      arm.eventStore.close();
+      await rmrfAsync(arm.stateDir);
+    }
+  }
+  while (repoDirs.length > 0) {
+    const dir = repoDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+/** Live process table reporting exactly the listed (pid, startTime) pairs alive. */
+function liveTable(pairs: ReadonlyArray<{ pid: number; startTime: string }>): ProcessTableSource {
+  const records: ProcessRecord[] = pairs.map(({ pid, startTime }) => ({
+    pid,
+    ppid: 1,
+    cwd: `/proc-fixture/${pid}`,
+    startTime,
+  }));
+  return { list: () => records };
+}
+
+/** Empty process table — every probed pid reads as absent (provably dead). */
+const EMPTY_TABLE: ProcessTableSource = { list: () => [] };
+
+/** A per-PID create-time source backed by a map (absent pid ⇒ exited). */
+function startTimeSource(table: Record<number, string>): ProcessSource {
+  return {
+    getStartTime(pid: number): StartTimeProbe {
+      return Object.prototype.hasOwnProperty.call(table, pid)
+        ? { status: 'present', startedAt: table[pid] }
+        : { status: 'absent' };
+    },
+  };
+}
+
+/** Directly seed a held lease (CLAIM) on the worktrees stream. */
+async function seedHolder(
+  arm: Arm,
+  holder: {
+    integrationRef: string;
+    operationId: string;
+    sourceBranch: string;
+    holderPid: number;
+    holderStartedAt: string;
+    worktreeId?: string;
+  },
+): Promise<void> {
+  await arm.eventStore.getAppender().append(
+    WORKTREES_STREAM,
+    [{ type: 'worktree.merge_requested', data: { ...holder } }],
+    `worktree.merge_requested:${holder.operationId}`,
+  );
+}
+
+async function foldWorktrees(arm: Arm): Promise<WorktreesProjection> {
+  const { aggregate } = await arm.eventStore
+    .getAppender()
+    .aggregateStream<WorktreesProjection>(WORKTREES_STREAM, WORKTREES_REDUCER);
+  return aggregate;
+}
+
+function executedFor(events: ReadonlyArray<{ type: string; data?: Record<string, unknown> }>, operationId: string) {
+  return events.filter(
+    (e) => e.type === 'worktree.merge_executed' && e.data?.operationId === operationId,
+  );
+}
+
+// ─── Test 1: crash-mid-merge resume emits a single terminal (real SQLite) ─────
+
+describe('DR-12 — crash-mid-merge resume', () => {
+  it('Recovery_MergeRequestedNoExecuted_ResumeEmitsSingleExecuted', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/resume';
+    const opId = 'self-stuck-op';
+    // A SAME-PROCESS stuck lease: this process holds it (best-effort release
+    // failed), so the inline dead-holder probe would never reclaim it (we are
+    // alive) — resumeCrashedMerge must finish OUR OWN lease.
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: opId,
+      sourceBranch: 'feat/resume',
+      holderPid: 321,
+      holderStartedAt: 'self-321',
+    });
+
+    const merged: string[] = [];
+    const outcome = await resumeCrashedMerge(
+      { featureId: 'F', integrationRef, strategy: 'merge', repoRoot: '/unused' },
+      arm.ctx,
+      {
+        selfPid: 321,
+        selfStartedAt: 'self-321',
+        processTableSource: liveTable([{ pid: 321, startTime: 'self-321' }]), // we are alive.
+        isMergeApplied: () => true, // the pre-crash merge SUCCEEDED → skip re-merge.
+        mergeOrchestrate: async (input) => {
+          merged.push(input.featureId);
+          return { success: true, data: { phase: 'completed' } };
+        },
+      },
+    );
+
+    expect(outcome.resumed).toBe(true);
+    if (outcome.resumed) {
+      expect(outcome.operationId).toBe(opId);
+      expect(outcome.holderKind).toBe('self');
+      expect(outcome.reMerged).toBe(false); // precheck said already applied.
+    }
+    // The precheck short-circuited the re-merge.
+    expect(merged).toEqual([]);
+
+    // Exactly ONE terminal release landed under the holder's ORIGINAL operationId.
+    let events = await arm.eventStore.query(WORKTREES_STREAM);
+    expect(executedFor(events, opId)).toHaveLength(1);
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+
+    // Idempotent: a SECOND resume finds no unpaired lease and emits nothing —
+    // the terminal stays exactly one (INV-8/13 exactly-once).
+    const again = await resumeCrashedMerge(
+      { featureId: 'F', integrationRef, strategy: 'merge', repoRoot: '/unused' },
+      arm.ctx,
+      { selfPid: 321, selfStartedAt: 'self-321', processTableSource: EMPTY_TABLE, isMergeApplied: () => true },
+    );
+    expect(again.resumed).toBe(false);
+    if (!again.resumed) expect(again.reason).toBe('no-lease');
+    events = await arm.eventStore.query(WORKTREES_STREAM);
+    expect(executedFor(events, opId)).toHaveLength(1);
+  });
+});
+
+// ─── Test 2: dead-holder reclaimed inline WITHOUT consuming the budget ────────
+
+describe('DR-12 — stale dead-holder reclamation', () => {
+  it('Recovery_StaleLeaseDeadHolder_WaitLoopReclaimsInlineNoFullTimeout', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/dead-inline';
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: 'dead-op',
+      sourceBranch: 'feat/dead',
+      holderPid: 9090,
+      holderStartedAt: 'gone-9090',
+    });
+
+    // A fake clock proves the budget was never spent: `sleep` throws, so any
+    // wait iteration fails the test — the dead holder must be reclaimed inline.
+    let clock = 0;
+    const sleep: SleepFn = async () => {
+      throw new Error('dead-holder reclaim must not wait out the budget');
+    };
+    const merged: string[] = [];
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef, sourceBranch: 'feat/live', strategy: 'merge', timeoutMs: 30_000 },
+      arm.ctx,
+      {
+        now: () => clock,
+        sleep,
+        processTableSource: EMPTY_TABLE, // pid 9090 absent → provably dead.
+        selfPid: 111,
+        selfStartedAt: 'self-111',
+        mergeOrchestrate: async (input) => {
+          merged.push(input.featureId);
+          return { success: true, data: { phase: 'completed' } };
+        },
+        readIntegrationHead: () => null,
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(merged).toEqual(['F']);
+    // The deadline (clock + timeoutMs) was never approached — clock never moved.
+    expect(clock).toBe(0);
+
+    // The dead holder's terminal rode its OWN operationId; the slot ends clear.
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    expect(executedFor(events, 'dead-op')).toHaveLength(1);
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+  });
+
+  it('Recovery_StaleLeaseDeadHolder_ReconcilePathAlsoReclaims', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/dead-reconcile';
+    // A DIFFERENT pid (4242), provably dead — the explicit recovery pass reclaims
+    // it too, not only the inline wait loop. Precheck says "not applied" so the
+    // resume re-runs the merge before terminating the lease.
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: 'crashed-op',
+      sourceBranch: 'feat/crashed',
+      holderPid: 4242,
+      holderStartedAt: 'gone-4242',
+    });
+
+    const merged: string[] = [];
+    const outcome = await resumeCrashedMerge(
+      { featureId: 'F', integrationRef, strategy: 'merge', repoRoot: '/unused' },
+      arm.ctx,
+      {
+        selfPid: 111,
+        selfStartedAt: 'self-111', // not the holder → relies on dead detection.
+        processTableSource: EMPTY_TABLE, // pid 4242 absent → provably dead.
+        isMergeApplied: () => false, // not applied → resume re-runs the merge.
+        mergeOrchestrate: async (input) => {
+          merged.push(input.featureId);
+          return { success: true, data: { phase: 'completed' } };
+        },
+      },
+    );
+
+    expect(outcome.resumed).toBe(true);
+    if (outcome.resumed) {
+      expect(outcome.holderKind).toBe('dead');
+      expect(outcome.reMerged).toBe(true);
+      expect(outcome.operationId).toBe('crashed-op');
+    }
+    expect(merged).toEqual(['F']); // the resume re-ran the merge.
+
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    expect(executedFor(events, 'crashed-op')).toHaveLength(1);
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+  });
+});
+
+// ─── Test 3: concurrent prune + merge — prune skips an in-flight lease ────────
+
+describe('DR-12 — concurrent prune + merge', () => {
+  // Real-git helpers (mirrors the prune suite's ground-truth setup).
+  function git(cwd: string, args: readonly string[]): string {
+    return execFileSync('git', args as string[], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  }
+
+  async function initRepoWithOrigin(workdir: string, name: string): Promise<string> {
+    const origin = path.join(workdir, `${name}-origin.git`);
+    git(workdir, ['init', '-q', '--bare', origin]);
+    const repo = path.join(workdir, name);
+    await mkdir(repo, { recursive: true });
+    git(repo, ['init', '-q', '-b', 'work']);
+    git(repo, ['config', 'user.email', 'wlm@example.com']);
+    git(repo, ['config', 'user.name', 'WLM Test']);
+    git(repo, ['config', 'commit.gpgsign', 'false']);
+    await writeFile(path.join(repo, 'README.md'), '# wlm recovery prune\n');
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-q', '-m', 'init']);
+    const real = realpathSync(repo);
+    git(real, ['remote', 'add', 'origin', origin]);
+    git(real, ['push', '-q', 'origin', 'work']);
+    return real;
+  }
+
+  it('Recovery_ConcurrentPruneAndMerge_PruneSkipsBranchWithInFlightLease', async () => {
+    const arm = await createArm();
+    const workdir = await mkdtemp(path.join(tmpdir(), 'wlm-recovery-work-'));
+    repoDirs.push(workdir);
+
+    const repo = await initRepoWithOrigin(workdir, 'repo');
+    const integrationRef = 'feat/integ';
+    git(repo, ['branch', integrationRef]); // integration ref at HEAD.
+    const wtPath = path.join(workdir, 'wt-merging');
+    git(repo, ['worktree', 'add', '-q', wtPath, '-b', 'wbranch']); // HEAD == integ → merged.
+    const wtId = canonicalWorktreeId(wtPath);
+
+    // Wire the worktree's feature → integration branch (per-worktree ref lookup).
+    await arm.eventStore.append('feat-merge', {
+      type: 'state.patched',
+      data: { patch: { 'synthesis.integrationBranch': integrationRef } },
+    });
+
+    const manager = new WorktreeManager({ eventStore: arm.eventStore });
+    // Reserve → release so it folds to `released` (clean, merged, origin-reachable
+    // = the exact delete-eligible shape the GC would otherwise reclaim).
+    await manager.reserve({
+      worktreeId: wtId,
+      path: wtPath,
+      featureId: 'feat-merge',
+      ownerPid: 4242,
+      ownerStartedAt: 'boot-4242',
+    });
+    await manager.release(wtId);
+
+    // A live `serialize_merge` holds the lease on the SAME integration branch —
+    // the serializer leaves `worktreeId` null, so the integration-ref match is
+    // what must catch the race.
+    await seedHolder(arm, {
+      integrationRef,
+      operationId: 'merge-in-flight',
+      sourceBranch: 'wbranch',
+      holderPid: 7777,
+      holderStartedAt: 'alive-7777',
+    });
+
+    const result = await manager.prune({ repoRoot: repo, apply: true });
+
+    // Skipped on the in-flight lease — never deleted (no double-free).
+    const report = result.candidates.find((c) => c.worktreeId === wtId);
+    expect(report?.classification).toEqual({ action: 'skip', reason: 'in-flight-merge' });
+    expect(result.deleted).not.toContain(wtId);
+    expect(result.skipsByReason['in-flight-merge']).toContain(wtId);
+    // The under-lock guard committed NO delete intent for it.
+    const removeReqs = (await arm.eventStore.query(WORKTREES_STREAM)).filter(
+      (e) => e.type === 'worktree.remove.requested' &&
+        (e.data as { worktreeId?: unknown }).worktreeId === wtId,
+    );
+    expect(removeReqs).toHaveLength(0);
+    // Still tracked + still on disk (released, not removed).
+    expect((await foldWorktrees(arm)).worktrees[wtId]?.state).toBe('released');
+  });
+});
+
+// ─── Test 4: exhausted index.lock retry surfaces structured error, no half-merge
+
+describe('DR-12 — exhausted index.lock retry', () => {
+  it('Recovery_ExhaustedIndexLockRetry_SurfacesStructuredErrorNoHalfMerge', async () => {
+    const arm = await createArm();
+    const integrationRef = 'integration/locked';
+
+    // merge_orchestrate's DR-8 retry seam exhausts and throws the structured
+    // contention error (the serializer composes merge_orchestrate UNCHANGED).
+    const lockErr = new IndexLockContentionError(
+      { lockPath: '/repo/.git/index.lock', attempts: 4, maxRetries: 3, delaysMs: [200, 400, 800] },
+      new Error("fatal: Unable to create '/repo/.git/index.lock': File exists."),
+    );
+
+    let caught: unknown;
+    try {
+      await serializeMerge(
+        { featureId: 'F', integrationRef, sourceBranch: 'feat/x', strategy: 'merge', timeoutMs: 10_000 },
+        arm.ctx,
+        {
+          selfPid: 555,
+          selfStartedAt: 'self-555',
+          mergeOrchestrate: async () => {
+            throw lockErr;
+          },
+          readIntegrationHead: () => null,
+        },
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    // The structured error reaches the caller UNCHANGED — never a silent no-op.
+    expect(caught).toBe(lockErr);
+    expect(caught).toBeInstanceOf(IndexLockContentionError);
+    expect((caught as IndexLockContentionError).code).toBe('INDEX_LOCK_CONTENTION');
+
+    // No half-merge: the lease was released in `finally`, so the slot is clear —
+    // the workflow is not left wedged mid-merge.
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+    const events = await arm.eventStore.query(WORKTREES_STREAM);
+    const claims = events.filter((e) => e.type === 'worktree.merge_requested');
+    const releases = events.filter((e) => e.type === 'worktree.merge_executed');
+    expect(claims).toHaveLength(1);
+    expect(releases).toHaveLength(1); // exactly one claim + one matching release.
+  });
+});
+
+// ─── Test 5: serializer introduces no reset --hard; recoveryError passes through
+
+describe('DR-12 — no reset --hard, INV-14 pass-through', () => {
+  it('Recovery_SerializerIntroducesNoResetHard_SurfacesRecoveryErrorFromMergeOrchestrate', async () => {
+    // (a) Static: the serializer source has NO `git reset --hard` path of its
+    // own. Strip comments first so the module's own prose ("never `--hard`")
+    // cannot false-negative the assertion.
+    const sourcePath = fileURLToPath(new URL('./merge-serializer.ts', import.meta.url));
+    const source = readFileSync(sourcePath, 'utf-8');
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+      .replace(/(^|[^:])\/\/.*$/gm, '$1'); // line comments (keep "://" in URLs)
+    expect(code).not.toMatch(/--hard/i);
+    expect(code).not.toMatch(/\breset\b/i); // no reset path at all in the serializer.
+
+    // (b) Behavioral: when the composed merge_orchestrate reverses via the INV-14
+    // ladder (`--abort` → `--keep`) and surfaces a `recoveryError`, the serializer
+    // passes the result through UNCHANGED and still releases the lease.
+    const arm = await createArm();
+    const integrationRef = 'integration/reversed';
+    const rolledBack: ToolResult = {
+      success: false,
+      error: { code: 'MERGE_ROLLED_BACK', message: 'merge reversed' },
+      data: {
+        phase: 'rolled-back',
+        recoveryError: 'reset-keep-blocked',
+        recoveryErrorDetail: 'git reset --keep refused to discard local work',
+      },
+    };
+
+    const result = await serializeMerge(
+      { featureId: 'F', integrationRef, sourceBranch: 'feat/x', strategy: 'merge', timeoutMs: 10_000 },
+      arm.ctx,
+      {
+        selfPid: 666,
+        selfStartedAt: 'self-666',
+        mergeOrchestrate: async () => rolledBack,
+        readIntegrationHead: () => null,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase).toBe('rolled-back');
+    expect(data.recoveryError).toBe('reset-keep-blocked');
+    expect(data.recoveryErrorDetail).toBe('git reset --keep refused to discard local work');
+    // The lease was released despite the reversal — no wedged slot.
+    expect((await foldWorktrees(arm)).inFlightMerges[integrationRef]).toBeUndefined();
+  });
+});

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -16,6 +16,7 @@ import {
   findActionInRegistry,
   ActionAnnotationsSchema,
   validateAnnotations,
+  validateAction,
   WorkflowSetOutputSchema,
   WorkflowTransitionOutputSchema,
   WorkflowUpdateOutputSchema,
@@ -1177,6 +1178,115 @@ describe('TOOL_REGISTRY', () => {
       expect(
         provenance!.schema.safeParse({ workflowId: 'wf-1' }).success,
       ).toBe(true);
+    });
+  });
+
+  // ─── WLM operational-core registration floor (DR-4 / DR-7) ────────────────
+  //
+  // The three new WLM operational-core actions are `serialize_merge` (the
+  // optimistic integration-branch merge lease, on exarchos_orchestrate, DR-7)
+  // and the liveness reads `ps` / `wait` (on exarchos_view, DR-4). The registry
+  // runs `validateAction` over EVERY action in a module-load loop, so any one of
+  // these missing its `outputSchema` or a malformed `annotations` block would
+  // throw at IMPORT time (DIM-3 contracts fail closed at startup, not at first
+  // call). These floor assertions pin that contract so a future registry edit
+  // that drops a schema/annotation on one of the new actions is caught here with
+  // a named failure rather than as an opaque import crash.
+  describe('WLM operational-core registration floor (DR-4/DR-7)', () => {
+    // [toolName, actionName] for each newly-registered operational-core action.
+    const NEW_ACTIONS: ReadonlyArray<readonly [string, string]> = [
+      ['exarchos_orchestrate', 'serialize_merge'],
+      ['exarchos_view', 'ps'],
+      ['exarchos_view', 'wait'],
+    ];
+
+    it('Registry_NewActions_DeclareOutputSchemaAndCoreAnnotations', () => {
+      for (const [tool, name] of NEW_ACTIONS) {
+        const action = findAction(tool, name);
+        expect(action, `${tool}.${name} must be registered`).toBeDefined();
+
+        // outputSchema: present AND a real Zod schema (has a `.parse` method —
+        // the exact shape `validateAction` requires before the response
+        // envelope can be type-checked).
+        expect(
+          action!.outputSchema,
+          `${tool}.${name} must declare an outputSchema`,
+        ).toBeDefined();
+        expect(
+          typeof (action!.outputSchema as { parse?: unknown }).parse,
+          `${tool}.${name}.outputSchema must be a Zod schema (got non-parseable value)`,
+        ).toBe('function');
+
+        // annotations: present AND every core boolean field typed correctly,
+        // plus a recognized `safety` class. This mirrors the per-field shape the
+        // registry's `ActionAnnotationsSchema` enforces.
+        const ann = action!.annotations;
+        expect(ann, `${tool}.${name} must declare annotations`).toBeDefined();
+        expect(typeof ann!.safety, `${tool}.${name}.annotations.safety`).toBe(
+          'string',
+        );
+        expect(
+          typeof ann!.readOnly,
+          `${tool}.${name}.annotations.readOnly`,
+        ).toBe('boolean');
+        expect(
+          typeof ann!.destructive,
+          `${tool}.${name}.annotations.destructive`,
+        ).toBe('boolean');
+        expect(
+          typeof ann!.idempotent,
+          `${tool}.${name}.annotations.idempotent`,
+        ).toBe('boolean');
+        expect(
+          typeof ann!.openWorld,
+          `${tool}.${name}.annotations.openWorld`,
+        ).toBe('boolean');
+      }
+
+      // The view liveness reads are wholesale read-only (they ride the
+      // read-only exarchos_view tool); serialize_merge mutates shared state.
+      const ps = findAction('exarchos_view', 'ps');
+      const wait = findAction('exarchos_view', 'wait');
+      expect(ps!.annotations!.readOnly).toBe(true);
+      expect(wait!.annotations!.readOnly).toBe(true);
+      const serializeMerge = findAction('exarchos_orchestrate', 'serialize_merge');
+      expect(serializeMerge!.annotations!.readOnly).toBe(false);
+    });
+
+    it('Registry_ModuleLoad_DoesNotThrowOnNewActions', () => {
+      // `TOOL_REGISTRY` was already imported at module top — its module-load
+      // `validateAction` loop ran without throwing, otherwise this test file
+      // could not have loaded. Re-running the SAME fail-closed gate over each
+      // new action proves explicitly that none of them would crash startup.
+      for (const [tool, name] of NEW_ACTIONS) {
+        const action = findAction(tool, name);
+        expect(action, `${tool}.${name} must be registered`).toBeDefined();
+        expect(
+          () => validateAction(action!, tool),
+          `${tool}.${name} fails the module-load validateAction gate — it would ` +
+            `throw at import time and crash MCP startup`,
+        ).not.toThrow();
+      }
+
+      // The module itself imports cleanly (cached re-import — asserts the
+      // load-time validation loop already succeeded for the whole registry).
+      return expect(import('./registry.js')).resolves.toBeDefined();
+    });
+
+    it('Registry_VisibleCompositeToolCount_StaysFour', () => {
+      // INV-5d: the WLM operational-core actions are ACTIONS on existing
+      // composites, NOT new visible tools. The visible (non-hidden) composite
+      // count must stay at exactly 4 (the four top-level CLI verbs / MCP tools),
+      // with exarchos_sync the sole hidden composite (total 5).
+      const visibleTools = TOOL_REGISTRY.filter((t) => !t.hidden);
+      expect(visibleTools.length).toBe(4);
+      expect(visibleTools.map((t) => t.name).sort()).toEqual([
+        'exarchos_event',
+        'exarchos_orchestrate',
+        'exarchos_view',
+        'exarchos_workflow',
+      ]);
+      expect(TOOL_REGISTRY).toHaveLength(5);
     });
   });
 

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -1243,11 +1243,17 @@ describe('TOOL_REGISTRY', () => {
         ).toBe('boolean');
       }
 
-      // The view liveness reads are wholesale read-only (they ride the
-      // read-only exarchos_view tool); serialize_merge mutates shared state.
+      // Annotation honesty (REV-L1): `ps probe:true` runs the DR-5 orphan
+      // emitter, a conditional idempotent write path — so `ps` is annotated
+      // local-mutation / idempotent (NOT readOnly), even though it rides the
+      // exarchos_view tool. `wait` is genuinely read-only; serialize_merge
+      // mutates shared state.
       const ps = findAction('exarchos_view', 'ps');
       const wait = findAction('exarchos_view', 'wait');
-      expect(ps!.annotations!.readOnly).toBe(true);
+      expect(ps!.annotations!.safety).toBe('local-mutation');
+      expect(ps!.annotations!.readOnly).toBe(false); // has a conditional write path.
+      expect(ps!.annotations!.idempotent).toBe(true); // the heals re-converge.
+      expect(ps!.annotations!.destructive).toBe(false);
       expect(wait!.annotations!.readOnly).toBe(true);
       const serializeMerge = findAction('exarchos_orchestrate', 'serialize_merge');
       expect(serializeMerge!.annotations!.readOnly).toBe(false);

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -705,7 +705,9 @@ describe('TOOL_REGISTRY', () => {
       // WLM foundation (task 008) added the three worktree-lifecycle ACTIONS
       // (`acquire_worktree`, `release_worktree`, `prune_worktrees`) onto
       // exarchos_orchestrate — INV-5d, no new visible tool: 72 → 75.
-      expect(composite!.actions).toHaveLength(75);
+      // WLM operational core (DR-7) added `serialize_merge` (the optimistic
+      // integration-branch merge lease) onto exarchos_orchestrate: 75 → 76.
+      expect(composite!.actions).toHaveLength(76);
 
       const actionNames = composite!.actions.map((a) => a.name);
       expect(actionNames).toEqual(
@@ -793,6 +795,9 @@ describe('TOOL_REGISTRY', () => {
           'acquire_worktree',
           'release_worktree',
           'prune_worktrees',
+          // WLM operational core (DR-7): explicit name assertion so the length
+          // bump cannot be satisfied by a different action.
+          'serialize_merge',
         ]),
       );
     });

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -2866,6 +2866,48 @@ const orchestrateActions: readonly ToolAction[] = [
       openWorld: false,
     },
   },
+  // ─── Integration-branch merge serializer (WLM operational core, DR-7) ──────
+  // INV-5d: an ACTION on exarchos_orchestrate, NOT a fifth visible tool. An
+  // OPTIMISTIC LEASE over `integrationRef` — the right to merge `sourceBranch`
+  // into `integrationRef` lives in the event log (the
+  // worktree.merge_requested / worktree.merge_executed pair on the singleton
+  // `worktrees` stream), enforcing at most one in-flight merge per integration
+  // ref. It then composes `merge_orchestrate` UNCHANGED for the git work. No
+  // flock / PID file / advisory-lock library — the lease IS the serialization.
+  {
+    name: 'serialize_merge',
+    description:
+      'Serialize an integration-branch merge behind an optimistic per-integrationRef lease, then compose merge_orchestrate UNCHANGED. Grants at most one in-flight merge per integrationRef: a held slot bounded-waits (re-folding worktrees@v1) and reclaims a provably-dead holder inline, or returns a structured merge-slot-timeout. Auto-emits worktree.merge_requested (claim) then worktree.merge_executed (release). Use for: landing a source branch onto a shared integration ref under cross-process serialization. Do NOT use for: a single unsynchronized merge (use merge_orchestrate); a raw provider PR merge (use merge_pr).',
+    schema: z.object({
+      featureId: z.string().min(1),
+      integrationRef: z.string().min(1),
+      sourceBranch: z.string().min(1),
+      strategy: z.enum(['squash', 'rebase', 'merge']),
+      taskId: z.string().optional(),
+      repoRoot: z.string().optional(),
+      // Bounded-wait budget before merge-slot-timeout. Same base type
+      // (ZodNumber) as `doctor.timeoutMs` so the MCP-registration flattener
+      // does not see a divergent shape for the shared `timeoutMs` field name.
+      timeoutMs: z.number().int().positive().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'worktree.merge_requested', condition: 'always', description: 'The lease CLAIM (single-writer per integrationRef)' },
+      { event: 'worktree.merge_executed', condition: 'always', description: 'The lease RELEASE (plain keyed append)' },
+    ],
+    // Multi-step serialized merge (wait → claim → compose merge_orchestrate →
+    // release) is the canonical long-running verb — advisory Tasks-augmented
+    // dispatch, mirroring merge_orchestrate.
+    dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 },
+    // Mutates shared state (the integration branch + working tree, via the
+    // composed merge_orchestrate) from the main worktree — the strictest
+    // mutating trust tier. Mirrors merge_orchestrate so the resolver mints the
+    // same fs:write + shell:exec capabilities.
+    posture: 'shared-mutating',
+    outputSchema: EnvelopeSchema(z.unknown()),
+    annotations: COMPENSABLE_REMOTE,
+  },
   makeDescribeAction(),
 ];
 

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -3267,23 +3267,29 @@ const viewActions: readonly ToolAction[] = [
     annotations: READ_ONLY_LOCAL,
   },
   // ─── Worktree-lifecycle liveness reads (WLM operational core, DR-4) ────────
-  // The `ps` / `wait` read leg over the singleton `worktrees` stream: `ps`
-  // surfaces the live `inFlightMerges` set, `wait` blocks (caller-bounded) on a
-  // serialized merge reaching its terminal. `ps probe:true` runs the on-demand
-  // DR-5 orphan probe and emits worktree.released / worktree.orphan_detected —
-  // the single write path — but both ride the wholesale-read-only exarchos_view
-  // tool (annotated read-only per the WLM view surface contract).
+  // The `ps` / `wait` leg over the singleton `worktrees` stream: `ps` surfaces
+  // the live `inFlightMerges` set, `wait` blocks (caller-bounded) on a serialized
+  // merge reaching its terminal. `ps probe:true` runs the on-demand DR-5 orphan
+  // probe and emits worktree.released / worktree.orphan_detected — a conditional
+  // idempotent heal. Annotation honesty: `wait` is genuinely read-only, but `ps`
+  // has that conditional write path, so it is annotated `local-mutation` /
+  // `idempotent` (NOT readOnly) — re-running converges (the heals are
+  // idempotent), it just is not a zero-append read.
   {
     name: 'ps',
     description:
-      'List the live serialized-merge set — the worktrees@v1 inFlightMerges (each: integrationRef, operationId, sourceBranch, holder pid/start-time) — as a pure fold, NO process scan. Pass probe:true to additionally run the on-demand DR-5 process probe and emit worktree.released (owner dead, idle) / worktree.orphan_detected (owner dead, still occupied) — the orphan emitter, the sole write path. Read-only by default.',
+      'List the live serialized-merge set — the worktrees@v1 inFlightMerges (each: integrationRef, operationId, sourceBranch, holder pid/start-time) — as a pure fold, NO process scan. Pass probe:true to additionally run the on-demand DR-5 process probe and emit worktree.released (owner dead, idle) / worktree.orphan_detected (owner dead, still occupied) — the orphan emitter, a conditional write path. Idempotent: without probe it is a pure read; with probe the heals re-converge on re-run.',
     schema: z.object({
       probe: z.boolean().optional(),
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
     outputSchema: EnvelopeSchema(z.unknown()),
-    annotations: READ_ONLY_LOCAL,
+    // `ps probe:true` can append worktree.released / worktree.orphan_detected, so
+    // it is NOT readOnly. The heals are idempotent (re-running a probe over an
+    // already-reconciled set emits nothing) and non-destructive → idempotent
+    // local-mutation. `wait` / `worktrees` stay genuinely READ_ONLY_LOCAL.
+    annotations: LOCAL_MUTATION_IDEMPOTENT,
   },
   {
     name: 'wait',

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -3266,6 +3266,41 @@ const viewActions: readonly ToolAction[] = [
     outputSchema: EnvelopeSchema(z.unknown()),
     annotations: READ_ONLY_LOCAL,
   },
+  // ─── Worktree-lifecycle liveness reads (WLM operational core, DR-4) ────────
+  // The `ps` / `wait` read leg over the singleton `worktrees` stream: `ps`
+  // surfaces the live `inFlightMerges` set, `wait` blocks (caller-bounded) on a
+  // serialized merge reaching its terminal. `ps probe:true` runs the on-demand
+  // DR-5 orphan probe and emits worktree.released / worktree.orphan_detected —
+  // the single write path — but both ride the wholesale-read-only exarchos_view
+  // tool (annotated read-only per the WLM view surface contract).
+  {
+    name: 'ps',
+    description:
+      'List the live serialized-merge set — the worktrees@v1 inFlightMerges (each: integrationRef, operationId, sourceBranch, holder pid/start-time) — as a pure fold, NO process scan. Pass probe:true to additionally run the on-demand DR-5 process probe and emit worktree.released (owner dead, idle) / worktree.orphan_detected (owner dead, still occupied) — the orphan emitter, the sole write path. Read-only by default.',
+    schema: z.object({
+      probe: z.boolean().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+    outputSchema: EnvelopeSchema(z.unknown()),
+    annotations: READ_ONLY_LOCAL,
+  },
+  {
+    name: 'wait',
+    description:
+      'Block until the serialized merge on integrationRef reaches its terminal worktree.merge_executed (caller-bounded poll, re-folding worktrees@v1 each iteration). Returns a structured wait-timeout on expiry; never hangs, spins up no background timer, and emits no events. timeoutMs bounds the wait.',
+    schema: z.object({
+      integrationRef: z.string().min(1),
+      // Bounded-wait budget. Same base type (ZodNumber) as serialize_merge /
+      // doctor `timeoutMs` so the MCP-registration flattener sees no divergent
+      // shape for the shared `timeoutMs` field name.
+      timeoutMs: z.number().int().positive().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+    outputSchema: EnvelopeSchema(z.unknown()),
+    annotations: READ_ONLY_LOCAL,
+  },
   makeDescribeAction(),
 ];
 
@@ -3312,7 +3347,7 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
     description: 'CQRS materialized views — pipeline, tasks, workflow status, stack, and telemetry',
     actions: viewActions,
     cli: { alias: 'vw' },
-    slimDescription: 'CQRS materialized views for pipeline, tasks, and telemetry. Use describe(actions) for schemas.\n\nActions: pipeline, tasks, workflow_status, stack_status, stack_place, telemetry, team_performance, delegation_timeline, code_quality, eval_results, quality_correlation, quality_attribution, quality_hints, delegation_readiness, synthesis_readiness, shepherd_status, convergence, session_provenance, provenance, invariants_effective, worktrees',
+    slimDescription: 'CQRS materialized views for pipeline, tasks, and telemetry. Use describe(actions) for schemas.\n\nActions: pipeline, tasks, workflow_status, stack_status, stack_place, telemetry, team_performance, delegation_timeline, code_quality, eval_results, quality_correlation, quality_attribution, quality_hints, delegation_readiness, synthesis_readiness, shepherd_status, convergence, session_provenance, provenance, invariants_effective, worktrees, ps, wait',
   },
   {
     name: 'exarchos_sync',

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -27,7 +27,12 @@ import {
   handleViewConvergence,
 } from './tools.js';
 import { handleViewInvariantsEffective } from './effective-catalog.js';
-import { handleViewWorktrees } from '../orchestrate/worktree/handlers.js';
+import {
+  handleViewWorktrees,
+  handleViewPs,
+  handleViewWait,
+  type WorktreeViewDeps,
+} from '../orchestrate/worktree/handlers.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
 import type { QualityHintsConfig } from '../capabilities/resolver.js';
@@ -76,6 +81,13 @@ function envelopeWrap(result: ToolResult, startedAt: number): ToolResult {
 export async function handleView(
   args: Record<string, unknown>,
   ctx: DispatchContext,
+  // WLM operational core (DR-4) — test-only DI seam for the `ps` / `wait`
+  // worktree-liveness arms (fake process-table source / realpath / sleep clock).
+  // Production dispatch (`core/dispatch.ts`) calls `handleView(args, ctx)` with
+  // no third argument, so the real OS-backed defaults are wired; only the named
+  // worktree tests thread it. Other action arms ignore it. An extra optional
+  // parameter keeps `handleView` assignable to `CompositeHandler` (2 params).
+  deps?: WorktreeViewDeps,
 ): Promise<ToolResult> {
   const startedAt = Date.now();
   const { stateDir, eventStore } = ctx;
@@ -370,6 +382,19 @@ export async function handleView(
       // (INV-2); the handler takes the full DispatchContext for `ctx.eventStore`.
       return envelopeWrap(await handleViewWorktrees(rest, ctx), startedAt);
 
+    case 'ps':
+      // WLM operational core (DR-4) — list the live serialized-merge set from
+      // `inFlightMerges` (no process scan). `probe: true` additionally pulls the
+      // DR-5 process probe and emits worktree.released / worktree.orphan_detected
+      // (the deferred orphan emitter — the sole write path on this view surface).
+      return envelopeWrap(await handleViewPs(rest, ctx, deps), startedAt);
+
+    case 'wait':
+      // WLM operational core (DR-4) — caller-bounded poll until the serialized
+      // merge on `integrationRef` reaches its terminal worktree.merge_executed.
+      // Read-only, structured-timeout-on-expiry, no background timer.
+      return envelopeWrap(await handleViewWait(rest, ctx, deps), startedAt);
+
     case 'describe':
       return envelopeWrap(
         await handleDescribe(rest as { actions: string[] }, viewActions),
@@ -404,6 +429,8 @@ export async function handleView(
             'convergence',
             'invariants_effective',
             'worktrees',
+            'ps',
+            'wait',
             'describe',
           ] as const,
         },

--- a/servers/exarchos-mcp/src/views/describe.coverage.test.ts
+++ b/servers/exarchos-mcp/src/views/describe.coverage.test.ts
@@ -23,6 +23,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { DispatchContext } from '../core/dispatch.js';
 import { EventStore } from '../event-store/store.js';
+import { TOOL_REGISTRY } from '../registry.js';
 import { handleView } from './composite.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,6 +66,98 @@ function collectDispatchedActionNames(): string[] {
   }
   return [...names].sort();
 }
+
+/**
+ * Registered view-action names on `exarchos_view`, EXCLUDING `describe`.
+ *
+ * `describe` is the introspection action itself: it is BOTH registered (via
+ * `makeDescribeAction` in TOOL_REGISTRY.viewActions) AND routed (a
+ * `case 'describe':` arm in `handleView`), but `collectDispatchedActionNames`
+ * deliberately omits it because it is not a materialized-view action. To put
+ * the routed surface and the registered surface on equal footing for the
+ * equality guard, we drop `describe` from BOTH sides. This is the view-side
+ * analogue of the orchestrate guard's documented `SPECIAL_ACTIONS` skip-set
+ * (`registry.test.ts` → `OrchestrateActions_MatchCompositeHandlers_InSync`) —
+ * the one intentional exception to set equality.
+ */
+function collectRegisteredViewActionNames(): string[] {
+  const view = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
+  if (!view) {
+    throw new Error(
+      'collectRegisteredViewActionNames: exarchos_view composite not found in TOOL_REGISTRY',
+    );
+  }
+  return view.actions
+    .map((a) => a.name)
+    .filter((n) => n !== 'describe')
+    .sort();
+}
+
+// ─── View-side EQUALITY guard (DR-4 / DR-7 — close the view DOA hole) ────────
+//
+// The pre-existing `describe.coverage` test above is a SUPERSET guard:
+// "registry COVERS the dispatched surface" (registered ⊇ routed). That shape
+// lets a view action be registered-but-UNROUTED — registered in
+// TOOL_REGISTRY.viewActions with NO `case` arm in `handleView` — ship Dead On
+// Arrival: every call falls through to `default` → UNKNOWN_ACTION at runtime,
+// while the action's own unit tests (which call the underlying handler
+// directly) stay green. This is exactly the class of bug the orchestrate twin
+// (`OrchestrateActions_MatchCompositeHandlers_InSync`) was added to fence after
+// `onboard` shipped registered-but-unrouted.
+//
+// This guard upgrades the contract to EQUALITY: the set of view actions routed
+// by the `handleView` switch (source-parsed via the same tightened regex the
+// coverage test uses) MUST equal the set registered on `exarchos_view`, modulo
+// the single documented `describe` exception. It turns red in BOTH directions —
+// a registered-but-unrouted action AND a routed-but-unregistered action.
+describe('ExarchosView — registry↔dispatch EQUALITY guard (DR-4/DR-7, view DOA fence)', () => {
+  it('ViewActions_MatchCompositeHandlers_InSync', () => {
+    const routed = collectDispatchedActionNames(); // case arms (minus describe)
+    const registered = collectRegisteredViewActionNames(); // registry (minus describe)
+
+    // Sanity: both surfaces must be non-empty, and must include the WLM
+    // operational-core liveness reads (`ps` / `wait`, Task 004) plus the
+    // foundation read (`worktrees`, Task 008). If a future regex/registry edit
+    // collapses either set to zero this fails loudly rather than passing
+    // vacuously (two empty sets are trivially equal).
+    expect(routed.length).toBeGreaterThan(0);
+    expect(registered.length).toBeGreaterThan(0);
+    for (const name of ['ps', 'wait', 'worktrees']) {
+      expect(routed, `handleView must route '${name}'`).toContain(name);
+      expect(
+        registered,
+        `exarchos_view must register '${name}'`,
+      ).toContain(name);
+    }
+
+    // Direction 1 — registered-but-UNROUTED (the DOA hole the superset test
+    // cannot see). A view action in the registry with no `case` arm in
+    // handleView would dispatch to UNKNOWN_ACTION at runtime.
+    const registeredNotRouted = registered.filter((n) => !routed.includes(n));
+    expect(
+      registeredNotRouted,
+      `View action(s) registered on exarchos_view but NOT routed by handleView ` +
+        `(would ship DOA → UNKNOWN_ACTION): [${registeredNotRouted.join(', ')}]. ` +
+        `Add a matching 'case' arm in views/composite.ts.`,
+    ).toEqual([]);
+
+    // Direction 2 — routed-but-UNREGISTERED. Per-action Zod validation in the
+    // dispatch core is silently skipped and the action is invisible to
+    // `describe`. (The superset test already covers this direction; the
+    // equality guard re-pins it so one test owns the full contract.)
+    const routedNotRegistered = routed.filter((n) => !registered.includes(n));
+    expect(
+      routedNotRegistered,
+      `View action(s) routed by handleView but NOT registered on exarchos_view ` +
+        `(Zod validation skipped + invisible to describe): ` +
+        `[${routedNotRegistered.join(', ')}]. ` +
+        `Add it to TOOL_REGISTRY.viewActions in src/registry.ts.`,
+    ).toEqual([]);
+
+    // Belt-and-suspenders: the two surfaces are identical sets.
+    expect(routed).toEqual(registered);
+  });
+});
 
 describe('ExarchosViewDescribe — registry-vs-dispatch parity (T1, #1446 residue)', () => {
   let tempStateDir: string;

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -651,6 +651,12 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
       case 'worktree.reserved':
       case 'worktree.released':
       case 'worktree.orphan_detected':
+      // WLM operational-core — serialized-merge lease pair (DR-4 / DR-7). These
+      // ride the singleton `worktrees` stream and are folded by the worktrees@v1
+      // projection, not by workflow-state; they carry no workflow_state-affecting
+      // fields, so this projection folds to identity like the lifecycle family.
+      case 'worktree.merge_requested':
+      case 'worktree.merge_executed':
       case 'test.result':
       case 'typecheck.result':
       case 'ci.status':


### PR DESCRIPTION
## Summary

The **operational-core** slice of epic #1574 (holistic Worktree Lifecycle Manager): event-sourced liveness + an integration-branch merge serializer. Builds directly on the already-shipped WLM foundation (#1575/#1576) and composes the hardened `merge_orchestrate` (PR #1571) **unchanged**.

Two launcher-stable capabilities the foundation deliberately left out:

1. **Liveness observability (DR-4/5)** — long-running worktree ops emit a `worktree.merge_requested` → `worktree.merge_executed` pair on the singleton `worktrees` stream (the INV-10 started/terminal signal, INV-13 intent/result split, and the serializer's lease record, all in one). `worktrees@v1` folds them into an integration-ref-keyed `inFlightMerges` sub-projection; `exarchos_view{ps|wait|worktrees}` answers "what worktree work is in flight?" **from events**. A process-cwd + fs ground-truth probe runs **on demand only** (no interval/loop/daemon, INV-10/15) and excludes the manager's own process ancestry (DR-5) so a self-rooted cwd never marks a worktree in-use.
2. **Integration-branch merge serialization (DR-7/8)** — `serialize_merge` guarantees one writer to an integration branch at a time via an **optimistic lease** (not a held lock): OCC claim inside the `decide` closure (mirrors the shipped `WorktreeManager.reserve` pattern), caller-bounded wait-for-slot on an injected sleep seam, inline dead-holder reclaim via the DR-5 probe, and a plain (non-CAS-pinned) release. It re-reads fresh integration HEAD and delegates to `merge_orchestrate` **unchanged**. Worktree-mutating git is wrapped with retry-on-`index.lock` (exp backoff + jitter) and burst-creation stagger, grounded in Claude Code #55724 — seams injected for deterministic tests.

Closes #1577
Closes #1578
Part of #1574 · Design: `docs/designs/2026-06-21-worktree-lifecycle-manager.md` (DR-4/5/7/8/12) · Spec: `docs/specs/2026-06-26-wlm-operational-core.md`

Out of scope (deferred behind the #1603 launcher fork): DR-9 boundary + DR-11 Windows-CI → #1579; the full DR-10 agent-first parity surface → #1580. The DR-10 registration floor (`outputSchema` + core per-action annotations, required fail-closed at MCP registry load) and dispatch wiring for the new verbs are **not** deferrable and are included here.

## Changes

- **Event schema** — add `worktree.merge_requested` / `worktree.merge_executed` to the closed `EventTypes` union + data schemas + emission registry (classified `auto`). `EventTypes` 136 → 138.
- **Projection** — `worktrees@v1` folds the merge-lease pair into an integration-ref-keyed `inFlightMerges` structure (distinct from worktreeId-keyed entries).
- **`serialize_merge`** — new `exarchos_orchestrate` action: optimistic-lease single-writer serializer delegating to unchanged `merge_orchestrate`; caller-bounded wait, inline dead-holder reclaim, structured `merge-slot-timeout` on expiry.
- **Ground-truth probe** — protected-ancestry process-cwd + fs probe (pure module), pulled on demand; deferred `orphan_detected` emitter wired.
- **View dispatch** — `exarchos_view{ps|wait|worktrees}` read the `inFlightMerges` fold; `wait --until=idle` resolves from terminal events with a structured timeout (never hangs).
- **git resilience** — injectable `index.lock` retry (exp backoff ±jitter) + burst-creation stagger seam.
- **Recovery edges (DR-12)** — crash-mid-operation resume-vs-skip via idempotent precheck; preserve-uncommitted on teardown; cwd-drift false-positive guard; origin-unreachable fail-closed.
- **Guards** — registry/parity + view-equality baselines updated for the new surface.
- **Docs** — unified ideate+plan spec `docs/specs/2026-06-26-wlm-operational-core.md`.

## Test Plan

Branch integrated with `main` (`origin/main` merged in; the only conflicts were additive count-pins in 4 test files — `EventTypes` reconciled 138 → **139** for main's `workflow.plan-revision`, `exarchos_orchestrate` action count reconciled 76 → **77** to keep both `serialize_merge` and main's `check_exploration_depth`).

Local validation (mirrors CI):

- `servers/exarchos-mcp` typecheck — clean
- `servers/exarchos-mcp` full suite — **8380 passed / 21 skipped**
- root typecheck — clean
- root `npm run build` — binaries + 108 skill variants + 20 agents, **no generated-file drift**
- `skills:guard` / `hooks:guard` / `runtimes:guard` — all in sync
- root suite — **861 passed / 6 skipped**

Key behavioral coverage (real-SQLite): two concurrent same-branch merges execute strictly sequentially against fresh HEAD; `serialize_merge`'s event timeline is byte-identical to a direct `merge_orchestrate` call; transient `index.lock` retried with asserted backoff sequence then succeeds; exhausted retries return a structured error (never a silent no-op); self-rooted cwd never marks its worktree in-use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
