### PR TITLE
fix(economy): resolve CodeRabbit/Sentry findings from #1682 (post-merge follow-up)

### DIFF
--- a/servers/exarchos-mcp/src/orchestrate/check-pr-comments.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/check-pr-comments.test.ts
@@ -155,6 +155,7 @@ describe('handleCheckPrComments', () => {
       author: `reviewer-${i}`,
       body: `comment-body-${i}`,
       createdAt: '2026-01-01T00:00:00Z',
+      source: 'review-inline',
       path: `src/file-${i}.ts`,
       line: i + 1,
     }));

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { runStaticAnalysis, FAIL_DETAIL_MAX_LINES } from './static-analysis.js';
+import {
+  runStaticAnalysis,
+  FAIL_DETAIL_MAX_LINES,
+  FAIL_DETAIL_MAX_FILES,
+} from './static-analysis.js';
 import type { StaticAnalysisResult, RunCommandFn } from './static-analysis.js';
 
 describe('runStaticAnalysis', () => {
@@ -647,6 +651,41 @@ describe('runStaticAnalysis', () => {
       expect(result.output).toContain('src/beta.ts: 1');
       // The complete set of distinct failing files is enumerated.
       expect(result.output).toContain('Failing files (3)');
+    });
+
+    it('checkStaticAnalysis_ManyFailingFiles_CapsBreakdownWithElidedCount', () => {
+      const repoRoot = createPackageJson({
+        lint: 'eslint .',
+        typecheck: 'tsc --noEmit',
+      });
+
+      // 30 distinct files, 2 lines each (60 lines total), so the head cap
+      // engages AND the per-file breakdown would list all 30 without a cap —
+      // itself blowing the DR-7 budget the line cap protects.
+      const fileCount = 30;
+      const lines: string[] = [];
+      for (let i = 1; i <= fileCount; i++) {
+        const name = `src/file${String(i).padStart(2, '0')}.ts`;
+        lines.push(`${name}(1,1): error TS2322: type error`);
+        lines.push(`${name}(2,1): error TS2345: bad arg`);
+      }
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: failingRunner({ typecheck: { stderr: lines.join('\n') } }),
+      });
+
+      expect(result.status).toBe('fail');
+      // Total distinct-file count is still reported honestly…
+      expect(result.output).toContain(`Failing files (${fileCount})`);
+      // …but only the first FAIL_DETAIL_MAX_FILES are enumerated, with an
+      // explicit elided-count line so the omission is perceivable.
+      expect(result.output).toContain(
+        `…and ${fileCount - FAIL_DETAIL_MAX_FILES} more files.`,
+      );
+      // The first file is shown; a folded-off file is absent entirely.
+      expect(result.output).toContain('src/file01.ts: 2');
+      expect(result.output).not.toContain('src/file30.ts');
     });
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
@@ -442,6 +442,13 @@ function readPackageJson(
 export const FAIL_DETAIL_MAX_LINES = 50;
 
 /**
+ * Maximum distinct failing files enumerated in the per-file breakdown. Without
+ * this cap a large cascade appends one line per file, so the "capped" detail can
+ * still blow the DR-7 response budget the line cap exists to protect.
+ */
+export const FAIL_DETAIL_MAX_FILES = 20;
+
+/**
  * Path-like token ending in a recognized source extension. Used to attribute
  * each transcript line to a failing file. Matches tsc (`src/foo.ts(12,5):`),
  * eslint stylish headers (`/abs/src/foo.ts`), eslint unix/compact
@@ -473,9 +480,10 @@ function fileFailureCounts(lines: readonly string[]): Map<string, number> {
 
 /**
  * Cap a verbose FAIL `detail` (raw lint/typecheck transcript) to the first
- * `FAIL_DETAIL_MAX_LINES` lines plus a total count, a complete per-file failing
- * breakdown, and a steering suffix. Returns the detail unchanged when it already
- * fits within the cap (preserving the exact shape of short single-line messages).
+ * `FAIL_DETAIL_MAX_LINES` lines plus a total count, a per-file failing breakdown
+ * (itself capped at `FAIL_DETAIL_MAX_FILES` with an elided-count line), and a
+ * steering suffix. Returns the detail unchanged when it already fits within the
+ * cap (preserving the exact shape of short single-line messages).
  *
  * @param rawDetail    the full (already-trimmed) tool transcript
  * @param rerunCommand the command the reviewer re-runs for the uncapped output
@@ -499,8 +507,12 @@ export function capFailDetail(rawDetail: string, rerunCommand: string): string {
     // Highest line count first; ties broken by first-seen order (Map iteration).
     const ordered = [...fileCounts.entries()].sort((a, b) => b[1] - a[1]);
     parts.push(`Failing files (${fileCounts.size}):`);
-    for (const [file, count] of ordered) {
+    const shown = ordered.slice(0, FAIL_DETAIL_MAX_FILES);
+    for (const [file, count] of shown) {
       parts.push(`  ${file}: ${count}`);
+    }
+    if (ordered.length > shown.length) {
+      parts.push(`  …and ${ordered.length - shown.length} more files.`);
     }
   }
 

--- a/servers/exarchos-mcp/src/orchestrate/vcs/get-pr-comments.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/get-pr-comments.test.ts
@@ -106,6 +106,28 @@ describe('handleGetPrComments', () => {
     // hasMore → a narrow affordance steering to the next page.
     expect(result.next_actions).toHaveLength(1);
     expect(result.next_actions?.[0]?.verb).toBe('get_pr_comments');
+    // The continuation command advances the offset AND preserves the projection
+    // — without --fields, page 2 would silently return full comments.
+    expect(result.next_actions?.[0]?.hint).toBe(
+      'get_pr_comments --pr 42 --offset 2 --limit 2 --fields id,author',
+    );
+  });
+
+  it('handleGetPrComments_NoFields_OmitsFieldsFromContinuation', async () => {
+    // No projection requested → the continuation command must not invent one.
+    const page = {
+      comments: [{ id: 5, author: 'z', body: 'b', createdAt: 't', source: 'issue-comment' }],
+      page: { total: 3, offset: 0, limit: 2, hasMore: true },
+    };
+    const getPrCommentsPage = vi.fn().mockResolvedValue(page);
+    mockProvider = makeMockProvider({ getPrCommentsPage });
+    vi.mocked(createVcsProvider).mockResolvedValue(mockProvider);
+
+    const result = await handleGetPrComments({ prId: '42', limit: 2 }, ctx);
+
+    expect(result.next_actions?.[0]?.hint).toBe(
+      'get_pr_comments --pr 42 --offset 2 --limit 2',
+    );
   });
 
   it('handleGetPrComments_ReadOnly_DoesNotEmitEvent', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/vcs/get-pr-comments.ts
+++ b/servers/exarchos-mcp/src/orchestrate/vcs/get-pr-comments.ts
@@ -44,6 +44,12 @@ export async function handleGetPrComments(
 
     if (page.page.hasMore) {
       const nextOffset = page.page.offset + page.page.limit;
+      // Carry the projection forward — otherwise page 2 silently returns full
+      // comments, defeating the DR-3 field-narrowing the caller asked for.
+      const fieldsArg =
+        args.fields && args.fields.length > 0
+          ? ` --fields ${args.fields.join(',')}`
+          : '';
       return {
         success: true,
         data: page,
@@ -52,7 +58,7 @@ export async function handleGetPrComments(
             'get_pr_comments',
             page.comments.length,
             page.page.total,
-            `get_pr_comments --pr ${args.prId} --offset ${nextOffset} --limit ${page.page.limit}`,
+            `get_pr_comments --pr ${args.prId} --offset ${nextOffset} --limit ${page.page.limit}${fieldsArg}`,
           ),
         ],
       };

--- a/servers/exarchos-mcp/src/utils/paths.test.ts
+++ b/servers/exarchos-mcp/src/utils/paths.test.ts
@@ -101,6 +101,13 @@ describe('resolveStateDir', () => {
     expect(resolveStateDir()).toBe('/home/testuser/.local/state/exarchos/state');
   });
 
+  it('expands tilde when XDG_STATE_HOME contains tilde', () => {
+    // Parity with the WORKFLOW_STATE_DIR branch — a leading `~` must not leak
+    // through as a cwd-relative path.
+    vi.stubEnv('XDG_STATE_HOME', '~/state');
+    expect(resolveStateDir()).toBe('/home/testuser/state/exarchos/state');
+  });
+
   it('returns universal default when no env vars are set', () => {
     expect(resolveStateDir()).toBe('/home/testuser/.exarchos/state');
   });

--- a/servers/exarchos-mcp/src/utils/paths.ts
+++ b/servers/exarchos-mcp/src/utils/paths.ts
@@ -257,7 +257,10 @@ function resolveDir(
 
   const xdgStateHome = env['XDG_STATE_HOME'];
   if (xdgStateHome) {
-    return toPosix(path.join(xdgStateHome, 'exarchos', exarchosSubdir));
+    // Expand a leading `~` here too — otherwise `XDG_STATE_HOME=~/state` opens
+    // the store at a cwd-relative path, diverging from the env-value branch
+    // above (which applies expandTilde) and from WORKFLOW_STATE_DIR.
+    return toPosix(path.join(expandTilde(xdgStateHome, home), 'exarchos', exarchosSubdir));
   }
 
   return toPosix(path.join(home, '.exarchos', exarchosSubdir));

--- a/servers/exarchos-mcp/src/vcs/provider.test.ts
+++ b/servers/exarchos-mcp/src/vcs/provider.test.ts
@@ -190,6 +190,15 @@ describe('windowPrComments', () => {
     expect(result.page.offset).toBe(0);
   });
 
+  it('windowPrComments_FractionalLimit_DoesNotFloorToZeroPage', () => {
+    // A limit in (0, 1) floors to 0; a zero-sized page would report
+    // hasMore:true forever. Must fall back to the default, not emit a 0 page.
+    const result = windowPrComments(makeComments(30), { limit: 0.5 });
+
+    expect(result.page.limit).toBe(DEFAULT_PR_COMMENTS_LIMIT);
+    expect(result.comments.length).toBeGreaterThan(0);
+  });
+
   it('windowPrComments_OffsetBeyondTotal_EmptyNoMore', () => {
     const result = windowPrComments(makeComments(10), { limit: 5, offset: 100 });
 

--- a/servers/exarchos-mcp/src/vcs/provider.ts
+++ b/servers/exarchos-mcp/src/vcs/provider.ts
@@ -181,7 +181,11 @@ function normalizePrCommentsLimit(limit?: number): number {
   if (limit === undefined || !Number.isFinite(limit) || limit <= 0) {
     return DEFAULT_PR_COMMENTS_LIMIT;
   }
-  return Math.floor(limit);
+  // A fractional limit in (0, 1) floors to 0 — a zero-sized page reports
+  // `hasMore: true` forever, so the schema-guarded boundary aside, this
+  // defense-in-depth normalizer must never emit 0 (mirrors resolveCommentWindow).
+  const normalized = Math.floor(limit);
+  return normalized > 0 ? normalized : DEFAULT_PR_COMMENTS_LIMIT;
 }
 
 /** Coerce an optional `offset` to a non-negative integer, defaulting to 0. */

--- a/test/fixtures/event-replay.ts
+++ b/test/fixtures/event-replay.ts
@@ -69,6 +69,8 @@ function isEventQueryData(d: unknown): d is EventQueryData {
     typeof p === 'object' &&
     p !== null &&
     typeof p.total === 'number' &&
+    typeof p.offset === 'number' &&
+    typeof p.limit === 'number' &&
     typeof p.hasMore === 'boolean'
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to the now-merged **#1682** (`refactor(economy): surface-wide response-economy contract`). PR #1682 merged at `ebcafde0` — *before* several still-valid CodeRabbit/Sentry inline findings were applied — so those findings landed on `main` as live defects. This PR resolves the ones that survived verification against the merged code, judged through our invariants catalog (`.exarchos/invariants.md`).

Findings that were **already fixed** (in `a7ad22d`) or **rejected at the schema boundary** are answered inline on #1682 rather than re-patched here — see "Not changed (with reason)" below.

## Changes

**Production fixes**
- **static-analysis** (`FAIL_DETAIL_MAX_FILES`) — the failing-file breakdown appended one line per distinct file with no cap; a large cascade blew the DR-7 response budget the line-cap exists to protect. Now capped with an explicit `…and N more files.` elision line. *(INV-5b output-contract; CodeRabbit #7)*
- **get_pr_comments** — the pagination continuation hint rebuilt only `--pr/--offset/--limit`, so a projected page 1 silently fell back to full comments on page 2. Now carries `--fields` forward when set. *(DR-3 / INV-12 affordance; CodeRabbit #8)*
- **normalizePrCommentsLimit** — a fractional limit in `(0,1)` floored to `0`, yielding a zero-sized page that reports `hasMore: true` forever. Now falls back to the default, mirroring the already-hardened `resolveCommentWindow`. Defense-in-depth behind the schema guard. *(CodeRabbit #10)*
- **paths** — `XDG_STATE_HOME` skipped tilde expansion while the sibling `WORKFLOW_STATE_DIR` branch applied it, so `XDG_STATE_HOME=~/state` opened the store at a cwd-relative path. Now expands `~`. *(INV-16 os-portability; CodeRabbit #9)*

**Test fixes / hardening**
- Added the required `PrComment.source` to the `manyComments` fixture (Critical — CodeRabbit #6). Root cause: the MCP `tsconfig.json` excludes `**/*.test.ts`, so `tsc` never type-checked the fixture (follow-up gap, see below).
- Strengthened the event-replay page-shape guard to validate `offset` + `limit`, not just `total` + `hasMore`. *(DR-5 wire-contract; CodeRabbit #11)*
- +4 regression tests: fractional limit → default, failing-file cap + elision, `--fields` continuation, `XDG_STATE_HOME` tilde.

**Not changed (with reason)**
- CodeRabbit #4 / #5 (fractional/negative event-query limit+offset) — rejected at the boundary by `coercedPositiveInt`/`coercedNonnegativeInt` (`.int().positive()` / `.int().nonnegative()`). Per **INV-5a**, the schema is the single enforcement point; handler validation would be redundant.
- Sentry #1, CodeRabbit #13/#14 (economy-seam no-bypass gate) — already fixed in `a7ad22d` (enclosing-match + regression fixtures present).
- Sentry #12 (ci-fix/review-address repeat per page) — documented by-design: bounded non-comment items intentionally appear on every page while comments are windowed.
- CodeRabbit #2 (co-locate `__tests__/event-store` suite) and #3 (bound the event-store query at the storage layer) — real tech-debt but heavy-lift and out of this remediation's scope → filed as follow-ups.

## Test Plan

- `npm run typecheck` (root) + `cd servers/exarchos-mcp && npx tsc --noEmit` — green
- `npm run test:run` (root) — 108/108 files, 898 tests green
- MCP `npx vitest run` — 695 pass; the only failures are the pre-existing `merge-orchestrate.*` + `store.race` known-red baseline (9 files / 26 tests), proven unchanged by an isolated baseline run
- `npm run skills:guard` — clean
- 4 new regression tests green

## Follow-ups (filed separately)

- **#1684** — MCP `tsconfig.json` excludes `**/*.test.ts` from `tsc` → type errors in tests go uncaught (this is how #6 slipped through). Widening it will surface pre-existing test type-errors, so it's scoped separately.
- **#1685** — Bound the default event-store query at the storage layer (count + `LIMIT`/`OFFSET`) instead of loading all events then slicing (CodeRabbit #3).
- **#1686** — Consolidate `__tests__/event-store/tools.test.ts` into the co-located `event-store/tools.test.ts` (CodeRabbit #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
