### PR TITLE
test(readme): retire SSH-fallback assertion, un-break main readme-validation

### DIFF
--- a/src/readme-validation.test.ts
+++ b/src/readme-validation.test.ts
@@ -8,7 +8,7 @@ const README_PATH = resolve(__dirname, '..', 'README.md');
 
 /**
  * Slice the `## Install` section out of the README so context-window
- * checks operate on the install prose only. Matching the same `httpsUrl`
+ * checks operate on the install prose only. Matching an install token
  * elsewhere in the doc (a "Related projects" link, an example, etc.)
  * would let the test pass for the wrong reason. Throws if the heading is
  * absent so a future README reorg can't silently turn this into a
@@ -29,31 +29,14 @@ function readInstallSection(content: string): string {
 }
 
 describe('README validation', () => {
-  it('Readme_InstallSection_MentionsHttpsFallback', () => {
+  it('Readme_InstallSection_DocumentsPrimaryInstaller', () => {
     const installSection = readInstallSection(readFileSync(README_PATH, 'utf8'));
-    const httpsUrl = 'https://github.com/lvlup-sw/.github.git';
 
-    // The HTTPS fallback URL must appear in the Install section.
-    expect(installSection).toContain(httpsUrl);
-
-    // The context must clarify this is the HTTPS/SSH fallback by mentioning
-    // either "HTTPS" or "SSH" within 500 characters of the URL — but the
-    // URL itself contains "https://" which would match a naive /HTTPS/i.
-    // Slice the URL out of the window so the regex catches genuine
-    // explanatory prose, not the URL protocol.
-    const urlIndex = installSection.indexOf(httpsUrl);
-    const windowStart = Math.max(0, urlIndex - 500);
-    const windowEnd = Math.min(installSection.length, urlIndex + httpsUrl.length + 500);
-    const leftContext = installSection.slice(windowStart, urlIndex);
-    const rightContext = installSection.slice(urlIndex + httpsUrl.length, windowEnd);
-    const contextWithoutUrl = leftContext + rightContext;
-
-    const mentionsFallbackContext =
-      /\bHTTPS\b/i.test(contextWithoutUrl) || /\bSSH\b/i.test(contextWithoutUrl);
-
-    expect(
-      mentionsFallbackContext,
-      'Expected "HTTPS" or "SSH" within 500 chars of the HTTPS URL inside the Install section',
-    ).toBe(true);
+    // The Install section must document the canonical one-line installer for
+    // the standalone CLI. Sliced to the Install section (readInstallSection
+    // throws if the heading is gone) so an install token elsewhere in the
+    // README can't satisfy this for the wrong reason, and a reorg that drops
+    // the install command can't silently turn this into a vacuous pass.
+    expect(installSection).toContain('get-exarchos.sh');
   });
 });


### PR DESCRIPTION
## Summary

`main` is currently red on `readme-validation`. Commit `22c45301` ("docs(readme): … trim length") intentionally removed the `> **No SSH key?** Use the HTTPS URL: …` line from the README Install section, but did not update `src/readme-validation.test.ts` — its `Readme_InstallSection_MentionsHttpsFallback` case still `expect(installSection).toContain('https://github.com/lvlup-sw/.github.git')`. The test now pins content the README no longer has, so `test-root` fails and every PR into `main` inherits a red `CI Gate` on its merge commit.

This reconciles the test to the trimmed README (per the maintainer decision that the SSH-fallback line stays removed).

## Changes

- `src/readme-validation.test.ts`: drop the retired SSH-fallback assertion; replace it with a check that the Install section documents the canonical one-line installer (`get-exarchos.sh`). Still sliced via `readInstallSection` (which throws if the `## Install` heading is ever removed), so the check can't pass vacuously.

## Test Plan

- `npx vitest run src/readme-validation.test.ts` → 1 passed against main's current (trimmed) README.
- Non-vacuous: the helper throws if `## Install` is absent; the assertion fails if the installer command is dropped from the section.

Unblocks `readme-validation` on `main` and every open PR (including #1639).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
