### PR TITLE
fix(delegation): thread planner risk/boundary stamps end-to-end + empirical benchmark (#1636)

### DIFF
--- a/docs/evals/2026-07-09-1636-plan-format-corpus.json
+++ b/docs/evals/2026-07-09-1636-plan-format-corpus.json
@@ -1,7 +1,6 @@
 {
   "corpus": {
     "specs": [
-      "2026-06-23-v2.11.0-rc.1-build.md",
       "2026-06-25-rc1-closeout.md",
       "2026-06-25-wlm-foundation.md",
       "2026-06-26-wlm-operational-core.md",
@@ -48,20 +47,19 @@
       "boundaryLost": 51
     },
     "vsHeuristicCeiling_H1": {
-      "tierMatch": 51,
-      "tierUnder": 8,
-      "tierOver": 41,
-      "integrationRungLost": 7,
+      "tierMatch": 48,
+      "tierUnder": 25,
+      "tierOver": 27,
+      "integrationRungLost": 24,
       "boundaryLost": 49,
       "boundaryPhantom": 0,
       "confusion": {
-        "medium→medium": 12,
-        "low→medium": 4,
-        "medium→high": 36,
-        "high→high": 38,
+        "medium→medium": 26,
+        "low→medium": 5,
+        "high→medium": 24,
+        "medium→high": 22,
+        "high→high": 21,
         "medium→low": 1,
-        "high→medium": 7,
-        "low→high": 1,
         "low→low": 1
       }
     }
@@ -177,7 +175,7 @@
       "title": "Coupling guard — shim command set == canonical SoT",
       "fileCount": 1,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -188,8 +186,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -198,7 +195,7 @@
       "title": "Implement `GitLabProvider.getPrComments` (two-source `PrComment` parity)",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -212,8 +209,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -222,7 +218,7 @@
       "title": "Implement `AzureDevOpsProvider.getPrComments` (two-source `PrComment` parity)",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -236,8 +232,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -246,7 +241,7 @@
       "title": "Narrow the `requiresGitHub` gate in `assess_stack` to enable GitLab/ADO",
       "fileCount": 2,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -259,8 +254,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -269,7 +263,7 @@
       "title": "Integration — GitLab/ADO comments surface via `assess_stack` (harvest loop branch-free, INV-6)",
       "fileCount": 1,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -280,8 +274,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -381,7 +374,7 @@
       "title": "Adopt harness-created worktrees (no pool) + stale-after-push re-verify",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -395,8 +388,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -405,7 +397,7 @@
       "title": "GC safety-ladder (pure)",
       "fileCount": 2,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -416,8 +408,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -426,7 +417,7 @@
       "title": "`prune_worktrees` handler — adopt-gate, TOCTOU-safe, two-event deletion",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -440,8 +431,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -536,7 +526,7 @@
       "title": "Fold merge pair into `inFlightMerges` + probe emissions in `worktrees@v1`; orphan emitter",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -548,8 +538,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -643,7 +632,7 @@
       "title": "Error handling & failure modes (crash-resume, stale-lease, concurrent prune+merge, retry exhaustion)",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -655,17 +644,16 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "001",
       "title": "`isRevision` flag + counted `plan-revision` event + projection fold",
-      "fileCount": 3,
+      "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -679,15 +667,14 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "002",
       "title": "HSM revise flag + precedence + `.exarchos.yml` cap (default 1)",
-      "fileCount": 7,
+      "fileCount": 6,
       "planTier": "high",
       "heuristicTier": "high",
       "planBoundary": true,
@@ -730,9 +717,9 @@
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "004",
       "title": "Derive + persist workflow `riskTier` (max-of-tiers)",
-      "fileCount": 3,
+      "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -746,17 +733,16 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "005",
       "title": "Project mutation dimension + no-toolchain skip-pass (dead-lock fix)",
-      "fileCount": 3,
+      "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -770,15 +756,14 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "006",
       "title": "Score enforcement at `review → synthesize` (pre-resolved + injected)",
-      "fileCount": 4,
+      "fileCount": 3,
       "planTier": "high",
       "heuristicTier": "high",
       "planBoundary": true,
@@ -802,9 +787,9 @@
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "007",
       "title": "`check_exploration_depth` gate handler + action",
-      "fileCount": 3,
+      "fileCount": 2,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -815,17 +800,16 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "008",
       "title": "`composeScopedCommand` diff seam + PIT + mutmut scoping",
-      "fileCount": 3,
+      "fileCount": 2,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -836,17 +820,16 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "009",
       "title": "Full-scope mutation execution behind an offline gate",
-      "fileCount": 2,
+      "fileCount": 1,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -857,17 +840,16 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-06-29-risk-verification-closeout.md",
       "id": "010",
       "title": "Route review enforcement through `resolveGateSet`; delete stale comments",
-      "fileCount": 3,
+      "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -881,8 +863,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1000,7 +981,7 @@
       "title": "Worktree creation — reserve → `create.requested` → `git worktree add` → `create.executed`",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1014,8 +995,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1069,7 +1049,7 @@
       "title": "Single-abstraction guard — pure-data descriptor + no per-harness branching",
       "fileCount": 1,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1080,8 +1060,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1204,9 +1183,9 @@
       "spec": "2026-07-02-harness-launcher.md",
       "id": "014",
       "title": "Per-harness on-ramps (5) + `runtimes/*.yaml` lifecycle semantics",
-      "fileCount": 3,
+      "fileCount": 1,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1220,8 +1199,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1295,7 +1273,7 @@
       "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
       "id": "002",
       "title": "`serialize_merge` lease-aware `dryRun` (default, handler short-circuit) + `mutable`-as-hard-gate",
-      "fileCount": 4,
+      "fileCount": 3,
       "planTier": "high",
       "heuristicTier": "high",
       "planBoundary": true,
@@ -1321,7 +1299,7 @@
       "title": "Registry-driven conformance rewrite of the worktree parity harness",
       "fileCount": 1,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1332,8 +1310,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1613,7 +1590,7 @@
       "title": "Compensation teardown dirty-guard (INV-14)",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1627,8 +1604,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1685,7 +1661,7 @@
       "title": "`shared-mutating` posture + resolver gate for worktree verbs",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1699,8 +1675,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1791,7 +1766,7 @@
       "title": "Mark `test-windows` lane required",
       "fileCount": 0,
       "planTier": "low",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1801,8 +1776,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1831,7 +1805,7 @@
       "title": "Wire or excise `resumeCrashedMerge`",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1845,8 +1819,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1855,7 +1828,7 @@
       "title": "#1635 — async origin probe in teardown + launcher `holderStartedAt`",
       "fileCount": 0,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -1866,8 +1839,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -1956,7 +1928,7 @@
       "spec": "2026-07-04-harness-conform-and-shrink.md",
       "id": "004",
       "title": "Atomic rename wave — one PR, every rename surface",
-      "fileCount": 12,
+      "fileCount": 11,
       "planTier": "high",
       "heuristicTier": "high",
       "planBoundary": false,
@@ -1978,7 +1950,7 @@
       "spec": "2026-07-04-harness-conform-and-shrink.md",
       "id": "006",
       "title": "Procedural rewrite to logical names + binding neutralization with its consumer",
-      "fileCount": 4,
+      "fileCount": 3,
       "planTier": "medium",
       "heuristicTier": "high",
       "planBoundary": false,
@@ -1999,7 +1971,7 @@
       "spec": "2026-07-04-harness-conform-and-shrink.md",
       "id": "007",
       "title": "Collapse fat `commands/*.md` bodies into skills; thin shims",
-      "fileCount": 17,
+      "fileCount": 16,
       "planTier": "medium",
       "heuristicTier": "high",
       "planBoundary": false,
@@ -2061,9 +2033,9 @@
       "spec": "2026-07-04-harness-conform-and-shrink.md",
       "id": "009",
       "title": "Consistency sweep — idempotence, golden fixture, full integration",
-      "fileCount": 1,
+      "fileCount": 0,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -2075,8 +2047,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -2085,7 +2056,7 @@
       "title": "Onboard rename migration — provenance-gated, multi-release bootstrap",
       "fileCount": 2,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -2098,8 +2069,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -2108,7 +2078,7 @@
       "title": "`insertManagedBlock` — consumer-side writer (server package)",
       "fileCount": 2,
       "planTier": "high",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -2122,17 +2092,16 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-07-04-harness-conform-and-shrink.md",
       "id": "013",
       "title": "Onboard writers — AGENTS.md block + CLAUDE.md shim + doctor drift",
-      "fileCount": 1,
+      "fileCount": 0,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": true,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -2145,17 +2114,16 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
       "spec": "2026-07-04-harness-conform-and-shrink.md",
       "id": "014",
       "title": "Injection-channel candidate lists on the harness registry",
-      "fileCount": 2,
+      "fileCount": 1,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -2166,8 +2134,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     },
     {
@@ -2270,7 +2237,7 @@
       "title": "Liveness-verb coverage + docs truth-up + ADR addendum",
       "fileCount": 2,
       "planTier": "medium",
-      "heuristicTier": "high",
+      "heuristicTier": "medium",
       "planBoundary": false,
       "heuristicBoundary": false,
       "agent": "implementer",
@@ -2281,8 +2248,7 @@
       ],
       "hGates": [
         "check_static_analysis",
-        "check_test_adequacy",
-        "check_integration_suite"
+        "check_test_adequacy"
       ]
     }
   ]

--- a/docs/evals/2026-07-09-1636-plan-format-corpus.json
+++ b/docs/evals/2026-07-09-1636-plan-format-corpus.json
@@ -1,0 +1,2289 @@
+{
+  "corpus": {
+    "specs": [
+      "2026-06-23-v2.11.0-rc.1-build.md",
+      "2026-06-25-rc1-closeout.md",
+      "2026-06-25-wlm-foundation.md",
+      "2026-06-26-wlm-operational-core.md",
+      "2026-06-29-risk-verification-closeout.md",
+      "2026-07-02-harness-launcher.md",
+      "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "2026-07-03-wlm-reconcile-enforce.md",
+      "2026-07-04-harness-conform-and-shrink.md"
+    ],
+    "tasks": 100,
+    "stamped": 100
+  },
+  "dimension1_model": {
+    "agentDist": {
+      "implementer": 99,
+      "scaffolder": 1
+    },
+    "modelDist": {
+      "opus": 99,
+      "haiku": 1
+    },
+    "modelByTier": {
+      "low": {
+        "opus": 6
+      },
+      "medium": {
+        "opus": 49
+      },
+      "high": {
+        "opus": 44,
+        "haiku": 1
+      }
+    },
+    "highTierCheapModel": 1,
+    "lowTierExpensiveModel": 6,
+    "cheaperThanNative": 1
+  },
+  "dimension2_verification": {
+    "vsTrueProduction_H0": {
+      "tierMatch": 49,
+      "tierUnder": 45,
+      "tierOver": 6,
+      "integrationRungLost": 45,
+      "boundaryLost": 51
+    },
+    "vsHeuristicCeiling_H1": {
+      "tierMatch": 51,
+      "tierUnder": 8,
+      "tierOver": 41,
+      "integrationRungLost": 7,
+      "boundaryLost": 49,
+      "boundaryPhantom": 0,
+      "confusion": {
+        "medium→medium": 12,
+        "low→medium": 4,
+        "medium→high": 36,
+        "high→high": 38,
+        "medium→low": 1,
+        "high→medium": 7,
+        "low→high": 1,
+        "low→low": 1
+      }
+    }
+  },
+  "rows": [
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "001",
+      "title": "Fix `github.createPr` — drop `--json`, capture URL from stdout",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "002",
+      "title": "Fix `gitlab.createPr` — drop the latent `--json` sibling",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "003",
+      "title": "Verify ADO `createPr` `--output json` validity + lock the class",
+      "fileCount": 2,
+      "planTier": "low",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "004",
+      "title": "Add `canonicalCommandSet()` accessor to the SoT",
+      "fileCount": 2,
+      "planTier": "low",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "005",
+      "title": "Collapse `CANONICAL_COMMANDS` to a description map + reconcile drift",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "006",
+      "title": "Coupling guard — shim command set == canonical SoT",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "007",
+      "title": "Implement `GitLabProvider.getPrComments` (two-source `PrComment` parity)",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "008",
+      "title": "Implement `AzureDevOpsProvider.getPrComments` (two-source `PrComment` parity)",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "010",
+      "title": "Narrow the `requiresGitHub` gate in `assess_stack` to enable GitLab/ADO",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-rc1-closeout.md",
+      "id": "009",
+      "title": "Integration — GitLab/ADO comments surface via `assess_stack` (harvest loop branch-free, INV-6)",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "001",
+      "title": "Reconcile the `worktree.*` event family + per-invocation idempotency keys",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "002",
+      "title": "`worktrees@v1` projection reducer",
+      "fileCount": 4,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "003",
+      "title": "Portable process-identity + symlink-resolved path-containment primitives",
+      "fileCount": 4,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "004",
+      "title": "Crash-safe ownership reservation + heal-as-reconcile-fold",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "005",
+      "title": "Adopt harness-created worktrees (no pool) + stale-after-push re-verify",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "006",
+      "title": "GC safety-ladder (pure)",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "007",
+      "title": "`prune_worktrees` handler — adopt-gate, TOCTOU-safe, two-event deletion",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "008",
+      "title": "Register + **dispatch-wire** composite actions (registry + handlers) + parity",
+      "fileCount": 4,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-25-wlm-foundation.md",
+      "id": "009",
+      "title": "Windows CI lane for the worktree suite",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "low",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "001",
+      "title": "Add `worktree.merge_requested`/`worktree.merge_executed` to the event-store union",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "002",
+      "title": "Protected-ancestry process probe (`pure/probe.ts`)",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "003",
+      "title": "Fold merge pair into `inFlightMerges` + probe emissions in `worktrees@v1`; orphan emitter",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "004",
+      "title": "Liveness emission + `exarchos_view{ps|wait|worktrees}` read path **through `handleView`**",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "005",
+      "title": "Injectable backoff/jitter/sleep seam + `index.lock` retry wrapper",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "006",
+      "title": "`serialize_merge` optimistic-lease funnel **through `handleOrchestrate`** (composes `merge_orchestrate`)",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "007",
+      "title": "Register `serialize_merge`/`ps`/`wait` (outputSchema + annotations) + close the view-side parity hole",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-26-wlm-operational-core.md",
+      "id": "008",
+      "title": "Error handling & failure modes (crash-resume, stale-lease, concurrent prune+merge, retry exhaustion)",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "001",
+      "title": "`isRevision` flag + counted `plan-revision` event + projection fold",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "002",
+      "title": "HSM revise flag + precedence + `.exarchos.yml` cap (default 1)",
+      "fileCount": 7,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "003",
+      "title": "Re-plumb `commands/plan.md` auto-loop through `transition`",
+      "fileCount": 2,
+      "planTier": "low",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "004",
+      "title": "Derive + persist workflow `riskTier` (max-of-tiers)",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "005",
+      "title": "Project mutation dimension + no-toolchain skip-pass (dead-lock fix)",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "006",
+      "title": "Score enforcement at `review → synthesize` (pre-resolved + injected)",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "007",
+      "title": "`check_exploration_depth` gate handler + action",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "008",
+      "title": "`composeScopedCommand` diff seam + PIT + mutmut scoping",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "009",
+      "title": "Full-scope mutation execution behind an offline gate",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "010",
+      "title": "Route review enforcement through `resolveGateSet`; delete stale comments",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-06-29-risk-verification-closeout.md",
+      "id": "011",
+      "title": "Chart verification data-flow + phase transitions in system-design.html",
+      "fileCount": 0,
+      "planTier": "low",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "001",
+      "title": "Event schema — shared-stem create pair + launch liveness (task-less, on the `worktrees` stream)",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "002",
+      "title": "Harness registry — declarative spawn descriptors + enum→runtime-id map",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "003",
+      "title": "Cross-OS async spawn primitive (one interface)",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "scaffolder",
+      "model": "haiku",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "004",
+      "title": "`exarchos <harness>` verb — schema + CLI adapter + `--dry-run`",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": true,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "005",
+      "title": "Worktree creation — reserve → `create.requested` → `git worktree add` → `create.executed`",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "006",
+      "title": "Launch liveness emission + `ps`/`worktrees` projection wiring",
+      "fileCount": 5,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "007",
+      "title": "WLM composition — producer wiring + retain adopt/reconcile + serialize merges",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "008",
+      "title": "Single-abstraction guard — pure-data descriptor + no per-harness branching",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "009",
+      "title": "Sibling worktree path derivation + nesting guard (pure, cross-OS)",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "010",
+      "title": "Launcher lifecycle orchestration — spawn→place→observe→teardown + real verb binding",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "011",
+      "title": "Signal handling + orphan prevention",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "012",
+      "title": "Teardown safety + recovery/crash/cwd-drift/origin edges",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "013",
+      "title": "Authority-bounded ephemeral orientation-injection seam",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "014",
+      "title": "Per-harness on-ramps (5) + `runtimes/*.yaml` lifecycle semantics",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "015",
+      "title": "Verb conformance + INV-5 + Windows CI lane (named, required)",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-02-harness-launcher.md",
+      "id": "016",
+      "title": "Phantom-launch reconciler — on-demand probe extension for uncatchable death",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "id": "001",
+      "title": "`surface` marker + typed `outputSchema`s (real-output validated) + \"do NOT use for\" guidance",
+      "fileCount": 5,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "id": "002",
+      "title": "`serialize_merge` lease-aware `dryRun` (default, handler short-circuit) + `mutable`-as-hard-gate",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "id": "003",
+      "title": "Registry-driven conformance rewrite of the worktree parity harness",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "id": "004",
+      "title": "Stateful `prepare_review scope:plan` — count + cap at the provisioning seam",
+      "fileCount": 5,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "id": "005",
+      "title": "Bypass-closure + off-by-one + delegate-untouched + overhaul-mirror regression",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "id": "006",
+      "title": "Item-count cap + measured-size summary for `pipeline` + `worktrees`",
+      "fileCount": 8,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-6-surface-and-workflow-fixes.md",
+      "id": "007",
+      "title": "Discovery workflow-type token alignment to canonical `'discovery'`",
+      "fileCount": 10,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "001",
+      "title": "Wrap the prune-executor remove path with `withIndexLockRetry`",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "medium",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "002",
+      "title": "Retry adapters + wrap the default GitExec composition; correct the false retry-seam comment",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "003",
+      "title": "Burst stagger at the worktree-creation seam",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "004",
+      "title": "CI wiring grep-gate (two rules)",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "005",
+      "title": "Lease-guard preflight + lease threading (ATOMIC — guard and threading ship together)",
+      "fileCount": 5,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "007",
+      "title": "Reroute skill surfaces to `serialize_merge` + GC cadence guidance",
+      "fileCount": 8,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "008",
+      "title": "`next_actions` prune-cadence affordance after synthesize",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "009",
+      "title": "Unify compensation `worktree.remove.*` onto the `worktrees` stream (+ retry wrap)",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "010",
+      "title": "Compensation teardown dirty-guard (INV-14)",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "011",
+      "title": "Prune INV-10 liveness pair — events, reducer, manager emission",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "021",
+      "title": "`ps`/`wait` surface the prune pair — idle mode + schema",
+      "fileCount": 4,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "012",
+      "title": "`shared-mutating` posture + resolver gate for worktree verbs",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "013",
+      "title": "#1301-shape regression audit/pin",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "014",
+      "title": "Null-ready `ownerStartedAt` threading (#1633a)",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "015",
+      "title": "win32 process source (cwd + create-time) behind the shim",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "016",
+      "title": "win32 path containment (8.3 + symlink canonicalization)",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "017",
+      "title": "Mark `test-windows` lane required",
+      "fileCount": 0,
+      "planTier": "low",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "018",
+      "title": "#1634 — teardown occupancy probe race",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "020",
+      "title": "Wire or excise `resumeCrashedMerge`",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-03-wlm-reconcile-enforce.md",
+      "id": "019",
+      "title": "#1635 — async origin probe in teardown + launcher `holderStartedAt`",
+      "fileCount": 0,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "001",
+      "title": "Renderer skill classification (procedural vs orchestration) with build-time assertion",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "002",
+      "title": "Placeholder-lint rules for the collapsed vocabulary",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "003",
+      "title": "`skills/standard/` single-render emission + guard + CHAIN validation (stale renders deleted here)",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "023",
+      "title": "Multi-release legacy-render hash manifest (git-history-derived)",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "medium",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "004",
+      "title": "Atomic rename wave — one PR, every rename surface",
+      "fileCount": 12,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "006",
+      "title": "Procedural rewrite to logical names + binding neutralization with its consumer",
+      "fileCount": 4,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "007",
+      "title": "Collapse fat `commands/*.md` bodies into skills; thin shims",
+      "fileCount": 17,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "021",
+      "title": "Root-package Windows CI lane",
+      "fileCount": 1,
+      "planTier": "low",
+      "heuristicTier": "low",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis"
+      ],
+      "hGates": [
+        "check_static_analysis"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "010",
+      "title": "Install layout — `.agents/skills/` + copy-mode + provenance manifest",
+      "fileCount": 3,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "009",
+      "title": "Consistency sweep — idempotence, golden fixture, full integration",
+      "fileCount": 1,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "011",
+      "title": "Onboard rename migration — provenance-gated, multi-release bootstrap",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "012",
+      "title": "`insertManagedBlock` — consumer-side writer (server package)",
+      "fileCount": 2,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "013",
+      "title": "Onboard writers — AGENTS.md block + CLAUDE.md shim + doctor drift",
+      "fileCount": 1,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "014",
+      "title": "Injection-channel candidate lists on the harness registry",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "015",
+      "title": "Spawn-time channel probe + `injectOrientation` wiring (fail-open, dry-run-visible)",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "016",
+      "title": "Hook-surface shrink (specified plugin carve-out)",
+      "fileCount": 4,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "017",
+      "title": "Onboard retired-hooks plumbing — check, ordering, uninstall, parity",
+      "fileCount": 3,
+      "planTier": "high",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "022",
+      "title": "Versioned packaging via the sync pipeline",
+      "fileCount": 7,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": true,
+      "heuristicBoundary": true,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite",
+        "check_contract_drift",
+        "check_mock_boundary"
+      ]
+    },
+    {
+      "spec": "2026-07-04-harness-conform-and-shrink.md",
+      "id": "018",
+      "title": "Liveness-verb coverage + docs truth-up + ADR addendum",
+      "fileCount": 2,
+      "planTier": "medium",
+      "heuristicTier": "high",
+      "planBoundary": false,
+      "heuristicBoundary": false,
+      "agent": "implementer",
+      "model": "opus",
+      "eGates": [
+        "check_static_analysis",
+        "check_test_adequacy"
+      ],
+      "hGates": [
+        "check_static_analysis",
+        "check_test_adequacy",
+        "check_integration_suite"
+      ]
+    }
+  ]
+}

--- a/docs/evals/2026-07-09-1636-plan-format-corpus.md
+++ b/docs/evals/2026-07-09-1636-plan-format-corpus.md
@@ -2,6 +2,8 @@
 
 Runs the production `classifyTask` / `renderImplementerPrompt` over every stamped plan-format spec in `docs/specs/`. Arms: **E** (exarchos, plan-honoring — the fix) · **H0** (true production, `{id,title}` only — the current #1636 dispatched behavior) · **H1** (heuristic ceiling, files+testLayer but no stamp) · **N** (native flat model).
 
+> ⚠️ **PROVISIONAL — models the decision, does not run the binary (#1670).** This calls the pure `classifyTask` directly; it does NOT go through the MCP schema/CLI/binary, and the E-arm numbers do NOT depend on the #1636 fix (`deriveRiskTier` already honored an explicit tier — the bug was that stamps never *reached* it). The `N` "native flat opus" model is an unvalidated assumption, not measured native behavior. Treat as directional pending the executed test in #1670.
+
 ## Corpus
 
 - Stamped specs: **8**

--- a/docs/evals/2026-07-09-1636-plan-format-corpus.md
+++ b/docs/evals/2026-07-09-1636-plan-format-corpus.md
@@ -1,0 +1,170 @@
+# Plan-Format Corpus Benchmark (#1636) — deterministic arm
+
+Runs the production `classifyTask` / `renderImplementerPrompt` over every stamped plan-format spec in `docs/specs/`. Compares three arms: **E** (exarchos, plan-honoring) · **H** (heuristic-only — the current #1636 dispatched behavior) · **N** (native flat model).
+
+## Corpus
+
+- Stamped specs: **9**
+- Tasks parsed: **100**
+- Tasks carrying a `riskTier` stamp: **100** (100%)
+- Tasks carrying an explicit `boundaryTouching` stamp: **63**
+
+## Dimension 1 — model & agent selection (arm E)
+
+Exarchos routes model via `classifyTaskCore` (scaffolding-keyword / testLayer / deps / file-count), **independent of `riskTier`**. Defaults: `scaffolder→haiku`, `implementer→opus`.
+
+- Agent mix: {"implementer":99,"scaffolder":1}
+- Model mix: {"opus":99,"haiku":1}
+- **vs native flat `opus`:** 1/100 tasks (1%) routed to the cheaper `haiku` — the cost saving from per-task routing.
+
+Model × risk-tier cross-tab (does the model track blast radius?):
+
+| risk tier | haiku | sonnet | opus |
+|---|---|---|---|
+| low | 0 | 0 | 6 |
+| medium | 0 | 0 | 49 |
+| high | 1 | 0 | 44 |
+
+- ⚠️ high-tier tasks on the cheap `haiku` model (possible under-powering): **1**
+- ⚠️ low-tier tasks on the expensive `opus` model (possible over-powering): **6**
+
+## Dimension 2 — verification depth
+
+### E (plan-honoring) vs H0 (true production — `{id,title}` only) — the actual #1636 harm
+
+`registry.ts:1441` registers `tasks: z.array(z.object({ id, title }))`, so today every task reaches the classifier as `{id, title}` — no stamp, no files, no testLayer. This is what actually ships.
+
+- Tier **match**: **49/100** (49%)
+- Tier **UNDER-provisioned** (H0 weaker than plan): **45/100** (45%)  ← the harm
+- Tier over-provisioned: **6/100** (6%)
+- **`check_integration_suite` rung lost**: **45/100** (45%) — every planner-`high` task ships without the integration rung
+- **Boundary mock-steer lost**: **51/100** (51%)
+
+### E (plan-honoring) vs H1 (heuristic ceiling — files+testLayer, no stamp)
+
+Isolates the heuristic quality itself: even IF the orchestrator forwarded full task context (which the registry schema forbids), how well does the keyword/glob heuristic recover the plan tier?
+
+- Tier **match** (H agrees with plan): **51/100** (51%)
+- Tier **UNDER-provisioned** by heuristic (H weaker than plan): **8/100** (8%)  ← the harm
+- Tier **over-provisioned** by heuristic (H stronger than plan): **41/100** (41%)
+- **`check_integration_suite` rung lost** (E has it, H doesn't): **7/100** (7%)
+- **Boundary mock-steer lost** (plan boundary=true, heuristic=false): **49/100** (49%)
+- Boundary phantom (heuristic adds boundary the plan didn't): **0/100**
+
+Tier confusion (`plan→heuristic`):
+
+| plan → heuristic | count |
+|---|---|
+| high→high | 38 |
+| medium→high | 36 |
+| medium→medium | 12 |
+| high→medium ⚠️ under | 7 |
+| low→medium | 4 |
+| medium→low ⚠️ under | 1 |
+| low→high | 1 |
+| low→low | 1 |
+
+## Per-task detail
+
+| spec | task | files | plan tier | heur tier | Δtier | plan bnd | heur bnd | agent | model |
+|---|---|---|---|---|---|---|---|---|---|
+| rc1-closeout | 001 | 2 | medium | medium | = | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 002 | 2 | medium | medium | = | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 003 | 2 | low | medium | over | false | false | implementer | opus |
+| rc1-closeout | 004 | 2 | low | medium | over | false | false | implementer | opus |
+| rc1-closeout | 005 | 2 | medium | medium | = | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 006 | 1 | medium | high | over | false | false | implementer | opus |
+| rc1-closeout | 007 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 008 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 010 | 2 | medium | high | over | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 009 | 1 | medium | high | over | false | false | implementer | opus |
+| wlm-foundation | 001 | 2 | medium | high | over | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 002 | 4 | medium | high | over | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 003 | 4 | medium | high | over | false | false | implementer | opus |
+| wlm-foundation | 004 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 005 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 006 | 2 | medium | high | over | false | false | implementer | opus |
+| wlm-foundation | 007 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 008 | 4 | medium | high | over | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 009 | 1 | medium | low | ⚠️ under | true ⚠️ | false | implementer | opus |
+| wlm-operational-core | 001 | 4 | high | high | = | false | false | implementer | opus |
+| wlm-operational-core | 002 | 2 | medium | medium | = | false | false | implementer | opus |
+| wlm-operational-core | 003 | 2 | high | high | = | false | false | implementer | opus |
+| wlm-operational-core | 004 | 4 | high | high | = | false | false | implementer | opus |
+| wlm-operational-core | 005 | 2 | medium | medium | = | false | false | implementer | opus |
+| wlm-operational-core | 006 | 4 | high | high | = | false | false | implementer | opus |
+| wlm-operational-core | 007 | 3 | medium | high | over | false | false | implementer | opus |
+| wlm-operational-core | 008 | 2 | high | high | = | false | false | implementer | opus |
+| risk-verification-closeout | 001 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 002 | 7 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 003 | 2 | low | medium | over | false | false | implementer | opus |
+| risk-verification-closeout | 004 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 005 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 006 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 007 | 3 | medium | high | over | false | false | implementer | opus |
+| risk-verification-closeout | 008 | 3 | medium | high | over | false | false | implementer | opus |
+| risk-verification-closeout | 009 | 2 | medium | high | over | false | false | implementer | opus |
+| risk-verification-closeout | 010 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 011 | 0 | low | medium | over | false | false | implementer | opus |
+| harness-launcher | 001 | 3 | medium | high | over | false | false | implementer | opus |
+| harness-launcher | 002 | 3 | medium | high | over | false | false | implementer | opus |
+| harness-launcher | 003 | 2 | high | medium | ⚠️ under | true ⚠️ | false | scaffolder | haiku |
+| harness-launcher | 004 | 3 | medium | high | over | true | true | implementer | opus |
+| harness-launcher | 005 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-launcher | 006 | 5 | high | high | = | false | false | implementer | opus |
+| harness-launcher | 007 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| harness-launcher | 008 | 1 | medium | high | over | false | false | implementer | opus |
+| harness-launcher | 009 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| harness-launcher | 010 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-launcher | 011 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| harness-launcher | 012 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| harness-launcher | 013 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| harness-launcher | 014 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-launcher | 015 | 3 | high | high | = | false | false | implementer | opus |
+| harness-launcher | 016 | 3 | high | high | = | false | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 001 | 5 | medium | high | over | true ⚠️ | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 002 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 003 | 1 | medium | high | over | false | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 004 | 5 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 005 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 006 | 8 | medium | high | over | true ⚠️ | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 007 | 10 | medium | high | over | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 001 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 002 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 003 | 2 | medium | medium | = | false | false | implementer | opus |
+| wlm-reconcile-enforce | 004 | 3 | medium | high | over | false | false | implementer | opus |
+| wlm-reconcile-enforce | 005 | 5 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 007 | 8 | medium | high | over | false | false | implementer | opus |
+| wlm-reconcile-enforce | 008 | 1 | medium | medium | = | false | false | implementer | opus |
+| wlm-reconcile-enforce | 009 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 010 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 011 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 021 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 012 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 013 | 1 | medium | medium | = | false | false | implementer | opus |
+| wlm-reconcile-enforce | 014 | 3 | medium | high | over | false | false | implementer | opus |
+| wlm-reconcile-enforce | 015 | 2 | medium | medium | = | false | false | implementer | opus |
+| wlm-reconcile-enforce | 016 | 3 | medium | high | over | false | false | implementer | opus |
+| wlm-reconcile-enforce | 017 | 0 | low | high | over | false | false | implementer | opus |
+| wlm-reconcile-enforce | 018 | 2 | medium | medium | = | false | false | implementer | opus |
+| wlm-reconcile-enforce | 020 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 019 | 0 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 001 | 2 | medium | medium | = | false | false | implementer | opus |
+| harness-conform-and-shrink | 002 | 3 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 003 | 3 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 023 | 2 | medium | medium | = | false | false | implementer | opus |
+| harness-conform-and-shrink | 004 | 12 | high | high | = | false | false | implementer | opus |
+| harness-conform-and-shrink | 006 | 4 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 007 | 17 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 021 | 1 | low | low | = | false | false | implementer | opus |
+| harness-conform-and-shrink | 010 | 3 | medium | high | over | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 009 | 1 | high | high | = | false | false | implementer | opus |
+| harness-conform-and-shrink | 011 | 2 | medium | high | over | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 012 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 013 | 1 | medium | high | over | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 014 | 2 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 015 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 016 | 4 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 017 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 022 | 7 | medium | high | over | true | true | implementer | opus |
+| harness-conform-and-shrink | 018 | 2 | medium | high | over | false | false | implementer | opus |

--- a/docs/evals/2026-07-09-1636-plan-format-corpus.md
+++ b/docs/evals/2026-07-09-1636-plan-format-corpus.md
@@ -1,10 +1,10 @@
 # Plan-Format Corpus Benchmark (#1636) — deterministic arm
 
-Runs the production `classifyTask` / `renderImplementerPrompt` over every stamped plan-format spec in `docs/specs/`. Compares three arms: **E** (exarchos, plan-honoring) · **H** (heuristic-only — the current #1636 dispatched behavior) · **N** (native flat model).
+Runs the production `classifyTask` / `renderImplementerPrompt` over every stamped plan-format spec in `docs/specs/`. Arms: **E** (exarchos, plan-honoring — the fix) · **H0** (true production, `{id,title}` only — the current #1636 dispatched behavior) · **H1** (heuristic ceiling, files+testLayer but no stamp) · **N** (native flat model).
 
 ## Corpus
 
-- Stamped specs: **9**
+- Stamped specs: **8**
 - Tasks parsed: **100**
 - Tasks carrying a `riskTier` stamp: **100** (100%)
 - Tasks carrying an explicit `boundaryTouching` stamp: **63**
@@ -44,10 +44,10 @@ Model × risk-tier cross-tab (does the model track blast radius?):
 
 Isolates the heuristic quality itself: even IF the orchestrator forwarded full task context (which the registry schema forbids), how well does the keyword/glob heuristic recover the plan tier?
 
-- Tier **match** (H agrees with plan): **51/100** (51%)
-- Tier **UNDER-provisioned** by heuristic (H weaker than plan): **8/100** (8%)  ← the harm
-- Tier **over-provisioned** by heuristic (H stronger than plan): **41/100** (41%)
-- **`check_integration_suite` rung lost** (E has it, H doesn't): **7/100** (7%)
+- Tier **match** (H agrees with plan): **48/100** (48%)
+- Tier **UNDER-provisioned** by heuristic (H weaker than plan): **25/100** (25%)  ← the harm
+- Tier **over-provisioned** by heuristic (H stronger than plan): **27/100** (27%)
+- **`check_integration_suite` rung lost** (E has it, H doesn't): **24/100** (24%)
 - **Boundary mock-steer lost** (plan boundary=true, heuristic=false): **49/100** (49%)
 - Boundary phantom (heuristic adds boundary the plan didn't): **0/100**
 
@@ -55,13 +55,12 @@ Tier confusion (`plan→heuristic`):
 
 | plan → heuristic | count |
 |---|---|
-| high→high | 38 |
-| medium→high | 36 |
-| medium→medium | 12 |
-| high→medium ⚠️ under | 7 |
-| low→medium | 4 |
+| medium→medium | 26 |
+| high→medium ⚠️ under | 24 |
+| medium→high | 22 |
+| high→high | 21 |
+| low→medium | 5 |
 | medium→low ⚠️ under | 1 |
-| low→high | 1 |
 | low→low | 1 |
 
 ## Per-task detail
@@ -73,58 +72,58 @@ Tier confusion (`plan→heuristic`):
 | rc1-closeout | 003 | 2 | low | medium | over | false | false | implementer | opus |
 | rc1-closeout | 004 | 2 | low | medium | over | false | false | implementer | opus |
 | rc1-closeout | 005 | 2 | medium | medium | = | true ⚠️ | false | implementer | opus |
-| rc1-closeout | 006 | 1 | medium | high | over | false | false | implementer | opus |
-| rc1-closeout | 007 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
-| rc1-closeout | 008 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
-| rc1-closeout | 010 | 2 | medium | high | over | true ⚠️ | false | implementer | opus |
-| rc1-closeout | 009 | 1 | medium | high | over | false | false | implementer | opus |
+| rc1-closeout | 006 | 1 | medium | medium | = | false | false | implementer | opus |
+| rc1-closeout | 007 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 008 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 010 | 2 | medium | medium | = | true ⚠️ | false | implementer | opus |
+| rc1-closeout | 009 | 1 | medium | medium | = | false | false | implementer | opus |
 | wlm-foundation | 001 | 2 | medium | high | over | true ⚠️ | false | implementer | opus |
 | wlm-foundation | 002 | 4 | medium | high | over | true ⚠️ | false | implementer | opus |
 | wlm-foundation | 003 | 4 | medium | high | over | false | false | implementer | opus |
 | wlm-foundation | 004 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
-| wlm-foundation | 005 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
-| wlm-foundation | 006 | 2 | medium | high | over | false | false | implementer | opus |
-| wlm-foundation | 007 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 005 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| wlm-foundation | 006 | 2 | medium | medium | = | false | false | implementer | opus |
+| wlm-foundation | 007 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | wlm-foundation | 008 | 4 | medium | high | over | true ⚠️ | false | implementer | opus |
 | wlm-foundation | 009 | 1 | medium | low | ⚠️ under | true ⚠️ | false | implementer | opus |
 | wlm-operational-core | 001 | 4 | high | high | = | false | false | implementer | opus |
 | wlm-operational-core | 002 | 2 | medium | medium | = | false | false | implementer | opus |
-| wlm-operational-core | 003 | 2 | high | high | = | false | false | implementer | opus |
+| wlm-operational-core | 003 | 2 | high | medium | ⚠️ under | false | false | implementer | opus |
 | wlm-operational-core | 004 | 4 | high | high | = | false | false | implementer | opus |
 | wlm-operational-core | 005 | 2 | medium | medium | = | false | false | implementer | opus |
 | wlm-operational-core | 006 | 4 | high | high | = | false | false | implementer | opus |
 | wlm-operational-core | 007 | 3 | medium | high | over | false | false | implementer | opus |
-| wlm-operational-core | 008 | 2 | high | high | = | false | false | implementer | opus |
-| risk-verification-closeout | 001 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
-| risk-verification-closeout | 002 | 7 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-operational-core | 008 | 2 | high | medium | ⚠️ under | false | false | implementer | opus |
+| risk-verification-closeout | 001 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 002 | 6 | high | high | = | true ⚠️ | false | implementer | opus |
 | risk-verification-closeout | 003 | 2 | low | medium | over | false | false | implementer | opus |
-| risk-verification-closeout | 004 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
-| risk-verification-closeout | 005 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
-| risk-verification-closeout | 006 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
-| risk-verification-closeout | 007 | 3 | medium | high | over | false | false | implementer | opus |
-| risk-verification-closeout | 008 | 3 | medium | high | over | false | false | implementer | opus |
-| risk-verification-closeout | 009 | 2 | medium | high | over | false | false | implementer | opus |
-| risk-verification-closeout | 010 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 004 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 005 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 006 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| risk-verification-closeout | 007 | 2 | medium | medium | = | false | false | implementer | opus |
+| risk-verification-closeout | 008 | 2 | medium | medium | = | false | false | implementer | opus |
+| risk-verification-closeout | 009 | 1 | medium | medium | = | false | false | implementer | opus |
+| risk-verification-closeout | 010 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | risk-verification-closeout | 011 | 0 | low | medium | over | false | false | implementer | opus |
 | harness-launcher | 001 | 3 | medium | high | over | false | false | implementer | opus |
 | harness-launcher | 002 | 3 | medium | high | over | false | false | implementer | opus |
 | harness-launcher | 003 | 2 | high | medium | ⚠️ under | true ⚠️ | false | scaffolder | haiku |
 | harness-launcher | 004 | 3 | medium | high | over | true | true | implementer | opus |
-| harness-launcher | 005 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-launcher | 005 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | harness-launcher | 006 | 5 | high | high | = | false | false | implementer | opus |
 | harness-launcher | 007 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
-| harness-launcher | 008 | 1 | medium | high | over | false | false | implementer | opus |
+| harness-launcher | 008 | 1 | medium | medium | = | false | false | implementer | opus |
 | harness-launcher | 009 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | harness-launcher | 010 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
 | harness-launcher | 011 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | harness-launcher | 012 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | harness-launcher | 013 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
-| harness-launcher | 014 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| harness-launcher | 014 | 1 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | harness-launcher | 015 | 3 | high | high | = | false | false | implementer | opus |
 | harness-launcher | 016 | 3 | high | high | = | false | false | implementer | opus |
 | wlm-6-surface-and-workflow-fixes | 001 | 5 | medium | high | over | true ⚠️ | false | implementer | opus |
-| wlm-6-surface-and-workflow-fixes | 002 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
-| wlm-6-surface-and-workflow-fixes | 003 | 1 | medium | high | over | false | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 002 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-6-surface-and-workflow-fixes | 003 | 1 | medium | medium | = | false | false | implementer | opus |
 | wlm-6-surface-and-workflow-fixes | 004 | 5 | high | high | = | true ⚠️ | false | implementer | opus |
 | wlm-6-surface-and-workflow-fixes | 005 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
 | wlm-6-surface-and-workflow-fixes | 006 | 8 | medium | high | over | true ⚠️ | false | implementer | opus |
@@ -137,34 +136,34 @@ Tier confusion (`plan→heuristic`):
 | wlm-reconcile-enforce | 007 | 8 | medium | high | over | false | false | implementer | opus |
 | wlm-reconcile-enforce | 008 | 1 | medium | medium | = | false | false | implementer | opus |
 | wlm-reconcile-enforce | 009 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
-| wlm-reconcile-enforce | 010 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 010 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | wlm-reconcile-enforce | 011 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
 | wlm-reconcile-enforce | 021 | 4 | high | high | = | true ⚠️ | false | implementer | opus |
-| wlm-reconcile-enforce | 012 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 012 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
 | wlm-reconcile-enforce | 013 | 1 | medium | medium | = | false | false | implementer | opus |
 | wlm-reconcile-enforce | 014 | 3 | medium | high | over | false | false | implementer | opus |
 | wlm-reconcile-enforce | 015 | 2 | medium | medium | = | false | false | implementer | opus |
 | wlm-reconcile-enforce | 016 | 3 | medium | high | over | false | false | implementer | opus |
-| wlm-reconcile-enforce | 017 | 0 | low | high | over | false | false | implementer | opus |
+| wlm-reconcile-enforce | 017 | 0 | low | medium | over | false | false | implementer | opus |
 | wlm-reconcile-enforce | 018 | 2 | medium | medium | = | false | false | implementer | opus |
-| wlm-reconcile-enforce | 020 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
-| wlm-reconcile-enforce | 019 | 0 | medium | high | over | false | false | implementer | opus |
+| wlm-reconcile-enforce | 020 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| wlm-reconcile-enforce | 019 | 0 | medium | medium | = | false | false | implementer | opus |
 | harness-conform-and-shrink | 001 | 2 | medium | medium | = | false | false | implementer | opus |
 | harness-conform-and-shrink | 002 | 3 | medium | high | over | false | false | implementer | opus |
 | harness-conform-and-shrink | 003 | 3 | medium | high | over | false | false | implementer | opus |
 | harness-conform-and-shrink | 023 | 2 | medium | medium | = | false | false | implementer | opus |
-| harness-conform-and-shrink | 004 | 12 | high | high | = | false | false | implementer | opus |
-| harness-conform-and-shrink | 006 | 4 | medium | high | over | false | false | implementer | opus |
-| harness-conform-and-shrink | 007 | 17 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 004 | 11 | high | high | = | false | false | implementer | opus |
+| harness-conform-and-shrink | 006 | 3 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 007 | 16 | medium | high | over | false | false | implementer | opus |
 | harness-conform-and-shrink | 021 | 1 | low | low | = | false | false | implementer | opus |
 | harness-conform-and-shrink | 010 | 3 | medium | high | over | true ⚠️ | false | implementer | opus |
-| harness-conform-and-shrink | 009 | 1 | high | high | = | false | false | implementer | opus |
-| harness-conform-and-shrink | 011 | 2 | medium | high | over | true ⚠️ | false | implementer | opus |
-| harness-conform-and-shrink | 012 | 2 | high | high | = | true ⚠️ | false | implementer | opus |
-| harness-conform-and-shrink | 013 | 1 | medium | high | over | true ⚠️ | false | implementer | opus |
-| harness-conform-and-shrink | 014 | 2 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 009 | 0 | high | medium | ⚠️ under | false | false | implementer | opus |
+| harness-conform-and-shrink | 011 | 2 | medium | medium | = | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 012 | 2 | high | medium | ⚠️ under | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 013 | 0 | medium | medium | = | true ⚠️ | false | implementer | opus |
+| harness-conform-and-shrink | 014 | 1 | medium | medium | = | false | false | implementer | opus |
 | harness-conform-and-shrink | 015 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
 | harness-conform-and-shrink | 016 | 4 | medium | high | over | false | false | implementer | opus |
 | harness-conform-and-shrink | 017 | 3 | high | high | = | true ⚠️ | false | implementer | opus |
 | harness-conform-and-shrink | 022 | 7 | medium | high | over | true | true | implementer | opus |
-| harness-conform-and-shrink | 018 | 2 | medium | high | over | false | false | implementer | opus |
+| harness-conform-and-shrink | 018 | 2 | medium | medium | = | false | false | implementer | opus |

--- a/docs/evals/quality-ab/ANALYSIS.md
+++ b/docs/evals/quality-ab/ANALYSIS.md
@@ -15,42 +15,50 @@ verification regime the agent is dispatched under:
   hermetic fixtures."
 - **Arm N (native):** no verification steer — "implement it."
 
-Two self-contained tasks, each with a spec + stub shown to the agent and a
-**hidden oracle** (a comprehensive edge-case suite the agent never sees), used
-only at grade time:
+Three self-contained tasks, each with a spec + stub shown to the agent and a
+**hidden oracle** (a comprehensive edge-case suite the agent never sees, each
+validated against a correct reference), used only at grade time:
 
-| task | tier | why it's a good probe |
-|---|---|---|
-| `TokenBucket` | high · boundary | injected-clock seam; lazy proportional refill, cap, all-or-nothing consume, no-partial-on-failure, fractional accrual across reads |
-| `parseDuration` | medium | the `ms`-vs-`m` trap, multi-segment sums, strict rejection of malformed input |
+| task | tier | model | why it's a good probe |
+|---|---|---|---|
+| `TokenBucket` | high · boundary | opus | injected-clock seam; lazy proportional refill, cap, all-or-nothing consume, no-partial-on-failure, fractional accrual across reads |
+| `parseDuration` | medium | opus | the `ms`-vs-`m` trap, multi-segment sums, strict rejection of malformed input |
+| `csvParseLine` | high · boundary | **sonnet** | RFC-4180 quoting/escaping traps (commas-in-quotes, `""` escaping, junk-after-quote errors); a *discriminating* round — a harder task on a **weaker model**, the condition under which a verification-correctness delta should appear if one exists |
 
-2 replicates per (task, arm) = **8 live agent runs**. Graded on: hidden-oracle
-pass rate (correctness / spec-conformance), strict `tsc` (type errors), and
-whether the agent produced durable tests (behavioral). See `RESULTS.md` /
-`results.json`; produced code is under `runs/`.
+**14 live agent runs** total (2–3 replicates per task×arm). Graded on: hidden-oracle
+pass rate (correctness / spec-conformance), strict `tsc` (type errors, `es2022`
+lib), and whether the agent produced durable tests (behavioral). See `RESULTS.md`
+/ `results.json`; produced code is under `runs/`.
 
 ## Results
 
-| task | arm | mean oracle pass rate | typecheck ok | durable tests |
-|---|---|---|---|---|
-| parse-duration | E | **100%** | 2/2 | **2/2** |
-| parse-duration | N | **100%** | 2/2 | 0/2 |
-| token-bucket | E | **100%** | 2/2 | **2/2** |
-| token-bucket | N | **100%** | 2/2 | 0/2 |
+| task | model | arm | mean oracle pass rate | typecheck ok | durable tests |
+|---|---|---|---|---|---|
+| token-bucket | opus | E | **100%** | 2/2 | **2/2** |
+| token-bucket | opus | N | **100%** | 2/2 | 0/2 |
+| parse-duration | opus | E | **100%** | 2/2 | **2/2** |
+| parse-duration | opus | N | **100%** | 2/2 | 0/2 |
+| csv-line | sonnet | E | **100%** | 3/3 | **3/3** |
+| csv-line | sonnet | N | **100%** | 3/3 | 0/3 |
 
-Two clear signals:
+Two clear signals, robust across **2 models × 3 tasks × 14 runs**:
 
-1. **Correctness: no delta.** Every run — both arms, both tasks — passed 100% of
-   the hidden oracle and typechecked clean. On well-specified tasks, a strong
-   model (opus) produced fully correct code *with or without* the verification
-   steer. The edge cases these tasks turn on (the `ms`/`m` distinction,
-   no-partial-consume, fractional refill) were handled unprompted.
+1. **Correctness: no delta.** Every run — both arms, all three tasks — passed 100%
+   of the hidden oracle and typechecked clean. This holds even in the
+   *discriminating* round: the weaker model (sonnet) on the trickiest task
+   (CSV quoting/escaping) still produced fully correct code in **both** arms. The
+   traps these tasks turn on (the `ms`/`m` distinction, no-partial-consume,
+   fractional refill, commas-inside-quotes, `""` escaping, junk-after-quote) were
+   handled unprompted — every Arm-N agent wrote a proper single-pass parser, not
+   the naive `split(',')` failure mode.
 
-2. **Process: a large, consistent delta.** Every Arm-E run produced a **durable
-   test file** and ran an explicit **kill-probe / mutation check** (from the agent
-   reports: *"all 27 tests fail against a constant-42 stub"*, *"an always-true
-   mutant fails 23 of them"*). No Arm-N run left a durable test behind; where N
-   agents tested at all it was ephemeral scratch they deleted. 4/4 vs 0/4.
+2. **Process: a large, consistent delta.** Every Arm-E run (7/7) produced a
+   **durable test file** and ran an explicit **kill-probe / mutation check** (from
+   the agent reports: *"all 27 tests fail against a constant-42 stub"*, *"an
+   always-true mutant fails 23 of them"*, *"three explicit kill-probes asserting
+   the output is not the naive/stub result"*). No Arm-N run (0/7) left a durable
+   test behind; where N agents tested at all it was ephemeral scratch they
+   deleted. **7/7 vs 0/7.**
 
 ## Interpretation — where the pipeline's value actually is (and isn't)
 
@@ -79,21 +87,29 @@ optimizer. The theoretical basis (tier-scaled verification) holds in the sense
 that E agents did more/deeper verification; the practical payoff shows up as test
 durability, and did not (here) change whether the code was right the first time.
 
-## Limitations (this is a pilot, read it as directional)
+## Limitations & what the null does / doesn't establish
 
-- **n is small:** 2 tasks × 2 arms × 2 replicates. Not statistically powered.
-- **Correctness ceiling:** both tasks were well-specified enough that N scored
-  100%, so they cannot *discriminate* on correctness — a 100/100 tie is consistent
-  with "no effect" AND with "tasks too easy." The informative next step is
-  **under-specified / adversarial tasks** (ambiguous specs, non-obvious edge cases,
-  hostile inputs) where a hasty impl plausibly misses cases the "cover the edge
-  cases" steer would catch — that is the condition under which a correctness delta,
-  if it exists, would appear.
-- **Single model (opus).** A weaker/cheaper model may depend on the steer more —
-  worth a model-crossed run, which also directly tests the Phase-0 model-routing
-  question (does haiku-on-scaffolding hold quality?).
-- The kill-probe was *self-reported* by the E agents, not independently run by the
-  grader. A stronger harness would run the diff-scoped mutation gate on each impl.
+- **n is small:** 14 runs, 2–3 replicates per cell. Directional, not statistically
+  powered — but the correctness result is a *unanimous* 14/14, not a narrow margin.
+- **Two candidate explanations for the correctness null were tested and rejected:**
+  "tasks too easy" (the CSV round is a genuinely trap-laden parser) and "model too
+  strong" (sonnet is materially weaker than opus). Both still tied at 100/100. So
+  the null is not simply an artifact of easy tasks or a strong model.
+- **The remaining untested discriminator is spec COMPLETENESS, not difficulty.**
+  All three specs *fully enumerate* their edge cases (rules + worked examples), so
+  both arms had only to *implement to spec* — and a competent model does that
+  without a verification steer. The steer says "cover the edge cases / write tests
+  that can fail"; that has correctness value only when the edge cases must be
+  **discovered**, i.e. on **under-specified** tasks (ambiguous or silent on the
+  corners). That is the one condition this study did not probe and the natural
+  next experiment.
+- **The kill-probe was self-reported** by the E agents, not independently run by
+  the grader. A stronger harness would run the diff-scoped mutation gate on each
+  produced impl to score test adequacy mechanically.
+- **Durable-tests is a proxy** for "the pipeline's verification actually happened":
+  N agents did test (ephemerally) but discarded it, so the metric captures
+  *durable coverage left behind*, which is the thing with regression value — but it
+  under-counts N's transient testing.
 
 ## Reproduce
 

--- a/docs/evals/quality-ab/ANALYSIS.md
+++ b/docs/evals/quality-ab/ANALYSIS.md
@@ -1,0 +1,104 @@
+# Does the verification pipeline improve generated-code quality? (empirical, #1636)
+
+Companion to the deterministic corpus benchmark (`../2026-07-09-1636-plan-format-corpus.md`).
+This is the **live A/B** that the deterministic arm cannot speak to: it actually
+generates code under two regimes and measures the result.
+
+## Design
+
+Same task, same environment, same model. The **only** variable is the
+verification regime the agent is dispatched under:
+
+- **Arm E (exarchos):** the verbatim production `renderImplementerPrompt`
+  tier-selected verification note — "cover the behavior with focused tests that
+  can actually fail; kill-probe mindset; (high tier) exercise the seam; (boundary)
+  hermetic fixtures."
+- **Arm N (native):** no verification steer — "implement it."
+
+Two self-contained tasks, each with a spec + stub shown to the agent and a
+**hidden oracle** (a comprehensive edge-case suite the agent never sees), used
+only at grade time:
+
+| task | tier | why it's a good probe |
+|---|---|---|
+| `TokenBucket` | high · boundary | injected-clock seam; lazy proportional refill, cap, all-or-nothing consume, no-partial-on-failure, fractional accrual across reads |
+| `parseDuration` | medium | the `ms`-vs-`m` trap, multi-segment sums, strict rejection of malformed input |
+
+2 replicates per (task, arm) = **8 live agent runs**. Graded on: hidden-oracle
+pass rate (correctness / spec-conformance), strict `tsc` (type errors), and
+whether the agent produced durable tests (behavioral). See `RESULTS.md` /
+`results.json`; produced code is under `runs/`.
+
+## Results
+
+| task | arm | mean oracle pass rate | typecheck ok | durable tests |
+|---|---|---|---|---|
+| parse-duration | E | **100%** | 2/2 | **2/2** |
+| parse-duration | N | **100%** | 2/2 | 0/2 |
+| token-bucket | E | **100%** | 2/2 | **2/2** |
+| token-bucket | N | **100%** | 2/2 | 0/2 |
+
+Two clear signals:
+
+1. **Correctness: no delta.** Every run — both arms, both tasks — passed 100% of
+   the hidden oracle and typechecked clean. On well-specified tasks, a strong
+   model (opus) produced fully correct code *with or without* the verification
+   steer. The edge cases these tasks turn on (the `ms`/`m` distinction,
+   no-partial-consume, fractional refill) were handled unprompted.
+
+2. **Process: a large, consistent delta.** Every Arm-E run produced a **durable
+   test file** and ran an explicit **kill-probe / mutation check** (from the agent
+   reports: *"all 27 tests fail against a constant-42 stub"*, *"an always-true
+   mutant fails 23 of them"*). No Arm-N run left a durable test behind; where N
+   agents tested at all it was ephemeral scratch they deleted. 4/4 vs 0/4.
+
+## Interpretation — where the pipeline's value actually is (and isn't)
+
+The verification pipeline is **not** what makes a capable model *correct on a
+well-specified task* — that null is robust here. Its measurable effect is on
+**process durability**: it reliably converts a throwaray one-shot into durable
+regression tests plus an adversarial self-check. That value accrues over time (a
+covered contract that catches the *next* change), not in the one-shot correctness
+of the initial implementation.
+
+This lines up with the deterministic arm's findings on the *other* dimensions:
+
+- **Model selection** (Phase 0): exarchos routes 99/100 corpus tasks to the same
+  `implementer/opus` a native flat run would use — ≈0 differentiation, and the one
+  downgrade was miscalibrated (a high-tier task sent to cheap haiku). No evidence
+  it helps.
+- **Verification depth** (Phase 0): the value is real but *latent* — pre-#1636 the
+  plan's tier never reached dispatch, so 45/100 tasks shipped under-provisioned.
+  The fix makes the depth actually track the plan; this A/B shows what that depth
+  buys (durable tests + kill-probe), which is regression protection, not one-shot
+  correctness.
+
+**Bottom line:** on this evidence the pipeline earns its keep as a *durable-test /
+regression-protection* mechanism, not as a one-shot correctness or model-cost
+optimizer. The theoretical basis (tier-scaled verification) holds in the sense
+that E agents did more/deeper verification; the practical payoff shows up as test
+durability, and did not (here) change whether the code was right the first time.
+
+## Limitations (this is a pilot, read it as directional)
+
+- **n is small:** 2 tasks × 2 arms × 2 replicates. Not statistically powered.
+- **Correctness ceiling:** both tasks were well-specified enough that N scored
+  100%, so they cannot *discriminate* on correctness — a 100/100 tie is consistent
+  with "no effect" AND with "tasks too easy." The informative next step is
+  **under-specified / adversarial tasks** (ambiguous specs, non-obvious edge cases,
+  hostile inputs) where a hasty impl plausibly misses cases the "cover the edge
+  cases" steer would catch — that is the condition under which a correctness delta,
+  if it exists, would appear.
+- **Single model (opus).** A weaker/cheaper model may depend on the steer more —
+  worth a model-crossed run, which also directly tests the Phase-0 model-routing
+  question (does haiku-on-scaffolding hold quality?).
+- The kill-probe was *self-reported* by the E agents, not independently run by the
+  grader. A stronger harness would run the diff-scoped mutation gate on each impl.
+
+## Reproduce
+
+```bash
+# 1. set up run dirs (SPEC.md + stub) outside the repo, dispatch agents per arm
+# 2. grade the produced impls against the hidden oracles:
+tsx docs/evals/quality-ab/grade.ts <runsBaseDir>
+```

--- a/docs/evals/quality-ab/ANALYSIS.md
+++ b/docs/evals/quality-ab/ANALYSIS.md
@@ -1,5 +1,13 @@
 # Does the verification pipeline improve generated-code quality? (empirical, #1636)
 
+> ⚠️ **PROVISIONAL — do not treat these as validated conclusions. Superseded by #1670.**
+> This A/B **never ran exarchos**: it pasted the production verification note into a
+> generic subagent, so it measures the *note's* effect, not the pipeline/binary. All
+> tasks are **fully specified**, so both arms tie at 100% simply by implementing to
+> spec — the correctness null cannot discriminate here. The properly-executed test
+> (real binary before/after, a *measured* native baseline via headless Claude Code, and
+> under-specified tasks) is tracked in **#1670**. Read the below as directional.
+
 Companion to the deterministic corpus benchmark (`../2026-07-09-1636-plan-format-corpus.md`).
 This is the **live A/B** that the deterministic arm cannot speak to: it actually
 generates code under two regimes and measures the result.

--- a/docs/evals/quality-ab/RESULTS.md
+++ b/docs/evals/quality-ab/RESULTS.md
@@ -1,0 +1,25 @@
+# Quality A/B — pilot results (#1636 Phase 2)
+
+Same task, same env, same model. The only variable is the verification regime: **E** = the production `renderImplementerPrompt` tier-selected verification note; **N** = none (bare "implement it"). `impl.ts` graded against a HIDDEN oracle the agent never saw, plus strict `tsc`.
+
+## Per-run
+
+| run | oracle | typecheck | wrote tests | key failures |
+|---|---|---|---|---|
+| parse-duration__E__r1 | 21/21 | ✓ | ✓ |  |
+| parse-duration__E__r2 | 21/21 | ✓ | ✓ |  |
+| parse-duration__N__r1 | 21/21 | ✓ | ✗ |  |
+| parse-duration__N__r2 | 21/21 | ✓ | ✗ |  |
+| token-bucket__E__r1 | 9/9 | ✓ | ✓ |  |
+| token-bucket__E__r2 | 9/9 | ✓ | ✓ |  |
+| token-bucket__N__r1 | 9/9 | ✓ | ✗ |  |
+| token-bucket__N__r2 | 9/9 | ✓ | ✗ |  |
+
+## Aggregate (task × arm)
+
+| task | arm | runs | mean oracle pass rate | typecheck ok | wrote tests |
+|---|---|---|---|---|---|
+| parse-duration | E | 2 | 100% | 2/2 | 2/2 |
+| parse-duration | N | 2 | 100% | 2/2 | 0/2 |
+| token-bucket | E | 2 | 100% | 2/2 | 2/2 |
+| token-bucket | N | 2 | 100% | 2/2 | 0/2 |

--- a/docs/evals/quality-ab/RESULTS.md
+++ b/docs/evals/quality-ab/RESULTS.md
@@ -6,6 +6,12 @@ Same task, same env, same model. The only variable is the verification regime: *
 
 | run | oracle | typecheck | wrote tests | key failures |
 |---|---|---|---|---|
+| csv-line__E__r1 | 21/21 | ✓ | ✓ |  |
+| csv-line__E__r2 | 21/21 | ✓ | ✓ |  |
+| csv-line__E__r3 | 21/21 | ✓ | ✓ |  |
+| csv-line__N__r1 | 21/21 | ✓ | ✗ |  |
+| csv-line__N__r2 | 21/21 | ✓ | ✗ |  |
+| csv-line__N__r3 | 21/21 | ✓ | ✗ |  |
 | parse-duration__E__r1 | 21/21 | ✓ | ✓ |  |
 | parse-duration__E__r2 | 21/21 | ✓ | ✓ |  |
 | parse-duration__N__r1 | 21/21 | ✓ | ✗ |  |
@@ -19,6 +25,8 @@ Same task, same env, same model. The only variable is the verification regime: *
 
 | task | arm | runs | mean oracle pass rate | typecheck ok | wrote tests |
 |---|---|---|---|---|---|
+| csv-line | E | 3 | 100% | 3/3 | 3/3 |
+| csv-line | N | 3 | 100% | 3/3 | 0/3 |
 | parse-duration | E | 2 | 100% | 2/2 | 2/2 |
 | parse-duration | N | 2 | 100% | 2/2 | 0/2 |
 | token-bucket | E | 2 | 100% | 2/2 | 2/2 |

--- a/docs/evals/quality-ab/RESULTS.md
+++ b/docs/evals/quality-ab/RESULTS.md
@@ -2,6 +2,8 @@
 
 Same task, same env, same model. The only variable is the verification regime: **E** = the production `renderImplementerPrompt` tier-selected verification note; **N** = none (bare "implement it"). `impl.ts` graded against a HIDDEN oracle the agent never saw, plus strict `tsc`.
 
+> ⚠️ **PROVISIONAL — does not run exarchos (#1670).** The verification note was pasted into a generic subagent; the exarchos binary/pipeline was never executed, and all tasks are fully specified (so both arms tie at 100% by implementing-to-spec). Directional only — the executed test + under-specified tasks live in #1670.
+
 ## Per-run
 
 | run | oracle | typecheck | wrote tests | key failures |

--- a/docs/evals/quality-ab/grade.ts
+++ b/docs/evals/quality-ab/grade.ts
@@ -12,6 +12,15 @@
 //   - wroteTests      — did the agent leave its own test file? (behavioral)
 //
 // Run: tsx docs/evals/quality-ab/grade.ts <baseRunsDir> [tasksDir]
+//
+// ⚠️ ORACLE ISOLATION (eval integrity). The hidden oracles under `tasks/*/oracle.ts`
+// are the answer key. They are committed for GRADE-TIME reproducibility only — an
+// agent under test MUST run in a workspace that does NOT contain them, or it can
+// read the answers. This harness enforces that by construction: run dirs are seeded
+// with ONLY `SPEC.md` + the `impl.ts` stub, and the oracle is copied in (and removed
+// again) here at grade time. NEVER dispatch an agent from the repo checkout or any
+// dir that includes `tasks/*/oracle.ts`. CI-only / out-of-repo oracle storage is the
+// durable hardening — tracked in #1670.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import * as fs from 'node:fs';

--- a/docs/evals/quality-ab/grade.ts
+++ b/docs/evals/quality-ab/grade.ts
@@ -70,7 +70,14 @@ function countOracleChecks(oraclePath: string): number {
 
 function gradeTypecheck(runDir: string): boolean {
   try {
-    execFileSync(TSC, ['--noEmit', '--strict', '--skipLibCheck', 'impl.ts'], { cwd: runDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    // Realistic target/lib (es2022) matching the repo — a bare `tsc` defaults to
+    // an ES5 lib and rejects modern-but-valid TS (private fields, sticky regex,
+    // etc.), which would be a grader artifact rather than an impl defect.
+    execFileSync(
+      TSC,
+      ['--noEmit', '--strict', '--skipLibCheck', '--target', 'es2022', '--lib', 'es2022', 'impl.ts'],
+      { cwd: runDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    );
     return true;
   } catch {
     return false;

--- a/docs/evals/quality-ab/grade.ts
+++ b/docs/evals/quality-ab/grade.ts
@@ -1,0 +1,153 @@
+// ─── Quality A/B grader (#1636 Phase 2) ──────────────────────────────────────
+//
+// Grades each produced `impl.ts` against its task's HIDDEN oracle + strict tsc.
+// Runs are directories named `<task>__<arm>__r<rep>` under the base dir; each
+// holds the arm's final `impl.ts`. The oracle is copied in ONLY at grade time
+// (the agent never saw it).
+//
+// Metrics per run:
+//   - oraclePassRate  — fraction of hidden edge-case checks the impl passes
+//                       (correctness / spec-conformance)
+//   - typecheckOk     — `tsc --noEmit --strict` clean on impl.ts (errors)
+//   - wroteTests      — did the agent leave its own test file? (behavioral)
+//
+// Run: tsx docs/evals/quality-ab/grade.ts <baseRunsDir> [tasksDir]
+// ─────────────────────────────────────────────────────────────────────────────
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+const TSX = path.join(REPO_ROOT, 'node_modules/.bin/tsx');
+const TSC = path.join(REPO_ROOT, 'node_modules/.bin/tsc');
+
+const baseDir = process.argv[2];
+const tasksDir = process.argv[3] ?? path.join(__dirname, 'tasks');
+if (!baseDir) {
+  console.error('usage: tsx grade.ts <baseRunsDir> [tasksDir]');
+  process.exit(2);
+}
+
+interface RunResult {
+  run: string;
+  task: string;
+  arm: string;
+  rep: string;
+  oraclePassed: number;
+  oracleTotal: number;
+  oracleFailures: string[];
+  typecheckOk: boolean;
+  wroteTests: boolean;
+  error?: string;
+}
+
+function gradeOracle(runDir: string, task: string): Pick<RunResult, 'oraclePassed' | 'oracleTotal' | 'oracleFailures' | 'error'> {
+  const oracleSrc = path.join(tasksDir, task, 'oracle.ts');
+  fs.copyFileSync(oracleSrc, path.join(runDir, 'oracle.ts'));
+  try {
+    const out = execFileSync(TSX, ['oracle.ts'], { cwd: runDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const line = out.trim().split('\n').filter(Boolean).pop() ?? '{}';
+    const parsed = JSON.parse(line) as { passed: number; total: number; failures: string[] };
+    return { oraclePassed: parsed.passed, oracleTotal: parsed.total, oracleFailures: parsed.failures };
+  } catch (err) {
+    // Oracle crashed (missing export, runtime throw, syntax error) → 0 correct.
+    const total = countOracleChecks(oracleSrc);
+    const msg = err instanceof Error ? (err as Error & { stderr?: string }).stderr ?? err.message : String(err);
+    return { oraclePassed: 0, oracleTotal: total, oracleFailures: ['oracle could not run against impl'], error: String(msg).split('\n').slice(0, 3).join(' ') };
+  }
+}
+
+function countOracleChecks(oraclePath: string): number {
+  // Best-effort count of `['...', () => ...]` entries for a denominator when the
+  // oracle can't run at all.
+  const src = fs.readFileSync(oraclePath, 'utf-8');
+  const m = src.match(/\[\s*'[^']+',\s*\(\)\s*=>/g);
+  return m ? m.length : 0;
+}
+
+function gradeTypecheck(runDir: string): boolean {
+  try {
+    execFileSync(TSC, ['--noEmit', '--strict', '--skipLibCheck', 'impl.ts'], { cwd: runDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectTests(runDir: string): boolean {
+  return fs
+    .readdirSync(runDir)
+    .some((f) => f !== 'oracle.ts' && f !== 'impl.ts' && f !== 'SPEC.md' && /\.(test|spec)\.[tj]s$|(^|[^a-z])test[^a-z]/i.test(f));
+}
+
+const runDirs = fs
+  .readdirSync(baseDir)
+  .filter((d) => /__[EN]__r\d+$/.test(d) && fs.statSync(path.join(baseDir, d)).isDirectory());
+
+const results: RunResult[] = [];
+for (const run of runDirs) {
+  const runDir = path.join(baseDir, run);
+  const [task, arm, repRaw] = run.split('__');
+  const rep = repRaw.replace(/^r/, '');
+  const oracle = gradeOracle(runDir, task);
+  results.push({
+    run,
+    task,
+    arm,
+    rep,
+    ...oracle,
+    typecheckOk: gradeTypecheck(runDir),
+    wroteTests: detectTests(runDir),
+  });
+}
+
+results.sort((a, b) => a.run.localeCompare(b.run));
+
+// Aggregate by task × arm.
+type Agg = { runs: number; oracleRate: number; typecheckOk: number; wroteTests: number };
+const agg: Record<string, Agg> = {};
+for (const r of results) {
+  const key = `${r.task}::${r.arm}`;
+  const a = (agg[key] ??= { runs: 0, oracleRate: 0, typecheckOk: 0, wroteTests: 0 });
+  a.runs++;
+  a.oracleRate += r.oracleTotal > 0 ? r.oraclePassed / r.oracleTotal : 0;
+  a.typecheckOk += r.typecheckOk ? 1 : 0;
+  a.wroteTests += r.wroteTests ? 1 : 0;
+}
+
+const lines: string[] = [];
+lines.push('# Quality A/B — pilot results (#1636 Phase 2)');
+lines.push('');
+lines.push('Same task, same env, same model. The only variable is the verification regime: **E** = the production `renderImplementerPrompt` tier-selected verification note; **N** = none (bare "implement it"). `impl.ts` graded against a HIDDEN oracle the agent never saw, plus strict `tsc`.');
+lines.push('');
+lines.push('## Per-run');
+lines.push('');
+lines.push('| run | oracle | typecheck | wrote tests | key failures |');
+lines.push('|---|---|---|---|---|');
+for (const r of results) {
+  const rate = `${r.oraclePassed}/${r.oracleTotal}`;
+  const fails = r.oracleFailures.slice(0, 2).join('; ').slice(0, 80);
+  lines.push(`| ${r.run} | ${rate} | ${r.typecheckOk ? '✓' : '✗'} | ${r.wroteTests ? '✓' : '✗'} | ${fails} |`);
+}
+lines.push('');
+lines.push('## Aggregate (task × arm)');
+lines.push('');
+lines.push('| task | arm | runs | mean oracle pass rate | typecheck ok | wrote tests |');
+lines.push('|---|---|---|---|---|---|');
+for (const key of Object.keys(agg).sort()) {
+  const [task, arm] = key.split('::');
+  const a = agg[key];
+  lines.push(`| ${task} | ${arm} | ${a.runs} | ${((a.oracleRate / a.runs) * 100).toFixed(0)}% | ${a.typecheckOk}/${a.runs} | ${a.wroteTests}/${a.runs} |`);
+}
+lines.push('');
+
+const report = lines.join('\n');
+const outMd = path.join(__dirname, 'RESULTS.md');
+const outJson = path.join(__dirname, 'results.json');
+fs.writeFileSync(outMd, report);
+fs.writeFileSync(outJson, JSON.stringify({ results, agg }, null, 2));
+process.stdout.write(report + '\n');
+process.stdout.write(`\n[written] ${path.relative(REPO_ROOT, outMd)}\n[written] ${path.relative(REPO_ROOT, outJson)}\n`);

--- a/docs/evals/quality-ab/grade.ts
+++ b/docs/evals/quality-ab/grade.ts
@@ -46,7 +46,8 @@ interface RunResult {
 
 function gradeOracle(runDir: string, task: string): Pick<RunResult, 'oraclePassed' | 'oracleTotal' | 'oracleFailures' | 'error'> {
   const oracleSrc = path.join(tasksDir, task, 'oracle.ts');
-  fs.copyFileSync(oracleSrc, path.join(runDir, 'oracle.ts'));
+  const oracleDst = path.join(runDir, 'oracle.ts');
+  fs.copyFileSync(oracleSrc, oracleDst);
   try {
     const out = execFileSync(TSX, ['oracle.ts'], { cwd: runDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
     const line = out.trim().split('\n').filter(Boolean).pop() ?? '{}';
@@ -57,6 +58,9 @@ function gradeOracle(runDir: string, task: string): Pick<RunResult, 'oraclePasse
     const total = countOracleChecks(oracleSrc);
     const msg = err instanceof Error ? (err as Error & { stderr?: string }).stderr ?? err.message : String(err);
     return { oraclePassed: 0, oracleTotal: total, oracleFailures: ['oracle could not run against impl'], error: String(msg).split('\n').slice(0, 3).join(' ') };
+  } finally {
+    // Don't leave the hidden oracle behind in the run dir.
+    fs.rmSync(oracleDst, { force: true });
   }
 }
 

--- a/docs/evals/quality-ab/grade.ts
+++ b/docs/evals/quality-ab/grade.ts
@@ -134,6 +134,8 @@ lines.push('# Quality A/B — pilot results (#1636 Phase 2)');
 lines.push('');
 lines.push('Same task, same env, same model. The only variable is the verification regime: **E** = the production `renderImplementerPrompt` tier-selected verification note; **N** = none (bare "implement it"). `impl.ts` graded against a HIDDEN oracle the agent never saw, plus strict `tsc`.');
 lines.push('');
+lines.push('> ⚠️ **PROVISIONAL — does not run exarchos (#1670).** The verification note was pasted into a generic subagent; the exarchos binary/pipeline was never executed, and all tasks are fully specified (so both arms tie at 100% by implementing-to-spec). Directional only — the executed test + under-specified tasks live in #1670.');
+lines.push('');
 lines.push('## Per-run');
 lines.push('');
 lines.push('| run | oracle | typecheck | wrote tests | key failures |');

--- a/docs/evals/quality-ab/results.json
+++ b/docs/evals/quality-ab/results.json
@@ -1,0 +1,118 @@
+{
+  "results": [
+    {
+      "run": "parse-duration__E__r1",
+      "task": "parse-duration",
+      "arm": "E",
+      "rep": "1",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": true
+    },
+    {
+      "run": "parse-duration__E__r2",
+      "task": "parse-duration",
+      "arm": "E",
+      "rep": "2",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": true
+    },
+    {
+      "run": "parse-duration__N__r1",
+      "task": "parse-duration",
+      "arm": "N",
+      "rep": "1",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": false
+    },
+    {
+      "run": "parse-duration__N__r2",
+      "task": "parse-duration",
+      "arm": "N",
+      "rep": "2",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": false
+    },
+    {
+      "run": "token-bucket__E__r1",
+      "task": "token-bucket",
+      "arm": "E",
+      "rep": "1",
+      "oraclePassed": 9,
+      "oracleTotal": 9,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": true
+    },
+    {
+      "run": "token-bucket__E__r2",
+      "task": "token-bucket",
+      "arm": "E",
+      "rep": "2",
+      "oraclePassed": 9,
+      "oracleTotal": 9,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": true
+    },
+    {
+      "run": "token-bucket__N__r1",
+      "task": "token-bucket",
+      "arm": "N",
+      "rep": "1",
+      "oraclePassed": 9,
+      "oracleTotal": 9,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": false
+    },
+    {
+      "run": "token-bucket__N__r2",
+      "task": "token-bucket",
+      "arm": "N",
+      "rep": "2",
+      "oraclePassed": 9,
+      "oracleTotal": 9,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": false
+    }
+  ],
+  "agg": {
+    "parse-duration::E": {
+      "runs": 2,
+      "oracleRate": 2,
+      "typecheckOk": 2,
+      "wroteTests": 2
+    },
+    "parse-duration::N": {
+      "runs": 2,
+      "oracleRate": 2,
+      "typecheckOk": 2,
+      "wroteTests": 0
+    },
+    "token-bucket::E": {
+      "runs": 2,
+      "oracleRate": 2,
+      "typecheckOk": 2,
+      "wroteTests": 2
+    },
+    "token-bucket::N": {
+      "runs": 2,
+      "oracleRate": 2,
+      "typecheckOk": 2,
+      "wroteTests": 0
+    }
+  }
+}

--- a/docs/evals/quality-ab/results.json
+++ b/docs/evals/quality-ab/results.json
@@ -1,6 +1,72 @@
 {
   "results": [
     {
+      "run": "csv-line__E__r1",
+      "task": "csv-line",
+      "arm": "E",
+      "rep": "1",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": true
+    },
+    {
+      "run": "csv-line__E__r2",
+      "task": "csv-line",
+      "arm": "E",
+      "rep": "2",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": true
+    },
+    {
+      "run": "csv-line__E__r3",
+      "task": "csv-line",
+      "arm": "E",
+      "rep": "3",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": true
+    },
+    {
+      "run": "csv-line__N__r1",
+      "task": "csv-line",
+      "arm": "N",
+      "rep": "1",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": false
+    },
+    {
+      "run": "csv-line__N__r2",
+      "task": "csv-line",
+      "arm": "N",
+      "rep": "2",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": false
+    },
+    {
+      "run": "csv-line__N__r3",
+      "task": "csv-line",
+      "arm": "N",
+      "rep": "3",
+      "oraclePassed": 21,
+      "oracleTotal": 21,
+      "oracleFailures": [],
+      "typecheckOk": true,
+      "wroteTests": false
+    },
+    {
       "run": "parse-duration__E__r1",
       "task": "parse-duration",
       "arm": "E",
@@ -90,6 +156,18 @@
     }
   ],
   "agg": {
+    "csv-line::E": {
+      "runs": 3,
+      "oracleRate": 3,
+      "typecheckOk": 3,
+      "wroteTests": 3
+    },
+    "csv-line::N": {
+      "runs": 3,
+      "oracleRate": 3,
+      "typecheckOk": 3,
+      "wroteTests": 0
+    },
     "parse-duration::E": {
       "runs": 2,
       "oracleRate": 2,

--- a/docs/evals/quality-ab/runs/csv-line__E__r1/impl.ts
+++ b/docs/evals/quality-ab/runs/csv-line__E__r1/impl.ts
@@ -1,0 +1,75 @@
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[] {
+  const fields: string[] = [];
+  const n = line.length;
+  let i = 0;
+
+  while (true) {
+    if (i < n && line[i] === '"') {
+      // Quoted field: skip opening quote, accumulate until an unescaped closing quote.
+      i++;
+      let value = '';
+      let closed = false;
+
+      while (i < n) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (i + 1 < n && line[i + 1] === '"') {
+            // Escaped quote (`""` -> `"`).
+            value += '"';
+            i += 2;
+          } else {
+            // Closing quote.
+            i++;
+            closed = true;
+            break;
+          }
+        } else {
+          value += ch;
+          i++;
+        }
+      }
+
+      if (!closed) {
+        throw new Error(`Unterminated quoted field at position ${i}`);
+      }
+
+      // After the closing quote, the next character must be a comma or end of line.
+      if (i >= n) {
+        fields.push(value);
+        break;
+      }
+      if (line[i] !== ',') {
+        throw new Error(
+          `Malformed CSV: unexpected character after closing quote at position ${i}`,
+        );
+      }
+      fields.push(value);
+      i++; // consume comma
+      if (i === n) {
+        // Trailing comma yields a trailing empty field.
+        fields.push('');
+        break;
+      }
+      continue;
+    }
+
+    // Unquoted field: literal text up to the next comma or end of line.
+    const start = i;
+    while (i < n && line[i] !== ',') {
+      i++;
+    }
+    fields.push(line.slice(start, i));
+
+    if (i >= n) {
+      break;
+    }
+    i++; // consume comma
+    if (i === n) {
+      fields.push('');
+      break;
+    }
+  }
+
+  return fields;
+}

--- a/docs/evals/quality-ab/runs/csv-line__E__r1/test.ts
+++ b/docs/evals/quality-ab/runs/csv-line__E__r1/test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { csvParseLine } from './impl.ts';
+
+let passed = 0;
+function check(actual: unknown, expected: unknown, label: string): void {
+  assert.deepEqual(actual, expected, label);
+  passed++;
+}
+
+function checkThrows(fn: () => void, label: string): void {
+  assert.throws(fn, Error, label);
+  passed++;
+}
+
+// --- Examples straight from SPEC.md ---
+check(csvParseLine('a,b,c'), ['a', 'b', 'c'], 'simple unquoted fields');
+check(csvParseLine('a,,c'), ['a', '', 'c'], 'empty middle field');
+check(csvParseLine('"a,b",c'), ['a,b', 'c'], 'quoted field containing a comma');
+check(csvParseLine('"a""b"'), ['a"b'], 'escaped quote inside quoted field');
+check(csvParseLine('a"b'), ['a"b'], 'unquoted field with embedded quote (not at start)');
+check(csvParseLine('"hi",,"x,y"'), ['hi', '', 'x,y'], 'mixed quoted/empty/quoted-with-comma');
+
+// --- Empty-field rules ---
+check(csvParseLine(''), [''], 'empty line yields single empty field');
+check(csvParseLine('a,'), ['a', ''], 'trailing comma yields trailing empty field');
+check(csvParseLine(','), ['', ''], 'lone comma yields two empty fields');
+check(csvParseLine('"a",,"b"'), ['a', '', 'b'], 'empty field flanked by quoted fields');
+
+// --- Quoting / escaping edge cases ---
+check(csvParseLine('""'), [''], 'empty quoted field');
+check(csvParseLine('"a"'), ['a'], 'single quoted field, no trailing comma/other fields');
+check(csvParseLine('""""'), ['"'], 'quoted field containing a single escaped quote only');
+check(csvParseLine('"a""""b"'), ['a""b'], 'two consecutive escaped quotes inside a field');
+check(csvParseLine('" "'), [' '], 'quoted field preserves interior whitespace');
+check(csvParseLine(' "a"'), [' "a"'], 'leading space makes the field unquoted (literal)');
+check(csvParseLine('a,"b,c",d'), ['a', 'b,c', 'd'], 'quoted comma field sandwiched by unquoted fields');
+check(
+  csvParseLine('"a""b","c""""d"'),
+  ['a"b', 'c""d'],
+  'multiple quoted fields each with internal escaped quotes',
+);
+check(csvParseLine('a,b,'), ['a', 'b', ''], 'trailing comma after multiple unquoted fields');
+check(csvParseLine('"a,b,c"'), ['a,b,c'], 'single quoted field containing multiple commas');
+check(csvParseLine('a b,c d'), ['a b', 'c d'], 'unquoted fields preserve internal whitespace');
+
+// --- Malformed input: must throw ---
+checkThrows(() => csvParseLine('"abc'), 'unterminated quoted field throws');
+checkThrows(() => csvParseLine('"a"b'), 'junk between closing quote and comma throws');
+checkThrows(() => csvParseLine('"a"b,c'), 'junk after closing quote before later comma throws');
+checkThrows(() => csvParseLine('a,"bc'), 'unterminated quote in second field throws');
+checkThrows(() => csvParseLine('"a""'), 'trailing lone quote after escape leaves field unterminated');
+checkThrows(() => csvParseLine('"a" extra text'), 'trailing junk with spaces after closing quote throws');
+
+// --- Kill-probe style checks: verify the function actually distinguishes cases ---
+// A field starting with a quote must strip the quotes (not return them verbatim).
+assert.notDeepEqual(csvParseLine('"a"'), ['"a"'], 'quotes must be stripped, not left literal');
+passed++;
+// A field NOT starting with a quote must NOT strip a quote appearing later.
+assert.notDeepEqual(csvParseLine('a"'), ['a'], 'quote must remain literal in unquoted field');
+passed++;
+// Escaped quote must collapse to one quote, not remain as two.
+assert.notDeepEqual(csvParseLine('"a""b"'), ['a""b'], 'escaped "" must collapse to a single quote');
+passed++;
+
+console.log(`All ${passed} checks passed.`);

--- a/docs/evals/quality-ab/runs/csv-line__E__r2/impl.test.ts
+++ b/docs/evals/quality-ab/runs/csv-line__E__r2/impl.test.ts
@@ -1,0 +1,105 @@
+import { csvParseLine } from './impl.ts';
+
+let passed = 0;
+let failed = 0;
+
+function assertEqual(actual: unknown, expected: unknown, label: string): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    passed++;
+    console.log(`PASS: ${label}`);
+  } else {
+    failed++;
+    console.error(`FAIL: ${label}\n  expected: ${e}\n  actual:   ${a}`);
+  }
+}
+
+function assertThrows(fn: () => void, label: string): void {
+  try {
+    fn();
+    failed++;
+    console.error(`FAIL: ${label} (expected throw, none occurred)`);
+  } catch (err) {
+    if (err instanceof Error) {
+      passed++;
+      console.log(`PASS: ${label} (threw: ${err.message})`);
+    } else {
+      failed++;
+      console.error(`FAIL: ${label} (threw non-Error)`);
+    }
+  }
+}
+
+// --- Spec examples ---
+assertEqual(csvParseLine('a,b,c'), ['a', 'b', 'c'], 'simple unquoted fields');
+assertEqual(csvParseLine('a,,c'), ['a', '', 'c'], 'empty field in middle');
+assertEqual(csvParseLine('"a,b",c'), ['a,b', 'c'], 'quoted field containing comma');
+assertEqual(csvParseLine('"a""b"'), ['a"b'], 'escaped quote inside quoted field');
+assertEqual(csvParseLine('a"b'), ['a"b'], 'unquoted field with embedded quote (literal)');
+assertEqual(
+  csvParseLine('"hi",,"x,y"'),
+  ['hi', '', 'x,y'],
+  'mix of quoted, empty, and quoted-with-comma fields'
+);
+
+// --- Additional rule coverage ---
+assertEqual(csvParseLine(''), [''], 'empty string yields single empty field');
+assertEqual(csvParseLine('a,'), ['a', ''], 'trailing comma yields trailing empty field');
+assertEqual(csvParseLine(','), ['', ''], 'lone comma yields two empty fields');
+assertEqual(csvParseLine('"a,,b"'), ['a,,b'], 'quoted field with multiple internal commas');
+assertEqual(csvParseLine('""'), [''], 'empty quoted field');
+assertEqual(csvParseLine('"",""'), ['', ''], 'two empty quoted fields');
+assertEqual(
+  csvParseLine('"a""""b"'),
+  ['a""b'],
+  'consecutive escaped quotes inside a quoted field'
+);
+assertEqual(
+  csvParseLine('""""'),
+  ['"'],
+  'quoted field that is only an escaped quote'
+);
+assertEqual(
+  csvParseLine('  a  , b '),
+  ['  a  ', ' b '],
+  'unquoted field preserves surrounding whitespace literally'
+);
+assertEqual(
+  csvParseLine('a,"b,c",d'),
+  ['a', 'b,c', 'd'],
+  'quoted field mid-record surrounded by unquoted fields'
+);
+assertEqual(
+  csvParseLine('"a"'),
+  ['a'],
+  'single quoted field, no trailing comma'
+);
+assertEqual(
+  csvParseLine('a,b,'),
+  ['a', 'b', ''],
+  'trailing comma after multiple fields'
+);
+assertEqual(
+  csvParseLine('"only","quoted","fields"'),
+  ['only', 'quoted', 'fields'],
+  'all-quoted record'
+);
+
+// --- Error cases ---
+assertThrows(() => csvParseLine('"abc'), 'unterminated quoted field throws');
+assertThrows(() => csvParseLine('"a"b'), 'junk after closing quote before end throws');
+assertThrows(() => csvParseLine('"a","b"c,d'), 'junk after closing quote before comma throws');
+assertThrows(() => csvParseLine('"'), 'lone opening quote throws');
+assertThrows(() => csvParseLine('a,"b'), 'unterminated quote in later field throws');
+
+// --- Kill-probe style checks: verify the two hallmark quoting behaviors independently ---
+// A naive "split on comma" implementation would break this: comma inside quotes must NOT split.
+assertEqual(csvParseLine('"a,b"').length, 1, 'quoted comma does not create extra field (length check)');
+// A naive implementation with no unescape would keep the doubled quote.
+assertEqual(csvParseLine('"""a"""'), ['"a"'], 'quote-wrapped field with escaped quotes at both ends');
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/docs/evals/quality-ab/runs/csv-line__E__r2/impl.ts
+++ b/docs/evals/quality-ab/runs/csv-line__E__r2/impl.ts
@@ -1,0 +1,76 @@
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[] {
+  const fields: string[] = [];
+  const n = line.length;
+  let i = 0;
+
+  while (true) {
+    if (i < n && line[i] === '"') {
+      // Quoted field.
+      i++; // consume opening quote
+      let value = '';
+      let closed = false;
+
+      while (i < n) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (i + 1 < n && line[i + 1] === '"') {
+            // Escaped quote.
+            value += '"';
+            i += 2;
+            continue;
+          }
+          // Closing quote.
+          i++;
+          closed = true;
+          break;
+        }
+        value += ch;
+        i++;
+      }
+
+      if (!closed) {
+        throw new Error(`Unterminated quoted field at position ${i}`);
+      }
+
+      if (i < n) {
+        if (line[i] === ',') {
+          fields.push(value);
+          i++;
+          if (i === n) {
+            fields.push('');
+            break;
+          }
+          continue;
+        }
+        throw new Error(
+          `Malformed CSV: unexpected character after closing quote at position ${i}`
+        );
+      }
+
+      // End of line right after the closing quote.
+      fields.push(value);
+      break;
+    }
+
+    // Unquoted field: literal up to the next comma or end of line.
+    const start = i;
+    while (i < n && line[i] !== ',') {
+      i++;
+    }
+    const value = line.slice(start, i);
+    fields.push(value);
+
+    if (i < n && line[i] === ',') {
+      i++;
+      if (i === n) {
+        fields.push('');
+        break;
+      }
+      continue;
+    }
+    break;
+  }
+
+  return fields;
+}

--- a/docs/evals/quality-ab/runs/csv-line__E__r3/impl.test.ts
+++ b/docs/evals/quality-ab/runs/csv-line__E__r3/impl.test.ts
@@ -1,0 +1,104 @@
+import { csvParseLine } from './impl.ts';
+
+let passed = 0;
+let failed = 0;
+
+function assertEqual(actual: unknown, expected: unknown, label: string): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    passed++;
+    console.log(`PASS: ${label}`);
+  } else {
+    failed++;
+    console.error(`FAIL: ${label}\n  expected: ${e}\n  actual:   ${a}`);
+  }
+}
+
+function assertThrows(fn: () => void, label: string): void {
+  try {
+    fn();
+    failed++;
+    console.error(`FAIL: ${label} (expected throw, but none occurred)`);
+  } catch (e) {
+    if (e instanceof Error) {
+      passed++;
+      console.log(`PASS: ${label} (threw: ${e.message})`);
+    } else {
+      failed++;
+      console.error(`FAIL: ${label} (threw non-Error: ${String(e)})`);
+    }
+  }
+}
+
+// --- Spec examples ---
+assertEqual(csvParseLine('a,b,c'), ['a', 'b', 'c'], 'simple fields');
+assertEqual(csvParseLine('a,,c'), ['a', '', 'c'], 'empty middle field');
+assertEqual(csvParseLine('"a,b",c'), ['a,b', 'c'], 'quoted field with comma');
+assertEqual(csvParseLine('"a""b"'), ['a"b'], 'escaped quote inside quoted field');
+assertEqual(csvParseLine('a"b'), ['a"b'], 'unquoted literal quote mid-field');
+assertEqual(
+  csvParseLine('"hi",,"x,y"'),
+  ['hi', '', 'x,y'],
+  'mixed quoted/empty/quoted-with-comma',
+);
+
+// --- Basic structural rules ---
+assertEqual(csvParseLine('a,'), ['a', ''], 'trailing comma yields trailing empty field');
+assertEqual(csvParseLine(''), [''], 'empty string yields single empty field');
+assertEqual(csvParseLine(','), ['', ''], 'lone comma yields two empty fields');
+assertEqual(csvParseLine('a,b,'), ['a', 'b', ''], 'trailing comma after multiple fields');
+assertEqual(csvParseLine(',a'), ['', 'a'], 'leading comma yields leading empty field');
+
+// --- Quoting/escaping edge cases ---
+assertEqual(csvParseLine('""'), [''], 'empty quoted field');
+assertEqual(csvParseLine('"a"'), ['a'], 'simple quoted field, no special chars');
+assertEqual(csvParseLine('""""'), ['"'], 'quoted field containing a single escaped quote');
+assertEqual(
+  csvParseLine('"a""""b"'),
+  ['a""b'],
+  'quoted field with two consecutive escaped quotes',
+);
+assertEqual(
+  csvParseLine('"a","b""c",d'),
+  ['a', 'b"c', 'd'],
+  'quoted field with escape among plain fields',
+);
+assertEqual(
+  csvParseLine('"","",""'),
+  ['', '', ''],
+  'three consecutive empty quoted fields',
+);
+assertEqual(
+  csvParseLine('"a\nb",c'),
+  ['a\nb', 'c'],
+  'quoted field may contain embedded newline literally',
+);
+assertEqual(
+  csvParseLine('"  a  ",b'),
+  ['  a  ', 'b'],
+  'whitespace inside quotes is preserved',
+);
+assertEqual(
+  csvParseLine('  a  ,b'),
+  ['  a  ', 'b'],
+  'whitespace in unquoted field is preserved literally',
+);
+assertEqual(
+  csvParseLine('a"b,c"d'),
+  ['a"b', 'c"d'],
+  'quote not at start of field is literal, per-field',
+);
+// --- Error cases ---
+assertThrows(() => csvParseLine('"abc'), 'unterminated quoted field throws');
+assertThrows(() => csvParseLine('""a'), 'junk immediately after empty quoted field throws');
+assertThrows(() => csvParseLine('"a"b'), 'junk between closing quote and next comma throws');
+assertThrows(() => csvParseLine('"a","b'), 'unterminated quoted field in later position throws');
+assertThrows(() => csvParseLine('"a"b,c'), 'junk after closing quote before comma throws');
+assertThrows(() => csvParseLine('a,"b'), 'unterminated quote after a valid first field throws');
+assertThrows(() => csvParseLine('"'), 'single lone quote character is unterminated');
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/docs/evals/quality-ab/runs/csv-line__E__r3/impl.ts
+++ b/docs/evals/quality-ab/runs/csv-line__E__r3/impl.ts
@@ -1,0 +1,79 @@
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[] {
+  const fields: string[] = [];
+  const n = line.length;
+  let i = 0;
+
+  for (;;) {
+    if (i < n && line[i] === '"') {
+      // Quoted field.
+      i++; // consume opening quote
+      let value = '';
+      let closed = false;
+
+      while (i < n) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (i + 1 < n && line[i + 1] === '"') {
+            // Escaped quote: "" -> literal "
+            value += '"';
+            i += 2;
+            continue;
+          }
+          // Closing quote.
+          i++;
+          closed = true;
+          break;
+        }
+        value += ch;
+        i++;
+      }
+
+      if (!closed) {
+        throw new Error(
+          `csvParseLine: unterminated quoted field in line: ${line}`,
+        );
+      }
+
+      if (i >= n) {
+        fields.push(value);
+        break;
+      }
+
+      if (line[i] === ',') {
+        fields.push(value);
+        i++;
+        if (i === n) {
+          // Trailing comma yields a trailing empty field.
+          fields.push('');
+          break;
+        }
+        continue;
+      }
+
+      throw new Error(
+        `csvParseLine: unexpected character after quoted field at position ${i} in line: ${line}`,
+      );
+    }
+
+    // Unquoted field: literal up to the next comma or end of line.
+    const start = i;
+    while (i < n && line[i] !== ',') {
+      i++;
+    }
+    fields.push(line.slice(start, i));
+
+    if (i < n && line[i] === ',') {
+      i++;
+      if (i === n) {
+        fields.push('');
+        break;
+      }
+      continue;
+    }
+
+    break;
+  }
+
+  return fields;
+}

--- a/docs/evals/quality-ab/runs/csv-line__N__r1/impl.ts
+++ b/docs/evals/quality-ab/runs/csv-line__N__r1/impl.ts
@@ -1,0 +1,69 @@
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[] {
+  const fields: string[] = [];
+  const n = line.length;
+  let i = 0;
+
+  while (true) {
+    if (line[i] === '"') {
+      // Quoted field: consume the opening quote, then scan until the
+      // matching (unescaped) closing quote, unescaping `""` to `"`.
+      i++;
+      let value = '';
+      let closed = false;
+      while (i < n) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (line[i + 1] === '"') {
+            value += '"';
+            i += 2;
+          } else {
+            i++;
+            closed = true;
+            break;
+          }
+        } else {
+          value += ch;
+          i++;
+        }
+      }
+      if (!closed) {
+        throw new Error(`Unterminated quoted field in CSV line: ${line}`);
+      }
+      if (i < n && line[i] !== ',') {
+        throw new Error(
+          `Malformed CSV: expected comma or end of line after closing quote ` +
+            `at position ${i} in line: ${line}`
+        );
+      }
+      fields.push(value);
+      if (i >= n) {
+        break;
+      }
+      // line[i] === ',' here.
+      i++;
+      if (i === n) {
+        fields.push('');
+        break;
+      }
+    } else {
+      // Unquoted field: taken literally up to the next comma or end of line.
+      const start = i;
+      while (i < n && line[i] !== ',') {
+        i++;
+      }
+      fields.push(line.slice(start, i));
+      if (i >= n) {
+        break;
+      }
+      // line[i] === ',' here.
+      i++;
+      if (i === n) {
+        fields.push('');
+        break;
+      }
+    }
+  }
+
+  return fields;
+}

--- a/docs/evals/quality-ab/runs/csv-line__N__r2/impl.ts
+++ b/docs/evals/quality-ab/runs/csv-line__N__r2/impl.ts
@@ -1,0 +1,61 @@
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[] {
+  const fields: string[] = [];
+  const n = line.length;
+  let i = 0;
+
+  for (;;) {
+    if (line.charAt(i) === '"') {
+      // Quoted field.
+      i++; // skip opening quote
+      let value = '';
+      let closed = false;
+
+      while (i < n) {
+        const ch = line.charAt(i);
+        if (ch === '"') {
+          if (line.charAt(i + 1) === '"') {
+            // Escaped quote.
+            value += '"';
+            i += 2;
+            continue;
+          }
+          // Closing quote.
+          i++;
+          closed = true;
+          break;
+        }
+        value += ch;
+        i++;
+      }
+
+      if (!closed) {
+        throw new Error(`Unterminated quoted field in CSV line: ${JSON.stringify(line)}`);
+      }
+
+      // After the closing quote, the next character must be a comma or the
+      // end of the line.
+      if (i < n && line.charAt(i) !== ',') {
+        throw new Error(
+          `Malformed CSV: expected comma or end of line after closing quote at index ${i} in ${JSON.stringify(line)}`,
+        );
+      }
+
+      fields.push(value);
+      if (i >= n) break;
+      i++; // consume the comma
+      continue;
+    }
+
+    // Unquoted field: literal text up to the next comma or end of line.
+    const start = i;
+    while (i < n && line.charAt(i) !== ',') {
+      i++;
+    }
+    fields.push(line.slice(start, i));
+    if (i >= n) break;
+    i++; // consume the comma
+  }
+
+  return fields;
+}

--- a/docs/evals/quality-ab/runs/csv-line__N__r3/impl.ts
+++ b/docs/evals/quality-ab/runs/csv-line__N__r3/impl.ts
@@ -1,0 +1,77 @@
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[] {
+  const fields: string[] = [];
+  const n = line.length;
+  let i = 0;
+
+  while (true) {
+    if (i < n && line[i] === '"') {
+      // Quoted field: consume the opening quote, then read until an
+      // unescaped closing quote, unescaping "" -> " along the way.
+      i++;
+      let value = '';
+      let closed = false;
+
+      while (i < n) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (i + 1 < n && line[i + 1] === '"') {
+            value += '"';
+            i += 2;
+            continue;
+          }
+          closed = true;
+          i++;
+          break;
+        }
+        value += ch;
+        i++;
+      }
+
+      if (!closed) {
+        throw new Error('Unterminated quoted field in CSV line');
+      }
+
+      if (i >= n) {
+        fields.push(value);
+        break;
+      }
+
+      if (line[i] !== ',') {
+        throw new Error(
+          `Malformed CSV: unexpected character after closing quote at position ${i}`
+        );
+      }
+
+      fields.push(value);
+      i++;
+      if (i === n) {
+        // Trailing comma yields a trailing empty field.
+        fields.push('');
+        break;
+      }
+      continue;
+    }
+
+    // Unquoted field: literal text up to the next comma or end of line.
+    let value = '';
+    while (i < n && line[i] !== ',') {
+      value += line[i];
+      i++;
+    }
+    fields.push(value);
+
+    if (i < n && line[i] === ',') {
+      i++;
+      if (i === n) {
+        fields.push('');
+        break;
+      }
+      continue;
+    }
+
+    break;
+  }
+
+  return fields;
+}

--- a/docs/evals/quality-ab/runs/parse-duration__E__r1/impl.test.ts
+++ b/docs/evals/quality-ab/runs/parse-duration__E__r1/impl.test.ts
@@ -1,0 +1,65 @@
+import { parseDuration } from './impl.ts';
+
+let pass = 0;
+let fail = 0;
+
+function eq(label: string, actual: number, expected: number): void {
+  if (actual === expected) {
+    pass++;
+  } else {
+    fail++;
+    console.error(`FAIL ${label}: got ${actual}, expected ${expected}`);
+  }
+}
+
+function throws(label: string, fn: () => unknown): void {
+  try {
+    const r = fn();
+    fail++;
+    console.error(`FAIL ${label}: expected throw, got ${String(r)}`);
+  } catch {
+    pass++;
+  }
+}
+
+// Spec examples
+eq('500ms', parseDuration('500ms'), 500);
+eq('1s', parseDuration('1s'), 1000);
+eq('5m', parseDuration('5m'), 300000);
+eq('1h', parseDuration('1h'), 3600000);
+eq('1d', parseDuration('1d'), 86400000);
+eq('1h30m', parseDuration('1h30m'), 5400000);
+eq('1h30m15s', parseDuration('1h30m15s'), 5415000);
+
+// ms/m distinction is the crux
+eq('500m != 500ms', parseDuration('500m'), 500 * 60 * 1000);
+eq('multi with ms', parseDuration('1h30m15s250ms'), 5415000 + 250);
+eq('90m', parseDuration('90m'), 90 * 60 * 1000);
+
+// Whitespace ignored anywhere
+eq('1h 30m', parseDuration('1h 30m'), 5400000);
+eq('leading/trailing ws', parseDuration('  2d  '), 2 * 86400000);
+eq('interior ws in number', parseDuration('1 h 3 0 m'), 5400000);
+
+// Zero amounts
+eq('0s', parseDuration('0s'), 0);
+eq('0h0m0s', parseDuration('0h0m0s'), 0);
+
+// Order-independent sum (grammar is concatenation; still just a sum)
+eq('multi-digit', parseDuration('120s'), 120000);
+
+// Errors
+throws('empty', () => parseDuration(''));
+throws('only whitespace', () => parseDuration('   '));
+throws('number no unit', () => parseDuration('10'));
+throws('unknown unit', () => parseDuration('10x'));
+throws('trailing junk', () => parseDuration('1h30'));
+throws('leading junk', () => parseDuration('x1h'));
+throws('unit no number', () => parseDuration('ms'));
+throws('negative', () => parseDuration('-5s'));
+throws('decimal', () => parseDuration('1.5h'));
+throws('uppercase unit', () => parseDuration('5M'));
+throws('bare unit mid', () => parseDuration('1hm'));
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);

--- a/docs/evals/quality-ab/runs/parse-duration__E__r1/impl.ts
+++ b/docs/evals/quality-ab/runs/parse-duration__E__r1/impl.ts
@@ -1,0 +1,44 @@
+/** Parse a human duration string into a total number of milliseconds. */
+export function parseDuration(input: string): number {
+  const UNIT_MS: Record<string, number> = {
+    ms: 1,
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+
+  // Whitespace anywhere is ignored.
+  const cleaned = input.replace(/\s+/g, '');
+
+  if (cleaned.length === 0) {
+    throw new Error(`Invalid duration: empty input ${JSON.stringify(input)}`);
+  }
+
+  // Match <digits><unit> segments. `ms` must precede `m` in the alternation
+  // so "500ms" parses as milliseconds, not "500m" + trailing "s".
+  const segment = /(\d+)(ms|s|m|h|d)/y;
+
+  let total = 0;
+  let matched = false;
+  let lastIndex = 0;
+
+  segment.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = segment.exec(cleaned)) !== null) {
+    matched = true;
+    const amount = Number(match[1]);
+    const unit = match[2];
+    total += amount * UNIT_MS[unit];
+    lastIndex = segment.lastIndex;
+  }
+
+  // The sticky regex must have consumed the entire cleaned string; any
+  // leftover means an unrecognized unit, a number without a unit, or stray
+  // characters.
+  if (!matched || lastIndex !== cleaned.length) {
+    throw new Error(`Invalid duration: ${JSON.stringify(input)}`);
+  }
+
+  return total;
+}

--- a/docs/evals/quality-ab/runs/parse-duration__E__r2/impl.test.ts
+++ b/docs/evals/quality-ab/runs/parse-duration__E__r2/impl.test.ts
@@ -1,0 +1,67 @@
+import { parseDuration } from './impl.ts';
+
+let passed = 0;
+let failed = 0;
+
+function eq(label: string, got: number, want: number): void {
+  if (got === want) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`FAIL ${label}: got ${got}, want ${want}`);
+  }
+}
+
+function throws(label: string, fn: () => unknown): void {
+  try {
+    const r = fn();
+    failed++;
+    console.error(`FAIL ${label}: expected throw, got ${JSON.stringify(r)}`);
+  } catch {
+    passed++;
+  }
+}
+
+// Spec examples
+eq('500ms', parseDuration('500ms'), 500);
+eq('1s', parseDuration('1s'), 1000);
+eq('5m', parseDuration('5m'), 300000);
+eq('1h', parseDuration('1h'), 3600000);
+eq('1d', parseDuration('1d'), 86400000);
+eq('1h30m', parseDuration('1h30m'), 5400000);
+eq('1h30m15s', parseDuration('1h30m15s'), 5415000);
+
+// ms vs m distinction — the crux
+eq('500ms not minutes', parseDuration('500ms'), 500);
+eq('2m minutes', parseDuration('2m'), 120000);
+eq('1m1ms mixed', parseDuration('1m1ms'), 60001);
+eq('1ms1m order-independent sum', parseDuration('1ms1m'), 60001);
+
+// Whitespace ignored anywhere
+eq('1h 30m spaces', parseDuration('1h 30m'), 5400000);
+eq('leading/trailing/internal ws', parseDuration('  1h30m15s  '), 5415000);
+eq('tabs/newlines', parseDuration('1h\t30m\n15s'), 5415000);
+
+// Zero and multi-segment
+eq('0s', parseDuration('0s'), 0);
+eq('90m', parseDuration('90m'), 5400000);
+eq('all units', parseDuration('1d1h1m1s1ms'), 86400000 + 3600000 + 60000 + 1000 + 1);
+eq('repeated units sum', parseDuration('1h1h'), 7200000);
+
+// Errors
+throws('empty', () => parseDuration(''));
+throws('only whitespace', () => parseDuration('   '));
+throws('number no unit', () => parseDuration('10'));
+throws('unknown unit', () => parseDuration('10x'));
+throws('trailing garbage', () => parseDuration('1h30'));
+throws('leading garbage', () => parseDuration('x10s'));
+throws('unit no amount', () => parseDuration('h'));
+throws('bare ms no amount', () => parseDuration('ms'));
+throws('embedded garbage', () => parseDuration('1h!30m'));
+throws('negative', () => parseDuration('-5s'));
+throws('float', () => parseDuration('1.5s'));
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/docs/evals/quality-ab/runs/parse-duration__E__r2/impl.ts
+++ b/docs/evals/quality-ab/runs/parse-duration__E__r2/impl.ts
@@ -1,0 +1,46 @@
+/** Parse a human duration string into a total number of milliseconds. */
+export function parseDuration(input: string): number {
+  // Whitespace anywhere in the input is ignored.
+  const cleaned = input.replace(/\s+/g, '');
+
+  if (cleaned.length === 0) {
+    throw new Error('parseDuration: empty input');
+  }
+
+  const unitToMs: Record<string, number> = {
+    ms: 1,
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+
+  // Match one <amount><unit> segment at a time. `ms` must precede `m` in the
+  // alternation so "500ms" parses as milliseconds, not "500m" + leftover "s".
+  const segment = /(\d+)(ms|s|m|h|d)/y;
+
+  let total = 0;
+  let pos = 0;
+  let matched = false;
+
+  segment.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = segment.exec(cleaned)) !== null) {
+    matched = true;
+    const amountStr = match[1];
+    const unit = match[2];
+    const unitMs = unit === undefined ? undefined : unitToMs[unit];
+    if (amountStr === undefined || unitMs === undefined) {
+      throw new Error(`parseDuration: invalid segment: ${JSON.stringify(input)}`);
+    }
+    total += Number(amountStr) * unitMs;
+    pos = segment.lastIndex;
+  }
+
+  // The concatenation of segments must cover the entire cleaned input.
+  if (!matched || pos !== cleaned.length) {
+    throw new Error(`parseDuration: invalid duration string: ${JSON.stringify(input)}`);
+  }
+
+  return total;
+}

--- a/docs/evals/quality-ab/runs/parse-duration__N__r1/impl.ts
+++ b/docs/evals/quality-ab/runs/parse-duration__N__r1/impl.ts
@@ -1,0 +1,43 @@
+/** Parse a human duration string into a total number of milliseconds. */
+export function parseDuration(input: string): number {
+  // Whitespace anywhere is ignored.
+  const normalized = input.replace(/\s+/g, '');
+
+  if (normalized.length === 0) {
+    throw new Error(`Invalid duration: empty input`);
+  }
+
+  const unitToMs: Record<string, number> = {
+    ms: 1,
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+
+  // One or more <amount><unit> segments. `ms` must be tried before `s`/`m`.
+  const segmentPattern = /(\d+)(ms|s|m|h|d)/g;
+
+  let total = 0;
+  let lastIndex = 0;
+  let matched = false;
+
+  for (const match of normalized.matchAll(segmentPattern)) {
+    // Reject anything between the previous match and this one.
+    if (match.index !== lastIndex) {
+      throw new Error(`Invalid duration: ${input}`);
+    }
+    matched = true;
+    const amount = Number.parseInt(match[1], 10);
+    const unit = match[2];
+    total += amount * unitToMs[unit];
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Ensure the entire string was consumed by valid segments.
+  if (!matched || lastIndex !== normalized.length) {
+    throw new Error(`Invalid duration: ${input}`);
+  }
+
+  return total;
+}

--- a/docs/evals/quality-ab/runs/parse-duration__N__r2/impl.ts
+++ b/docs/evals/quality-ab/runs/parse-duration__N__r2/impl.ts
@@ -1,0 +1,39 @@
+/** Parse a human duration string into a total number of milliseconds. */
+export function parseDuration(input: string): number {
+  // Whitespace anywhere in the input is ignored.
+  const stripped = input.replace(/\s+/g, '');
+
+  if (stripped.length === 0) {
+    throw new Error(`Invalid duration: empty input`);
+  }
+
+  // Milliseconds per unit. `ms` must precede `s`/`m` in the alternation so the
+  // longer match wins (e.g. "500ms" is 500 milliseconds, not 500 minutes).
+  const unitMs: Record<string, number> = {
+    ms: 1,
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+
+  const segment = /(\d+)(ms|s|m|h|d)/y;
+  let total = 0;
+  let matched = false;
+
+  while (segment.lastIndex < stripped.length) {
+    const match = segment.exec(stripped);
+    if (match === null) {
+      throw new Error(`Invalid duration: ${JSON.stringify(input)}`);
+    }
+    matched = true;
+    const amount = Number(match[1]);
+    total += amount * unitMs[match[2]];
+  }
+
+  if (!matched) {
+    throw new Error(`Invalid duration: ${JSON.stringify(input)}`);
+  }
+
+  return total;
+}

--- a/docs/evals/quality-ab/runs/token-bucket__E__r1/impl.test.ts
+++ b/docs/evals/quality-ab/runs/token-bucket__E__r1/impl.test.ts
@@ -1,0 +1,157 @@
+import { TokenBucket, type Clock } from './impl.ts';
+
+/**
+ * Hermetic fake clock — a real collaborator across the injected seam.
+ * It honors the Clock contract (monotonic, non-decreasing, ms) and is the
+ * only time source the bucket ever sees.
+ */
+class FakeClock implements Clock {
+  private t: number;
+  constructor(start = 0) {
+    this.t = start;
+  }
+  now(): number {
+    return this.t;
+  }
+  /** Advance time by `ms` milliseconds (must be >= 0 to stay monotonic). */
+  advance(ms: number): void {
+    if (ms < 0) throw new Error('clock cannot go backwards');
+    this.t += ms;
+  }
+}
+
+let failures = 0;
+let count = 0;
+
+function check(name: string, cond: boolean): void {
+  count++;
+  if (!cond) {
+    failures++;
+    console.error(`  FAIL: ${name}`);
+  } else {
+    console.log(`  ok:   ${name}`);
+  }
+}
+
+function approx(a: number, b: number, eps = 1e-9): boolean {
+  return Math.abs(a - b) <= eps;
+}
+
+// 1. Bucket starts full: capacity=5 → can immediately remove 5, not 6.
+{
+  const clk = new FakeClock(1000);
+  const b = new TokenBucket(5, 10, clk);
+  check('starts full: can remove exactly capacity', b.tryRemove(5) === true);
+}
+{
+  const clk = new FakeClock(1000);
+  const b = new TokenBucket(5, 10, clk);
+  check('starts full: cannot remove capacity+1', b.tryRemove(6) === false);
+}
+
+// 2. Default count = 1.
+{
+  const clk = new FakeClock(0);
+  const b = new TokenBucket(2, 1, clk);
+  check('default removes 1 (first)', b.tryRemove() === true);
+  check('default removes 1 (second)', b.tryRemove() === true);
+  check('default fails when empty (no time passed)', b.tryRemove() === false);
+}
+
+// 3. Insufficient → false and consumes NOTHING.
+{
+  const clk = new FakeClock(0);
+  const b = new TokenBucket(3, 1, clk);
+  check('consume 2 of 3', b.tryRemove(2) === true);
+  // 1 token left, ask for 2 → false, must leave the 1 untouched.
+  check('reject 2 with only 1 left', b.tryRemove(2) === false);
+  check('the untouched token is still consumable', b.tryRemove(1) === true);
+  check('now truly empty', b.tryRemove(1) === false);
+}
+
+// 4. Continuous proportional refill across the clock seam.
+//    refillPerSec=2 → 0.5s later, 1 token returns.
+{
+  const clk = new FakeClock(0);
+  const b = new TokenBucket(10, 2, clk);
+  // Drain to empty.
+  check('drain 10', b.tryRemove(10) === true);
+  check('empty rejects 1', b.tryRemove(1) === false);
+  clk.advance(500); // 0.5s * 2/s = 1 token
+  check('after 500ms one token available', b.tryRemove(1) === true);
+  check('but not a second token', b.tryRemove(1) === false);
+}
+
+// 5. Fractional/partial refill accumulates precisely.
+{
+  const clk = new FakeClock(0);
+  const b = new TokenBucket(10, 4, clk); // 4 tokens/sec
+  check('drain 10 (frac test)', b.tryRemove(10) === true);
+  clk.advance(250); // 0.25s * 4 = 1.0 token
+  clk.advance(250); // another 1.0 → 2.0 total, proving refill isn't reset spuriously
+  check('two 250ms steps yield 2 tokens', b.tryRemove(2) === true);
+  check('no third token', b.tryRemove(1) === false);
+}
+
+// 6. Refill never exceeds capacity (over-long idle does not overfill).
+{
+  const clk = new FakeClock(0);
+  const b = new TokenBucket(3, 1000, clk);
+  check('drain 3', b.tryRemove(3) === true);
+  clk.advance(10_000); // would add 10000 tokens uncapped
+  check('cap holds: can take exactly capacity', b.tryRemove(3) === true);
+  check('cap holds: cannot take capacity+1', b.tryRemove(1) === false);
+}
+
+// 7. Request > capacity can NEVER succeed, even after long refill.
+{
+  const clk = new FakeClock(0);
+  const b = new TokenBucket(4, 100, clk);
+  clk.advance(1_000_000);
+  check('over-capacity request always false', b.tryRemove(5) === false);
+  // And it consumed nothing: full capacity still removable.
+  check('over-capacity request consumed nothing', b.tryRemove(4) === true);
+}
+
+// 8. Token count never goes negative + refill math sanity via a fractional
+//    balance that is not yet enough.
+{
+  const clk = new FakeClock(0);
+  const b = new TokenBucket(10, 2, clk); // 2/sec
+  check('drain 10 (neg test)', b.tryRemove(10) === true);
+  clk.advance(400); // 0.8 tokens — less than 1
+  check('0.8 tokens not enough for 1', b.tryRemove(1) === false);
+  clk.advance(100); // +0.2 → 1.0 exactly
+  check('reaching exactly 1.0 succeeds', b.tryRemove(1) === true);
+  check('back to empty, reject', b.tryRemove(1) === false);
+}
+
+// 9. Zero elapsed time between calls must not fabricate tokens.
+{
+  const clk = new FakeClock(42);
+  const b = new TokenBucket(2, 1000, clk);
+  check('drain 2', b.tryRemove(2) === true);
+  // No advance → same instant.
+  check('same instant: no free token', b.tryRemove(1) === false);
+}
+
+// 10. Direct arithmetic contract: after draining and advancing, the exact
+//     fractional balance is what the spec formula predicts.
+{
+  const clk = new FakeClock(0);
+  const refillPerSec = 3;
+  const b = new TokenBucket(20, refillPerSec, clk);
+  check('drain 20', b.tryRemove(20) === true);
+  const dtMs = 700;
+  clk.advance(dtMs);
+  const expected = (refillPerSec * dtMs) / 1000; // 2.1
+  check('formula: 2.1 tokens → can take floor 2', b.tryRemove(2) === true);
+  // 0.1 remains; taking 1 must fail.
+  check('formula: 0.1 remains, reject 1', b.tryRemove(1) === false);
+  check('formula sanity (approx)', approx(expected, 2.1));
+}
+
+console.log(`\n${count - failures}/${count} checks passed`);
+if (failures > 0) {
+  throw new Error(`${failures} FAILURES`);
+}

--- a/docs/evals/quality-ab/runs/token-bucket__E__r1/impl.ts
+++ b/docs/evals/quality-ab/runs/token-bucket__E__r1/impl.ts
@@ -1,0 +1,68 @@
+export interface Clock {
+  /** Current time in milliseconds (monotonic, non-decreasing). */
+  now(): number;
+}
+
+export class TokenBucket {
+  private tokens: number;
+  private lastRefillMs: number;
+
+  /**
+   * @param capacity      max tokens the bucket holds (> 0)
+   * @param refillPerSec  tokens added per second (> 0), continuous/proportional
+   * @param clock         injected time source (do NOT read wall-clock directly)
+   */
+  constructor(
+    private readonly capacity: number,
+    private readonly refillPerSec: number,
+    private readonly clock: Clock,
+  ) {
+    if (!(capacity > 0)) {
+      throw new Error('capacity must be > 0');
+    }
+    if (!(refillPerSec > 0)) {
+      throw new Error('refillPerSec must be > 0');
+    }
+    // Bucket starts full.
+    this.tokens = capacity;
+    this.lastRefillMs = clock.now();
+  }
+
+  /** Apply lazy, proportional refill for time elapsed since the last update. */
+  private refill(): void {
+    const nowMs = this.clock.now();
+    const elapsedMs = nowMs - this.lastRefillMs;
+    // Clock is monotonic/non-decreasing, but guard against zero/negative drift.
+    if (elapsedMs > 0) {
+      const added = (this.refillPerSec * elapsedMs) / 1000;
+      this.tokens = Math.min(this.capacity, this.tokens + added);
+    }
+    // Advance the marker so refill is not double-counted on the next call.
+    this.lastRefillMs = nowMs;
+  }
+
+  /**
+   * Attempt to remove `count` tokens (default 1, a positive integer).
+   * Returns true and consumes them if enough are available; otherwise returns
+   * false and consumes NOTHING.
+   */
+  tryRemove(count = 1): boolean {
+    if (!Number.isInteger(count) || count <= 0) {
+      throw new Error('count must be a positive integer');
+    }
+    // A request larger than capacity can never succeed.
+    if (count > this.capacity) {
+      // Still fold in elapsed refill so state stays consistent.
+      this.refill();
+      return false;
+    }
+
+    this.refill();
+
+    if (this.tokens >= count) {
+      this.tokens -= count;
+      return true;
+    }
+    return false;
+  }
+}

--- a/docs/evals/quality-ab/runs/token-bucket__E__r2/impl.test.ts
+++ b/docs/evals/quality-ab/runs/token-bucket__E__r2/impl.test.ts
@@ -1,0 +1,164 @@
+import { TokenBucket, type Clock } from './impl.ts';
+
+// Hermetic fake clock — a real collaborator across the injected time seam.
+// It honors the Clock contract (monotonic, non-decreasing ms) and is the only
+// time source the bucket sees. We advance it explicitly; no wall-clock leakage.
+class FakeClock implements Clock {
+  private ms: number;
+  constructor(startMs = 0) {
+    this.ms = startMs;
+  }
+  now(): number {
+    return this.ms;
+  }
+  advanceMs(delta: number): void {
+    if (delta < 0) throw new Error('FakeClock must not go backward');
+    this.ms += delta;
+  }
+  advanceSec(delta: number): void {
+    this.advanceMs(delta * 1000);
+  }
+}
+
+let passed = 0;
+let failed = 0;
+function check(name: string, cond: boolean): void {
+  if (cond) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`FAIL: ${name}`);
+  }
+}
+function approx(a: number, b: number, eps = 1e-9): boolean {
+  return Math.abs(a - b) <= eps;
+}
+
+// 1. Starts full: can drain exactly `capacity` at t0, next unit fails.
+{
+  const clk = new FakeClock(1000);
+  const b = new TokenBucket(5, 1, clk);
+  check('starts full: remove all capacity at once', b.tryRemove(5) === true);
+  check('empty after draining: 1 more fails', b.tryRemove(1) === false);
+}
+
+// 2. Default count is 1.
+{
+  const clk = new FakeClock();
+  const b = new TokenBucket(2, 1, clk);
+  check('default remove 1 #1', b.tryRemove() === true);
+  check('default remove 1 #2', b.tryRemove() === true);
+  check('default remove 1 #3 (empty)', b.tryRemove() === false);
+}
+
+// 3. No partial consumption on failure: a failed larger request leaves balance intact.
+{
+  const clk = new FakeClock();
+  const b = new TokenBucket(10, 1, clk);
+  check('drain to 3 left', b.tryRemove(7) === true);
+  check('request 5 (only 3) fails', b.tryRemove(5) === false);
+  // Balance untouched -> the 3 that remain are still fully spendable.
+  check('remaining 3 still fully available', b.tryRemove(3) === true);
+  check('now truly empty', b.tryRemove(1) === false);
+}
+
+// 4. Request > capacity can never succeed, even on a full bucket, and consumes nothing.
+{
+  const clk = new FakeClock();
+  const b = new TokenBucket(4, 1, clk);
+  check('over-capacity request fails on full bucket', b.tryRemove(5) === false);
+  check('full bucket untouched after over-cap request', b.tryRemove(4) === true);
+}
+
+// 5. Continuous/proportional refill across the real clock seam.
+{
+  const clk = new FakeClock();
+  const b = new TokenBucket(10, 2, clk); // 2 tokens/sec
+  check('drain full', b.tryRemove(10) === true);
+  check('empty right after drain', b.tryRemove(1) === false);
+  clk.advanceMs(500); // 0.5s * 2/s = 1 token
+  check('after 500ms exactly 1 token: remove 1 ok', b.tryRemove(1) === true);
+  check('after spending it, empty again', b.tryRemove(1) === false);
+  clk.advanceMs(1500); // 1.5s * 2/s = 3 tokens
+  check('after 1500ms: 3 available, 4 not', b.tryRemove(4) === false);
+  check('after 1500ms: 3 available', b.tryRemove(3) === true);
+}
+
+// 6. Fractional balances accumulate and are not lost between calls.
+{
+  const clk = new FakeClock();
+  const b = new TokenBucket(10, 1, clk); // 1 token/sec
+  check('drain full', b.tryRemove(10) === true);
+  clk.advanceMs(400); // +0.4
+  check('0.4 tokens: cannot remove 1', b.tryRemove(1) === false);
+  clk.advanceMs(400); // +0.4 -> 0.8
+  check('0.8 tokens: still cannot remove 1', b.tryRemove(1) === false);
+  clk.advanceMs(400); // +0.4 -> 1.2
+  check('1.2 tokens: can remove 1', b.tryRemove(1) === true);
+  // ~0.2 left now, cannot remove another whole token
+  check('~0.2 left: cannot remove 1', b.tryRemove(1) === false);
+}
+
+// 7. Refill never exceeds capacity (long idle does not overfill).
+{
+  const clk = new FakeClock();
+  const b = new TokenBucket(3, 5, clk); // huge refill rate
+  check('drain full', b.tryRemove(3) === true);
+  clk.advanceSec(1000); // would add 5000 tokens uncapped
+  check('capped at capacity: remove 3 ok', b.tryRemove(3) === true);
+  check('capped at capacity: not 4th (would exceed cap)', b.tryRemove(1) === false);
+}
+
+// 8. Balance never goes negative and refill anchors from consumption, not idle time.
+{
+  const clk = new FakeClock();
+  const b = new TokenBucket(2, 1, clk);
+  check('remove 2 ok', b.tryRemove(2) === true);
+  clk.advanceMs(999); // +0.999, still < 1
+  check('0.999: cannot remove 1 (no negative, no round-up)', b.tryRemove(1) === false);
+  clk.advanceMs(1); // -> 1.0 exactly
+  check('exactly 1.0: remove 1 ok', b.tryRemove(1) === true);
+}
+
+// 9. Monotonic-but-stalled clock (delta 0) is a no-op refill.
+{
+  const clk = new FakeClock(50);
+  const b = new TokenBucket(5, 10, clk);
+  b.tryRemove(5);
+  // No time advance between calls.
+  check('no time passed: still empty', b.tryRemove(1) === false);
+  check('no time passed: still empty (repeat)', b.tryRemove(1) === false);
+}
+
+// 10. Cross-seam integration: interleave consumption and refill many times,
+// tracking an independent oracle balance to confirm the contract end-to-end.
+{
+  const clk = new FakeClock();
+  const capacity = 100;
+  const rate = 3; // tokens/sec
+  const b = new TokenBucket(capacity, rate, clk);
+  let oracle = capacity;
+  const stepsMs = [250, 1000, 40, 5000, 333, 700, 9999, 12];
+  const asks = [10, 3, 100, 7, 250, 1, 55, 2];
+  for (let i = 0; i < stepsMs.length; i++) {
+    clk.advanceMs(stepsMs[i]!);
+    oracle = Math.min(capacity, oracle + (rate * stepsMs[i]!) / 1000);
+    const ask = asks[i]!;
+    const expected = ask <= capacity && oracle + 1e-9 >= ask;
+    const got = b.tryRemove(ask);
+    check(`oracle step ${i} (ask ${ask})`, got === expected);
+    if (got) oracle -= ask;
+    check(`oracle non-negative step ${i}`, oracle >= -1e-9);
+  }
+}
+
+// Meta kill-probe: prove approx helper + at least one contract assertion truly discriminates.
+check('approx sanity true', approx(1.0, 1.0));
+check('approx sanity false-detect', !approx(1.0, 1.2, 1e-9));
+
+if (failed === 0) {
+  console.log(`OK — ${passed} assertions passed`);
+} else {
+  console.error(`${failed} assertion(s) FAILED (${passed} passed)`);
+  process.exit(1);
+}

--- a/docs/evals/quality-ab/runs/token-bucket__E__r2/impl.ts
+++ b/docs/evals/quality-ab/runs/token-bucket__E__r2/impl.ts
@@ -1,0 +1,64 @@
+export interface Clock {
+  /** Current time in milliseconds (monotonic, non-decreasing). */
+  now(): number;
+}
+
+export class TokenBucket {
+  private tokens: number;
+  private lastRefillMs: number;
+
+  /**
+   * @param capacity      max tokens the bucket holds (> 0)
+   * @param refillPerSec  tokens added per second (> 0), continuous/proportional
+   * @param clock         injected time source (do NOT read wall-clock directly)
+   */
+  constructor(
+    private readonly capacity: number,
+    private readonly refillPerSec: number,
+    private readonly clock: Clock,
+  ) {
+    if (!(capacity > 0)) {
+      throw new Error('capacity must be > 0');
+    }
+    if (!(refillPerSec > 0)) {
+      throw new Error('refillPerSec must be > 0');
+    }
+    // The bucket starts full.
+    this.tokens = capacity;
+    this.lastRefillMs = clock.now();
+  }
+
+  /** Lazily add tokens proportional to elapsed clock time, capped at capacity. */
+  private refill(): void {
+    const nowMs = this.clock.now();
+    const elapsedMs = nowMs - this.lastRefillMs;
+    // Clock is monotonic/non-decreasing; guard against zero/backward drift so
+    // we never subtract tokens or move lastRefill backwards.
+    if (elapsedMs > 0) {
+      const added = (this.refillPerSec * elapsedMs) / 1000;
+      this.tokens = Math.min(this.capacity, this.tokens + added);
+      this.lastRefillMs = nowMs;
+    }
+  }
+
+  /**
+   * Attempt to remove `count` tokens (default 1, a positive integer).
+   * Returns true and consumes them if enough are available; otherwise returns
+   * false and consumes NOTHING.
+   */
+  tryRemove(count = 1): boolean {
+    if (!Number.isInteger(count) || count <= 0) {
+      throw new Error('count must be a positive integer');
+    }
+    // A request for more than capacity can never succeed.
+    if (count > this.capacity) {
+      return false;
+    }
+    this.refill();
+    if (this.tokens >= count) {
+      this.tokens -= count;
+      return true;
+    }
+    return false;
+  }
+}

--- a/docs/evals/quality-ab/runs/token-bucket__N__r1/impl.ts
+++ b/docs/evals/quality-ab/runs/token-bucket__N__r1/impl.ts
@@ -1,0 +1,91 @@
+export interface Clock {
+  /** Current time in milliseconds (monotonic, non-decreasing). */
+  now(): number;
+}
+
+export class TokenBucket {
+  private readonly capacity: number;
+  private readonly refillPerSec: number;
+  private readonly clock: Clock;
+
+  /** Current (possibly fractional) token balance. */
+  private tokens: number;
+  /** Clock time (ms) at which `tokens` was last computed. */
+  private lastRefillMs: number;
+
+  /**
+   * @param capacity      max tokens the bucket holds (> 0)
+   * @param refillPerSec  tokens added per second (> 0), continuous/proportional
+   * @param clock         injected time source (do NOT read wall-clock directly)
+   */
+  constructor(capacity: number, refillPerSec: number, clock: Clock) {
+    if (typeof capacity !== 'number' || !isFinite(capacity) || capacity <= 0) {
+      throw new RangeError(`capacity must be a positive finite number, got ${capacity}`);
+    }
+    if (typeof refillPerSec !== 'number' || !isFinite(refillPerSec) || refillPerSec <= 0) {
+      throw new RangeError(
+        `refillPerSec must be a positive finite number, got ${refillPerSec}`,
+      );
+    }
+
+    this.capacity = capacity;
+    this.refillPerSec = refillPerSec;
+    this.clock = clock;
+
+    // Bucket starts full.
+    this.tokens = capacity;
+    this.lastRefillMs = clock.now();
+  }
+
+  /**
+   * Bring the token balance up to date for the elapsed clock time, capping at
+   * capacity. Lazy refill: only ever called from `tryRemove`.
+   */
+  private refill(): void {
+    const nowMs = this.clock.now();
+    const elapsedMs = nowMs - this.lastRefillMs;
+
+    // Clock is documented monotonic/non-decreasing; guard defensively so a
+    // stalled or non-advancing reading never subtracts tokens.
+    if (elapsedMs > 0) {
+      const added = (this.refillPerSec * elapsedMs) / 1000;
+      this.tokens = Math.min(this.capacity, this.tokens + added);
+    }
+
+    // Always advance the reference point to the observed time so future
+    // refills measure from "now", not from the last positive step.
+    if (nowMs > this.lastRefillMs) {
+      this.lastRefillMs = nowMs;
+    }
+  }
+
+  /**
+   * Attempt to remove `count` tokens (default 1, a positive integer).
+   * Returns true and consumes them if enough are available; otherwise returns
+   * false and consumes NOTHING.
+   */
+  tryRemove(count = 1): boolean {
+    if (
+      typeof count !== 'number' ||
+      !isFinite(count) ||
+      Math.floor(count) !== count ||
+      count <= 0
+    ) {
+      throw new RangeError(`count must be a positive integer, got ${count}`);
+    }
+
+    // A request for more than capacity can never succeed, and never consumes.
+    if (count > this.capacity) {
+      return false;
+    }
+
+    this.refill();
+
+    if (this.tokens >= count) {
+      this.tokens -= count;
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/docs/evals/quality-ab/runs/token-bucket__N__r2/impl.ts
+++ b/docs/evals/quality-ab/runs/token-bucket__N__r2/impl.ts
@@ -1,0 +1,56 @@
+export interface Clock {
+  /** Current time in milliseconds (monotonic, non-decreasing). */
+  now(): number;
+}
+
+export class TokenBucket {
+  /** Current token balance; may be fractional. Starts full. */
+  private tokens: number;
+  /** Clock time (ms) at which `tokens` was last recomputed. */
+  private lastRefill: number;
+
+  constructor(
+    private readonly capacity: number,
+    private readonly refillPerSec: number,
+    private readonly clock: Clock,
+  ) {
+    if (!(capacity > 0)) {
+      throw new Error('capacity must be > 0');
+    }
+    if (!(refillPerSec > 0)) {
+      throw new Error('refillPerSec must be > 0');
+    }
+    this.tokens = capacity;
+    this.lastRefill = clock.now();
+  }
+
+  /** Lazily add tokens for the elapsed time, capped at `capacity`. */
+  private refill(): void {
+    const now = this.clock.now();
+    const elapsedMs = now - this.lastRefill;
+    // Clock is monotonic/non-decreasing; guard against any non-positive delta
+    // so a zero-time or stalled clock never removes tokens.
+    if (elapsedMs > 0) {
+      const added = (this.refillPerSec * elapsedMs) / 1000;
+      this.tokens = Math.min(this.capacity, this.tokens + added);
+    }
+    this.lastRefill = now;
+  }
+
+  tryRemove(count = 1): boolean {
+    if (!Number.isInteger(count) || count <= 0) {
+      throw new Error('count must be a positive integer');
+    }
+    // A request larger than capacity can never be satisfied.
+    if (count > this.capacity) {
+      this.refill();
+      return false;
+    }
+    this.refill();
+    if (this.tokens >= count) {
+      this.tokens -= count;
+      return true;
+    }
+    return false;
+  }
+}

--- a/docs/evals/quality-ab/tasks/csv-line/SPEC.md
+++ b/docs/evals/quality-ab/tasks/csv-line/SPEC.md
@@ -1,0 +1,47 @@
+# Task: csvParseLine
+
+**Risk Tier:** high · **Boundary Touching:** true
+**Test Layer:** unit
+
+Implement `csvParseLine` in `impl.ts`, exporting exactly:
+
+```ts
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[];
+```
+
+## Rules
+
+- Fields are separated by commas (`,`).
+- A field is **quoted** if and only if its first character is a double quote (`"`).
+  - A quoted field ends at the next unescaped double quote.
+  - Inside a quoted field, a literal double quote is written as two double quotes
+    (`""`) and unescapes to a single `"`.
+  - A quoted field may contain commas — they are part of the value, not
+    separators.
+  - The surrounding quotes are removed from the returned value.
+  - After a quoted field's closing quote, the next character must be either a
+    comma or the end of the line. Anything else is malformed.
+- An **unquoted** field is taken literally, including any whitespace and any
+  double quotes that are not at the start (`a"b` is the literal 3-char field
+  `a"b`).
+- Empty fields are allowed: `"a,,b"` → `["a", "", "b"]`.
+- A trailing comma yields a trailing empty field: `"a,"` → `["a", ""]`.
+- The empty string yields a single empty field: `""` → `[""]`.
+
+## Errors — throw an `Error` for malformed input
+
+- an unterminated quoted field (`"abc`)
+- junk between a quoted field's closing quote and the next comma/end (`"a"b`)
+
+## Examples
+
+- `csvParseLine("a,b,c")` → `["a", "b", "c"]`
+- `csvParseLine("a,,c")` → `["a", "", "c"]`
+- `csvParseLine('"a,b",c')` → `["a,b", "c"]`
+- `csvParseLine('"a""b"')` → `['a"b']`
+- `csvParseLine('a"b')` → `['a"b']`
+- `csvParseLine('"hi",,"x,y"')` → `["hi", "", "x,y"]`
+
+This is a high-risk parsing contract — cover the quoting/escaping edge cases and
+make sure your tests can actually fail.

--- a/docs/evals/quality-ab/tasks/csv-line/impl.stub.ts
+++ b/docs/evals/quality-ab/tasks/csv-line/impl.stub.ts
@@ -1,0 +1,5 @@
+/** Parse ONE CSV record (a single line) into its fields (RFC 4180 style). */
+export function csvParseLine(line: string): string[] {
+  // TODO: implement
+  throw new Error('not implemented');
+}

--- a/docs/evals/quality-ab/tasks/csv-line/oracle.ts
+++ b/docs/evals/quality-ab/tasks/csv-line/oracle.ts
@@ -1,0 +1,59 @@
+// HIDDEN ORACLE — the agent never sees this. Grades impl.ts against the spec's
+// quoting/escaping edge cases. Run: `tsx oracle.ts` in a dir with `impl.ts`.
+import { csvParseLine } from './impl.ts';
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+function eq(input: string, want: string[]): void {
+  const got = csvParseLine(input);
+  assert(
+    Array.isArray(got) && got.length === want.length && got.every((v, i) => v === want[i]),
+    `csvParseLine(${JSON.stringify(input)}) = ${JSON.stringify(got)}, want ${JSON.stringify(want)}`,
+  );
+}
+function throws(input: string): void {
+  let threw = false;
+  try {
+    csvParseLine(input);
+  } catch {
+    threw = true;
+  }
+  assert(threw, `csvParseLine(${JSON.stringify(input)}) should throw`);
+}
+
+const checks: Array<[string, () => void]> = [
+  ['simple', () => eq('a,b,c', ['a', 'b', 'c'])],
+  ['empty middle field', () => eq('a,,c', ['a', '', 'c'])],
+  ['lone comma', () => eq(',', ['', ''])],
+  ['empty string is one empty field', () => eq('', [''])],
+  ['quoted empty', () => eq('""', [''])],
+  ['single field', () => eq('hello', ['hello'])],
+  ['unquoted whitespace preserved', () => eq(' a , b ', [' a ', ' b '])],
+  ['trailing comma', () => eq('a,', ['a', ''])],
+  ['leading comma', () => eq(',b', ['', 'b'])],
+  ['quoted field', () => eq('"a"', ['a'])],
+  ['comma inside quotes', () => eq('"a,b",c', ['a,b', 'c'])],
+  ['escaped quote inside quotes', () => eq('"a""b"', ['a"b'])],
+  ['escaped quote then more', () => eq('"a""b",c', ['a"b', 'c'])],
+  ['quote literal in unquoted field', () => eq('a"b', ['a"b'])],
+  ['multiple quoted with commas', () => eq('"a,b","c,d"', ['a,b', 'c,d'])],
+  ['mixed quoted/empty/quoted', () => eq('"hi",,"x,y"', ['hi', '', 'x,y'])],
+  ['quoted empty between values', () => eq('a,"",b', ['a', '', 'b'])],
+  ['only-quotes escaped pair', () => eq('""""', ['"'])],
+  ['unterminated quote throws', () => throws('"abc')],
+  ['junk after closing quote throws', () => throws('"a"b')],
+  ['unterminated after escaped quote throws', () => throws('"a""')],
+];
+
+let passed = 0;
+const failures: string[] = [];
+for (const [name, fn] of checks) {
+  try {
+    fn();
+    passed++;
+  } catch (e) {
+    failures.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+console.log(JSON.stringify({ passed, failed: failures.length, total: checks.length, failures }));

--- a/docs/evals/quality-ab/tasks/parse-duration/SPEC.md
+++ b/docs/evals/quality-ab/tasks/parse-duration/SPEC.md
@@ -1,0 +1,42 @@
+# Task: parseDuration
+
+**Risk Tier:** medium
+**Test Layer:** unit
+
+Implement `parseDuration` in `impl.ts`, exporting exactly:
+
+```ts
+/** Parse a human duration string into a total number of milliseconds. */
+export function parseDuration(input: string): number;
+```
+
+## Grammar & semantics
+
+- The input is a concatenation of one or more `<amount><unit>` segments, e.g.
+  `"1h30m"`, `"500ms"`, `"2d"`, `"1h30m15s"`, `"90m"`.
+- `<amount>` is a non-negative integer (one or more digits).
+- `<unit>` is one of: `ms` (milliseconds), `s` (seconds), `m` (minutes),
+  `h` (hours), `d` (days). Units are lowercase.
+- Unit values: `1s = 1000ms`, `1m = 60s`, `1h = 60m`, `1d = 24h`.
+- Whitespace anywhere in the input is ignored (`"1h 30m"` === `"1h30m"`).
+- The result is the sum of all segments in milliseconds.
+
+## Errors — throw an `Error` for any invalid input
+
+- empty string (or only whitespace)
+- a number with no unit (`"10"`)
+- an unrecognized unit (`"10x"`)
+- any characters that are not part of a valid `<amount><unit>` sequence
+
+## Examples
+
+- `parseDuration("500ms")` → `500`
+- `parseDuration("1s")` → `1000`
+- `parseDuration("5m")` → `300000`
+- `parseDuration("1h")` → `3600000`
+- `parseDuration("1d")` → `86400000`
+- `parseDuration("1h30m")` → `5400000`
+- `parseDuration("1h30m15s")` → `5415000`
+
+Note the `ms` / `m` distinction: `"500ms"` is 500 milliseconds, not 500 minutes.
+This is a medium-risk task — cover the behavior with tests judged by outcome.

--- a/docs/evals/quality-ab/tasks/parse-duration/impl.stub.ts
+++ b/docs/evals/quality-ab/tasks/parse-duration/impl.stub.ts
@@ -1,0 +1,5 @@
+/** Parse a human duration string into a total number of milliseconds. */
+export function parseDuration(input: string): number {
+  // TODO: implement
+  throw new Error('not implemented');
+}

--- a/docs/evals/quality-ab/tasks/parse-duration/oracle.ts
+++ b/docs/evals/quality-ab/tasks/parse-duration/oracle.ts
@@ -1,0 +1,56 @@
+// HIDDEN ORACLE — the agent never sees this. Grades impl.ts against the spec's
+// edge cases. Run: `tsx oracle.ts` in a dir containing the produced `impl.ts`.
+import { parseDuration } from './impl.ts';
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+function eq(input: string, want: number): void {
+  const got = parseDuration(input);
+  assert(got === want, `parseDuration(${JSON.stringify(input)}) = ${got}, want ${want}`);
+}
+function throws(input: string): void {
+  let threw = false;
+  try {
+    parseDuration(input);
+  } catch {
+    threw = true;
+  }
+  assert(threw, `parseDuration(${JSON.stringify(input)}) should throw`);
+}
+
+const checks: Array<[string, () => void]> = [
+  ['ms unit', () => eq('500ms', 500)],
+  ['s unit', () => eq('1s', 1000)],
+  ['m unit', () => eq('5m', 300000)],
+  ['h unit', () => eq('1h', 3600000)],
+  ['d unit', () => eq('1d', 86400000)],
+  ['multi-segment h+m', () => eq('1h30m', 5400000)],
+  ['multi-segment h+m+s', () => eq('1h30m15s', 5415000)],
+  ['minutes overflow into value', () => eq('90m', 5400000)],
+  ['ms vs m: 500ms is not 500 minutes', () => eq('500ms', 500)],
+  ['ms after other segments', () => eq('1s500ms', 1500)],
+  ['multi-digit amount', () => eq('1000ms', 1000)],
+  ['zero amount', () => eq('0s', 0)],
+  ['whitespace ignored', () => eq('1h 30m', 5400000)],
+  ['leading/trailing whitespace', () => eq('  2d  ', 172800000)],
+  ['empty string throws', () => throws('')],
+  ['whitespace-only throws', () => throws('   ')],
+  ['number with no unit throws', () => throws('10')],
+  ['unknown unit throws', () => throws('10x')],
+  ['trailing junk throws', () => throws('1h30')],
+  ['pure junk throws', () => throws('abc')],
+  ['unit with no amount throws', () => throws('ms')],
+];
+
+let passed = 0;
+const failures: string[] = [];
+for (const [name, fn] of checks) {
+  try {
+    fn();
+    passed++;
+  } catch (e) {
+    failures.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+console.log(JSON.stringify({ passed, failed: failures.length, total: checks.length, failures }));

--- a/docs/evals/quality-ab/tasks/token-bucket/SPEC.md
+++ b/docs/evals/quality-ab/tasks/token-bucket/SPEC.md
@@ -1,0 +1,47 @@
+# Task: TokenBucket rate limiter
+
+**Risk Tier:** high · **Boundary Touching:** true
+**Test Layer:** integration
+
+Implement a token-bucket rate limiter in `impl.ts`, exporting exactly:
+
+```ts
+export interface Clock {
+  /** Current time in milliseconds (monotonic, non-decreasing). */
+  now(): number;
+}
+
+export class TokenBucket {
+  /**
+   * @param capacity      max tokens the bucket holds (> 0)
+   * @param refillPerSec  tokens added per second (> 0), continuous/proportional
+   * @param clock         injected time source (do NOT read wall-clock directly)
+   */
+  constructor(capacity: number, refillPerSec: number, clock: Clock);
+
+  /**
+   * Attempt to remove `count` tokens (default 1, a positive integer).
+   * Returns true and consumes them if enough are available; otherwise returns
+   * false and consumes NOTHING.
+   */
+  tryRemove(count?: number): boolean;
+}
+```
+
+## Semantics
+
+- The bucket starts **full** (`capacity` tokens).
+- Tokens refill **continuously and proportionally** to elapsed clock time since
+  the last update: after `Δms`, `refillPerSec * Δms / 1000` tokens are added.
+  Refill is lazy (compute it when `tryRemove` is called), never exceeding
+  `capacity`.
+- `tryRemove(n)`: first apply refill for the elapsed time, then if the bucket
+  holds at least `n` tokens, subtract `n` and return `true`; otherwise return
+  `false` and leave the token count unchanged (no partial consumption).
+- A request for more than `capacity` tokens can never succeed.
+- Token count must never go negative.
+- Fractional token balances are allowed internally (time-based refill); only the
+  cap and the "enough for this request" check matter externally.
+
+Implement it well. This is a high-risk, boundary-touching task (it defines a
+reusable contract with an injected time seam) — verify the behavior thoroughly.

--- a/docs/evals/quality-ab/tasks/token-bucket/impl.stub.ts
+++ b/docs/evals/quality-ab/tasks/token-bucket/impl.stub.ts
@@ -1,0 +1,19 @@
+export interface Clock {
+  /** Current time in milliseconds (monotonic, non-decreasing). */
+  now(): number;
+}
+
+export class TokenBucket {
+  constructor(
+    private readonly capacity: number,
+    private readonly refillPerSec: number,
+    private readonly clock: Clock,
+  ) {
+    // TODO: implement
+  }
+
+  tryRemove(count = 1): boolean {
+    // TODO: implement
+    throw new Error('not implemented');
+  }
+}

--- a/docs/evals/quality-ab/tasks/token-bucket/oracle.ts
+++ b/docs/evals/quality-ab/tasks/token-bucket/oracle.ts
@@ -1,0 +1,123 @@
+// HIDDEN ORACLE — the agent never sees this. Grades impl.ts against the spec's
+// edge cases. Run: `tsx oracle.ts` in a dir containing the produced `impl.ts`.
+import { TokenBucket, type Clock } from './impl.ts';
+
+class FakeClock implements Clock {
+  constructor(public t = 0) {}
+  now(): number {
+    return this.t;
+  }
+  advance(ms: number): void {
+    this.t += ms;
+  }
+}
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+const checks: Array<[string, () => void]> = [
+  [
+    'starts full: capacity tokens available at t=0',
+    () => {
+      const c = new FakeClock();
+      const b = new TokenBucket(5, 1, c);
+      assert(b.tryRemove(5) === true, 'should grant a full bucket');
+      assert(b.tryRemove(1) === false, 'empty bucket at t=0 should deny');
+    },
+  ],
+  [
+    'default count is 1',
+    () => {
+      const b = new TokenBucket(2, 1, new FakeClock());
+      assert(b.tryRemove() === true, 'first default remove');
+      assert(b.tryRemove() === true, 'second default remove');
+      assert(b.tryRemove() === false, 'third should deny');
+    },
+  ],
+  [
+    'request larger than capacity always denied, consumes nothing',
+    () => {
+      const b = new TokenBucket(3, 1, new FakeClock());
+      assert(b.tryRemove(5) === false, 'over-capacity request denied');
+      assert(b.tryRemove(3) === true, 'full bucket still intact after denied over-cap request');
+    },
+  ],
+  [
+    'proportional refill over time',
+    () => {
+      const c = new FakeClock();
+      const b = new TokenBucket(10, 2, c); // 2 tokens/sec
+      assert(b.tryRemove(10) === true, 'drain');
+      c.advance(1000); // +2 tokens
+      assert(b.tryRemove(2) === true, 'refilled 2 after 1s');
+      assert(b.tryRemove(1) === false, 'no more than refilled');
+    },
+  ],
+  [
+    'refill caps at capacity',
+    () => {
+      const c = new FakeClock();
+      const b = new TokenBucket(5, 100, c);
+      assert(b.tryRemove(5) === true, 'drain');
+      c.advance(10_000); // would be +1000, must cap at 5
+      assert(b.tryRemove(5) === true, 'capped refill grants exactly capacity');
+      assert(b.tryRemove(1) === false, 'not more than capacity');
+    },
+  ],
+  [
+    'fractional refill (sub-token) accrues correctly',
+    () => {
+      const c = new FakeClock();
+      const b = new TokenBucket(10, 2, c); // 2/sec => 1 token per 500ms
+      assert(b.tryRemove(10) === true, 'drain');
+      c.advance(500); // +1 token
+      assert(b.tryRemove(1) === true, 'half second refills exactly 1');
+      assert(b.tryRemove(1) === false, 'nothing left');
+    },
+  ],
+  [
+    'failed request consumes nothing (no partial consumption)',
+    () => {
+      const c = new FakeClock();
+      const b = new TokenBucket(5, 1, c); // 1/sec
+      assert(b.tryRemove(5) === true, 'drain');
+      c.advance(2000); // +2 tokens => balance 2
+      assert(b.tryRemove(3) === false, 'insufficient, must deny');
+      assert(b.tryRemove(2) === true, 'the 2 tokens were NOT consumed by the failed call');
+    },
+  ],
+  [
+    'never goes negative / repeated denials on empty bucket',
+    () => {
+      const b = new TokenBucket(1, 1, new FakeClock());
+      assert(b.tryRemove(1) === true, 'take the one token');
+      assert(b.tryRemove(1) === false, 'empty');
+      assert(b.tryRemove(1) === false, 'still empty (no negative balance)');
+    },
+  ],
+  [
+    'refill accrues across multiple reads without losing time',
+    () => {
+      const c = new FakeClock();
+      const b = new TokenBucket(10, 1, c); // 1/sec
+      assert(b.tryRemove(10) === true, 'drain');
+      c.advance(500); // +0.5
+      assert(b.tryRemove(1) === false, 'only 0.5 accrued');
+      c.advance(500); // +0.5 => total 1.0 (must not have dropped the first 0.5)
+      assert(b.tryRemove(1) === true, 'two half-seconds accrue to a full token');
+    },
+  ],
+];
+
+let passed = 0;
+const failures: string[] = [];
+for (const [name, fn] of checks) {
+  try {
+    fn();
+    passed++;
+  } catch (e) {
+    failures.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+console.log(JSON.stringify({ passed, failed: failures.length, total: checks.length, failures }));

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "hooks:guard": "node dist/hooks-guard.js",
     "prepare": "tsc",
     "bench": "cd servers/exarchos-mcp && npx vitest bench",
+    "bench:plan-format": "tsx servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts",
     "test": "vitest",
     "test:unit": "vitest run --project unit --project integration",
     "test:process": "vitest run --project process --passWithNoTests",

--- a/servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts
+++ b/servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts
@@ -2,12 +2,12 @@
 //
 // Deterministic benchmark: run the REAL production classifiers over the corpus
 // of stamped plan-format specs in `docs/specs/`, and measure how the delegation
-// DECISION diverges across three arms:
+// DECISION diverges across arms:
 //
-//   E  (exarchos, plan-honoring) — classifyTask WITH the planner's stamp
-//   H  (heuristic-only)          — classifyTask with the stamp STRIPPED (the
-//                                  current #1636 behavior: stamp dropped at the
-//                                  MCP boundary, tier re-derived by heuristic)
+//   E  (exarchos, plan-honoring) — classifyTask WITH the planner's stamp (the fix)
+//   H0 (true production)         — classifyTask({id,title}) — everything else is
+//                                  stripped at the MCP boundary today (#1636)
+//   H1 (heuristic ceiling)       — stamp stripped but files/testLayer retained
 //   N  (native flat model)       — no per-task routing; one flat model (opus)
 //
 // Dimensions measured (no live agents — this is the deterministic backbone):
@@ -26,115 +26,21 @@ import {
   type TaskClassification,
   type RiskTier,
 } from '../../orchestrate/prepare-delegation.js';
+import { parseTaskStamps, type TaskStamp } from '../../orchestrate/parse-task-stamps.js';
 
 // ─── Corpus parsing ──────────────────────────────────────────────────────────
+//
+// The corpus is parsed by the PRODUCTION stamp parser (`parseTaskStamps`) — the
+// same code that lifts stamps onto `prepare_delegation` — so the benchmark and
+// the dispatch path can never drift.
 
-interface ParsedTask {
-  readonly spec: string;
-  readonly id: string;
-  readonly title: string;
-  readonly riskTier?: RiskTier;
-  readonly boundaryTouching?: boolean;
-  readonly testLayer?: TaskInput['testLayer'];
-  readonly files: string[];
-  readonly blockedBy: string[];
-}
-
-const TASK_HEADER = /^#{3,4}\s+Task\s+([0-9A-Za-z.\-]+)\s*[:—-]\s*(.+?)\s*$/;
-const SECTION_HEADER = /^#{1,2}\s+\S/; // a top-level section ends a task block
-const RISK_TIER = /risk\s*tier\*{0,2}\s*:\s*\*{0,2}\s*(low|medium|high)(?![\w-])/i;
-const BOUNDARY = /boundary\s*touching\*{0,2}\s*:\s*\*{0,2}\s*(true|false)(?![\w-])/i;
-const TEST_LAYER = /test\s*layer\*{0,2}\s*:\s*\*{0,2}\s*(acceptance|integration|unit|property)/i;
-const FILE_EXT = /\.(ts|tsx|js|mjs|cjs|md|json|ya?ml|proto|graphql|d\.ts|sh|ps1)$/;
-
-function parseFiles(block: string): string[] {
-  const files = new Set<string>();
-  const lines = block.split('\n');
-  const collect = (line: string): void => {
-    for (const tok of line.match(/`([^`]+)`/g) ?? []) {
-      const p = tok.replace(/`/g, '').trim();
-      // Reject prose-in-backticks: a real path token has no spaces and a known ext.
-      if (!/\s/.test(p) && FILE_EXT.test(p)) files.add(p);
-    }
-  };
-  for (let i = 0; i < lines.length; i++) {
-    if (!/\*\*Files?:\*\*/i.test(lines[i])) continue;
-    collect(lines[i]); // inline form: `**Files:** `a`, `b``
-    // Bullet-list form: consume following `- `/`* ` lines until the next
-    // bold field, a blockquote, or a blank line.
-    for (let j = i + 1; j < lines.length; j++) {
-      const l = lines[j];
-      if (/^\s*[-*]\s/.test(l)) {
-        collect(l);
-        continue;
-      }
-      break; // non-bullet line ends the file list
-    }
-  }
-  return [...files];
-}
-
-function parseBlockedBy(block: string): string[] {
-  for (const line of block.split('\n')) {
-    const m = /\*\*Dependencies:\*\*\s*(.+?)(?:·|$)/i.exec(line);
-    if (!m) continue;
-    const raw = m[1].trim();
-    if (/^none$/i.test(raw)) return [];
-    return raw
-      .split(/[,\s]+/)
-      .map((s) => s.replace(/[^0-9A-Za-z.\-]/g, ''))
-      .filter((s) => s.length > 0 && !/^none$/i.test(s));
-  }
-  return [];
-}
-
-function parseSpec(specPath: string): ParsedTask[] {
-  const content = fs.readFileSync(specPath, 'utf-8');
-  const lines = content.split('\n');
-  const spec = path.basename(specPath);
-  const tasks: ParsedTask[] = [];
-
-  // Locate task-header line indices.
-  const headers: Array<{ idx: number; id: string; title: string }> = [];
-  lines.forEach((line, idx) => {
-    const m = TASK_HEADER.exec(line);
-    if (m) headers.push({ idx, id: m[1], title: m[2] });
-  });
-
-  for (let h = 0; h < headers.length; h++) {
-    const start = headers[h].idx;
-    // Block ends at the next task header OR the next top-level section header.
-    let end = h + 1 < headers.length ? headers[h + 1].idx : lines.length;
-    for (let i = start + 1; i < end; i++) {
-      if (SECTION_HEADER.test(lines[i])) {
-        end = i;
-        break;
-      }
-    }
-    const block = lines.slice(start, end).join('\n');
-    const riskMatch = RISK_TIER.exec(block);
-    const boundaryMatch = BOUNDARY.exec(block);
-    const testLayerMatch = TEST_LAYER.exec(block);
-    tasks.push({
-      spec,
-      id: headers[h].id,
-      title: headers[h].title,
-      ...(riskMatch ? { riskTier: riskMatch[1].toLowerCase() as RiskTier } : {}),
-      ...(boundaryMatch ? { boundaryTouching: boundaryMatch[1].toLowerCase() === 'true' } : {}),
-      ...(testLayerMatch
-        ? { testLayer: testLayerMatch[1].toLowerCase() as TaskInput['testLayer'] }
-        : {}),
-      files: parseFiles(block),
-      blockedBy: parseBlockedBy(block),
-    });
-  }
-  return tasks;
-}
+/** A parsed corpus task = a plan stamp plus the spec it came from. */
+type CorpusTask = TaskStamp & { readonly spec: string };
 
 // ─── Arms ────────────────────────────────────────────────────────────────────
 
 /** Build the TaskInput for the plan-honoring arm (E): includes the stamp. */
-function stampedInput(t: ParsedTask): TaskInput {
+function stampedInput(t: CorpusTask): TaskInput {
   return {
     id: t.id,
     title: t.title,
@@ -152,7 +58,7 @@ function stampedInput(t: ParsedTask): TaskInput {
  * orchestrator forwarded task context (which the current registry schema does
  * NOT accept). Isolates "heuristic vs plan" holding context constant.
  */
-function strippedInput(t: ParsedTask): TaskInput {
+function strippedInput(t: CorpusTask): TaskInput {
   return {
     id: t.id,
     title: t.title,
@@ -170,7 +76,7 @@ function strippedInput(t: ParsedTask): TaskInput {
  * AND the planner stamp before the handler runs, and the delegate skill only
  * sends `{id, title, modules}`. This is the real #1636 dispatched behavior.
  */
-function trueProductionInput(t: ParsedTask): TaskInput {
+function trueProductionInput(t: CorpusTask): TaskInput {
   return { id: t.id, title: t.title };
 }
 
@@ -194,12 +100,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../../../../../');
 const SPECS_DIR = path.join(REPO_ROOT, 'docs/specs');
 
-function specsWithStamps(): string[] {
-  return fs
+/** Load every spec, parse via the production parser, keep those with a stamp. */
+function loadCorpus(): { specPaths: string[]; tasks: CorpusTask[] } {
+  const all = fs
     .readdirSync(SPECS_DIR)
     .filter((f) => f.endsWith('.md'))
-    .map((f) => path.join(SPECS_DIR, f))
-    .filter((p) => RISK_TIER.test(fs.readFileSync(p, 'utf-8')));
+    .map((f) => path.join(SPECS_DIR, f));
+  const specPaths: string[] = [];
+  const tasks: CorpusTask[] = [];
+  for (const p of all) {
+    const parsed = parseTaskStamps(fs.readFileSync(p, 'utf-8'));
+    const stamped = parsed.filter((t) => t.riskTier !== undefined);
+    if (stamped.length === 0) continue;
+    specPaths.push(p);
+    for (const t of parsed) tasks.push({ ...t, spec: path.basename(p) });
+  }
+  return { specPaths, tasks };
 }
 
 function pct(n: number, d: number): string {
@@ -207,8 +123,7 @@ function pct(n: number, d: number): string {
 }
 
 function main(): void {
-  const specPaths = specsWithStamps();
-  const parsed = specPaths.flatMap(parseSpec);
+  const { specPaths, tasks: parsed } = loadCorpus();
   const rows: Row[] = parsed.map((t) => ({
     spec: t.spec,
     id: t.id,

--- a/servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts
+++ b/servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts
@@ -223,6 +223,14 @@ function main(): void {
       `**H1** (heuristic ceiling, files+testLayer but no stamp) · **N** (native flat model).`,
   );
   out.push('');
+  out.push(
+    '> ⚠️ **PROVISIONAL — models the decision, does not run the binary (#1670).** This calls the ' +
+      'pure `classifyTask` directly; it does NOT go through the MCP schema/CLI/binary, and the E-arm ' +
+      'numbers do NOT depend on the #1636 fix (`deriveRiskTier` already honored an explicit tier — the ' +
+      'bug was that stamps never *reached* it). The `N` "native flat opus" model is an unvalidated ' +
+      'assumption, not measured native behavior. Treat as directional pending the executed test in #1670.',
+  );
+  out.push('');
   out.push('## Corpus');
   out.push('');
   out.push(`- Stamped specs: **${specPaths.length}**`);

--- a/servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts
+++ b/servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts
@@ -1,0 +1,430 @@
+// ─── Plan-Format Corpus Benchmark (#1636) ────────────────────────────────────
+//
+// Deterministic benchmark: run the REAL production classifiers over the corpus
+// of stamped plan-format specs in `docs/specs/`, and measure how the delegation
+// DECISION diverges across three arms:
+//
+//   E  (exarchos, plan-honoring) — classifyTask WITH the planner's stamp
+//   H  (heuristic-only)          — classifyTask with the stamp STRIPPED (the
+//                                  current #1636 behavior: stamp dropped at the
+//                                  MCP boundary, tier re-derived by heuristic)
+//   N  (native flat model)       — no per-task routing; one flat model (opus)
+//
+// Dimensions measured (no live agents — this is the deterministic backbone):
+//   1. Model / agent selection  (scaffolder|implementer, haiku|opus, vs flat N)
+//   2. Verification depth        (riskTier, boundaryTouching, gate sequence)
+//
+// Run:  npx tsx servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts
+// ─────────────────────────────────────────────────────────────────────────────
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  classifyTask,
+  type TaskInput,
+  type TaskClassification,
+  type RiskTier,
+} from '../../orchestrate/prepare-delegation.js';
+
+// ─── Corpus parsing ──────────────────────────────────────────────────────────
+
+interface ParsedTask {
+  readonly spec: string;
+  readonly id: string;
+  readonly title: string;
+  readonly riskTier?: RiskTier;
+  readonly boundaryTouching?: boolean;
+  readonly testLayer?: TaskInput['testLayer'];
+  readonly files: string[];
+  readonly blockedBy: string[];
+}
+
+const TASK_HEADER = /^#{3,4}\s+Task\s+([0-9A-Za-z.\-]+)\s*[:—-]\s*(.+?)\s*$/;
+const SECTION_HEADER = /^#{1,2}\s+\S/; // a top-level section ends a task block
+const RISK_TIER = /risk\s*tier\*{0,2}\s*:\s*\*{0,2}\s*(low|medium|high)(?![\w-])/i;
+const BOUNDARY = /boundary\s*touching\*{0,2}\s*:\s*\*{0,2}\s*(true|false)(?![\w-])/i;
+const TEST_LAYER = /test\s*layer\*{0,2}\s*:\s*\*{0,2}\s*(acceptance|integration|unit|property)/i;
+const FILE_EXT = /\.(ts|tsx|js|mjs|cjs|md|json|ya?ml|proto|graphql|d\.ts|sh|ps1)$/;
+
+function parseFiles(block: string): string[] {
+  const files = new Set<string>();
+  const lines = block.split('\n');
+  const collect = (line: string): void => {
+    for (const tok of line.match(/`([^`]+)`/g) ?? []) {
+      const p = tok.replace(/`/g, '').trim();
+      // Reject prose-in-backticks: a real path token has no spaces and a known ext.
+      if (!/\s/.test(p) && FILE_EXT.test(p)) files.add(p);
+    }
+  };
+  for (let i = 0; i < lines.length; i++) {
+    if (!/\*\*Files?:\*\*/i.test(lines[i])) continue;
+    collect(lines[i]); // inline form: `**Files:** `a`, `b``
+    // Bullet-list form: consume following `- `/`* ` lines until the next
+    // bold field, a blockquote, or a blank line.
+    for (let j = i + 1; j < lines.length; j++) {
+      const l = lines[j];
+      if (/^\s*[-*]\s/.test(l)) {
+        collect(l);
+        continue;
+      }
+      break; // non-bullet line ends the file list
+    }
+  }
+  return [...files];
+}
+
+function parseBlockedBy(block: string): string[] {
+  for (const line of block.split('\n')) {
+    const m = /\*\*Dependencies:\*\*\s*(.+?)(?:·|$)/i.exec(line);
+    if (!m) continue;
+    const raw = m[1].trim();
+    if (/^none$/i.test(raw)) return [];
+    return raw
+      .split(/[,\s]+/)
+      .map((s) => s.replace(/[^0-9A-Za-z.\-]/g, ''))
+      .filter((s) => s.length > 0 && !/^none$/i.test(s));
+  }
+  return [];
+}
+
+function parseSpec(specPath: string): ParsedTask[] {
+  const content = fs.readFileSync(specPath, 'utf-8');
+  const lines = content.split('\n');
+  const spec = path.basename(specPath);
+  const tasks: ParsedTask[] = [];
+
+  // Locate task-header line indices.
+  const headers: Array<{ idx: number; id: string; title: string }> = [];
+  lines.forEach((line, idx) => {
+    const m = TASK_HEADER.exec(line);
+    if (m) headers.push({ idx, id: m[1], title: m[2] });
+  });
+
+  for (let h = 0; h < headers.length; h++) {
+    const start = headers[h].idx;
+    // Block ends at the next task header OR the next top-level section header.
+    let end = h + 1 < headers.length ? headers[h + 1].idx : lines.length;
+    for (let i = start + 1; i < end; i++) {
+      if (SECTION_HEADER.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    const block = lines.slice(start, end).join('\n');
+    const riskMatch = RISK_TIER.exec(block);
+    const boundaryMatch = BOUNDARY.exec(block);
+    const testLayerMatch = TEST_LAYER.exec(block);
+    tasks.push({
+      spec,
+      id: headers[h].id,
+      title: headers[h].title,
+      ...(riskMatch ? { riskTier: riskMatch[1].toLowerCase() as RiskTier } : {}),
+      ...(boundaryMatch ? { boundaryTouching: boundaryMatch[1].toLowerCase() === 'true' } : {}),
+      ...(testLayerMatch
+        ? { testLayer: testLayerMatch[1].toLowerCase() as TaskInput['testLayer'] }
+        : {}),
+      files: parseFiles(block),
+      blockedBy: parseBlockedBy(block),
+    });
+  }
+  return tasks;
+}
+
+// ─── Arms ────────────────────────────────────────────────────────────────────
+
+/** Build the TaskInput for the plan-honoring arm (E): includes the stamp. */
+function stampedInput(t: ParsedTask): TaskInput {
+  return {
+    id: t.id,
+    title: t.title,
+    files: t.files,
+    blockedBy: t.blockedBy,
+    ...(t.testLayer ? { testLayer: t.testLayer } : {}),
+    ...(t.riskTier ? { riskTier: t.riskTier } : {}),
+    ...(t.boundaryTouching !== undefined ? { boundaryTouching: t.boundaryTouching } : {}),
+  };
+}
+
+/**
+ * Heuristic-with-context arm (H1): stamp stripped, but files/testLayer/deps
+ * retained. This is the heuristic's CEILING — the best it could do if a diligent
+ * orchestrator forwarded task context (which the current registry schema does
+ * NOT accept). Isolates "heuristic vs plan" holding context constant.
+ */
+function strippedInput(t: ParsedTask): TaskInput {
+  return {
+    id: t.id,
+    title: t.title,
+    files: t.files,
+    blockedBy: t.blockedBy,
+    ...(t.testLayer ? { testLayer: t.testLayer } : {}),
+    // riskTier / boundaryTouching intentionally omitted — force heuristic derivation.
+  };
+}
+
+/**
+ * True-production arm (H0): `{ id, title }` ONLY. This is what actually reaches
+ * `handlePrepareDelegation` today — `registry.ts:1441` registers
+ * `tasks: z.array(z.object({ id, title }))`, so Zod strips files/testLayer/deps
+ * AND the planner stamp before the handler runs, and the delegate skill only
+ * sends `{id, title, modules}`. This is the real #1636 dispatched behavior.
+ */
+function trueProductionInput(t: ParsedTask): TaskInput {
+  return { id: t.id, title: t.title };
+}
+
+const TIER_RANK: Record<RiskTier, number> = { low: 0, medium: 1, high: 2 };
+
+interface Row {
+  readonly spec: string;
+  readonly id: string;
+  readonly title: string;
+  readonly stamped: boolean;
+  readonly boundaryStamped: boolean;
+  readonly fileCount: number;
+  readonly E: TaskClassification; // plan-honoring (the fix)
+  readonly H: TaskClassification; // H1: heuristic ceiling (files+testLayer, no stamp)
+  readonly H0: TaskClassification; // true production ({id,title} only)
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../../../');
+const SPECS_DIR = path.join(REPO_ROOT, 'docs/specs');
+
+function specsWithStamps(): string[] {
+  return fs
+    .readdirSync(SPECS_DIR)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => path.join(SPECS_DIR, f))
+    .filter((p) => RISK_TIER.test(fs.readFileSync(p, 'utf-8')));
+}
+
+function pct(n: number, d: number): string {
+  return d === 0 ? '0%' : `${((100 * n) / d).toFixed(0)}%`;
+}
+
+function main(): void {
+  const specPaths = specsWithStamps();
+  const parsed = specPaths.flatMap(parseSpec);
+  const rows: Row[] = parsed.map((t) => ({
+    spec: t.spec,
+    id: t.id,
+    title: t.title,
+    stamped: t.riskTier !== undefined,
+    boundaryStamped: t.boundaryTouching !== undefined,
+    fileCount: t.files.length,
+    E: classifyTask(stampedInput(t)),
+    H: classifyTask(strippedInput(t)),
+    H0: classifyTask(trueProductionInput(t)),
+  }));
+
+  // Only tasks that actually carry a planner riskTier stamp are meaningful for
+  // the divergence dimension (the corpus is authored to always stamp riskTier).
+  const stampedRows = rows.filter((r) => r.stamped);
+
+  // ── Dimension 2: verification-depth divergence (E vs H) ──
+  let tierMatch = 0;
+  let tierUnder = 0; // heuristic weaker than plan → UNDER-verified (the #1636 harm)
+  let tierOver = 0; // heuristic stronger than plan → wasted verification
+  const confusion: Record<string, number> = {};
+  let boundaryLost = 0; // plan says boundary, heuristic misses it → steer dropped
+  let boundaryPhantom = 0; // heuristic says boundary, plan didn't
+  let integrationRungLost = 0; // E has check_integration_suite, H doesn't
+  for (const r of stampedRows) {
+    const pt = r.E.riskTier;
+    const ht = r.H.riskTier;
+    const key = `${pt}→${ht}`;
+    confusion[key] = (confusion[key] ?? 0) + 1;
+    if (pt === ht) tierMatch++;
+    else if (TIER_RANK[ht] < TIER_RANK[pt]) tierUnder++;
+    else tierOver++;
+    if (r.E.boundaryTouching && !r.H.boundaryTouching) boundaryLost++;
+    if (!r.E.boundaryTouching && r.H.boundaryTouching) boundaryPhantom++;
+    const eHasIntegration = r.E.verificationSequence.includes('check_integration_suite');
+    const hHasIntegration = r.H.verificationSequence.includes('check_integration_suite');
+    if (eHasIntegration && !hHasIntegration) integrationRungLost++;
+  }
+
+  // ── Same divergence, but against the TRUE-production arm (H0: {id,title}) ──
+  // This is what actually ships today. H1 above is the heuristic's ceiling.
+  let tierMatch0 = 0;
+  let tierUnder0 = 0;
+  let tierOver0 = 0;
+  let boundaryLost0 = 0;
+  let integrationRungLost0 = 0;
+  for (const r of stampedRows) {
+    const pt = r.E.riskTier;
+    const ht = r.H0.riskTier;
+    if (pt === ht) tierMatch0++;
+    else if (TIER_RANK[ht] < TIER_RANK[pt]) tierUnder0++;
+    else tierOver0++;
+    if (r.E.boundaryTouching && !r.H0.boundaryTouching) boundaryLost0++;
+    if (
+      r.E.verificationSequence.includes('check_integration_suite') &&
+      !r.H0.verificationSequence.includes('check_integration_suite')
+    ) {
+      integrationRungLost0++;
+    }
+  }
+
+  // ── Dimension 1: model / agent selection ──
+  const modelDist: Record<string, number> = {};
+  const agentDist: Record<string, number> = {};
+  // model × tier cross-tab (does model track blast-radius tier?)
+  const modelByTier: Record<string, Record<string, number>> = {
+    low: {},
+    medium: {},
+    high: {},
+  };
+  let highTierCheapModel = 0; // high-risk task routed to haiku (under-powered?)
+  let lowTierExpensiveModel = 0; // low-risk task routed to opus (over-powered?)
+  const NATIVE_FLAT_MODEL = 'opus'; // native default (session model / defaultModel)
+  let cheaperThanNative = 0; // E routes below the native flat model
+  for (const r of stampedRows) {
+    modelDist[r.E.recommendedModel] = (modelDist[r.E.recommendedModel] ?? 0) + 1;
+    agentDist[r.E.recommendedAgent] = (agentDist[r.E.recommendedAgent] ?? 0) + 1;
+    modelByTier[r.E.riskTier][r.E.recommendedModel] =
+      (modelByTier[r.E.riskTier][r.E.recommendedModel] ?? 0) + 1;
+    if (r.E.riskTier === 'high' && r.E.recommendedModel === 'haiku') highTierCheapModel++;
+    if (r.E.riskTier === 'low' && r.E.recommendedModel === 'opus') lowTierExpensiveModel++;
+    if (r.E.recommendedModel !== NATIVE_FLAT_MODEL && r.E.recommendedModel === 'haiku') {
+      cheaperThanNative++;
+    }
+  }
+
+  const n = stampedRows.length;
+
+  // ── Emit markdown report ──
+  const out: string[] = [];
+  out.push('# Plan-Format Corpus Benchmark (#1636) — deterministic arm');
+  out.push('');
+  out.push(
+    `Runs the production \`classifyTask\` / \`renderImplementerPrompt\` over every stamped ` +
+      `plan-format spec in \`docs/specs/\`. Arms: **E** (exarchos, plan-honoring — the fix) · ` +
+      `**H0** (true production, \`{id,title}\` only — the current #1636 dispatched behavior) · ` +
+      `**H1** (heuristic ceiling, files+testLayer but no stamp) · **N** (native flat model).`,
+  );
+  out.push('');
+  out.push('## Corpus');
+  out.push('');
+  out.push(`- Stamped specs: **${specPaths.length}**`);
+  out.push(`- Tasks parsed: **${rows.length}**`);
+  out.push(`- Tasks carrying a \`riskTier\` stamp: **${n}** (${pct(n, rows.length)})`);
+  out.push(
+    `- Tasks carrying an explicit \`boundaryTouching\` stamp: **${rows.filter((r) => r.boundaryStamped).length}**`,
+  );
+  out.push('');
+  out.push('## Dimension 1 — model & agent selection (arm E)');
+  out.push('');
+  out.push('Exarchos routes model via `classifyTaskCore` (scaffolding-keyword / testLayer / deps / file-count), **independent of `riskTier`**. Defaults: `scaffolder→haiku`, `implementer→opus`.');
+  out.push('');
+  out.push(`- Agent mix: ${JSON.stringify(agentDist)}`);
+  out.push(`- Model mix: ${JSON.stringify(modelDist)}`);
+  out.push(`- **vs native flat \`${NATIVE_FLAT_MODEL}\`:** ${cheaperThanNative}/${n} tasks (${pct(cheaperThanNative, n)}) routed to the cheaper \`haiku\` — the cost saving from per-task routing.`);
+  out.push('');
+  out.push('Model × risk-tier cross-tab (does the model track blast radius?):');
+  out.push('');
+  out.push('| risk tier | haiku | sonnet | opus |');
+  out.push('|---|---|---|---|');
+  for (const tier of ['low', 'medium', 'high'] as const) {
+    const m = modelByTier[tier];
+    out.push(`| ${tier} | ${m.haiku ?? 0} | ${m.sonnet ?? 0} | ${m.opus ?? 0} |`);
+  }
+  out.push('');
+  out.push(`- ⚠️ high-tier tasks on the cheap \`haiku\` model (possible under-powering): **${highTierCheapModel}**`);
+  out.push(`- ⚠️ low-tier tasks on the expensive \`opus\` model (possible over-powering): **${lowTierExpensiveModel}**`);
+  out.push('');
+  out.push('## Dimension 2 — verification depth');
+  out.push('');
+  out.push('### E (plan-honoring) vs H0 (true production — `{id,title}` only) — the actual #1636 harm');
+  out.push('');
+  out.push('`registry.ts:1441` registers `tasks: z.array(z.object({ id, title }))`, so today every task reaches the classifier as `{id, title}` — no stamp, no files, no testLayer. This is what actually ships.');
+  out.push('');
+  out.push(`- Tier **match**: **${tierMatch0}/${n}** (${pct(tierMatch0, n)})`);
+  out.push(`- Tier **UNDER-provisioned** (H0 weaker than plan): **${tierUnder0}/${n}** (${pct(tierUnder0, n)})  ← the harm`);
+  out.push(`- Tier over-provisioned: **${tierOver0}/${n}** (${pct(tierOver0, n)})`);
+  out.push(`- **\`check_integration_suite\` rung lost**: **${integrationRungLost0}/${n}** (${pct(integrationRungLost0, n)}) — every planner-\`high\` task ships without the integration rung`);
+  out.push(`- **Boundary mock-steer lost**: **${boundaryLost0}/${n}** (${pct(boundaryLost0, n)})`);
+  out.push('');
+  out.push('### E (plan-honoring) vs H1 (heuristic ceiling — files+testLayer, no stamp)');
+  out.push('');
+  out.push('Isolates the heuristic quality itself: even IF the orchestrator forwarded full task context (which the registry schema forbids), how well does the keyword/glob heuristic recover the plan tier?');
+  out.push('');
+  out.push(`- Tier **match** (H agrees with plan): **${tierMatch}/${n}** (${pct(tierMatch, n)})`);
+  out.push(`- Tier **UNDER-provisioned** by heuristic (H weaker than plan): **${tierUnder}/${n}** (${pct(tierUnder, n)})  ← the harm`);
+  out.push(`- Tier **over-provisioned** by heuristic (H stronger than plan): **${tierOver}/${n}** (${pct(tierOver, n)})`);
+  out.push(`- **\`check_integration_suite\` rung lost** (E has it, H doesn't): **${integrationRungLost}/${n}** (${pct(integrationRungLost, n)})`);
+  out.push(`- **Boundary mock-steer lost** (plan boundary=true, heuristic=false): **${boundaryLost}/${n}** (${pct(boundaryLost, n)})`);
+  out.push(`- Boundary phantom (heuristic adds boundary the plan didn't): **${boundaryPhantom}/${n}**`);
+  out.push('');
+  out.push('Tier confusion (`plan→heuristic`):');
+  out.push('');
+  out.push('| plan → heuristic | count |');
+  out.push('|---|---|');
+  for (const [k, v] of Object.entries(confusion).sort((a, b) => b[1] - a[1])) {
+    const [pt, ht] = k.split('→');
+    const flag = TIER_RANK[ht as RiskTier] < TIER_RANK[pt as RiskTier] ? ' ⚠️ under' : '';
+    out.push(`| ${k}${flag} | ${v} |`);
+  }
+  out.push('');
+  out.push('## Per-task detail');
+  out.push('');
+  out.push('| spec | task | files | plan tier | heur tier | Δtier | plan bnd | heur bnd | agent | model |');
+  out.push('|---|---|---|---|---|---|---|---|---|---|');
+  for (const r of stampedRows) {
+    const under = TIER_RANK[r.H.riskTier] < TIER_RANK[r.E.riskTier];
+    const over = TIER_RANK[r.H.riskTier] > TIER_RANK[r.E.riskTier];
+    const delta = under ? '⚠️ under' : over ? 'over' : '=';
+    const bndLost = r.E.boundaryTouching && !r.H.boundaryTouching ? ' ⚠️' : '';
+    out.push(
+      `| ${r.spec.replace(/^\d{4}-\d\d-\d\d-/, '').replace(/\.md$/, '')} | ${r.id} | ${r.fileCount} | ${r.E.riskTier} | ${r.H.riskTier} | ${delta} | ${r.E.boundaryTouching}${bndLost} | ${r.H.boundaryTouching} | ${r.E.recommendedAgent} | ${r.E.recommendedModel} |`,
+    );
+  }
+  out.push('');
+
+  const report = out.join('\n');
+  const outDir = path.join(REPO_ROOT, 'docs/evals');
+  fs.mkdirSync(outDir, { recursive: true });
+  const mdPath = path.join(outDir, '2026-07-09-1636-plan-format-corpus.md');
+  const jsonPath = path.join(outDir, '2026-07-09-1636-plan-format-corpus.json');
+  fs.writeFileSync(mdPath, report);
+  fs.writeFileSync(
+    jsonPath,
+    JSON.stringify(
+      {
+        corpus: { specs: specPaths.map((p) => path.basename(p)), tasks: rows.length, stamped: n },
+        dimension1_model: { agentDist, modelDist, modelByTier, highTierCheapModel, lowTierExpensiveModel, cheaperThanNative },
+        dimension2_verification: {
+          vsTrueProduction_H0: { tierMatch: tierMatch0, tierUnder: tierUnder0, tierOver: tierOver0, integrationRungLost: integrationRungLost0, boundaryLost: boundaryLost0 },
+          vsHeuristicCeiling_H1: { tierMatch, tierUnder, tierOver, integrationRungLost, boundaryLost, boundaryPhantom, confusion },
+        },
+        rows: stampedRows.map((r) => ({
+          spec: r.spec,
+          id: r.id,
+          title: r.title,
+          fileCount: r.fileCount,
+          planTier: r.E.riskTier,
+          heuristicTier: r.H.riskTier,
+          planBoundary: r.E.boundaryTouching,
+          heuristicBoundary: r.H.boundaryTouching,
+          agent: r.E.recommendedAgent,
+          model: r.E.recommendedModel,
+          eGates: r.E.verificationSequence,
+          hGates: r.H.verificationSequence,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Console summary
+  process.stdout.write(report + '\n');
+  process.stdout.write(`\n[written] ${path.relative(REPO_ROOT, mdPath)}\n`);
+  process.stdout.write(`[written] ${path.relative(REPO_ROOT, jsonPath)}\n`);
+}
+
+main();

--- a/servers/exarchos-mcp/src/orchestrate/parse-task-stamps.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/parse-task-stamps.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { parseTaskStamps, stampForTask } from './parse-task-stamps.js';
+
+describe('parseTaskStamps', () => {
+  it('ParseTaskStamps_HighBoundarySingleLine_LiftsBothStamps', () => {
+    const md = [
+      '## Decomposition',
+      '### Tasks',
+      '#### Task 001: Wrap the prune-executor remove path',
+      '**Risk Tier:** high · **Boundary Touching:** true',
+      '**Files:** `servers/exarchos-mcp/src/orchestrate/worktree/manager.ts`',
+      '**Dependencies:** None · **Parallelizable:** Yes',
+    ].join('\n');
+    const [task] = parseTaskStamps(md);
+    expect(task.id).toBe('001');
+    expect(task.riskTier).toBe('high');
+    expect(task.boundaryTouching).toBe(true);
+    expect(task.files).toContain('servers/exarchos-mcp/src/orchestrate/worktree/manager.ts');
+    expect(task.blockedBy).toEqual([]);
+  });
+
+  it('ParseTaskStamps_RiskTierOnly_LeavesBoundaryUndefined', () => {
+    const md = ['#### Task 003: Burst stagger', '**Risk Tier:** medium'].join('\n');
+    const [task] = parseTaskStamps(md);
+    expect(task.riskTier).toBe('medium');
+    expect(task.boundaryTouching).toBeUndefined();
+  });
+
+  it('ParseTaskStamps_CamelCaseSpelling_Parsed', () => {
+    const md = ['#### Task 5: Something', '**riskTier:** low'].join('\n');
+    expect(parseTaskStamps(md)[0].riskTier).toBe('low');
+  });
+
+  it('ParseTaskStamps_ThreeHashHeader_AlsoParsed', () => {
+    const md = ['### Task 1: Legacy header', '**Risk Tier:** high'].join('\n');
+    const tasks = parseTaskStamps(md);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].riskTier).toBe('high');
+  });
+
+  it('ParseTaskStamps_ExplicitBoundaryFalse_CapturedAsFalse', () => {
+    const md = ['#### Task 2: x', '**Risk Tier:** medium', '**Boundary Touching:** false'].join('\n');
+    expect(parseTaskStamps(md)[0].boundaryTouching).toBe(false);
+  });
+
+  it('ParseTaskStamps_TestLayerStamp_Parsed', () => {
+    const md = ['#### Task 2: x', '**Risk Tier:** high', '**Test Layer:** integration'].join('\n');
+    expect(parseTaskStamps(md)[0].testLayer).toBe('integration');
+  });
+
+  it('ParseTaskStamps_BulletFileList_ExtractedViaProductionExtractor', () => {
+    const md = [
+      '#### Task 001: x',
+      '**Risk Tier:** medium',
+      '**Files:**',
+      '- `servers/exarchos-mcp/src/event-store/schemas.ts`',
+      '- `servers/exarchos-mcp/src/event-store/schemas.test.ts`',
+      '**Dependencies:** None',
+    ].join('\n');
+    const [task] = parseTaskStamps(md);
+    expect(task.files).toEqual([
+      'servers/exarchos-mcp/src/event-store/schemas.ts',
+      'servers/exarchos-mcp/src/event-store/schemas.test.ts',
+    ]);
+  });
+
+  it('ParseTaskStamps_MalformedTierValue_FallsThroughToUndefined', () => {
+    // `low-priority` must NOT read as `low` — a malformed stamp should fall
+    // through to heuristic derivation, not silently misclassify.
+    const md = ['#### Task 9: x', '**Risk Tier:** low-priority'].join('\n');
+    expect(parseTaskStamps(md)[0].riskTier).toBeUndefined();
+  });
+
+  it('ParseTaskStamps_SectionHeaderEndsBlock_StampsDoNotBleed', () => {
+    const md = [
+      '#### Task 001: first',
+      '**Risk Tier:** low',
+      '## Appendix',
+      '**Risk Tier:** high — narrative mention, not a task stamp',
+    ].join('\n');
+    const tasks = parseTaskStamps(md);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].riskTier).toBe('low');
+  });
+
+  it('ParseTaskStamps_TasksSectionHeader_NotParsedAsTask', () => {
+    // `### Tasks` (plural, no id) is a section header, not a task.
+    const md = ['### Tasks', '#### Task 001: real', '**Risk Tier:** medium'].join('\n');
+    const tasks = parseTaskStamps(md);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe('001');
+  });
+
+  it('ParseTaskStamps_MultipleTasks_EachBlockScopedIndependently', () => {
+    const md = [
+      '#### Task 001: a',
+      '**Risk Tier:** high · **Boundary Touching:** true',
+      '#### Task 002: b',
+      '**Risk Tier:** low',
+    ].join('\n');
+    const tasks = parseTaskStamps(md);
+    expect(tasks.map((t) => t.riskTier)).toEqual(['high', 'low']);
+    expect(tasks.map((t) => t.boundaryTouching)).toEqual([true, undefined]);
+  });
+});
+
+describe('stampForTask', () => {
+  const stamps = parseTaskStamps(
+    ['#### Task 001: a', '**Risk Tier:** high', '#### Task 012: b', '**Risk Tier:** medium'].join('\n'),
+  );
+
+  it('StampForTask_CanonicalIdMatch_MatchesAcrossSpellings', () => {
+    expect(stampForTask(stamps, 'task-001')?.riskTier).toBe('high');
+    expect(stampForTask(stamps, 'T001')?.riskTier).toBe('high');
+    expect(stampForTask(stamps, '001')?.riskTier).toBe('high');
+    expect(stampForTask(stamps, 'Task 012')?.riskTier).toBe('medium');
+  });
+
+  it('StampForTask_UnknownId_ReturnsUndefined', () => {
+    expect(stampForTask(stamps, '999')).toBeUndefined();
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/parse-task-stamps.ts
+++ b/servers/exarchos-mcp/src/orchestrate/parse-task-stamps.ts
@@ -1,0 +1,136 @@
+// ─── Plan-Format Stamp Parser (#1636) ────────────────────────────────────────
+//
+// Lifts the planner's per-task verification-routing stamps out of a decomposition
+// markdown document so they can reach `prepare_delegation` / `classifyTask`.
+//
+// Motivation (#1636): the planner authors `**Risk Tier:**` / `**Boundary
+// Touching:**` per task (task-template.md), and `deriveRiskTier` /
+// `deriveBoundaryTouching` honor an explicit value ("planner value always wins").
+// But nothing lifted those stamps out of the plan and onto the task objects, and
+// the MCP `tasks` schema stripped them — so the override branch was structurally
+// unreachable and every task fell through to the keyword/glob heuristic. This
+// module is the deterministic lift: no LLM in the hot path.
+//
+// SoT note: this owns the stamp regexes for the DISPATCH path. The plan-coverage
+// GATE (`task-decomposition.ts` `extractTaskRiskTier`, #1544) keeps its own
+// riskTier regex — different concern, frozen parity tests. Both accept the same
+// `**Risk Tier:** <tier>` / `**riskTier:** <tier>` spellings.
+//
+// Header note: the actual `docs/specs/` corpus authors task headers as `####`
+// with numeric ids (`#### Task 001: …`), while `parseTaskBlocks` (the gate path)
+// matches only `###` + `T-NN|NN`. This parser accepts BOTH `###` and `####` and
+// a broader id token so it works on the real corpus.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { RiskTier } from '../workflow/verification-policy.js';
+import {
+  canonicaliseTaskId,
+  extractFiles,
+  extractDependencies,
+} from './task-decomposition.js';
+
+export type TestLayer = 'acceptance' | 'integration' | 'unit' | 'property';
+
+/**
+ * Normalise a task id for cross-form matching. `canonicaliseTaskId` collapses
+ * `T-01`/`T01`/`01`/`1` → `1`, but it does NOT handle the spelled-out `task`
+ * prefix the delegate skill emits (`id: "task-001"`): `^T-?` there strips only
+ * the leading `t`, leaving `ask-001`. So a plan header `Task 001` (→ `1`) would
+ * never match a caller's `task-001`. Strip a spelled-out `task<sep>` prefix
+ * first (separator required, so a real word id like `taskrunner` is untouched),
+ * then delegate to `canonicaliseTaskId` for the `T-?`/leading-zero collapse.
+ */
+export function normalizeTaskId(id: string): string {
+  return canonicaliseTaskId(id.replace(/^task[-_\s]+/i, ''));
+}
+
+/** A task's planner-authored verification-routing stamps, lifted from the plan. */
+export interface TaskStamp {
+  /** Task id exactly as written in the plan header (e.g. "001", "T-03"). */
+  readonly id: string;
+  /** `normalizeTaskId(id)` — the form used to match against caller task ids. */
+  readonly canonicalId: string;
+  /** The header title text after the id. */
+  readonly title: string;
+  /** `**Risk Tier:**` stamp, if present. */
+  readonly riskTier?: RiskTier;
+  /** `**Boundary Touching:**` stamp, if present (may be explicitly `false`). */
+  readonly boundaryTouching?: boolean;
+  /** `**Test Layer:**` stamp, if present. */
+  readonly testLayer?: TestLayer;
+  /** Files declared under `**Files:**` (via the production `extractFiles`). */
+  readonly files: string[];
+  /** Dependency ids from `**Dependencies:**` (via `extractDependencies`). */
+  readonly blockedBy: string[];
+}
+
+// A task header: `###`/`####`, then `Task`, then an id token, then a `:`/`—`/`-`
+// separator, then the title. `Task\s+` (whitespace-required) means `### Tasks`
+// (a section header) does not match.
+const TASK_HEADER = /^#{3,4}\s+Task\s+([0-9A-Za-z.\-]+)\s*[:—-]\s*(.+?)\s*$/;
+// A top-level section header (`#` / `##`) ends the preceding task block.
+const SECTION_HEADER = /^#{1,2}\s+\S/;
+
+// Stamp regexes. `(?![\w-])` (not `\b`): the value must end the token, so
+// `riskTier: low-priority` does NOT read as `low` — a malformed stamp falls
+// through to heuristic derivation instead of silently misclassifying (#1544).
+const RISK_TIER_STAMP = /risk\s*tier\*{0,2}\s*:\s*\*{0,2}\s*(low|medium|high)(?![\w-])/i;
+const BOUNDARY_STAMP = /boundary\s*touching\*{0,2}\s*:\s*\*{0,2}\s*(true|false)(?![\w-])/i;
+const TEST_LAYER_STAMP =
+  /test\s*layer\*{0,2}\s*:\s*\*{0,2}\s*(acceptance|integration|unit|property)(?![\w-])/i;
+
+/**
+ * Parse every task block out of a decomposition markdown document, returning the
+ * per-task planner stamps. Pure: no I/O.
+ *
+ * A block runs from its `#### Task <id>:` header to the next task header or the
+ * next top-level (`#`/`##`) section header, whichever comes first.
+ */
+export function parseTaskStamps(planMarkdown: string): TaskStamp[] {
+  const lines = planMarkdown.split('\n');
+  const headers: Array<{ idx: number; id: string; title: string }> = [];
+  lines.forEach((line, idx) => {
+    const m = TASK_HEADER.exec(line);
+    if (m) headers.push({ idx, id: m[1], title: m[2].trim() });
+  });
+
+  const stamps: TaskStamp[] = [];
+  for (let h = 0; h < headers.length; h++) {
+    const start = headers[h].idx;
+    let end = h + 1 < headers.length ? headers[h + 1].idx : lines.length;
+    for (let i = start + 1; i < end; i++) {
+      if (SECTION_HEADER.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    const block = lines.slice(start, end).join('\n');
+    const risk = RISK_TIER_STAMP.exec(block);
+    const boundary = BOUNDARY_STAMP.exec(block);
+    const testLayer = TEST_LAYER_STAMP.exec(block);
+    stamps.push({
+      id: headers[h].id,
+      canonicalId: normalizeTaskId(headers[h].id),
+      title: headers[h].title,
+      ...(risk ? { riskTier: risk[1].toLowerCase() as RiskTier } : {}),
+      ...(boundary ? { boundaryTouching: boundary[1].toLowerCase() === 'true' } : {}),
+      ...(testLayer ? { testLayer: testLayer[1].toLowerCase() as TestLayer } : {}),
+      files: extractFiles(block),
+      blockedBy: extractDependencies(block),
+    });
+  }
+  return stamps;
+}
+
+/**
+ * Look up a task's stamp by id, matching on the canonical form so callers may
+ * pass `task-001` / `T001` / `001` interchangeably against a plan that authored
+ * `Task 001`. Returns `undefined` when the plan has no such task.
+ */
+export function stampForTask(
+  stamps: readonly TaskStamp[],
+  taskId: string,
+): TaskStamp | undefined {
+  const canonical = normalizeTaskId(taskId);
+  return stamps.find((s) => s.canonicalId === canonical);
+}

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.stamp.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.stamp.test.ts
@@ -1,0 +1,126 @@
+// ─── #1636 Regression: planner stamps reach dispatch ─────────────────────────
+//
+// These tests pin the two halves of the #1636 fix that the existing
+// prepare-delegation tests do NOT cover:
+//   1. the REGISTERED MCP schema no longer strips per-task stamps (previously
+//      `tasks: z.array(z.object({ id, title }))` dropped them before the handler
+//      ever ran — the bug's structural root);
+//   2. the plan-stamp lift + classification: a high+boundary stamped task yields
+//      riskTier:high / boundaryTouching:true / a verification sequence that
+//      includes the integration-suite rung.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { TOOL_REGISTRY } from '../registry.js';
+import { parseTaskStamps } from './parse-task-stamps.js';
+import { applyPlanStamps, classifyTask } from './prepare-delegation.js';
+
+function prepareDelegationSchema() {
+  const tool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_orchestrate');
+  const action = tool?.actions.find((a) => a.name === 'prepare_delegation');
+  if (!action) throw new Error('prepare_delegation action not found in registry');
+  return action.schema;
+}
+
+describe('#1636 registered schema retains per-task stamps', () => {
+  it('RegisteredSchema_TaskWithStamps_FieldsSurviveParse', () => {
+    const parsed = prepareDelegationSchema().parse({
+      featureId: 'f',
+      tasks: [
+        {
+          id: 'task-001',
+          title: 'Wrap the remove path',
+          riskTier: 'high',
+          boundaryTouching: true,
+          files: ['servers/exarchos-mcp/src/orchestrate/worktree/manager.ts'],
+          blockedBy: ['002'],
+          testLayer: 'integration',
+        },
+      ],
+    }) as { tasks: Array<Record<string, unknown>> };
+
+    const t = parsed.tasks[0];
+    // The exact fields that #1636 reported as silently stripped MUST survive.
+    expect(t.riskTier).toBe('high');
+    expect(t.boundaryTouching).toBe(true);
+    expect(t.files).toEqual(['servers/exarchos-mcp/src/orchestrate/worktree/manager.ts']);
+    expect(t.blockedBy).toEqual(['002']);
+    expect(t.testLayer).toBe('integration');
+  });
+
+  it('RegisteredSchema_UnknownTaskField_StillStripped', () => {
+    // We widened the schema deliberately, not by opening it to passthrough — an
+    // undeclared key is still dropped.
+    const parsed = prepareDelegationSchema().parse({
+      featureId: 'f',
+      tasks: [{ id: '001', title: 'x', bogusField: 42 }],
+    }) as { tasks: Array<Record<string, unknown>> };
+    expect(parsed.tasks[0].bogusField).toBeUndefined();
+  });
+
+  it('RegisteredSchema_PlanPath_Accepted', () => {
+    const parsed = prepareDelegationSchema().parse({
+      featureId: 'f',
+      planPath: 'docs/specs/some-plan.md',
+    }) as { planPath?: string };
+    expect(parsed.planPath).toBe('docs/specs/some-plan.md');
+  });
+
+  it('RegisteredSchema_BadRiskTier_Rejected', () => {
+    expect(() =>
+      prepareDelegationSchema().parse({
+        featureId: 'f',
+        tasks: [{ id: '001', title: 'x', riskTier: 'critical' }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('#1636 applyPlanStamps lifts markdown stamps onto bare tasks', () => {
+  it('ApplyPlanStamps_HighBoundaryStamp_ClassifiesHighBoundaryIntegration', () => {
+    const stamps = parseTaskStamps(
+      '#### Task 001: Wrap the remove path\n**Risk Tier:** high · **Boundary Touching:** true',
+    );
+    // The orchestrator passes only {id, title} today — that is the bug's input.
+    const { tasks } = applyPlanStamps([{ id: 'task-001', title: 'Wrap the remove path' }], stamps);
+    expect(tasks[0].riskTier).toBe('high');
+    expect(tasks[0].boundaryTouching).toBe(true);
+
+    const c = classifyTask(tasks[0]);
+    expect(c.riskTier).toBe('high');
+    expect(c.boundaryTouching).toBe(true);
+    expect(c.verificationSequence).toContain('check_integration_suite');
+  });
+
+  it('ApplyPlanStamps_ExplicitCallerField_WinsOverStamp', () => {
+    const stamps = parseTaskStamps('#### Task 001: x\n**Risk Tier:** high');
+    const { tasks } = applyPlanStamps([{ id: '001', title: 'x', riskTier: 'low' }], stamps);
+    expect(tasks[0].riskTier).toBe('low'); // caller-supplied value is never overridden
+  });
+
+  it('ApplyPlanStamps_HeuristicDisagreesWithStamp_EmitsAdvisory', () => {
+    // Bare {id,title} → heuristic derives `medium`; the plan stamps `high`.
+    const stamps = parseTaskStamps('#### Task 001: x\n**Risk Tier:** high');
+    const { advisories } = applyPlanStamps([{ id: '001', title: 'x' }], stamps);
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain('high');
+    expect(advisories[0]).toContain('medium');
+  });
+
+  it('ApplyPlanStamps_StampAgreesWithHeuristic_NoAdvisory', () => {
+    // A schema file → heuristic already derives `high`; stamp `high` agrees.
+    const stamps = parseTaskStamps('#### Task 001: x\n**Risk Tier:** high');
+    const { advisories } = applyPlanStamps(
+      [{ id: '001', title: 'x', files: ['src/types/foo.d.ts'] }],
+      stamps,
+    );
+    expect(advisories).toHaveLength(0);
+  });
+
+  it('ApplyPlanStamps_UnmatchedTask_PassesThroughUnchanged', () => {
+    const stamps = parseTaskStamps('#### Task 001: x\n**Risk Tier:** high');
+    const { tasks } = applyPlanStamps([{ id: '999', title: 'orphan' }], stamps);
+    expect(tasks[0].riskTier).toBeUndefined();
+    expect(tasks[0].boundaryTouching).toBeUndefined();
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.stamp.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.stamp.test.ts
@@ -94,8 +94,11 @@ describe('#1636 applyPlanStamps lifts markdown stamps onto bare tasks', () => {
 
   it('ApplyPlanStamps_ExplicitCallerField_WinsOverStamp', () => {
     const stamps = parseTaskStamps('#### Task 001: x\n**Risk Tier:** high');
-    const { tasks } = applyPlanStamps([{ id: '001', title: 'x', riskTier: 'low' }], stamps);
+    const { tasks, advisories } = applyPlanStamps([{ id: '001', title: 'x', riskTier: 'low' }], stamps);
     expect(tasks[0].riskTier).toBe('low'); // caller-supplied value is never overridden
+    // The caller's own value must NOT be misattributed to the plan stamp — the
+    // advisory only fires for a stamp-sourced tier (CodeRabbit/Sentry).
+    expect(advisories).toHaveLength(0);
   });
 
   it('ApplyPlanStamps_HeuristicDisagreesWithStamp_EmitsAdvisory', () => {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -42,6 +42,8 @@ import { generateQualityHints } from '../quality/hints.js';
 import type { QualityHint } from '../quality/hints.js';
 import { emitGateEvent } from './gate-utils.js';
 import { canonicaliseTaskId } from './task-decomposition.js';
+import { parseTaskStamps, stampForTask } from './parse-task-stamps.js';
+import { readFile } from 'node:fs/promises';
 import { queryTelemetryState } from '../telemetry/telemetry-queries.js';
 import type { TelemetryViewState } from '../telemetry/telemetry-projection.js';
 import {
@@ -584,6 +586,68 @@ export function classifyTasksFailClosed(
   }
 }
 
+// ─── Plan-Stamp Lift (#1636) ────────────────────────────────────────────────
+
+/**
+ * Merge the planner's parsed per-task stamps onto the caller's task inputs.
+ *
+ * Precedence (highest first): an explicit field ALREADY on the `tasks[]` entry →
+ * the parsed plan stamp → the classifier heuristic (applied later by
+ * `deriveRiskTier`/`deriveBoundaryTouching` when neither supplied a value). Only
+ * a MISSING field is filled from the stamp, so a caller that hand-supplies a
+ * value is never overridden.
+ *
+ * Also emits a DISAGREEMENT advisory (informational — never blocks) when the
+ * resolved `riskTier` differs from what the pure heuristic would have derived, so
+ * an operator can see that a plan stamp overrode a divergent heuristic rather
+ * than the override happening silently (issue #1636, proposed fix §3).
+ *
+ * Pure: no I/O (the caller reads the plan file and passes parsed stamps).
+ */
+export function applyPlanStamps(
+  tasks: readonly TaskInput[],
+  stamps: ReturnType<typeof parseTaskStamps>,
+): { readonly tasks: TaskInput[]; readonly advisories: string[] } {
+  const advisories: string[] = [];
+  const merged = tasks.map((t) => {
+    const stamp = stampForTask(stamps, t.id);
+    if (!stamp) return t;
+    const hasFiles = t.files !== undefined && t.files.length > 0;
+    const hasDeps = t.blockedBy !== undefined && t.blockedBy.length > 0;
+    const resolved: TaskInput = {
+      ...t,
+      ...(t.riskTier === undefined && stamp.riskTier !== undefined
+        ? { riskTier: stamp.riskTier }
+        : {}),
+      ...(t.boundaryTouching === undefined && stamp.boundaryTouching !== undefined
+        ? { boundaryTouching: stamp.boundaryTouching }
+        : {}),
+      ...(t.testLayer === undefined && stamp.testLayer !== undefined
+        ? { testLayer: stamp.testLayer }
+        : {}),
+      ...(!hasFiles && stamp.files.length > 0 ? { files: stamp.files } : {}),
+      ...(!hasDeps && stamp.blockedBy.length > 0 ? { blockedBy: stamp.blockedBy } : {}),
+    };
+    if (resolved.riskTier !== undefined) {
+      // Recompute the PURE heuristic (no riskTier override) to detect divergence.
+      const heuristicTier = deriveRiskTier({
+        id: resolved.id,
+        title: resolved.title,
+        files: resolved.files,
+        blockedBy: resolved.blockedBy,
+        testLayer: resolved.testLayer,
+      });
+      if (heuristicTier !== resolved.riskTier) {
+        advisories.push(
+          `task ${t.id}: plan stamp riskTier="${resolved.riskTier}" overrode heuristic "${heuristicTier}"`,
+        );
+      }
+    }
+    return resolved;
+  });
+  return { tasks: merged, advisories };
+}
+
 // ─── Worktree Blocker Patterns ──────────────────────────────────────────────
 
 const WORKTREE_BLOCKER_PATTERNS = [
@@ -810,6 +874,13 @@ export async function handlePrepareDelegation(
   args: {
     featureId: string;
     tasks?: TaskInput[];
+    /**
+     * #1636: path to the decomposition markdown. When present, the planner's
+     * per-task `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted onto
+     * the matching `tasks[]` entries (an explicit field on the entry still wins;
+     * the parsed stamp wins over the heuristic). Absent, behavior is unchanged.
+     */
+    planPath?: string;
     nativeIsolation?: boolean;
     /**
      * task 004 (DR-2): an explicit workflow-level risk-tier override. When
@@ -1316,14 +1387,35 @@ export async function handlePrepareDelegation(
     const agentConfig = ctx?.projectConfig?.agents ?? DEFAULTS.agents;
     const projectConfig = ctx?.projectConfig;
 
+    // ─── #1636: lift planner stamps from the decomposition markdown ──────────
+    // When `planPath` is supplied, parse its per-task `**Risk Tier:**` /
+    // `**Boundary Touching:**` stamps and merge them onto the caller's tasks so
+    // the classifier's "planner value wins" branch is reachable. Best-effort: an
+    // unreadable plan leaves tasks unchanged (heuristic still applies) and only
+    // surfaces an advisory — the readiness dispatch path must not hard-depend on
+    // a plan read.
+    let effectiveTasks = args.tasks;
+    if (args.tasks && args.planPath) {
+      try {
+        const planMarkdown = await readFile(args.planPath, 'utf-8');
+        const lifted = applyPlanStamps(args.tasks, parseTaskStamps(planMarkdown));
+        effectiveTasks = lifted.tasks;
+        for (const advisory of lifted.advisories) warnings.push(`stamp: ${advisory}`);
+      } catch (err) {
+        warnings.push(
+          `planPath unreadable (${args.planPath}) — proceeding with heuristic tiers: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     // DR-7: classify the wave through the fail-closed boundary. A resolver
     // throw (e.g. a deferred-kind 'not-yet-wired' fault) no longer propagates
     // and fails the dispatch OPEN; instead the boundary records `phase.blocked`
     // and refuses to proceed (no task classifications stamped).
     let taskClassifications: TaskClassification[] | undefined;
-    if (args.tasks) {
+    if (effectiveTasks) {
       const classified = classifyTasksFailClosed(
-        args.tasks,
+        effectiveTasks,
         agentConfig,
         projectConfig,
         workflowState.phase ?? 'delegate',

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -628,18 +628,19 @@ export function applyPlanStamps(
       ...(!hasFiles && stamp.files.length > 0 ? { files: stamp.files } : {}),
       ...(!hasDeps && stamp.blockedBy.length > 0 ? { blockedBy: stamp.blockedBy } : {}),
     };
-    if (resolved.riskTier !== undefined) {
-      // Recompute the PURE heuristic (no riskTier override) to detect divergence.
-      const heuristicTier = deriveRiskTier({
-        id: resolved.id,
-        title: resolved.title,
-        files: resolved.files,
-        blockedBy: resolved.blockedBy,
-        testLayer: resolved.testLayer,
-      });
-      if (heuristicTier !== resolved.riskTier) {
+    // Emit the advisory ONLY when the applied tier actually CAME FROM the plan
+    // stamp — a caller-supplied `riskTier` wins over the stamp and is not a "plan
+    // stamp override", so attributing it to the stamp would misdiagnose the source
+    // (CodeRabbit/Sentry). Compare against the heuristic derived from the ORIGINAL
+    // task `t` (no stamp-provided files/testLayer/deps) so it is genuinely PURE —
+    // deriving from `resolved` would fold the stamp's own context back in and could
+    // suppress a real divergence.
+    const riskTierFromStamp = t.riskTier === undefined && stamp.riskTier !== undefined;
+    if (riskTierFromStamp) {
+      const heuristicTier = deriveRiskTier(t);
+      if (heuristicTier !== stamp.riskTier) {
         advisories.push(
-          `task ${t.id}: plan stamp riskTier="${resolved.riskTier}" overrode heuristic "${heuristicTier}"`,
+          `task ${t.id}: plan stamp riskTier="${stamp.riskTier}" overrode heuristic "${heuristicTier}"`,
         );
       }
     }

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1438,7 +1438,27 @@ const orchestrateActions: readonly ToolAction[] = [
     description: 'Query delegation readiness and prepare quality hints for subagent dispatch',
     schema: z.object({
       featureId: z.string().min(1),
-      tasks: z.array(z.object({ id: z.string(), title: z.string() })).optional(),
+      // #1636: the per-task object accepts the planner's verification-routing
+      // stamps. Previously `z.object({ id, title })` default-stripped them, so
+      // `deriveRiskTier`/`deriveBoundaryTouching`'s "planner value wins" branch
+      // was structurally unreachable via MCP and every task fell through to the
+      // keyword/glob heuristic. `files`/`blockedBy`/`testLayer` feed the heuristic
+      // fallback for UNstamped tasks. Base types match the top-level `riskTier`
+      // override to stay clear of the joint-schema collision guard.
+      tasks: z.array(z.object({
+        id: z.string(),
+        title: z.string(),
+        riskTier: z.enum(['low', 'medium', 'high']).optional(),
+        boundaryTouching: z.boolean().optional(),
+        files: z.array(z.string()).optional(),
+        blockedBy: z.array(z.string()).optional(),
+        testLayer: z.enum(['acceptance', 'integration', 'unit', 'property']).optional(),
+      })).optional(),
+      // #1636: point at the decomposition markdown to have the per-task stamps
+      // lifted automatically (deterministic parse — no LLM). An explicit field on
+      // a `tasks[]` entry still wins over the parsed stamp; the parsed stamp wins
+      // over the heuristic. Absent, behavior is unchanged.
+      planPath: z.string().optional().describe('Decomposition markdown path; lifts per-task **Risk Tier:**/**Boundary Touching:** stamps onto tasks'),
       nativeIsolation: z.boolean().default(false).describe('When true, skip worktree-related blockers (the host platform handles isolation natively)'),
       // DR-2: explicit workflow-level risk-tier override. Absent, prepare_delegation
       // derives state.riskTier as the max-of-tiers over the classified wave; when

--- a/skills-src/delegate/SKILL.md
+++ b/skills-src/delegate/SKILL.md
@@ -87,9 +87,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 ```
+
+**Pass `planPath`.** It points `prepare_delegation` at the decomposition markdown so it lifts each task's `**Risk Tier:**` / `**Boundary Touching:**` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without `planPath` (and without an explicit `riskTier`/`boundaryTouching` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-`high`/boundary tasks (#1636). You may still set `riskTier`/`boundaryTouching` explicitly on a `tasks[]` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates `.worktrees/task-<id>` with `git worktree add`, runs `npm install`
@@ -110,6 +113,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted automatically when you pass `planPath` (above) — you do NOT need to re-transcribe them into `tasks[]`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -147,7 +151,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-`prepare_delegation` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+`prepare_delegation` resolves each task's risk tier — from the plan stamp when you passed `planPath` (the planner's authored value wins over the heuristic; a divergence is surfaced as a `stamp:` advisory in `warnings`) — and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped `agents/implementer.md` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from `taskClassifications[i].implementerPrompt`, then fill its `taskDescription` / `requirements` / `filePaths` placeholders (the same template slots in `references/implementer-prompt.md`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/skills/claude/delegate/SKILL.md
+++ b/skills/claude/delegate/SKILL.md
@@ -86,9 +86,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 ```
+
+**Pass `planPath`.** It points `prepare_delegation` at the decomposition markdown so it lifts each task's `**Risk Tier:**` / `**Boundary Touching:**` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without `planPath` (and without an explicit `riskTier`/`boundaryTouching` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-`high`/boundary tasks (#1636). You may still set `riskTier`/`boundaryTouching` explicitly on a `tasks[]` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates `.worktrees/task-<id>` with `git worktree add`, runs `npm install`
@@ -109,6 +112,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted automatically when you pass `planPath` (above) — you do NOT need to re-transcribe them into `tasks[]`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -145,7 +149,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-`prepare_delegation` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+`prepare_delegation` resolves each task's risk tier — from the plan stamp when you passed `planPath` (the planner's authored value wins over the heuristic; a divergence is surfaced as a `stamp:` advisory in `warnings`) — and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped `agents/implementer.md` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from `taskClassifications[i].implementerPrompt`, then fill its `taskDescription` / `requirements` / `filePaths` placeholders (the same template slots in `references/implementer-prompt.md`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/skills/codex/delegate/SKILL.md
+++ b/skills/codex/delegate/SKILL.md
@@ -77,9 +77,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 ```
+
+**Pass `planPath`.** It points `prepare_delegation` at the decomposition markdown so it lifts each task's `**Risk Tier:**` / `**Boundary Touching:**` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without `planPath` (and without an explicit `riskTier`/`boundaryTouching` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-`high`/boundary tasks (#1636). You may still set `riskTier`/`boundaryTouching` explicitly on a `tasks[]` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates `.worktrees/task-<id>` with `git worktree add`, runs `npm install`
@@ -100,6 +103,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted automatically when you pass `planPath` (above) — you do NOT need to re-transcribe them into `tasks[]`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -136,7 +140,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-`prepare_delegation` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+`prepare_delegation` resolves each task's risk tier — from the plan stamp when you passed `planPath` (the planner's authored value wins over the heuristic; a divergence is surfaced as a `stamp:` advisory in `warnings`) — and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped `agents/implementer.md` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from `taskClassifications[i].implementerPrompt`, then fill its `taskDescription` / `requirements` / `filePaths` placeholders (the same template slots in `references/implementer-prompt.md`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/skills/copilot/delegate/SKILL.md
+++ b/skills/copilot/delegate/SKILL.md
@@ -77,9 +77,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 ```
+
+**Pass `planPath`.** It points `prepare_delegation` at the decomposition markdown so it lifts each task's `**Risk Tier:**` / `**Boundary Touching:**` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without `planPath` (and without an explicit `riskTier`/`boundaryTouching` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-`high`/boundary tasks (#1636). You may still set `riskTier`/`boundaryTouching` explicitly on a `tasks[]` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates `.worktrees/task-<id>` with `git worktree add`, runs `npm install`
@@ -100,6 +103,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted automatically when you pass `planPath` (above) — you do NOT need to re-transcribe them into `tasks[]`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -136,7 +140,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-`prepare_delegation` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+`prepare_delegation` resolves each task's risk tier — from the plan stamp when you passed `planPath` (the planner's authored value wins over the heuristic; a divergence is surfaced as a `stamp:` advisory in `warnings`) — and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped `agents/implementer.md` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from `taskClassifications[i].implementerPrompt`, then fill its `taskDescription` / `requirements` / `filePaths` placeholders (the same template slots in `references/implementer-prompt.md`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/skills/cursor/delegate/SKILL.md
+++ b/skills/cursor/delegate/SKILL.md
@@ -77,9 +77,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 ```
+
+**Pass `planPath`.** It points `prepare_delegation` at the decomposition markdown so it lifts each task's `**Risk Tier:**` / `**Boundary Touching:**` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without `planPath` (and without an explicit `riskTier`/`boundaryTouching` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-`high`/boundary tasks (#1636). You may still set `riskTier`/`boundaryTouching` explicitly on a `tasks[]` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates `.worktrees/task-<id>` with `git worktree add`, runs `npm install`
@@ -100,6 +103,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted automatically when you pass `planPath` (above) — you do NOT need to re-transcribe them into `tasks[]`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -136,7 +140,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-`prepare_delegation` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+`prepare_delegation` resolves each task's risk tier — from the plan stamp when you passed `planPath` (the planner's authored value wins over the heuristic; a divergence is surfaced as a `stamp:` advisory in `warnings`) — and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped `agents/implementer.md` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from `taskClassifications[i].implementerPrompt`, then fill its `taskDescription` / `requirements` / `filePaths` placeholders (the same template slots in `references/implementer-prompt.md`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/skills/generic/delegate/SKILL.md
+++ b/skills/generic/delegate/SKILL.md
@@ -77,9 +77,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 ```
+
+**Pass `planPath`.** It points `prepare_delegation` at the decomposition markdown so it lifts each task's `**Risk Tier:**` / `**Boundary Touching:**` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without `planPath` (and without an explicit `riskTier`/`boundaryTouching` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-`high`/boundary tasks (#1636). You may still set `riskTier`/`boundaryTouching` explicitly on a `tasks[]` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates `.worktrees/task-<id>` with `git worktree add`, runs `npm install`
@@ -100,6 +103,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted automatically when you pass `planPath` (above) — you do NOT need to re-transcribe them into `tasks[]`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -127,7 +131,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-`prepare_delegation` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+`prepare_delegation` resolves each task's risk tier — from the plan stamp when you passed `planPath` (the planner's authored value wins over the heuristic; a divergence is surfaced as a `stamp:` advisory in `warnings`) — and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped `agents/implementer.md` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from `taskClassifications[i].implementerPrompt`, then fill its `taskDescription` / `requirements` / `filePaths` placeholders (the same template slots in `references/implementer-prompt.md`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/skills/opencode/delegate/SKILL.md
+++ b/skills/opencode/delegate/SKILL.md
@@ -77,9 +77,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 ```
+
+**Pass `planPath`.** It points `prepare_delegation` at the decomposition markdown so it lifts each task's `**Risk Tier:**` / `**Boundary Touching:**` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without `planPath` (and without an explicit `riskTier`/`boundaryTouching` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-`high`/boundary tasks (#1636). You may still set `riskTier`/`boundaryTouching` explicitly on a `tasks[]` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates `.worktrees/task-<id>` with `git worktree add`, runs `npm install`
@@ -100,6 +103,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The `**Risk Tier:**` / `**Boundary Touching:**` stamps are lifted automatically when you pass `planPath` (above) — you do NOT need to re-transcribe them into `tasks[]`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. `src/foo.ts`) — never an absolute parent-repo path, and never a `..` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -136,7 +140,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-`prepare_delegation` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+`prepare_delegation` resolves each task's risk tier — from the plan stamp when you passed `planPath` (the planner's authored value wins over the heuristic; a divergence is surfaced as a `stamp:` advisory in `warnings`) — and returns a **per-task rendered prompt** on its classification: `taskClassifications[i].implementerPrompt`. This is the implementer system prompt with the verification note already selected for that task's `riskTier`/`boundaryTouching` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped `agents/implementer.md` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from `taskClassifications[i].implementerPrompt`, then fill its `taskDescription` / `requirements` / `filePaths` placeholders (the same template slots in `references/implementer-prompt.md`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -89,9 +89,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 \`\`\`
+
+**Pass \`planPath\`.** It points \`prepare_delegation\` at the decomposition markdown so it lifts each task's \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without \`planPath\` (and without an explicit \`riskTier\`/\`boundaryTouching\` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-\`high\`/boundary tasks (#1636). You may still set \`riskTier\`/\`boundaryTouching\` explicitly on a \`tasks[]\` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates \`.worktrees/task-<id>\` with \`git worktree add\`, runs \`npm install\`
@@ -112,6 +115,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamps are lifted automatically when you pass \`planPath\` (above) — you do NOT need to re-transcribe them into \`tasks[]\`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -148,7 +152,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-\`prepare_delegation\` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+\`prepare_delegation\` resolves each task's risk tier — from the plan stamp when you passed \`planPath\` (the planner's authored value wins over the heuristic; a divergence is surfaced as a \`stamp:\` advisory in \`warnings\`) — and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped \`agents/implementer.md\` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from \`taskClassifications[i].implementerPrompt\`, then fill its \`taskDescription\` / \`requirements\` / \`filePaths\` placeholders (the same template slots in \`references/implementer-prompt.md\`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 
@@ -1038,9 +1042,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 \`\`\`
+
+**Pass \`planPath\`.** It points \`prepare_delegation\` at the decomposition markdown so it lifts each task's \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without \`planPath\` (and without an explicit \`riskTier\`/\`boundaryTouching\` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-\`high\`/boundary tasks (#1636). You may still set \`riskTier\`/\`boundaryTouching\` explicitly on a \`tasks[]\` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates \`.worktrees/task-<id>\` with \`git worktree add\`, runs \`npm install\`
@@ -1061,6 +1068,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamps are lifted automatically when you pass \`planPath\` (above) — you do NOT need to re-transcribe them into \`tasks[]\`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -1097,7 +1105,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-\`prepare_delegation\` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+\`prepare_delegation\` resolves each task's risk tier — from the plan stamp when you passed \`planPath\` (the planner's authored value wins over the heuristic; a divergence is surfaced as a \`stamp:\` advisory in \`warnings\`) — and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped \`agents/implementer.md\` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from \`taskClassifications[i].implementerPrompt\`, then fill its \`taskDescription\` / \`requirements\` / \`filePaths\` placeholders (the same template slots in \`references/implementer-prompt.md\`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 
@@ -1929,9 +1937,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 \`\`\`
+
+**Pass \`planPath\`.** It points \`prepare_delegation\` at the decomposition markdown so it lifts each task's \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without \`planPath\` (and without an explicit \`riskTier\`/\`boundaryTouching\` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-\`high\`/boundary tasks (#1636). You may still set \`riskTier\`/\`boundaryTouching\` explicitly on a \`tasks[]\` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates \`.worktrees/task-<id>\` with \`git worktree add\`, runs \`npm install\`
@@ -1952,6 +1963,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamps are lifted automatically when you pass \`planPath\` (above) — you do NOT need to re-transcribe them into \`tasks[]\`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -1988,7 +2000,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-\`prepare_delegation\` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+\`prepare_delegation\` resolves each task's risk tier — from the plan stamp when you passed \`planPath\` (the planner's authored value wins over the heuristic; a divergence is surfaced as a \`stamp:\` advisory in \`warnings\`) — and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped \`agents/implementer.md\` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from \`taskClassifications[i].implementerPrompt\`, then fill its \`taskDescription\` / \`requirements\` / \`filePaths\` placeholders (the same template slots in \`references/implementer-prompt.md\`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 
@@ -2812,9 +2824,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 \`\`\`
+
+**Pass \`planPath\`.** It points \`prepare_delegation\` at the decomposition markdown so it lifts each task's \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without \`planPath\` (and without an explicit \`riskTier\`/\`boundaryTouching\` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-\`high\`/boundary tasks (#1636). You may still set \`riskTier\`/\`boundaryTouching\` explicitly on a \`tasks[]\` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates \`.worktrees/task-<id>\` with \`git worktree add\`, runs \`npm install\`
@@ -2835,6 +2850,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamps are lifted automatically when you pass \`planPath\` (above) — you do NOT need to re-transcribe them into \`tasks[]\`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -2871,7 +2887,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-\`prepare_delegation\` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+\`prepare_delegation\` resolves each task's risk tier — from the plan stamp when you passed \`planPath\` (the planner's authored value wins over the heuristic; a divergence is surfaced as a \`stamp:\` advisory in \`warnings\`) — and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped \`agents/implementer.md\` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from \`taskClassifications[i].implementerPrompt\`, then fill its \`taskDescription\` / \`requirements\` / \`filePaths\` placeholders (the same template slots in \`references/implementer-prompt.md\`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 
@@ -3705,9 +3721,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 \`\`\`
+
+**Pass \`planPath\`.** It points \`prepare_delegation\` at the decomposition markdown so it lifts each task's \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without \`planPath\` (and without an explicit \`riskTier\`/\`boundaryTouching\` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-\`high\`/boundary tasks (#1636). You may still set \`riskTier\`/\`boundaryTouching\` explicitly on a \`tasks[]\` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates \`.worktrees/task-<id>\` with \`git worktree add\`, runs \`npm install\`
@@ -3728,6 +3747,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamps are lifted automatically when you pass \`planPath\` (above) — you do NOT need to re-transcribe them into \`tasks[]\`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -3755,7 +3775,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-\`prepare_delegation\` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+\`prepare_delegation\` resolves each task's risk tier — from the plan stamp when you passed \`planPath\` (the planner's authored value wins over the heuristic; a divergence is surfaced as a \`stamp:\` advisory in \`warnings\`) — and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped \`agents/implementer.md\` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from \`taskClassifications[i].implementerPrompt\`, then fill its \`taskDescription\` / \`requirements\` / \`filePaths\` placeholders (the same template slots in \`references/implementer-prompt.md\`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 
@@ -4569,9 +4589,12 @@ exarchos_event({
 exarchos_orchestrate({
   action: "prepare_delegation",
   featureId: "<featureId>",
+  planPath: "docs/specs/<the-decomposition-spec>.md",
   tasks: [{ id: "task-001", title: "...", modules: [...] }, ...]
 })
 \`\`\`
+
+**Pass \`planPath\`.** It points \`prepare_delegation\` at the decomposition markdown so it lifts each task's \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamp automatically (deterministic parse — no hand-transcription). The stamp is what selects the per-task verification depth below; without \`planPath\` (and without an explicit \`riskTier\`/\`boundaryTouching\` on a task) every task falls back to a keyword/glob heuristic that under-provisions planner-\`high\`/boundary tasks (#1636). You may still set \`riskTier\`/\`boundaryTouching\` explicitly on a \`tasks[]\` entry to override the plan for one task; an explicit value always wins.
 
 The composite action performs:
 1. **Worktree creation** — creates \`.worktrees/task-<id>\` with \`git worktree add\`, runs \`npm install\`
@@ -4592,6 +4615,7 @@ The composite action performs:
 
 From the implementation plan, extract for each task:
 - Full task description (paste inline; never reference external files)
+- The \`**Risk Tier:**\` / \`**Boundary Touching:**\` stamps are lifted automatically when you pass \`planPath\` (above) — you do NOT need to re-transcribe them into \`tasks[]\`; pass them explicitly only to override the plan for a specific task
 - Files to create/modify as **worktree-relative paths rooted inside the worktree** (e.g. \`src/foo.ts\`) — never an absolute parent-repo path, and never a \`..\` sequence that escapes the worktree root. Either form resolves outside the agent's worktree cwd and silently writes into the main worktree. This is the platform-agnostic line of defense — it must hold on every runtime.
 - Test file paths (worktree-relative) and expected test names
 - Dependencies on other tasks (for sequencing)
@@ -4628,7 +4652,7 @@ For each task:
 
 ### Tier-selected verification note — dispatch the rendered prompt
 
-\`prepare_delegation\` resolves each task's risk tier and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
+\`prepare_delegation\` resolves each task's risk tier — from the plan stamp when you passed \`planPath\` (the planner's authored value wins over the heuristic; a divergence is surfaced as a \`stamp:\` advisory in \`warnings\`) — and returns a **per-task rendered prompt** on its classification: \`taskClassifications[i].implementerPrompt\`. This is the implementer system prompt with the verification note already selected for that task's \`riskTier\`/\`boundaryTouching\` — a low-tier task carries a terse static-analysis steer, a high-tier task carries the test-after + integration-suite rung.
 
 **Dispatch THAT prompt — not the static agent default.** The shipped \`agents/implementer.md\` bakes a fixed medium-tier note (a self-contained fallback for runtimes that pre-bind a named agent). Use it verbatim only when no classification exists (e.g. a fixer dispatch). Otherwise, the orchestrator's dispatch payload must be built from \`taskClassifications[i].implementerPrompt\`, then fill its \`taskDescription\` / \`requirements\` / \`filePaths\` placeholders (the same template slots in \`references/implementer-prompt.md\`) with the task-specific context above. Dispatching the static default instead re-imposes medium-RGR ceremony on every task regardless of tier — the exact gap this seam closes. The tier is pure data from the classification stamp; no workflow-type branching is involved.
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,12 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 import { fileURLToPath } from 'node:url';
+
+// Captured eval ARTIFACTS under `docs/evals/` include agent-authored `*.test.ts`
+// files that are verbatim records, not project tests (they use a module-load
+// harness, not describe/it). They are already outside every `include` allow-list
+// below; this explicit exclude makes that intent durable so a future glob change
+// can never collect them (and their `process.exit` can never reach a worker).
+const EXCLUDE = [...configDefaults.exclude, 'docs/**'];
 
 export default defineConfig({
   test: {
@@ -29,12 +36,14 @@ export default defineConfig({
             'test/smoke/**/*.test.ts',
             'test/e2e/**/*.test.ts',
           ],
+          exclude: EXCLUDE,
         },
       },
       {
         test: {
           name: 'process',
           include: ['test/process/**/*.test.ts'],
+          exclude: EXCLUDE,
           testTimeout: 15000,
           setupFiles: ['./test/setup/global.ts'],
         },
@@ -62,6 +71,7 @@ export default defineConfig({
         test: {
           name: 'outcome',
           include: ['tests/outcome/**/*.test.ts'],
+          exclude: EXCLUDE,
           testTimeout: 30000,
           fileParallelism: false,
           passWithNoTests: true,


### PR DESCRIPTION
## Summary

Fixes #1636 (planner risk-tier / boundary stamps dropped before dispatch) **and** empirically benchmarks the delegation pipeline against native Claude Code, per the request to validate — not just assert — that the verification ladder and per-task model routing earn their keep.

This is a multi-phase deliverable. Phases land as commits on this branch:

- **Phase 0 — deterministic corpus benchmark (landed).** Runs the *real* production `classifyTask` / `renderImplementerPrompt` over every stamped plan-format spec in `docs/specs/` (9 specs, 100 tasks) and measures decision divergence across arms **E** (plan-honoring / the fix), **H0** (true production — `{id,title}` only, today's #1636 behavior), **H1** (heuristic ceiling), **N** (native flat model). No live agents.
- **Phase 1 — the #1636 fix (landed).** Threads the planner stamp end-to-end: widened the registry `tasks[]` schema, a new `parse-task-stamps.ts` (SoT parser, `####`/`###`-aware, `task-001`-id-safe), `applyPlanStamps` in `prepare_delegation` (explicit field > plan stamp > heuristic) with a disagreement advisory, `planPath` wiring, delegate-skill update + regenerated runtimes. Regression tests round-trip through the registration schema (the layer existing tests bypass). 22 new tests; full prepare-delegation (131) + registry/dispatch/adapter/describe (256) suites green; `skills:guard` green.
- **Phase 2 — live A/B on code quality (landed).** Controlled A/B with a hidden oracle over **14 live runs (2 models × 3 tasks)**: real agents under the exarchos tier-selected verification regime (E) vs. a native plan-only regime (N). Result: **correctness is a null** — every run of both arms passed 100% of its hidden oracle and typechecked clean, including the discriminating round (a trap-laden CSV parser on the weaker sonnet model). The delta is **process**: durable tests + kill-probes on **E 7/7 vs N 0/7**. Interpretation + honest limitations in `docs/evals/quality-ab/ANALYSIS.md`.

### What the benchmark answers

- **Model selection (Phase 0):** exarchos routes 99/100 corpus tasks to the same `implementer/opus` a native flat run uses — ≈0 differentiation, and its one cheap-model downgrade was a *high-tier* task (miscalibrated).
- **Verification depth (Phase 0):** real but *latent* pre-fix — 45/100 tasks shipped under-provisioned because the plan tier never reached dispatch; 51/100 lost the boundary steer. The fix makes depth track the plan.
- **Code quality (Phase 2):** the verification pipeline is a **durable-test / regression-protection** mechanism, not a first-pass-correctness or model-cost optimizer. A capable model implements a *complete* spec correctly with or without the steer; the steer's correctness value would only appear on *under-specified* tasks (the identified next probe).

## Changes

- `servers/exarchos-mcp/src/evals/benchmarks/plan-format-corpus.ts` — deterministic benchmark runner (parses the corpus, classifies each arm, emits report).
- `docs/evals/2026-07-09-1636-plan-format-corpus.{md,json}` — generated report + machine-readable data.
- `package.json` — `bench:plan-format` script.

### Phase 0 headline findings

- **Verification depth (E vs H0 — what ships today):** **45/100** tasks under-provisioned — every planner-`high` task loses the `check_integration_suite` rung; **51/100** lose the boundary mock-steer.
- **Model selection:** **99/100** route to `implementer/opus`, identical to native flat opus and *decoupled from `riskTier`* — the single `haiku` downgrade is a **high-tier** task (under-powered). Per-task model routing delivers ≈0 differentiation on this corpus.

## Test Plan

- [x] `npm run bench:plan-format` runs clean and regenerates the report.
- [x] `tsc --noEmit` clean on the MCP server.
- [x] Phase 1: registration-schema round-trip retains the stamps; `high`+`boundary` stamped task → `riskTier:high` / `boundaryTouching:true` / `verificationSequence ⊇ check_integration_suite`.
- [x] `prepare-delegation` (131), `registry`/`dispatch`/`mcp`/`describe`/`register` (256), `parse-task-stamps` (13) suites green; `skills:guard` green.
- [x] Phase 2: live A/B grading harness + 14-run results; oracles validated against correct references (9/9, 21/21, 21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
