### PR TITLE
feat(lifecycle): generic ps/inspect/wait/export lifecycle verbs

### DIFF
--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -129,9 +129,14 @@ Generic queries over the event log using the liveness convention (§6). Four ver
 
 **`inspect`** — Single-workflow cold-probe projection. Returns phase, phase history, task state, and next-action affordances for a workflow without side effects. Schema discovery via `inspect --schema`.
 
-**`wait`** — Caller-bounded poll with structured timeout (never hangs, no background timers). Blocks until a condition is reached or timeout expires:
-- Default `until: 'merge'` — block until the serialized merge on `integrationRef` reaches its terminal `worktree.merge_executed` event. `integrationRef` is required. When a merge crashes mid-operation (stuck in `executing` phase with an unpaired `merge.executing_started`), this predicate resolves when the terminal event is detected — the operation-level invariant (§6) detects completion regardless of workflow phase, solving the S-6 stuck-operation recovery scenario without per-feature supervisor logic.
-- `until: 'idle'` — block until no in-flight `prune_worktrees` GC pass remains (i.e., `inFlightPrunes` list clears). `integrationRef` not consulted.
+**`wait`** — Caller-bounded poll with structured timeout (never hangs, no background timers). A pure consumer: appends no events on any path and returns a structured `WAIT_TIMEOUT` on expiry. Blocks until an event-log predicate holds. Two scopes:
+- **Feature-scoped predicates** (require a `featureId`):
+  - `--phase <phase>` — reached-or-passed: returns immediately if the projection already reached (or passed) the target phase, else resolves on the `workflow.transition` into it; a `failed`/`cancelled` terminal first ⇒ `WAIT_FAILED`.
+  - `--status <terminal>` — resolves when the workflow reaches the *requested* terminal status (`completed`/`failed`/`cancelled`); a *different* terminal first ⇒ `WAIT_FAILED`.
+  - `--operation <surface>` — the **S-6 predicate**, valid only for the feature-scoped liveness surfaces (`merge`, `mutation`, per §6). Resolves when the feature stream's unpaired `<surface>.executing_started` (by instance key) gains its registry terminal — for `merge` that terminal is `merge.executed` **or** `merge.recovered`; returns immediately if none is in flight. This — **not** `until: 'merge'` — is how a stuck merge is waited out: a crash mid-merge leaves an unpaired `merge.executing_started` on the *feature* stream, and `wait <id> --operation merge` resolves when its terminal lands (or exits 17 on timeout), needing no per-feature supervisor and no workflow-phase transition (`merge.recovered` folds into the `mergeOrchestrator` sub-view, never a phase change).
+- **Worktree scope** — the singleton `launch`/`prune` surfaces emit to the `worktrees` stream and are **not** feature-observable, so they ride `until` rather than `--operation`:
+  - `until: 'merge'` (default) — block until the serialized `serialize_merge` on `integrationRef` reaches its `worktrees`-stream terminal (`worktree.merge_executed`, the lease-release event — a distinct event family from the feature-scoped `merge.*` liveness pair above); `integrationRef` is required.
+  - `until: 'idle'` — block until no in-flight `prune_worktrees` GC pass remains (i.e., `inFlightPrunes` list clears); `integrationRef` not consulted.
 
 **`export`** — Two-event export operation split: `export.requested` (persists full intent) → `export.executed` (records result). Follows the process-manager pattern (§4) for side-effect durability.
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -119,9 +119,32 @@ Four visible: `exarchos_workflow`, `exarchos_event`, `exarchos_orchestrate`, `ex
 
 ### L7 — Process lifecycle verbs (v2.12)
 
-`ps`, `describe`, `wait`, `export`. Generic queries over the event log: `ps` lists in-flight workflows by reading liveness-start events without corresponding terminal events; `wait --workflow=<id> --phase=<target> --timeout=<ms>` blocks until the projection reaches the target. Every long-running operation (merge, shepherd, TDD swarm) emits `<surface>.executing_started` so these verbs work without per-feature code.
+Generic queries over the event log using the liveness convention (§6). Four verbs:
 
-Launcher-spawned sessions ride the same convention (v2.12.0-preview.1, DR-7): `ps` / `wait` answer a launch's liveness from the `launch.executing_started` / `launch.executed` pair **alone** — a pure fold of `worktrees@v1`, no process scan (the opt-in `ps --probe` reclaim path is the only thing that consults the live process table). The launcher is the lifecycle authority; direct (non-launcher) launches answer lifecycle from event-sourced reconciliation (INV-10, reconcile-on-next-entry — never a daemon), which is also the documented `generic`-runtime contract. Known follow-up: spawn-time injection *degradation* is recorded on the launcher lifecycle result but not yet on the `launch.executing_started` event, so these verbs surface launch *liveness* — not injection *degradation* — from events alone.
+**`ps`** — List in-flight operations. Reads `worktrees@v1` and feature-level folds to return:
+- **In-flight merges** — keyed by `sourceBranch → targetBranch`; a merge is in-flight iff its `merge.executing_started` has no paired `merge.executed` or `merge.recovered` event.
+- **In-flight launches** — keyed by `worktreeId`; a launch is in-flight iff its `launch.executing_started` has no paired `launch.executed` event (DR-7, v2.12.0-preview.1). Launcher-spawned sessions answer liveness from the `launch.*` event pair **alone** — a pure fold of `worktrees@v1`, no process scan. The launcher is the lifecycle authority; direct (non-launcher) launches answer lifecycle from event-sourced reconciliation (INV-10, reconcile-on-next-entry — never a daemon), which is also the documented `generic`-runtime contract.
+- **In-flight prunes** — keyed by `operationId`; a prune pass is in-flight iff its `prune.executing_started` has no paired `prune.executed` event.
+- Optional `--probe` flag: additionally pulls the process table source and emits `worktree.released` / `worktree.orphan_detected` events for crashed holders, then re-folds post-reconcile.
+
+**`inspect`** — Single-workflow cold-probe projection. Returns phase, phase history, task state, and next-action affordances for a workflow without side effects. Schema discovery via `inspect --schema`.
+
+**`wait`** — Caller-bounded poll with structured timeout (never hangs, no background timers). Blocks until a condition is reached or timeout expires:
+- Default `until: 'merge'` — block until the serialized merge on `integrationRef` reaches its terminal `worktree.merge_executed` event. `integrationRef` is required. When a merge crashes mid-operation (stuck in `executing` phase with an unpaired `merge.executing_started`), this predicate resolves when the terminal event is detected — the operation-level invariant (§6) detects completion regardless of workflow phase, solving the S-6 stuck-operation recovery scenario without per-feature supervisor logic.
+- `until: 'idle'` — block until no in-flight `prune_worktrees` GC pass remains (i.e., `inFlightPrunes` list clears). `integrationRef` not consulted.
+
+**`export`** — Two-event export operation split: `export.requested` (persists full intent) → `export.executed` (records result). Follows the process-manager pattern (§4) for side-effect durability.
+
+**`describe`** — Schema discovery for progressive UI rendering. Returns `outputSchema` and emission catalog for requested actions, surfacing annotations (`taskSuitable`, `taskTtlSuggestionMs`) for long-running operations.
+
+### Subscription contract (DR-1)
+
+Clients may subscribe to the event stream with a cursor-pump abstraction: `subscribe(filter, onEvent, {fromSequence?, floorMs?})`. Guarantees:
+- **Exactly-once global-sequence delivery** — each event is delivered to the subscription callback exactly once.
+- **Two-tier wake strategy** — Tier-1 (in-process, post-commit wake) for single-process subscribers; Tier-2 (configurable poll floor `floorMs`) for cross-process subscribers polling the event log. An ephemeral subscription (no durability for fromSequence) is the default; persistent cursor tracking is client-owned.
+- **Filter-first query** — subscriptions apply the filter at the event-store query layer before waking, not at the callback layer, for efficient multi-subscriber scenarios.
+
+Known follow-up: spawn-time injection *degradation* is recorded on the launcher lifecycle result but not yet on the `launch.executing_started` event, so these verbs surface launch *liveness* — not injection *degradation* — from events alone.
 
 ### L8 — Adapters
 
@@ -212,10 +235,27 @@ Resume after crash: handler reads the projection, sees the last terminal phase, 
 Events are the only source of truth. Everything else — projections, state files, view caches — is a cache derived from events. Three observable categories:
 
 - **Lifecycle events** — phase transitions, task assignments, gate executions. `workflow.transition`, `task.assigned`, `gate.executed`, `merge.preflight`, `merge.executed`, `merge.recovered`. These are the events the HSM consumes and the projections fold.
-- **Liveness signals** — `<surface>.executing_started` events emitted at the entry of long-running operations. `merge.executing_started` (#1309) is the first; shepherd and TDD swarm follow the pattern. v2.12 `ps` and `wait` query these to detect stuck operations.
+- **Liveness signals** — `<surface>.executing_started` events emitted at the entry of long-running operations. Each surface follows an invariant pairing convention (INV-10) so that `ps` and `wait` can detect in-flight operations and stuck scenarios without external process inspection or daemon infrastructure.
 - **Telemetry events** — `dispatch.preflight`, `stash.detected`, deprecation invocations, migration steps. Observable but not load-bearing for state.
 
 Operators inspect the timeline through `exarchos_event({action: 'query'})`; agents inspect through `next_actions` envelope hints; developers inspect through CLI `ps` / `describe` / `wait`. All three see the same underlying event stream.
+
+### Liveness convention (INV-10)
+
+Every long-running operation emits a `<surface>.executing_started` event ("claim") at its entry, paired with one or more possible terminal events ("completion"). The runtime operates on the invariant: **an operation is in-flight iff its start event has no later matching terminal event in the stream, keyed by an operation-specific instance key**.
+
+Four surfaces follow this convention, each with a canonical start type, terminal types, stream scope, and instance key scheme:
+
+| Surface | Scope | Start event | Terminal events | Instance key |
+|---|---|---|---|---|
+| **merge** | feature | `merge.executing_started` | `merge.executed`, `merge.recovered` | `sourceBranch → targetBranch` (or `taskId` if available) |
+| **mutation** | feature | `mutation.executing_started` | `mutation.executed` | `operationId` |
+| **launch** | worktrees | `launch.executing_started` | `launch.executed` | `worktreeId` |
+| **prune** | worktrees | `prune.executing_started` | `prune.executed` | `operationId` |
+
+Each `<surface>.executing_started` event carries an ISO 8601 `startedAt` timestamp; the envelope-derived `livenessStartedAt()` function extracts this to compute elapsed time for stuck-operation detection.
+
+The pairing rule is **per-stream**: merge operations are keyed within their feature stream, while launch and prune operations are keyed within the singleton `worktrees` stream. This allows `ps` to list all in-flight operations by reading a single stream fold, and `wait` to block on specific conditions (terminal event arrival for a merge or launch, or zero in-flight prunes for idle detection) without background timers or daemon infrastructure.
 
 ---
 

--- a/docs/specs/2026-07-07-lifecycle-verbs.md
+++ b/docs/specs/2026-07-07-lifecycle-verbs.md
@@ -1,0 +1,525 @@
+# Spec: Process Lifecycle Verbs — generic ps / describe / wait / export over the event log
+
+**Date:** 2026-07-07 · **Feature:** `lifecycle-verbs` · **Depth:** deep
+**Inputs:** #1316 (design spike, this spec closes it) · #1090 (epic; children #1103–#1106 absorbed here) · #1315 (subscription primitive — contract defined here) · #1599 roadmap (Z2 critical path, coordination rules 2–4) · `docs/specs/2026-07-03-wlm-6-surface-and-workflow-fixes.md` · `docs/specs/2026-06-26-wlm-operational-core.md` · `docs/architecture/runtime.md` §L7/§6 · `.exarchos/invariants.md` (INV-1/2/5a–d/6/7/8/10/12/15/16)
+
+> One unified artifact: `## Design & Rationale` is the DR-N source; `## Decomposition` maps tasks → DR-N within this same document.
+
+## Design & Rationale
+
+### Problem Statement
+
+Epic #1090 promises generic workflow-lifecycle verbs — `ps` (list), `describe` (project), `wait` (event-driven gate), `export` (diagnostic bundle) — as layer L7 of the runtime: supervisor primitives over the event log, replacing ad-hoc `view pipeline` / `workflow get` polling. What exists today diverges:
+
+- **WLM-6 (PR #1642) shipped worktree-scoped `ps`/`wait`** on `exarchos_view` — a `worktrees@v1` fold (merges/launches/prunes) with `until: merge|idle` polling. Same names as #1090, different semantics. Preview-only (v2.12.0-preview.1), so the shapes are still cheap to change.
+- **The workflow-projection `describe` is absent**; the `describe` name on every composite tool is taken by GA'd schema-introspection.
+- **`export` is absent.**
+- **The #1315 subscription primitive is absent** — every waiter re-folds a projection on a sleep loop.
+- **INV-10 is aspirational**: four surfaces emit `<surface>.executing_started`/terminal pairs (merge, launch, mutation, prune) as ad-hoc per-surface schemas with no shared base and no generic consumer; `mutation` is observable by nothing.
+- **Audit S-6 (stuck-`executing` recovery) remains open**: no generic way to wait out or inspect a crashed long-running operation.
+
+Without one design, the four implementation issues (#1103–#1106) would diverge on subscription handling, predicate language, output schemas, and postures — exactly what #1316 was filed to prevent.
+
+### Chosen Approach
+
+**Unify under generic verbs on the two-tier subscription substrate** (Exploration, Option 2 — decided with the owner 2026-07-07):
+
+1. **One subscription primitive (DR-1)** — in-process post-commit notification plus a `PRAGMA data_version` cross-process poll floor — serves `wait`, `describe --follow`, and every future waiter. Subscriptions are ephemeral (per-dispatch), so INV-15's no-daemon frame holds by construction.
+2. **One liveness contract (DR-2)** — `ExecutingStartedBase` + a liveness-pair registry — turns INV-10 from convention into checkable contract, and gives `ps` its generic operations fold (adopted from Exploration Option 3, without its row-shape conflation).
+3. **The verbs are pure consumers** — `ps`/`inspect`/`wait` are projections or subscriptions (no writes; `wait` emits no events, revising #1316 Q7); `export` is the one emitter and follows INV-13's two-event split.
+4. **CLI promotion (DR-7)** hoists the verbs to `exarchos ps|describe|wait|export` through a registry-driven mechanism, keeping INV-2 parity.
+
+Compatibility posture: **break-in-preview** — the WLM-6 `ps`/`wait` schemas are redesigned freely (no shims); the unified surface lands before v2.12.0 GA. Worktree capabilities (probe/reconcile, merge/idle waits) are preserved as a *scope* of the generic verbs.
+
+### Requirements (DR-N)
+
+The DR-N identifiers below are the single source the decomposition traces against.
+
+#### DR-1: Two-tier subscription primitive (#1315)
+
+The event store exposes `subscribe(filter, onEvent): SubscriptionHandle` where `filter` is `{ streamId?, eventTypes?[] }`. Tier 1 (in-process): after a successful append commits, matching listeners fire synchronously, post-commit — a listener failure is isolated and never affects the append result (at-most-once; mirrors INV-7's two-tier split). Tier 2 (cross-process): a bounded poll floor re-checks `PRAGMA data_version` (near-free) and re-reads only when another connection has committed, delivering matching events in sequence order. Subscriptions are ephemeral: registered by a dispatch, disposed when it returns — nothing outlives the verb (INV-15).
+
+**Acceptance criteria:**
+- Given a subscription on stream S for type T, when a matching event is appended in-process, then `onEvent` fires after commit without waiting any poll interval.
+- Given an append from a second process (test: second connection), when `data_version` changes, then matching events are delivered in sequence order within one floor interval (default documented; configurable per call).
+- Given a listener that throws, when the append commits, then the append result is unchanged and remaining listeners still fire.
+- Given a dispatch that registered subscriptions, when it returns (success or error), then all its handles are disposed — a leak test asserts the registry count returns to zero.
+- With zero subscribers, the append hot path executes no listener-related work beyond a single guard check (benchmarked: no measurable regression in the append benchmark).
+
+#### DR-2: `ExecutingStartedBase` and the liveness-pair registry (INV-10 made checkable)
+
+Extract a shared Zod base `{ surface, instanceId, startedAt, expectedDurationMs? }`; the four existing schemas (`merge`/`launch`/`mutation`/`prune` `.executing_started`) retrofit via `.extend(...)` with **byte-identical event data** (no migration). A liveness-pair registry — one table mapping each `<surface>.executing_started` to its terminal event types — becomes the single source `ps`'s operations fold and `wait`'s terminal detection consume. Adding a surface to the lifecycle plane = one registry entry, zero verb code.
+
+**Acceptance criteria:**
+- All four existing `*.executing_started` schemas extend the base; snapshot tests prove emitted event data is unchanged.
+- A conformance test fails if any `*.executing_started` event type in the emission catalog lacks a registry entry with ≥1 terminal type.
+- `docs/architecture/runtime.md` §6 documents the convention (base schema + pairing rule) and cites the registry as its enforcement.
+
+#### DR-3: Generic `ps` — scope-parameterized process listing
+
+`exarchos_view { action: 'ps', scope: 'workflow' | 'worktree' | 'all' }` (default `all`). Output has two honestly-shaped sections, never conflated rows: `workflows` (fold of `workflow_state` joined with `streams.workflow_type`: featureId, workflowType, phase, status, ageMs) and `operations` (generic fold over the DR-2 registry: any `executing_started` without its terminal — including `mutation`, which today nothing surfaces). Filters: `workflowType` (indexed pushdown via `streams.workflow_type`), `status`, `phase`, `all` (include completed/cancelled; default excludes them). The WLM-6 worktree fold (in-flight merges/launches/prunes + `probe` reconciliation) is preserved under `scope: 'worktree' | 'all'`; `probe: true` remains a conditional writer with its existing `LOCAL_MUTATION_IDEMPOTENT` annotation.
+
+**Acceptance criteria:**
+- Given workflows of mixed types and phases, when `ps --workflow-type feature`, then only `feature` rows return, and the query uses the indexed `streams.workflow_type` column.
+- Given a completed workflow, then default `ps` excludes it and `--all` includes it.
+- Given a synthetic `mutation.executing_started` without terminal, then it appears in `operations` with no mutation-specific code in any verb handler (generic-fold test).
+- Given `scope: 'workflow'` with `probe: true`, then the input is rejected as `INVALID_INPUT` (probe is a worktree-scope capability).
+- Worktree-scope output preserves every WLM-6 capability (in-flight pairs, launches, prunes, probe reconcile) under the redesigned schema.
+
+#### DR-4: `inspect` — the workflow-projection describe
+
+New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite projection returning workflow state (via the canonical `resolveWorkflowState`/rehydration path — never `.state.json` presence), recent events (with `operationId`/`correlationId`/`causationId`), artifacts, and task progress. Existence signal is `_meta.workflowExists`; a cold probe of an unknown featureId is side-effect-free. `--follow` consumes DR-1 and streams through two carriers per #1316 Q3: NDJSON frames on the CLI (existing encoder/heartbeat), MCP Tasks (SEP-1686) on the MCP path — one contract, two presentations (INV-5b). The MCP action name avoids the GA'd schema-`describe` (no rename, no Zod-union overload — a known CLI-parity hazard); DR-7 maps the CLI top-level verb `exarchos describe <id>` onto it.
+
+**Acceptance criteria:**
+- Given an unknown featureId, when `inspect` runs, then `_meta.workflowExists: false` with `expectedShape` in the error envelope, and no event is appended.
+- Given `--follow`, when events append to the feature's stream (in-process or cross-process), then they appear as NDJSON `event` frames deduplicated by sequence; heartbeat frames cover silent gaps.
+- The MCP path exposes follow via Tasks (`tasks/get`/`tasks/result`), sharing the DR-1 subscription with the CLI carrier.
+- Schema-introspection `describe` on all four composite tools is byte-unchanged.
+
+#### DR-5: Generic `wait` — event-driven phase gate, no self-journaling
+
+`wait(featureId, phase?, status?, until?, integrationRef?, timeoutMs)`: phase targets use **reached-or-passed** semantics — the projection is checked first, returning immediately if the target phase was already reached (idempotent re-runs, #1316 Q2); otherwise a DR-1 subscription on `workflow.transition` + registry terminal events resolves it. `status` supports terminal waits (`completed`/`failed`/`cancelled`). The WLM-6 worktree predicates (`until: merge|idle` + `integrationRef`) are retained as the worktree scope of the same action. `wait` emits **no events** (revises #1316 Q7): posture read-only, `readOnlyHint: true`, `idempotentHint: true` — the log records domain facts, not observations of them. Timeout/failure return structured `WAIT_TIMEOUT` / `WAIT_FAILED` envelopes; the CLI adapter maps them to exit codes 17/18 as pure presentation (a generic errorCode→exitCode map, INV-2-safe).
+
+**Acceptance criteria:**
+- Given a workflow already past `--phase plan-review`, when `wait --phase plan-review` runs, then it returns success immediately (exit 0) without subscribing.
+- Given no matching transition within `timeoutMs`, then `WAIT_TIMEOUT` is returned and the CLI exits 17.
+- Given the workflow enters `failed`/`cancelled` while waiting on a phase, then `WAIT_FAILED` is returned and the CLI exits 18.
+- Given an in-process `workflow.transition` to the target phase, then `wait` resolves without waiting a poll interval (Tier-1 path test).
+- **S-6 closure walkthrough:** given `merge.executing_started` with no terminal (simulated crash), `wait <id> --phase delegate --timeout 10m` resolves when `merge.recovered` lands, or exits 17 on timeout; `inspect` shows the unpaired `executing_started`; no merge-specific code exists in `wait` (grep-asserted).
+- `wait` appends zero events across all paths (asserted by event-count invariance in tests).
+
+#### DR-6: `export` — event-log bundle with the INV-13 two-event split
+
+`export(featureId, output?)`: writes a zip containing `events.jsonl` (full stream extract), `state.json` (projection snapshot), `metadata.json` (version, eventCount, phase, exportedAt), and `artifacts/` (referenced artifact files that exist on disk). Writing outside `.exarchos/` is a non-idempotent external side effect, so export follows INV-13: `export.requested` (intent + resolved path) before the write, `export.executed` (result + content hash) after. Crash between the two → the next invocation runs an idempotent precheck (zip exists + hash matches manifest) to re-emit or skip. Posture `task-isolated`, `openWorldHint: true`. Default output `./<featureId>-export.zip`; invalid paths return `suggestedFix` with the default.
+
+**Acceptance criteria:**
+- Given an exported bundle, when `events.jsonl` is replayed through the reducers, then the result equals `state.json` (round-trip test) — the event log **is** the export.
+- Every successful export appends exactly the `export.requested`/`export.executed` pair, idempotency-keyed per INV-8.
+- Given a crash simulated between the pair, when export re-runs, then the precheck detects the existing/partial zip and completes without duplicating the `requested` intent.
+- Given an invalid `--output` path, then a structured error with `suggestedFix` (default location) returns and no events are appended.
+- Zip paths are built with `path.join` / POSIX-normalized entries; tests close SQLite handles before temp-dir removal (INV-16).
+
+#### DR-7: Registry-driven CLI top-level promotion
+
+`CliActionHints` gains `topLevel?: string`. The CLI adapter hoists any action carrying it to a top-level command (name = the field's value) that dispatches through the identical core path with flags derived from the same Zod schema — zero adapter behavior (INV-2). Stamps: `ps`→`ps`, `wait`→`wait`, `export`→`export`, `inspect`→`describe` (epic UX preserved without touching the GA'd schema-describe). A build-time collision guard fails fast if a `topLevel` name collides with a tool name, alias, or another promotion. The subcommand forms (`exarchos view ps`) keep working.
+
+**Acceptance criteria:**
+- `exarchos ps|describe <id>|wait <id>|export <id>` all resolve and dispatch.
+- Parity fixtures assert byte-identical `ToolResult` across the three invocation paths: top-level CLI, `view <action>` subcommand, and MCP `exarchos_view` — for each promoted verb.
+- A registry entry with a colliding `topLevel` name fails the build/registration test, not runtime.
+- Visible MCP tool count is unchanged (still 4 composite tools, INV-5d).
+
+#### DR-8: Error handling, failure modes, and edge cases
+
+Cross-cutting failure contract for the verb surface.
+
+**Acceptance criteria:**
+- Given `wait --phase <invalid>`, then the error envelope's `validTargets` is populated from the HSM topology **for that workflow's type**.
+- Given an unknown featureId on `inspect`/`wait`/`export`, then a side-effect-free error with `expectedShape` returns (cold-probe rule; no stream registration, no events).
+- Given a subscription whose consumer disconnects mid-follow (CLI SIGINT, MCP task cancel), then the handle is disposed and the leak test passes.
+- Cross-process wait latency is bounded: ≤ one floor interval + one projection fold; the floor default is documented in the subscription contract and surfaced in `_perf`.
+- Given concurrent `wait`s on the same stream from two dispatches, then both resolve independently (no shared-handle interference).
+- All new paths run on Windows CI (INV-16): no separator string-concat, handles closed before temp-dir removal, `resolveExecutable` for any spawns.
+
+### Technical Design
+
+**New substrate:** `servers/exarchos-mcp/src/event-store/subscriptions.ts` — the listener registry + `SubscriptionHandle`; a post-commit hook point in the append path (`store.ts`/`atomic-appender.ts`) guarded to zero-cost when empty; `data_version` floor helper in `storage/sqlite-backend.ts`.
+
+**Liveness contract:** base schema + pair registry live beside the event schemas (`event-store/schemas.ts`); the generic "in-flight operations" fold becomes a small reusable projection consumed by `ps` — not a new stored projection table.
+
+**Verbs:** new handlers under `src/views/lifecycle/` (ps/inspect/wait/export), routed via `views/composite.ts`; the WLM-6 worktree fold (`orchestrate/worktree/handlers.ts`) is called by the `ps` worktree scope rather than duplicated. `wait` composes: projection precheck → DR-1 subscribe → registry-terminal detection. Registry entries stamp postures, `outputSchema`, annotations, and `cli.topLevel` per DR-7 (#1316 Q7/Q8 land as registration facts, not prose).
+
+**CLI:** promotion loop + errorCode→exitCode map in `adapters/cli.ts`; follow carriers reuse `src/ndjson/` (CLI) and `src/mcp/tasks-methods.ts` (MCP), both fed by DR-1.
+
+**SDK-lowering mapping (#1599 rule 3):** `wait --phase` lowers as the IR's `awaitPhase(featureId, phase)` combinator; the subscription primitive is the runtime service IR await-nodes bind to; `ps`/`inspect`/`export` are read-side projections with no IR footprint. No edits to `hsm-definitions.ts`/`playbooks.ts`.
+
+**Q11 alignment:** INV-1 (all verbs are folds/subscriptions/emitters — no side stores); INV-2 (parity fixtures per verb); INV-6 (verbs read topology/projections generically — no workflow-type branching); INV-12 (`wait` complements `next_actions`: affordances say what *can* run, `wait` observes what *did*).
+
+### Integration Points
+
+- `servers/exarchos-mcp/src/event-store/store.ts` + `atomic-appender.ts` — post-commit notification hook (guarded, zero-cost empty path)
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` — **new**: registry, handle lifecycle, data_version floor
+- `servers/exarchos-mcp/src/event-store/schemas.ts` — `ExecutingStartedBase` + liveness-pair registry; four schema retrofits
+- `servers/exarchos-mcp/src/views/composite.ts` — route `ps`(redesigned)/`inspect`(new)/`wait`(redesigned)/`export`(new)
+- `servers/exarchos-mcp/src/views/lifecycle/` — **new**: verb handlers
+- `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` — worktree fold consumed as `ps` scope; WLM-6 wait kernel absorbed into generic `wait`
+- `servers/exarchos-mcp/src/registry.ts` — action defs, postures, outputSchemas, `CliActionHints.topLevel`
+- `servers/exarchos-mcp/src/adapters/cli.ts` — top-level promotion, exit-code map, follow carrier wiring
+- `servers/exarchos-mcp/src/ndjson/` + `src/mcp/tasks-methods.ts` — carriers over the DR-1 contract
+- `docs/architecture/runtime.md` §6/§L7 — liveness convention + verb docs
+
+### Exploration
+
+Divergent loop run 2026-07-07 (deep rung; `correlationId: c3c85d7a-8abf-48e4-9121-f96f5e504198`). Grounding: a full codebase sweep of the shipped surface (WLM-6 `ps`/`wait` worktree scoping, absent subscription primitive, ad-hoc INV-10 schemas, no CLI promotion mechanism) plus #1316/#1090/#1599 and the four WLM specs. The `/exarchos:discover` bridge was offered and declined — the sweep plus shipped specs gave sufficient grounding.
+
+- **Option 1 — Formalized bounded poll:** declare polling *is* the #1315 contract; generalize the WLM-6 wait kernel; no event-store changes. Rejected: enshrines the active polling INV-10 exists to replace; latency floor on every wait; O(poll × fold) waste.
+- **Option 2 — Two-tier subscription substrate (chosen):** in-process post-commit notify + `data_version` cross-process floor; ephemeral per-dispatch handles (INV-15-safe); one contract, two carriers. Delivers #1315 rather than renaming polling.
+- **Option 3 — Uniform process table:** a `liveness@v1` projection folding all INV-10 pairs; workflows and operations as uniform rows. Partially adopted — the generic operations fold (via the DR-2 registry) — but the uniform row shape was rejected: an *operation* (bounded, liveness-paired) and a *workflow* (long-lived, phase-structured) are semantically distinct, and one row shape muddies both.
+
+Owner decisions converged in one iteration: unify (vs coexist) · full pickup (spec through implementation) · break-in-preview (no shims) · build CLI promotion · Option 2 · `wait` emits no events · MCP `inspect` / CLI `describe`.
+
+### Alternatives considered
+
+- **Coexist (freeze WLM-6 verbs, add new names)** — rejected: permanently splits the lifecycle surface and squats the #1090 names on worktree semantics.
+- **Compat shims / additive-only schemas** — rejected: the shapes are preview-only; shim debt for zero GA consumers.
+- **`wait.started`/`wait.completed`/`wait.timeout` emission (#1316 Q7 original)** — rejected: observation verbs stay pure reads; log noise proportional to observation frequency; Aspire's `wait` does not journal itself. Exit codes 17/18 survive as CLI presentation.
+- **Zod-union overload of `describe`** — rejected: known `coerceFlags` CLI-parity break on unions; agent-facing schema ambiguity (INV-5a).
+- **Renaming schema-`describe` to free the name** — rejected: breaks a GA'd discovery surface all agents use.
+- **OS-level notification (fs-watch on the SQLite WAL, LISTEN/NOTIFY-style IPC)** — rejected: imports watcher/daemon primitives from outside the INV-15 frame; `data_version` polling floor achieves the cross-process bound within it.
+
+### Open Questions
+
+- **Rich `wait` predicates (JSONPath over projection state, any-of/all-of):** deferred — phase/status/until covers S-6 and the v2.12 consumers; file a follow-up when a concrete consumer needs more (per #1316 Q2's own recommendation).
+- **MCP `resources/subscribe` exposure of DR-1:** deferred to the #1604 MCP-migration tranche (Z3) — the primitive is transport-agnostic; exposing it remotely is a harness-boundary question (#1599 rule 5).
+- **Import/replay tooling for export bundles:** deferred; the round-trip test (DR-6) guarantees replayability, tooling lands with a concrete diagnostic consumer.
+- **`shepherd`/`tdd-swarm` liveness conformance:** out of scope per #1316; the DR-2 registry makes each a one-entry addition tracked on their own issues.
+
+## Decomposition
+
+The decomposition maps every task to one or more DR-N from the section above.
+
+### Scope
+
+**Target:** Full design (DR-1 … DR-8)
+**Excluded:** None — the design's Open Questions are explicitly deferred there with rationale; no DR is partially implemented.
+
+### Traceability matrix (DR-N → tasks)
+
+| DR | Requirement | Tasks |
+|----|-------------|-------|
+| DR-1 | Two-tier subscription primitive (#1315) | 001, 002, 017, 018 |
+| DR-2 | ExecutingStartedBase + liveness-pair registry | 003, 004, 018 |
+| DR-3 | Generic `ps` (scope-parameterized) | 005, 006, 007 |
+| DR-4 | `inspect` workflow-projection describe | 008, 009 |
+| DR-5 | Generic `wait` (event-driven gate, no self-journaling) | 010, 011 |
+| DR-6 | `export` with INV-13 two-event split | 012, 013 |
+| DR-7 | Registry-driven CLI top-level promotion | 014, 015 |
+| DR-8 | Error handling, failure modes, edge cases | 011, 016, 017 |
+
+### Tasks
+
+#### Task 001: Subscription registry + post-commit notification hook (Tier 1)
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-1
+
+**Files:**
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (new — registry, `SubscriptionHandle`, filter matching)
+- `servers/exarchos-mcp/src/event-store/subscriptions.test.ts` (new)
+- `servers/exarchos-mcp/src/event-store/store.ts` (post-commit hook point, guarded zero-cost when empty)
+- `servers/exarchos-mcp/src/event-store/atomic-appender.ts` (fire-after-commit ordering)
+
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Subscribe_InProcessAppend_FiresPostCommitWithoutPoll`, `Subscribe_ListenerThrows_AppendUnaffectedAndSiblingsFire`, `Subscribe_DispatchReturns_HandleDisposed`, `Append_ZeroSubscribers_NoListenerWork`.
+**testingStrategy:** `propertyTests: true` (property: events delivered to a matching subscriber are exactly the appended events, in sequence order, for arbitrary interleavings of matching/non-matching appends); `benchmarks: true` (SLA: append p99 regression < 5% with zero subscribers vs baseline); `characterizationRequired: true` (append path is existing code).
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 002: Cross-process poll floor via `PRAGMA data_version` (Tier 2)
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-1
+
+**Files:**
+- `servers/exarchos-mcp/src/storage/sqlite-backend.ts` (`dataVersion()` accessor)
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (floor loop: re-check data_version, re-read + deliver by sequence only on change)
+- `servers/exarchos-mcp/src/event-store/subscriptions.test.ts`
+
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Floor_SecondConnectionAppend_DeliveredInSequenceOrderWithinOneInterval`, `Floor_NoForeignCommit_NoReRead`, `Floor_DefaultInterval_SurfacedInPerf`.
+**testingStrategy:** `propertyTests: true` (property: for any split of appends across two connections, the subscriber observes every matching event exactly once, in global sequence order); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 001
+**Parallelizable:** No (extends 001's module)
+
+#### Task 003: `ExecutingStartedBase` schema + retrofit of the four surfaces
+
+**Risk Tier:** medium
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-2
+
+**Files:**
+- `servers/exarchos-mcp/src/event-store/schemas.ts` (base + `merge`/`launch`/`mutation`/`prune` `.executing_started` retrofit via `.extend`)
+- `servers/exarchos-mcp/src/event-store/schemas.test.ts` (byte-identity snapshots)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `ExecutingStartedSchemas_Retrofit_EmittedDataByteIdentical` (snapshot per surface), `ExecutingStartedBase_RequiredFields_Validated`.
+**testingStrategy:** `propertyTests: true` (property: schema compliance — every payload accepted by a retrofit schema is accepted by the base's field contract; serialization category); `benchmarks: false`; `characterizationRequired: true` (modifies existing schemas).
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 004: Liveness-pair registry + conformance test
+
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Test Layer:** integration
+**Implements:** DR-2
+
+**Files:**
+- `servers/exarchos-mcp/src/event-store/liveness-registry.ts` (new — `{ startType, terminalTypes[] }` per surface)
+- `servers/exarchos-mcp/src/event-store/liveness-registry.test.ts` (new)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `LivenessRegistry_EveryExecutingStartedInCatalog_HasEntryWithTerminal` (conformance — fails on unregistered `*.executing_started`), `LivenessRegistry_AddSurface_OneEntryNoVerbCode`.
+**testingStrategy:** `propertyTests: false` (registry is a static table; the conformance test is the guarantee); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 003
+**Parallelizable:** No (follows 003's schema names)
+
+#### Task 005: `ps` workflows fold (workflow_state ⋈ streams.workflow_type + filters)
+
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Test Layer:** integration
+**Implements:** DR-3
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/workflow-fold.ts` (new — rows: featureId, workflowType, phase, status, ageMs; filters: workflowType pushdown, status, phase, all)
+- `servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts` (new)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `WorkflowFold_TypeFilter_UsesIndexedStreamsColumn`, `WorkflowFold_Default_ExcludesTerminalStates`, `WorkflowFold_AllFlag_IncludesCompleted`.
+**testingStrategy:** `propertyTests: true` (properties: filter idempotence `filter(filter(rows)) === filter(rows)`; filtered set ⊆ unfiltered set; collections category); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 006: `ps` operations fold (generic in-flight over the liveness registry)
+
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Test Layer:** integration
+**Implements:** DR-3
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/operations-fold.ts` (new — `executing_started` without matching terminal, per registry)
+- `servers/exarchos-mcp/src/views/lifecycle/operations-fold.test.ts` (new)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `OperationsFold_StartedWithoutTerminal_ListedInFlight`, `OperationsFold_MutationSurface_ListedGenerically` (DR-3 AC: no mutation-specific code), `OperationsFold_TerminalPresent_Excluded`.
+**testingStrategy:** `propertyTests: true` (property: for any event sequence, an operation is listed iff its start event has no later matching terminal — state-machine category); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 004
+**Parallelizable:** Yes (after 004)
+
+#### Task 007: `ps` handler redesign — scope parameter, composition, probe gating
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-3
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/ps.ts` (new — composes 005 + 006 + the WLM-6 worktree fold)
+- `servers/exarchos-mcp/src/views/lifecycle/ps.test.ts` (new)
+- `servers/exarchos-mcp/src/views/composite.ts` (route redesigned `ps`)
+- `servers/exarchos-mcp/src/registry.ts` (redesigned schema: `scope`, filters; `outputSchema`; annotations)
+- `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` (worktree fold consumed, not duplicated)
+
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (redesigns a shipped preview surface; parity baselines updated). Tests: `Ps_DefaultScope_All_ReturnsWorkflowsAndOperationsSections`, `Ps_WorkflowScopeWithProbe_RejectedInvalidInput`, `Ps_WorktreeScope_PreservesWlm6Capabilities`.
+**testingStrategy:** `propertyTests: false` (composition wiring; folds carry the PBT in 005/006); `benchmarks: false`; `characterizationRequired: true` (WLM-6 worktree behavior pinned before redesign).
+**Dependencies:** 005, 006
+**Parallelizable:** No
+
+#### Task 008: `inspect` handler — composite workflow projection
+
+**Risk Tier:** medium
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-4
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/inspect.ts` (new — state via `resolveWorkflowState`/rehydration, recent events + correlation tuple, artifacts, task progress)
+- `servers/exarchos-mcp/src/views/lifecycle/inspect.test.ts` (new)
+- `servers/exarchos-mcp/src/views/composite.ts` (route `inspect`)
+- `servers/exarchos-mcp/src/registry.ts` (action def + `outputSchema` + `readOnlyHint`)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `Inspect_UnknownFeatureId_WorkflowExistsFalseNoSideEffect` (event-count invariance), `Inspect_KnownWorkflow_ReturnsStateEventsArtifacts`, `Inspect_SchemaDescribe_ByteUnchanged`.
+**testingStrategy:** `propertyTests: false` (projection composition; no transformation core); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 009: `--follow` carriers — NDJSON (CLI) + Tasks (MCP) over the subscription
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-4
+
+**Files:**
+- `servers/exarchos-mcp/src/adapters/cli.ts` (`inspect` joins the follow set; carrier wiring)
+- `servers/exarchos-mcp/src/cli/follow-loop.ts` (subscription-fed source replacing pure poll for `inspect`)
+- `servers/exarchos-mcp/src/mcp/tasks-methods.ts` (Tasks arm over the same DR-1 contract)
+- `servers/exarchos-mcp/src/views/lifecycle/inspect.follow.test.ts` (new)
+
+**Verification:** scoped tests + `check_test_adequacy` + integration suite across the CLI/MCP seam. Tests: `InspectFollow_AppendedEvents_NdjsonFramesDedupedBySequence`, `InspectFollow_SilentGap_HeartbeatFrames`, `InspectFollow_McpTasks_SharesSubscriptionContract`.
+**testingStrategy:** `propertyTests: true` (property: NDJSON frame stream contains each event sequence exactly once, monotonically — dedup roundtrip; data-transformation category); `benchmarks: false`; `characterizationRequired: true` (follow-loop is existing code).
+**Dependencies:** 001, 002, 008
+**Parallelizable:** No
+
+#### Task 010: Generic `wait` — reached-or-passed precheck + subscription resolution
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-5
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (new — projection precheck; DR-1 subscribe on `workflow.transition` + registry terminals; `phase`/`status`/worktree `until` predicates; structured `WAIT_TIMEOUT`/`WAIT_FAILED`)
+- `servers/exarchos-mcp/src/views/lifecycle/wait.test.ts` (new)
+- `servers/exarchos-mcp/src/views/composite.ts` (route redesigned `wait`)
+- `servers/exarchos-mcp/src/registry.ts` (redesigned schema + `readOnlyHint`/`idempotentHint`)
+- `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` (WLM-6 wait kernel absorbed)
+
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Wait_PhaseAlreadyPassed_ReturnsImmediatelyWithoutSubscribing`, `Wait_InProcessTransition_ResolvesWithoutPollInterval`, `Wait_Timeout_StructuredWaitTimeout`, `Wait_WorkflowCancelledMidWait_WaitFailed`, `Wait_AllPaths_AppendZeroEvents` (event-count invariance).
+**testingStrategy:** `propertyTests: true` (property: for any transition sequence, `wait --phase P` resolves iff P appears at-or-before now or arrives before timeout — state-machine category); `benchmarks: false`; `characterizationRequired: true` (absorbs shipped worktree kernel).
+**Dependencies:** 001, 002, 004
+**Parallelizable:** No
+
+#### Task 011: S-6 stuck-executing recovery — acceptance north-star
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** acceptance
+**Implements:** DR-5, DR-8
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/s6-recovery.acceptance.test.ts` (new — real store, real handlers, no mocks)
+
+**Verification:** the acceptance walkthrough from DR-5: seed `merge.executing_started` with no terminal (simulated crash); `wait <id> --phase delegate --timeout` resolves on `merge.recovered` and times out (17) without it; `inspect` shows the unpaired start; grep-assert no merge-specific code in `wait.ts`/`operations-fold.ts`.
+**testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 008, 010
+**Parallelizable:** No
+
+#### Task 012: `export.requested` / `export.executed` event schemas
+
+**Risk Tier:** medium
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-6
+
+**Files:**
+- `servers/exarchos-mcp/src/event-store/schemas.ts` (two event types + emission-registry entries, idempotency-keyed per INV-8)
+- `servers/exarchos-mcp/src/event-store/schemas.test.ts`
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `ExportEventSchemas_RequestedExecutedPair_RegisteredWithEmissionSource`, `ExportRequested_CarriesResolvedPathIntent`.
+**testingStrategy:** `propertyTests: true` (schema-compliance property; serialization category); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 013: `export` handler — zip bundle + INV-13 precheck + replay round-trip
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-6
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/export.ts` (new — events.jsonl / state.json / metadata.json / artifacts/; requested→write→executed; crash precheck)
+- `servers/exarchos-mcp/src/views/lifecycle/export.test.ts` (new)
+- `servers/exarchos-mcp/src/views/composite.ts` (route `export`)
+- `servers/exarchos-mcp/src/registry.ts` (action def, `task-isolated` posture, `openWorldHint: true`)
+
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Export_Bundle_ReplayEventsJsonlEqualsStateJson` (round-trip), `Export_CrashBetweenPair_PrecheckCompletesWithoutDuplicateIntent`, `Export_InvalidOutputPath_SuggestedFixNoEvents`, `Export_UnknownFeatureId_ExpectedShapeNoZip`. Windows: POSIX zip entries, handles closed before temp-dir removal (INV-16).
+**testingStrategy:** `propertyTests: true` (property: `replay(export(store)) === projection(store)` for arbitrary event sequences — data-transformation round-trip); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 012
+**Parallelizable:** No
+
+#### Task 014: CLI top-level promotion mechanism (`CliActionHints.topLevel`)
+
+**Risk Tier:** high
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-7
+
+**Files:**
+- `servers/exarchos-mcp/src/registry.ts` (`CliActionHints.topLevel?: string`)
+- `servers/exarchos-mcp/src/adapters/cli.ts` (hoist loop — same dispatch path, flags from the same Zod schema)
+- `servers/exarchos-mcp/src/adapters/cli.test.ts` (promotion + collision guard)
+
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Promotion_TopLevelStamp_CommandRegisteredAndDispatches`, `Promotion_CollidingName_FailsRegistrationNotRuntime`, `Promotion_SubcommandForm_StillWorks`.
+**testingStrategy:** `propertyTests: false` (adapter wiring; parity fixtures in 015 are the contract check); `benchmarks: false`; `characterizationRequired: true` (modifies CLI generation for every tool).
+**Dependencies:** None
+**Parallelizable:** Yes
+
+#### Task 015: Stamp promotions + exit-code map + three-path parity fixtures
+
+**Risk Tier:** medium
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-7
+
+**Files:**
+- `servers/exarchos-mcp/src/registry.ts` (`ps`→`ps`, `wait`→`wait`, `export`→`export`, `inspect`→`describe`)
+- `servers/exarchos-mcp/src/adapters/cli.ts` (generic errorCode→exitCode map: `WAIT_TIMEOUT`→17, `WAIT_FAILED`→18 — presentation only)
+- `servers/exarchos-mcp/src/parity/lifecycle-verbs.parity.test.ts` (new)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `Parity_EachPromotedVerb_ByteIdenticalToolResultAcrossThreePaths`, `ExitCodeMap_WaitTimeout_17`, `ExitCodeMap_WaitFailed_18`, `ExitCodeMap_Success_0`.
+**testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 007, 008, 010, 013, 014
+**Parallelizable:** No
+
+#### Task 016: Error-envelope edge cases across the verb surface
+
+**Risk Tier:** medium
+**Boundary Touching:** false
+**Test Layer:** integration
+**Implements:** DR-8
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (`validTargets` from HSM topology for the workflow's type)
+- `servers/exarchos-mcp/src/views/lifecycle/errors.test.ts` (new — consolidated edge-case suite)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `Wait_InvalidPhase_ValidTargetsFromTopologyForWorkflowType`, `Verbs_UnknownFeatureId_SideEffectFreeExpectedShape` (inspect/wait/export; event-count invariance), `Ps_ProbeOutsideWorktreeScope_InvalidInputWithSuggestedFix`.
+**testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 007, 008, 010, 013
+**Parallelizable:** Yes (after deps)
+
+#### Task 017: Subscription lifecycle hardening — disposal, cancellation, concurrency
+
+**Risk Tier:** medium
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-1, DR-8
+
+**Files:**
+- `servers/exarchos-mcp/src/event-store/subscriptions.test.ts` (leak + concurrency suites)
+- `servers/exarchos-mcp/src/cli/follow-loop.ts` (SIGINT disposal)
+- `servers/exarchos-mcp/src/mcp/tasks-methods.ts` (task-cancel disposal)
+
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `Follow_ConsumerDisconnect_HandleDisposedRegistryZero`, `TasksCancel_MidFollow_HandleDisposed`, `Wait_ConcurrentSameStream_BothResolveIndependently`.
+**testingStrategy:** `propertyTests: true` (concurrency category — property: any interleaving of N concurrent subscribe/dispose/append operations leaves the registry consistent and delivers each subscriber only its matches); `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 009, 010
+**Parallelizable:** Yes (after deps)
+
+#### Task 018: Documentation — liveness convention + subscription contract + verb surface
+
+**Risk Tier:** low
+**Boundary Touching:** false
+**Test Layer:** unit
+**Implements:** DR-1, DR-2
+
+**Files:**
+- `docs/architecture/runtime.md` (§6 liveness convention: base schema + pairing rule + registry as enforcement; §L7 verbs updated to the shipped shape)
+
+**Verification:** static analysis + `verify_doc_links`. The #1315 subscription contract is this spec's DR-1; runtime.md links here.
+**testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** 010
+**Parallelizable:** Yes (after 010)
+
+### Parallelization
+
+**Critical path:** 001 → 002 → 010 → 011 (S-6 acceptance) and 010 → 015 (parity closure).
+
+| Wave | Tasks (parallel within wave) |
+|---|---|
+| 1 | 001, 003, 005, 008, 012, 014 |
+| 2 | 002, 004, 013 |
+| 3 | 006, 007 (after 005+006), 009, 010 |
+| 4 | 011, 015, 016, 017, 018 |
+
+No two parallel tasks in the same wave modify the same file (`registry.ts`/`composite.ts`/`cli.ts` touches are serialized across waves 3–4 via dependencies; wave-1 tasks touch disjoint modules).
+
+### Completion checklist
+
+- [x] Every DR-N in `## Design & Rationale` maps to at least one task in the matrix
+- [x] Every task `Implements:` a DR-N that exists in this document
+- [x] Every task carries a `riskTier` stamp
+- [x] Medium/high-tier tasks carry adequacy-judged tests (test-after); low-tier tasks lean on static analysis
+- [x] Open questions are resolved OR explicitly deferred with rationale
+- [ ] Ready for `plan-review`

--- a/docs/specs/2026-07-07-lifecycle-verbs.md
+++ b/docs/specs/2026-07-07-lifecycle-verbs.md
@@ -1,7 +1,7 @@
 # Spec: Process Lifecycle Verbs — generic ps / describe / wait / export over the event log
 
-**Date:** 2026-07-07 · **Feature:** `lifecycle-verbs` · **Depth:** deep
-**Inputs:** #1316 (design spike, this spec closes it) · #1090 (epic; children #1103–#1106 absorbed here) · #1315 (subscription primitive — contract defined here) · #1599 roadmap (Z2 critical path, coordination rules 2–4) · `docs/specs/2026-07-03-wlm-6-surface-and-workflow-fixes.md` · `docs/specs/2026-06-26-wlm-operational-core.md` · `docs/architecture/runtime.md` §L7/§6 · `.exarchos/invariants.md` (INV-1/2/5a–d/6/7/8/10/12/15/16)
+**Date:** 2026-07-07 (rev. 1: 2026-07-08) · **Feature:** `lifecycle-verbs` · **Depth:** deep
+**Inputs:** #1316 (design spike, this spec closes it) · #1090 (epic; children #1103–#1106 absorbed here) · #1315 (subscription primitive — contract defined here) · #1599 roadmap (Z2 critical path, coordination rules 2–4) · `docs/specs/2026-07-03-wlm-6-surface-and-workflow-fixes.md` · `docs/specs/2026-06-26-wlm-operational-core.md` · `docs/architecture/runtime.md` §L7/§6 · `.exarchos/invariants.md` (INV-1/2/5a–d/6/7/8/10/12/13/15/16)
 
 > One unified artifact: `## Design & Rationale` is the DR-N source; `## Decomposition` maps tasks → DR-N within this same document.
 
@@ -16,7 +16,7 @@ Epic #1090 promises generic workflow-lifecycle verbs — `ps` (list), `describe`
 - **`export` is absent.**
 - **The #1315 subscription primitive is absent** — every waiter re-folds a projection on a sleep loop.
 - **INV-10 is aspirational**: four surfaces emit `<surface>.executing_started`/terminal pairs (merge, launch, mutation, prune) as ad-hoc per-surface schemas with no shared base and no generic consumer; `mutation` is observable by nothing.
-- **Audit S-6 (stuck-`executing` recovery) remains open**: no generic way to wait out or inspect a crashed long-running operation.
+- **Audit S-6 (stuck-`executing` recovery) remains open**: no generic way to wait out or inspect a crashed long-running operation. Note: the original #1090/#1316 sketch (`wait <id> --phase delegate` resolving merge stalls) is **semantically unsound** against shipped reducer behavior — `merge.recovered` folds into the `mergeOrchestrator` sub-view and never produces a phase transition, and merges run while the workflow is already *in* `delegate`. S-6 closure requires an operation-level predicate (DR-5), not a phase predicate.
 
 Without one design, the four implementation issues (#1103–#1106) would diverge on subscription handling, predicate language, output schemas, and postures — exactly what #1316 was filed to prevent.
 
@@ -24,8 +24,8 @@ Without one design, the four implementation issues (#1103–#1106) would diverge
 
 **Unify under generic verbs on the two-tier subscription substrate** (Exploration, Option 2 — decided with the owner 2026-07-07):
 
-1. **One subscription primitive (DR-1)** — in-process post-commit notification plus a `PRAGMA data_version` cross-process poll floor — serves `wait`, `describe --follow`, and every future waiter. Subscriptions are ephemeral (per-dispatch), so INV-15's no-daemon frame holds by construction.
-2. **One liveness contract (DR-2)** — `ExecutingStartedBase` + a liveness-pair registry — turns INV-10 from convention into checkable contract, and gives `ps` its generic operations fold (adopted from Exploration Option 3, without its row-shape conflation).
+1. **One subscription primitive (DR-1)** — a **cursor-pump**: each subscription holds a sequence cursor and delivery is always a cursor-driven drain; an in-process post-commit hook and a `PRAGMA data_version` cross-process poll floor are merely *wake signals*. Exactly-once, globally sequence-ordered delivery holds by construction. Subscriptions are ephemeral (per-dispatch), so INV-15's no-daemon frame holds by construction.
+2. **One liveness contract (DR-2)** — `ExecutingStartedBase` + a liveness-pair registry — turns INV-10 from convention into checkable contract, and gives `ps` its generic operations fold and `wait` its operation predicate (adopted from Exploration Option 3, without its row-shape conflation).
 3. **The verbs are pure consumers** — `ps`/`inspect`/`wait` are projections or subscriptions (no writes; `wait` emits no events, revising #1316 Q7); `export` is the one emitter and follows INV-13's two-event split.
 4. **CLI promotion (DR-7)** hoists the verbs to `exarchos ps|describe|wait|export` through a registry-driven mechanism, keeping INV-2 parity.
 
@@ -35,20 +35,23 @@ Compatibility posture: **break-in-preview** — the WLM-6 `ps`/`wait` schemas ar
 
 The DR-N identifiers below are the single source the decomposition traces against.
 
-#### DR-1: Two-tier subscription primitive (#1315)
+#### DR-1: Cursor-pump subscription primitive with two wake tiers (#1315)
 
-The event store exposes `subscribe(filter, onEvent): SubscriptionHandle` where `filter` is `{ streamId?, eventTypes?[] }`. Tier 1 (in-process): after a successful append commits, matching listeners fire synchronously, post-commit — a listener failure is isolated and never affects the append result (at-most-once; mirrors INV-7's two-tier split). Tier 2 (cross-process): a bounded poll floor re-checks `PRAGMA data_version` (near-free) and re-reads only when another connection has committed, delivering matching events in sequence order. Subscriptions are ephemeral: registered by a dispatch, disposed when it returns — nothing outlives the verb (INV-15).
+The event store exposes `subscribe(filter, onEvent, { fromSequence?, floorMs? }): SubscriptionHandle` where `filter` is `{ streamId?, eventTypes?[] }`. Each subscription holds a **sequence cursor** (initialized to the current head, or `fromSequence`); delivery is always a **cursor-driven drain** — read matching events after the cursor, deliver in global sequence order, advance the cursor. Two wake signals trigger drains: **Tier 1** (in-process): a post-commit hook fires after the append transaction commits **and after the per-stream mutex releases** (never inside the lock — the appender's per-stream Promise mutex is non-reentrant, so a listener that itself appends must not deadlock). **Tier 2** (cross-process): a bounded poll floor re-checks `dataVersion()` (near-free) and drains only when a foreign connection has committed. Because both tiers converge on the same cursor drain, a Tier-1 wake at sequence N+1 delivers a not-yet-seen foreign event at sequence N first — no gaps, no double delivery. Listener failures are isolated (never affect an append result or sibling listeners). INV-8 idempotency cache-hits commit nothing and do **not** wake subscriptions. Subscriptions are ephemeral: registered by a dispatch, disposed when it returns (INV-15). `dataVersion(): number` joins the `StorageBackend` interface — SQLite via `PRAGMA data_version`, memory backend via a monotonic append counter — so Tier-2 behavior is defined on every backend.
 
 **Acceptance criteria:**
-- Given a subscription on stream S for type T, when a matching event is appended in-process, then `onEvent` fires after commit without waiting any poll interval.
-- Given an append from a second process (test: second connection), when `data_version` changes, then matching events are delivered in sequence order within one floor interval (default documented; configurable per call).
-- Given a listener that throws, when the append commits, then the append result is unchanged and remaining listeners still fire.
+- Given a subscription with cursor at sequence N, when matching events N+1…N+k are appended in-process, then the drain delivers them post-commit in order; a listener that throws on N+1 does not affect the append result, sibling listeners, or delivery of N+2…N+k.
+- Given interleaved appends from a second connection (sequence N, undrained) and the own process (sequence N+1), then delivery order is N, N+1 — exactly once each (gap-detection property, injectable clock).
+- Given a listener that appends to the same stream during delivery, then no deadlock occurs (hook fires outside the per-stream mutex) and the new event arrives in a subsequent drain.
+- Given an INV-8 idempotency cache-hit (duplicate append, no new commit), then no wake fires and nothing is re-delivered.
 - Given a dispatch that registered subscriptions, when it returns (success or error), then all its handles are disposed — a leak test asserts the registry count returns to zero.
-- With zero subscribers, the append hot path executes no listener-related work beyond a single guard check (benchmarked: no measurable regression in the append benchmark).
+- With zero subscribers, the append hot path executes no listener-related work beyond a single guard check (append benchmark: p99 regression < 5% vs baseline).
+- The floor interval has a documented default, honored per-call `floorMs` override (test), and is driven by an injectable clock so floor tests are deterministic (no wall-clock sleeps).
+- `MemoryBackend.dataVersion()` increases on every committed append and is stable otherwise (contract test shared across backends).
 
 #### DR-2: `ExecutingStartedBase` and the liveness-pair registry (INV-10 made checkable)
 
-Extract a shared Zod base `{ surface, instanceId, startedAt, expectedDurationMs? }`; the four existing schemas (`merge`/`launch`/`mutation`/`prune` `.executing_started`) retrofit via `.extend(...)` with **byte-identical event data** (no migration). A liveness-pair registry — one table mapping each `<surface>.executing_started` to its terminal event types — becomes the single source `ps`'s operations fold and `wait`'s terminal detection consume. Adding a surface to the lifecycle plane = one registry entry, zero verb code.
+Extract a shared Zod base `{ surface, instanceId, startedAt, expectedDurationMs? }`; the four existing schemas (`merge`/`launch`/`mutation`/`prune` `.executing_started`) retrofit via `.extend(...)` with **byte-identical event data** (no migration). A liveness-pair registry — one table mapping each `<surface>.executing_started` to its terminal event types — becomes the single source consumed by `ps`'s operations fold and `wait`'s operation predicate. Adding a surface to the lifecycle plane = one registry entry, zero verb code.
 
 **Acceptance criteria:**
 - All four existing `*.executing_started` schemas extend the base; snapshot tests prove emitted event data is unchanged.
@@ -57,7 +60,7 @@ Extract a shared Zod base `{ surface, instanceId, startedAt, expectedDurationMs?
 
 #### DR-3: Generic `ps` — scope-parameterized process listing
 
-`exarchos_view { action: 'ps', scope: 'workflow' | 'worktree' | 'all' }` (default `all`). Output has two honestly-shaped sections, never conflated rows: `workflows` (fold of `workflow_state` joined with `streams.workflow_type`: featureId, workflowType, phase, status, ageMs) and `operations` (generic fold over the DR-2 registry: any `executing_started` without its terminal — including `mutation`, which today nothing surfaces). Filters: `workflowType` (indexed pushdown via `streams.workflow_type`), `status`, `phase`, `all` (include completed/cancelled; default excludes them). The WLM-6 worktree fold (in-flight merges/launches/prunes + `probe` reconciliation) is preserved under `scope: 'worktree' | 'all'`; `probe: true` remains a conditional writer with its existing `LOCAL_MUTATION_IDEMPOTENT` annotation.
+`exarchos_view { action: 'ps', scope: 'workflow' | 'worktree' | 'all' }` (default `all`). Output has two honestly-shaped sections, never conflated rows: `workflows` (fold of `workflow_state` joined with `streams.workflow_type`: featureId, workflowType, phase, status, ageMs) and `operations` (generic fold over the DR-2 registry: any `executing_started` without its terminal — including `mutation`, which today nothing surfaces). Filters: `workflowType` (indexed pushdown via `streams.workflow_type`), `status`, `phase`, `all` (include completed/cancelled; default excludes them). The WLM-6 worktree fold (in-flight merges/launches/prunes + `probe` reconciliation) is preserved under `scope: 'worktree' | 'all'`; `probe: true` remains a conditional writer with its existing `LOCAL_MUTATION_IDEMPOTENT` annotation. All new/redesigned action fields come from the shared lifecycle field-shape module (DR-8) so cross-action base types cannot collide.
 
 **Acceptance criteria:**
 - Given workflows of mixed types and phases, when `ps --workflow-type feature`, then only `feature` rows return, and the query uses the indexed `streams.workflow_type` column.
@@ -68,36 +71,47 @@ Extract a shared Zod base `{ surface, instanceId, startedAt, expectedDurationMs?
 
 #### DR-4: `inspect` — the workflow-projection describe
 
-New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite projection returning workflow state (via the canonical `resolveWorkflowState`/rehydration path — never `.state.json` presence), recent events (with `operationId`/`correlationId`/`causationId`), artifacts, and task progress. Existence signal is `_meta.workflowExists`; a cold probe of an unknown featureId is side-effect-free. `--follow` consumes DR-1 and streams through two carriers per #1316 Q3: NDJSON frames on the CLI (existing encoder/heartbeat), MCP Tasks (SEP-1686) on the MCP path — one contract, two presentations (INV-5b). The MCP action name avoids the GA'd schema-`describe` (no rename, no Zod-union overload — a known CLI-parity hazard); DR-7 maps the CLI top-level verb `exarchos describe <id>` onto it.
+New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite projection returning workflow state (via the canonical `resolveWorkflowState`/rehydration path — never `.state.json` presence), recent events (with `operationId`/`correlationId`/`causationId`), artifacts, and task progress. Existence signal is `_meta.workflowExists`; a cold probe of an unknown featureId is side-effect-free. `--follow` consumes DR-1 and streams through two carriers per #1316 Q3: NDJSON frames on the CLI (existing encoder/heartbeat, heartbeats on the injectable timer), MCP Tasks (SEP-1686) on the MCP path — one contract, two presentations (INV-5b). Follow disposal is `AbortSignal`-based (SIGINT wired to abort on POSIX and Windows alike — no POSIX-only signal semantics). The MCP action name avoids the GA'd schema-`describe` (no rename, no Zod-union overload — a known CLI-parity hazard); DR-7 maps the CLI top-level verb `exarchos describe <id>` onto it.
 
 **Acceptance criteria:**
 - Given an unknown featureId, when `inspect` runs, then `_meta.workflowExists: false` with `expectedShape` in the error envelope, and no event is appended.
-- Given `--follow`, when events append to the feature's stream (in-process or cross-process), then they appear as NDJSON `event` frames deduplicated by sequence; heartbeat frames cover silent gaps.
+- Given `--follow`, when events append to the feature's stream (in-process or cross-process), then they appear as NDJSON `event` frames deduplicated by sequence; heartbeat frames cover silent gaps (injected timer).
 - The MCP path exposes follow via Tasks (`tasks/get`/`tasks/result`), sharing the DR-1 subscription with the CLI carrier.
+- Given abort (CLI SIGINT→AbortSignal, MCP task cancel), the follow loop exits and its subscription handle is disposed.
 - Schema-introspection `describe` on all four composite tools is byte-unchanged.
 
-#### DR-5: Generic `wait` — event-driven phase gate, no self-journaling
+#### DR-5: Generic `wait` — event-driven gate with phase, status, and operation predicates; no self-journaling
 
-`wait(featureId, phase?, status?, until?, integrationRef?, timeoutMs)`: phase targets use **reached-or-passed** semantics — the projection is checked first, returning immediately if the target phase was already reached (idempotent re-runs, #1316 Q2); otherwise a DR-1 subscription on `workflow.transition` + registry terminal events resolves it. `status` supports terminal waits (`completed`/`failed`/`cancelled`). The WLM-6 worktree predicates (`until: merge|idle` + `integrationRef`) are retained as the worktree scope of the same action. `wait` emits **no events** (revises #1316 Q7): posture read-only, `readOnlyHint: true`, `idempotentHint: true` — the log records domain facts, not observations of them. Timeout/failure return structured `WAIT_TIMEOUT` / `WAIT_FAILED` envelopes; the CLI adapter maps them to exit codes 17/18 as pure presentation (a generic errorCode→exitCode map, INV-2-safe).
+`wait(featureId, phase?, status?, operation?, until?, integrationRef?, timeoutMs)`:
+
+- **`phase`** — reached-or-passed semantics: the projection is checked first, returning immediately if the target phase was already reached (idempotent re-runs, #1316 Q2); otherwise a DR-1 subscription on `workflow.transition` resolves it.
+- **`status`** — terminal waits (`completed` / `failed` / `cancelled`).
+- **`operation <surface>`** — the **S-6 predicate**: resolves when the feature's unpaired `<surface>.executing_started` gains a terminal event per the DR-2 registry; resolves immediately if no such operation is in flight. This — not `--phase` — is how a stuck merge is waited out: `merge.recovered` never transitions the workflow phase (it folds into the `mergeOrchestrator` sub-view), so the original epic sketch is explicitly corrected here.
+- **`until: merge|idle` + `integrationRef`** — the WLM-6 worktree predicates, retained as the worktree scope of the same action.
+
+`wait` emits **no events** (revises #1316 Q7): posture read-only, `readOnlyHint: true`, `idempotentHint: true` — the log records domain facts, not observations of them. Timeout/failure return structured `WAIT_TIMEOUT` / `WAIT_FAILED` envelopes; the CLI adapter maps them to exit codes 17/18 as pure presentation (a generic errorCode→exitCode map, INV-2-safe).
 
 **Acceptance criteria:**
 - Given a workflow already past `--phase plan-review`, when `wait --phase plan-review` runs, then it returns success immediately (exit 0) without subscribing.
-- Given no matching transition within `timeoutMs`, then `WAIT_TIMEOUT` is returned and the CLI exits 17.
+- Given an in-process `workflow.transition` to the target phase, then `wait` resolves on the Tier-1 wake (injected clock; no floor tick consumed).
+- Given no matching event within `timeoutMs`, then `WAIT_TIMEOUT` is returned and the CLI exits 17.
 - Given the workflow enters `failed`/`cancelled` while waiting on a phase, then `WAIT_FAILED` is returned and the CLI exits 18.
-- Given an in-process `workflow.transition` to the target phase, then `wait` resolves without waiting a poll interval (Tier-1 path test).
-- **S-6 closure walkthrough:** given `merge.executing_started` with no terminal (simulated crash), `wait <id> --phase delegate --timeout 10m` resolves when `merge.recovered` lands, or exits 17 on timeout; `inspect` shows the unpaired `executing_started`; no merge-specific code exists in `wait` (grep-asserted).
-- `wait` appends zero events across all paths (asserted by event-count invariance in tests).
+- Given an unpaired `merge.executing_started`, when `wait --operation merge` runs, then it resolves when any registry terminal for `merge` lands (e.g. `merge.recovered`, `merge.executed`); given none in flight, it returns immediately; given no terminal within `timeoutMs`, exit 17.
+- Worktree retention: `Wait_WorktreeScope_PreservesWlm6Capabilities` — `until: merge` (with `integrationRef`) and `until: idle` behave per the WLM-6 contract under the redesigned schema.
+- **S-6 closure walkthrough:** given `merge.executing_started` with no terminal (simulated crash), `wait <id> --operation merge --timeout 10m` resolves when `merge.recovered` lands, or exits 17 on timeout; `inspect` shows the unpaired `executing_started`; no merge-specific code exists in `wait.ts` or `operations-fold.ts` (grep-asserted; behavioral assertions carry the adequacy).
+- `wait` appends zero events across all paths (event-count invariance in tests).
 
 #### DR-6: `export` — event-log bundle with the INV-13 two-event split
 
-`export(featureId, output?)`: writes a zip containing `events.jsonl` (full stream extract), `state.json` (projection snapshot), `metadata.json` (version, eventCount, phase, exportedAt), and `artifacts/` (referenced artifact files that exist on disk). Writing outside `.exarchos/` is a non-idempotent external side effect, so export follows INV-13: `export.requested` (intent + resolved path) before the write, `export.executed` (result + content hash) after. Crash between the two → the next invocation runs an idempotent precheck (zip exists + hash matches manifest) to re-emit or skip. Posture `task-isolated`, `openWorldHint: true`. Default output `./<featureId>-export.zip`; invalid paths return `suggestedFix` with the default.
+`export(featureId, output?)`: writes a zip containing `events.jsonl` (full stream extract), `state.json` (projection snapshot), `metadata.json` (version, eventCount, phase, exportedAt), and `artifacts/` (referenced artifact files that exist on disk; missing references tolerated and listed in metadata). Zip writing uses **`yazl`** (pure-JS, pinned) — no zip capability exists in the repo today, and a hand-rolled binary format is riskier than a small mature dependency; the single-file bun bundle must still build and export must work from it. Writing outside `.exarchos/` is a non-idempotent external side effect, so export follows INV-13: `export.requested` (intent + resolved path) before the write, `export.executed` (result + content hash) after. Crash between the two → the next invocation runs an idempotent precheck (zip exists + hash matches manifest) to re-emit or skip. Posture `task-isolated`, `openWorldHint: true`. Default output `./<featureId>-export.zip`; invalid paths return `suggestedFix` with the default.
 
 **Acceptance criteria:**
 - Given an exported bundle, when `events.jsonl` is replayed through the reducers, then the result equals `state.json` (round-trip test) — the event log **is** the export.
-- Every successful export appends exactly the `export.requested`/`export.executed` pair, idempotency-keyed per INV-8.
+- `Export_Success_AppendsExactlyRequestedExecutedPair` — every successful export appends exactly one `export.requested`/`export.executed` pair, idempotency-keyed per INV-8; re-running export produces a new pair for the new zip, never a duplicate of a prior intent.
 - Given a crash simulated between the pair, when export re-runs, then the precheck detects the existing/partial zip and completes without duplicating the `requested` intent.
+- Given referenced artifacts where some paths are missing on disk, then existing ones are bundled under `artifacts/` and missing ones are listed in `metadata.json` without failing the export.
 - Given an invalid `--output` path, then a structured error with `suggestedFix` (default location) returns and no events are appended.
-- Zip paths are built with `path.join` / POSIX-normalized entries; tests close SQLite handles before temp-dir removal (INV-16).
+- Zip entry paths are POSIX-normalized and built with `path.join`; tests close SQLite handles before temp-dir removal (INV-16); `npm run build` still produces a working single-file bundle containing the zip writer.
 
 #### DR-7: Registry-driven CLI top-level promotion
 
@@ -105,47 +119,50 @@ New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite proj
 
 **Acceptance criteria:**
 - `exarchos ps|describe <id>|wait <id>|export <id>` all resolve and dispatch.
-- Parity fixtures assert byte-identical `ToolResult` across the three invocation paths: top-level CLI, `view <action>` subcommand, and MCP `exarchos_view` — for each promoted verb.
+- Parity fixtures assert byte-identical `ToolResult` across the three invocation paths — top-level CLI, `view <action>` subcommand, MCP `exarchos_view` — for each promoted verb, with volatile fields (`_perf`, timestamps, `ageMs`) normalized per the existing parity-harness conventions (injected clock where needed).
 - A registry entry with a colliding `topLevel` name fails the build/registration test, not runtime.
-- Visible MCP tool count is unchanged (still 4 composite tools, INV-5d).
+- `Registry_VisibleCompositeCount_RemainsFour` — the visible MCP tool count stays 4 (INV-5d); extend/cite the existing visible-count fence in `registry.test.ts`.
 
 #### DR-8: Error handling, failure modes, and edge cases
 
 Cross-cutting failure contract for the verb surface.
 
 **Acceptance criteria:**
-- Given `wait --phase <invalid>`, then the error envelope's `validTargets` is populated from the HSM topology **for that workflow's type**.
+- Given `wait --phase <invalid>`, then the error envelope's `validTargets` is populated from the HSM topology **for that workflow's type**; given `--operation <unknown-surface>`, `validTargets` lists the registry's surfaces.
 - Given an unknown featureId on `inspect`/`wait`/`export`, then a side-effect-free error with `expectedShape` returns (cold-probe rule; no stream registration, no events).
-- Given a subscription whose consumer disconnects mid-follow (CLI SIGINT, MCP task cancel), then the handle is disposed and the leak test passes.
-- Cross-process wait latency is bounded: ≤ one floor interval + one projection fold; the floor default is documented in the subscription contract and surfaced in `_perf`.
+- Given a subscription whose consumer disconnects mid-follow (CLI abort, MCP task cancel), then the handle is disposed and the leak test passes.
 - Given concurrent `wait`s on the same stream from two dispatches, then both resolve independently (no shared-handle interference).
-- All new paths run on Windows CI (INV-16): no separator string-concat, handles closed before temp-dir removal, `resolveExecutable` for any spawns.
+- Cross-process wait latency is bounded by one floor interval + one drain: verified deterministically with the injected clock (advance one floor tick → foreign event delivered); the floor default is documented and surfaced in `_perf`.
+- **Registration integrity:** the composed `exarchos_view` registration schema — including every new/redesigned lifecycle field — constructs without `buildRegistrationSchema` throwing (the documented same-field-name/different-base-type THROW class). All lifecycle actions source shared field names from one field-shape module; a construction test guards the composed registry.
+- **Windows (INV-16), owned by Task 017:** the win32 CI lane runs every new path green with **no new `skipIf(win32)` entries**; the poll floor holds no open SQLite statement across ticks (handle-close class, #1620); two-connection tests set an explicit `busy_timeout` posture; follow disposal is AbortSignal-based (no POSIX-only signal semantics); all timing tests use the injectable clock (no wall-clock sleeps — the #1641 nondeterminism class).
 
 ### Technical Design
 
-**New substrate:** `servers/exarchos-mcp/src/event-store/subscriptions.ts` — the listener registry + `SubscriptionHandle`; a post-commit hook point in the append path (`store.ts`/`atomic-appender.ts`) guarded to zero-cost when empty; `data_version` floor helper in `storage/sqlite-backend.ts`.
+**New substrate:** `servers/exarchos-mcp/src/event-store/subscriptions.ts` — subscription registry, `SubscriptionHandle`, the **cursor pump** (per-subscription `lastDeliveredSeq`; wake → drain matching events after cursor in global order → advance), and the Tier-2 floor loop on an **injectable clock**. The Tier-1 hook point lands in the append path (`store.ts`/`atomic-appender.ts`) and fires **after commit and after the per-stream mutex releases** — listener-initiated appends re-enter the normal append path without deadlock; the hook is a single guard check when no subscribers exist. INV-8 cache-hit short-circuits (pre-transaction, no commit) never wake. `dataVersion()` joins `StorageBackend` (`storage/backend.ts`): SQLite = `PRAGMA data_version`; memory = monotonic append counter.
 
-**Liveness contract:** base schema + pair registry live beside the event schemas (`event-store/schemas.ts`); the generic "in-flight operations" fold becomes a small reusable projection consumed by `ps` — not a new stored projection table.
+**Liveness contract:** base schema + pair registry live beside the event schemas (`event-store/schemas.ts`, `event-store/liveness-registry.ts`); the generic "in-flight operations" fold is a small reusable module consumed by `ps` and by `wait --operation` — not a new stored projection table.
 
-**Verbs:** new handlers under `src/views/lifecycle/` (ps/inspect/wait/export), routed via `views/composite.ts`; the WLM-6 worktree fold (`orchestrate/worktree/handlers.ts`) is called by the `ps` worktree scope rather than duplicated. `wait` composes: projection precheck → DR-1 subscribe → registry-terminal detection. Registry entries stamp postures, `outputSchema`, annotations, and `cli.topLevel` per DR-7 (#1316 Q7/Q8 land as registration facts, not prose).
+**Verbs:** new handlers under `src/views/lifecycle/` (ps/inspect/wait/export), routed via `views/composite.ts`; the WLM-6 worktree fold (`orchestrate/worktree/handlers.ts`) is called by the `ps` worktree scope rather than duplicated; the WLM-6 wait kernel is absorbed by generic `wait`. All lifecycle action schemas import field definitions from `src/views/lifecycle/schema-fields.ts` (one canonical Zod shape per field name — `scope`, `status`, `phase`, `workflowType`, `all`, `follow`, `limit`, `output`, `operation`) so `buildRegistrationSchema`'s same-name/different-base-type THROW is unrepresentable; a registry-construction test enforces it. Registry entries stamp postures, `outputSchema`, annotations, and `cli.topLevel` (#1316 Q7/Q8 land as registration facts, not prose).
 
-**CLI:** promotion loop + errorCode→exitCode map in `adapters/cli.ts`; follow carriers reuse `src/ndjson/` (CLI) and `src/mcp/tasks-methods.ts` (MCP), both fed by DR-1.
+**CLI:** promotion loop + errorCode→exitCode map in `adapters/cli.ts`; follow carriers reuse `src/ndjson/` (CLI) and `src/mcp/tasks-methods.ts` (MCP), both fed by DR-1; follow lifecycle is AbortSignal-driven.
 
-**SDK-lowering mapping (#1599 rule 3):** `wait --phase` lowers as the IR's `awaitPhase(featureId, phase)` combinator; the subscription primitive is the runtime service IR await-nodes bind to; `ps`/`inspect`/`export` are read-side projections with no IR footprint. No edits to `hsm-definitions.ts`/`playbooks.ts`.
+**SDK-lowering mapping (#1599 rule 3):** `wait --phase` lowers as the IR's `awaitPhase(featureId, phase)` combinator and `wait --operation` as `awaitOperationIdle(featureId, surface)`; the subscription primitive is the runtime service IR await-nodes bind to; `ps`/`inspect`/`export` are read-side projections with no IR footprint. No edits to `hsm-definitions.ts`/`playbooks.ts`.
 
 **Q11 alignment:** INV-1 (all verbs are folds/subscriptions/emitters — no side stores); INV-2 (parity fixtures per verb); INV-6 (verbs read topology/projections generically — no workflow-type branching); INV-12 (`wait` complements `next_actions`: affordances say what *can* run, `wait` observes what *did*).
 
 ### Integration Points
 
-- `servers/exarchos-mcp/src/event-store/store.ts` + `atomic-appender.ts` — post-commit notification hook (guarded, zero-cost empty path)
-- `servers/exarchos-mcp/src/event-store/subscriptions.ts` — **new**: registry, handle lifecycle, data_version floor
-- `servers/exarchos-mcp/src/event-store/schemas.ts` — `ExecutingStartedBase` + liveness-pair registry; four schema retrofits
+- `servers/exarchos-mcp/src/event-store/store.ts` + `atomic-appender.ts` — post-commit notification hook (outside the per-stream mutex; guarded, zero-cost empty path; no wake on idempotency cache-hits)
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` — **new**: registry, cursor pump, handle lifecycle, injectable-clock floor
+- `servers/exarchos-mcp/src/storage/backend.ts` + `sqlite-backend.ts` + `memory-backend.ts` — `dataVersion()` contract
+- `servers/exarchos-mcp/src/event-store/schemas.ts` + `liveness-registry.ts` — `ExecutingStartedBase`; four schema retrofits; pair registry; `export.*` events
 - `servers/exarchos-mcp/src/views/composite.ts` — route `ps`(redesigned)/`inspect`(new)/`wait`(redesigned)/`export`(new)
-- `servers/exarchos-mcp/src/views/lifecycle/` — **new**: verb handlers
-- `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` — worktree fold consumed as `ps` scope; WLM-6 wait kernel absorbed into generic `wait`
+- `servers/exarchos-mcp/src/views/lifecycle/` — **new**: verb handlers + `schema-fields.ts` shared shapes
+- `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` — worktree fold consumed as `ps` scope; WLM-6 wait kernel absorbed
 - `servers/exarchos-mcp/src/registry.ts` — action defs, postures, outputSchemas, `CliActionHints.topLevel`
 - `servers/exarchos-mcp/src/adapters/cli.ts` — top-level promotion, exit-code map, follow carrier wiring
 - `servers/exarchos-mcp/src/ndjson/` + `src/mcp/tasks-methods.ts` — carriers over the DR-1 contract
+- `servers/exarchos-mcp/package.json` — `yazl` (pinned) for DR-6
 - `docs/architecture/runtime.md` §6/§L7 — liveness convention + verb docs
 
 ### Exploration
@@ -158,6 +175,8 @@ Divergent loop run 2026-07-07 (deep rung; `correlationId: c3c85d7a-8abf-48e4-912
 
 Owner decisions converged in one iteration: unify (vs coexist) · full pickup (spec through implementation) · break-in-preview (no shims) · build CLI promotion · Option 2 · `wait` emits no events · MCP `inspect` / CLI `describe`.
 
+**Plan-review revision 1 (2026-07-08).** A 3-voter fresh-context adversarial panel (coverage / feasibility / adequacy) refuted rev. 0 unanimously. Design-level corrections absorbed: (a) DR-1 re-specified as a **cursor-pump** — the naive "synchronous notify" wording could not jointly satisfy exactly-once and global order across two connections, and left the listener-vs-per-stream-mutex re-entrancy contract undefined; (b) DR-5 gained the **`operation` predicate** after the panel proved the epic's phase-based S-6 walkthrough unsound against shipped reducer semantics (`merge.recovered` never transitions phase); (c) DR-6 pinned the zip dependency (`yazl` — none exists in-repo); (d) DR-8 gained the registration-integrity and Windows/INV-16 criteria with owning tasks (019/017). Decomposition re-waved to eliminate three same-file wave collisions; six tiers raised to match the mechanical derivation.
+
 ### Alternatives considered
 
 - **Coexist (freeze WLM-6 verbs, add new names)** — rejected: permanently splits the lifecycle surface and squats the #1090 names on worktree semantics.
@@ -166,10 +185,12 @@ Owner decisions converged in one iteration: unify (vs coexist) · full pickup (s
 - **Zod-union overload of `describe`** — rejected: known `coerceFlags` CLI-parity break on unions; agent-facing schema ambiguity (INV-5a).
 - **Renaming schema-`describe` to free the name** — rejected: breaks a GA'd discovery surface all agents use.
 - **OS-level notification (fs-watch on the SQLite WAL, LISTEN/NOTIFY-style IPC)** — rejected: imports watcher/daemon primitives from outside the INV-15 frame; `data_version` polling floor achieves the cross-process bound within it.
+- **Hand-rolled STORE-method zip writer** — rejected in rev. 1: a bespoke binary format is higher-risk than a pinned, tiny, pure-JS `yazl`; bundle-size impact verified in Task 013.
+- **Phase-based S-6 recovery (`wait --phase delegate`)** — rejected in rev. 1 (see DR-5): unsound against reducer semantics; replaced by the operation predicate.
 
 ### Open Questions
 
-- **Rich `wait` predicates (JSONPath over projection state, any-of/all-of):** deferred — phase/status/until covers S-6 and the v2.12 consumers; file a follow-up when a concrete consumer needs more (per #1316 Q2's own recommendation).
+- **Rich `wait` predicates (JSONPath over projection state, any-of/all-of):** deferred — phase/status/operation/until covers S-6 and the v2.12 consumers; file a follow-up when a concrete consumer needs more (per #1316 Q2's own recommendation).
 - **MCP `resources/subscribe` exposure of DR-1:** deferred to the #1604 MCP-migration tranche (Z3) — the primitive is transport-agnostic; exposing it remotely is a harness-boundary question (#1599 rule 5).
 - **Import/replay tooling for export bundles:** deferred; the round-trip test (DR-6) guarantees replayability, tooling lands with a concrete diagnostic consumer.
 - **`shepherd`/`tdd-swarm` liveness conformance:** out of scope per #1316; the DR-2 registry makes each a one-entry addition tracked on their own issues.
@@ -187,55 +208,59 @@ The decomposition maps every task to one or more DR-N from the section above.
 
 | DR | Requirement | Tasks |
 |----|-------------|-------|
-| DR-1 | Two-tier subscription primitive (#1315) | 001, 002, 017, 018 |
+| DR-1 | Cursor-pump subscription primitive (#1315) | 001, 002, 017, 018 |
 | DR-2 | ExecutingStartedBase + liveness-pair registry | 003, 004, 018 |
 | DR-3 | Generic `ps` (scope-parameterized) | 005, 006, 007 |
 | DR-4 | `inspect` workflow-projection describe | 008, 009 |
-| DR-5 | Generic `wait` (event-driven gate, no self-journaling) | 010, 011 |
+| DR-5 | Generic `wait` (phase/status/operation predicates) | 010, 011 |
 | DR-6 | `export` with INV-13 two-event split | 012, 013 |
 | DR-7 | Registry-driven CLI top-level promotion | 014, 015 |
-| DR-8 | Error handling, failure modes, edge cases | 011, 016, 017 |
+| DR-8 | Error handling, failure modes, edge cases | 011, 016, 017, 019 |
 
 ### Tasks
 
-#### Task 001: Subscription registry + post-commit notification hook (Tier 1)
+#### Task 001: Subscription registry + cursor pump + post-commit wake (Tier 1)
 
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 011
 **Implements:** DR-1
 
 **Files:**
-- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (new — registry, `SubscriptionHandle`, filter matching)
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (new — registry, `SubscriptionHandle`, cursor pump, filter matching, injectable clock seam)
 - `servers/exarchos-mcp/src/event-store/subscriptions.test.ts` (new)
-- `servers/exarchos-mcp/src/event-store/store.ts` (post-commit hook point, guarded zero-cost when empty)
-- `servers/exarchos-mcp/src/event-store/atomic-appender.ts` (fire-after-commit ordering)
+- `servers/exarchos-mcp/src/event-store/store.ts` (post-commit hook point — guarded zero-cost when empty)
+- `servers/exarchos-mcp/src/event-store/atomic-appender.ts` (wake fired after commit AND after per-stream mutex release; no wake on INV-8 cache-hits)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Subscribe_InProcessAppend_FiresPostCommitWithoutPoll`, `Subscribe_ListenerThrows_AppendUnaffectedAndSiblingsFire`, `Subscribe_DispatchReturns_HandleDisposed`, `Append_ZeroSubscribers_NoListenerWork`.
-**testingStrategy:** `propertyTests: true` (property: events delivered to a matching subscriber are exactly the appended events, in sequence order, for arbitrary interleavings of matching/non-matching appends); `benchmarks: true` (SLA: append p99 regression < 5% with zero subscribers vs baseline); `characterizationRequired: true` (append path is existing code).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Subscribe_InProcessAppend_CursorDrainDeliversPostCommitInOrder`, `Subscribe_ListenerThrows_AppendUnaffectedSiblingsAndLaterEventsDelivered`, `Subscribe_ListenerAppendsSameStream_NoDeadlockDeliveredNextDrain`, `Subscribe_IdempotencyCacheHit_NoWakeNoRedelivery`, `Subscribe_DispatchReturns_HandleDisposedRegistryZero`, `Append_ZeroSubscribers_GuardCheckOnly`. INV-16: no wall-clock sleeps (injectable clock); SQLite handles closed before temp-dir removal.
+**testingStrategy:** `propertyTests: true` (property: for arbitrary interleavings of matching/non-matching appends and wakes, each subscriber receives exactly its matches, exactly once, in global sequence order — concurrency category); `benchmarks: true` (SLA: append p99 regression < 5% with zero subscribers vs baseline; boundary/offline cadence, not the inner vitest loop); `characterizationRequired: true` (append path is existing code).
 **Dependencies:** None
 **Parallelizable:** Yes
 
-#### Task 002: Cross-process poll floor via `PRAGMA data_version` (Tier 2)
+#### Task 002: Tier-2 poll floor — `dataVersion()` backend contract + gap-free drain
 
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 011
 **Implements:** DR-1
 
 **Files:**
-- `servers/exarchos-mcp/src/storage/sqlite-backend.ts` (`dataVersion()` accessor)
-- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (floor loop: re-check data_version, re-read + deliver by sequence only on change)
+- `servers/exarchos-mcp/src/storage/backend.ts` (`dataVersion(): number` joins the interface)
+- `servers/exarchos-mcp/src/storage/sqlite-backend.ts` (`PRAGMA data_version`)
+- `servers/exarchos-mcp/src/storage/memory-backend.ts` (monotonic append counter)
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (floor loop on the injectable clock; drain only on version change; no open statement held across ticks)
 - `servers/exarchos-mcp/src/event-store/subscriptions.test.ts`
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Floor_SecondConnectionAppend_DeliveredInSequenceOrderWithinOneInterval`, `Floor_NoForeignCommit_NoReRead`, `Floor_DefaultInterval_SurfacedInPerf`.
-**testingStrategy:** `propertyTests: true` (property: for any split of appends across two connections, the subscriber observes every matching event exactly once, in global sequence order); `benchmarks: false`; `characterizationRequired: false`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Floor_ForeignCommit_DrainedInGlobalOrderNextTick` (injected clock), `Floor_ForeignThenOwnAppend_NoGapNoDoubleDelivery` (foreign seq N + own seq N+1 → delivered N, N+1), `Floor_NoForeignCommit_NoReRead`, `Floor_PerCallIntervalOverride_Honored`, `Floor_DefaultInterval_SurfacedInPerf`, `DataVersion_MemoryBackend_MonotonicOnAppend` (shared backend-contract test). Two-connection tests set explicit `busy_timeout` (INV-16 / SQLITE_BUSY posture).
+**testingStrategy:** `propertyTests: true` (property: for any split of appends across two connections and any wake/tick schedule, the subscriber observes every matching event exactly once in global sequence order); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 001
 **Parallelizable:** No (extends 001's module)
 
 #### Task 003: `ExecutingStartedBase` schema + retrofit of the four surfaces
 
-**Risk Tier:** medium
+**Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-2
@@ -244,7 +269,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/event-store/schemas.ts` (base + `merge`/`launch`/`mutation`/`prune` `.executing_started` retrofit via `.extend`)
 - `servers/exarchos-mcp/src/event-store/schemas.test.ts` (byte-identity snapshots)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `ExecutingStartedSchemas_Retrofit_EmittedDataByteIdentical` (snapshot per surface), `ExecutingStartedBase_RequiredFields_Validated`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (shared-contract surface — schema glob classifies this high mechanically). Tests: `ExecutingStartedSchemas_Retrofit_EmittedDataByteIdentical` (snapshot per surface), `ExecutingStartedBase_RequiredFields_Validated`.
 **testingStrategy:** `propertyTests: true` (property: schema compliance — every payload accepted by a retrofit schema is accepted by the base's field contract; serialization category); `benchmarks: false`; `characterizationRequired: true` (modifies existing schemas).
 **Dependencies:** None
 **Parallelizable:** Yes
@@ -252,7 +277,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 #### Task 004: Liveness-pair registry + conformance test
 
 **Risk Tier:** medium
-**Boundary Touching:** false
+**Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-2
 
@@ -260,15 +285,15 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/event-store/liveness-registry.ts` (new — `{ startType, terminalTypes[] }` per surface)
 - `servers/exarchos-mcp/src/event-store/liveness-registry.test.ts` (new)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `LivenessRegistry_EveryExecutingStartedInCatalog_HasEntryWithTerminal` (conformance — fails on unregistered `*.executing_started`), `LivenessRegistry_AddSurface_OneEntryNoVerbCode`.
-**testingStrategy:** `propertyTests: false` (registry is a static table; the conformance test is the guarantee); `benchmarks: false`; `characterizationRequired: false`.
+**Verification:** scoped tests + `check_test_adequacy` + `check_contract_drift` (this registry is the contract `ps` and `wait --operation` consume). Tests: `LivenessRegistry_EveryExecutingStartedInCatalog_HasEntryWithTerminal` (conformance — fails on unregistered `*.executing_started`), `LivenessRegistry_Lookup_ReturnsTerminalTypesForSurface`. (The "adding a surface needs zero verb code" property is proven by 006's generic-fold test and 011's grep — not assertable here before verbs exist.)
+**testingStrategy:** `propertyTests: false` (static table; the conformance test is the guarantee); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 003
-**Parallelizable:** No (follows 003's schema names)
+**Parallelizable:** Yes (within wave 2 — disjoint files)
 
 #### Task 005: `ps` workflows fold (workflow_state ⋈ streams.workflow_type + filters)
 
 **Risk Tier:** medium
-**Boundary Touching:** false
+**Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-3
 
@@ -277,14 +302,14 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts` (new)
 
 **Verification:** scoped tests + `check_test_adequacy`. Tests: `WorkflowFold_TypeFilter_UsesIndexedStreamsColumn`, `WorkflowFold_Default_ExcludesTerminalStates`, `WorkflowFold_AllFlag_IncludesCompleted`.
-**testingStrategy:** `propertyTests: true` (properties: filter idempotence `filter(filter(rows)) === filter(rows)`; filtered set ⊆ unfiltered set; collections category); `benchmarks: false`; `characterizationRequired: false`.
+**testingStrategy:** `propertyTests: true` (properties: filter idempotence `filter(filter(rows)) === filter(rows)`; filtered set ⊆ unfiltered set; collections category); `benchmarks: true` (view-materialization category — projection-fold events/sec SLA at boundary/offline cadence); `characterizationRequired: false`.
 **Dependencies:** None
 **Parallelizable:** Yes
 
 #### Task 006: `ps` operations fold (generic in-flight over the liveness registry)
 
 **Risk Tier:** medium
-**Boundary Touching:** false
+**Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-3
 
@@ -293,9 +318,9 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/views/lifecycle/operations-fold.test.ts` (new)
 
 **Verification:** scoped tests + `check_test_adequacy`. Tests: `OperationsFold_StartedWithoutTerminal_ListedInFlight`, `OperationsFold_MutationSurface_ListedGenerically` (DR-3 AC: no mutation-specific code), `OperationsFold_TerminalPresent_Excluded`.
-**testingStrategy:** `propertyTests: true` (property: for any event sequence, an operation is listed iff its start event has no later matching terminal — state-machine category); `benchmarks: false`; `characterizationRequired: false`.
+**testingStrategy:** `propertyTests: true` (property: for any event sequence, an operation is listed iff its start event has no later matching terminal — state-machine category); `benchmarks: true` (view-materialization category — fold throughput SLA at boundary/offline cadence); `characterizationRequired: false`.
 **Dependencies:** 004
-**Parallelizable:** Yes (after 004)
+**Parallelizable:** Yes (wave 3 — disjoint files)
 
 #### Task 007: `ps` handler redesign — scope parameter, composition, probe gating
 
@@ -305,7 +330,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-3
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/ps.ts` (new — composes 005 + 006 + the WLM-6 worktree fold)
+- `servers/exarchos-mcp/src/views/lifecycle/ps.ts` (new — composes 005 + 006 + the WLM-6 worktree fold; fields from `schema-fields.ts`)
 - `servers/exarchos-mcp/src/views/lifecycle/ps.test.ts` (new)
 - `servers/exarchos-mcp/src/views/composite.ts` (route redesigned `ps`)
 - `servers/exarchos-mcp/src/registry.ts` (redesigned schema: `scope`, filters; `outputSchema`; annotations)
@@ -313,26 +338,27 @@ The decomposition maps every task to one or more DR-N from the section above.
 
 **Verification:** scoped tests + `check_test_adequacy` + integration suite (redesigns a shipped preview surface; parity baselines updated). Tests: `Ps_DefaultScope_All_ReturnsWorkflowsAndOperationsSections`, `Ps_WorkflowScopeWithProbe_RejectedInvalidInput`, `Ps_WorktreeScope_PreservesWlm6Capabilities`.
 **testingStrategy:** `propertyTests: false` (composition wiring; folds carry the PBT in 005/006); `benchmarks: false`; `characterizationRequired: true` (WLM-6 worktree behavior pinned before redesign).
-**Dependencies:** 005, 006
-**Parallelizable:** No
+**Dependencies:** 005, 006, 010, 019
+**Parallelizable:** No (serialized on `registry.ts`/`composite.ts`/`handlers.ts` after 010)
 
 #### Task 008: `inspect` handler — composite workflow projection
 
-**Risk Tier:** medium
+**Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 011
 **Implements:** DR-4
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/inspect.ts` (new — state via `resolveWorkflowState`/rehydration, recent events + correlation tuple, artifacts, task progress)
+- `servers/exarchos-mcp/src/views/lifecycle/inspect.ts` (new — state via `resolveWorkflowState`/rehydration, recent events + correlation tuple, artifacts, task progress; fields from `schema-fields.ts`)
 - `servers/exarchos-mcp/src/views/lifecycle/inspect.test.ts` (new)
 - `servers/exarchos-mcp/src/views/composite.ts` (route `inspect`)
 - `servers/exarchos-mcp/src/registry.ts` (action def + `outputSchema` + `readOnlyHint`)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `Inspect_UnknownFeatureId_WorkflowExistsFalseNoSideEffect` (event-count invariance), `Inspect_KnownWorkflow_ReturnsStateEventsArtifacts`, `Inspect_SchemaDescribe_ByteUnchanged`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (cold-probe side-effect-free invariant is the 2026-05-30 state-source-integrity RCA class). Tests: `Inspect_UnknownFeatureId_WorkflowExistsFalseNoSideEffect` (event-count invariance), `Inspect_KnownWorkflow_ReturnsStateEventsArtifacts`, `Inspect_SchemaDescribe_ByteUnchanged`.
 **testingStrategy:** `propertyTests: false` (projection composition; no transformation core); `benchmarks: false`; `characterizationRequired: false`.
-**Dependencies:** None
-**Parallelizable:** Yes
+**Dependencies:** 014, 019
+**Parallelizable:** Yes (wave 2 — disjoint files within the wave)
 
 #### Task 009: `--follow` carriers — NDJSON (CLI) + Tasks (MCP) over the subscription
 
@@ -343,33 +369,34 @@ The decomposition maps every task to one or more DR-N from the section above.
 
 **Files:**
 - `servers/exarchos-mcp/src/adapters/cli.ts` (`inspect` joins the follow set; carrier wiring)
-- `servers/exarchos-mcp/src/cli/follow-loop.ts` (subscription-fed source replacing pure poll for `inspect`)
-- `servers/exarchos-mcp/src/mcp/tasks-methods.ts` (Tasks arm over the same DR-1 contract)
+- `servers/exarchos-mcp/src/cli/follow-loop.ts` (subscription-fed source for `inspect`; AbortSignal-based disposal — SIGINT wired to abort, no POSIX-only semantics)
+- `servers/exarchos-mcp/src/mcp/tasks-methods.ts` (Tasks arm over the same DR-1 contract; cancel → dispose)
 - `servers/exarchos-mcp/src/views/lifecycle/inspect.follow.test.ts` (new)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite across the CLI/MCP seam. Tests: `InspectFollow_AppendedEvents_NdjsonFramesDedupedBySequence`, `InspectFollow_SilentGap_HeartbeatFrames`, `InspectFollow_McpTasks_SharesSubscriptionContract`.
-**testingStrategy:** `propertyTests: true` (property: NDJSON frame stream contains each event sequence exactly once, monotonically — dedup roundtrip; data-transformation category); `benchmarks: false`; `characterizationRequired: true` (follow-loop is existing code).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite across the CLI/MCP seam. Tests: `InspectFollow_AppendedEvents_NdjsonFramesDedupedBySequence`, `InspectFollow_SilentGap_HeartbeatFramesOnInjectedTimer`, `InspectFollow_McpTasks_SharesSubscriptionContract`, `InspectFollow_Abort_SubscriptionDisposed`. INV-16: heartbeats/timing on the injected timer; abort path exercised without process signals.
+**testingStrategy:** `propertyTests: true` (property: the NDJSON frame stream contains each event sequence exactly once, monotonically — dedup roundtrip; data-transformation category); `benchmarks: false`; `characterizationRequired: true` (follow-loop is existing code).
 **Dependencies:** 001, 002, 008
-**Parallelizable:** No
+**Parallelizable:** Yes (wave 3 — disjoint files within the wave)
 
-#### Task 010: Generic `wait` — reached-or-passed precheck + subscription resolution
+#### Task 010: Generic `wait` — phase/status/operation predicates + subscription resolution
 
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 011
 **Implements:** DR-5
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (new — projection precheck; DR-1 subscribe on `workflow.transition` + registry terminals; `phase`/`status`/worktree `until` predicates; structured `WAIT_TIMEOUT`/`WAIT_FAILED`)
+- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (new — projection precheck; DR-1 subscription on `workflow.transition` + registry terminals; `phase`/`status`/`operation`/worktree `until` predicates; structured `WAIT_TIMEOUT`/`WAIT_FAILED`; fields from `schema-fields.ts`)
 - `servers/exarchos-mcp/src/views/lifecycle/wait.test.ts` (new)
 - `servers/exarchos-mcp/src/views/composite.ts` (route redesigned `wait`)
 - `servers/exarchos-mcp/src/registry.ts` (redesigned schema + `readOnlyHint`/`idempotentHint`)
 - `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` (WLM-6 wait kernel absorbed)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Wait_PhaseAlreadyPassed_ReturnsImmediatelyWithoutSubscribing`, `Wait_InProcessTransition_ResolvesWithoutPollInterval`, `Wait_Timeout_StructuredWaitTimeout`, `Wait_WorkflowCancelledMidWait_WaitFailed`, `Wait_AllPaths_AppendZeroEvents` (event-count invariance).
-**testingStrategy:** `propertyTests: true` (property: for any transition sequence, `wait --phase P` resolves iff P appears at-or-before now or arrives before timeout — state-machine category); `benchmarks: false`; `characterizationRequired: true` (absorbs shipped worktree kernel).
-**Dependencies:** 001, 002, 004
-**Parallelizable:** No
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Wait_PhaseAlreadyPassed_ReturnsImmediatelyWithoutSubscribing`, `Wait_InProcessTransition_ResolvesOnTier1Wake` (injected clock), `Wait_Timeout_StructuredWaitTimeout`, `Wait_WorkflowCancelledMidWait_WaitFailed`, `Wait_OperationPredicate_ResolvesOnRegistryTerminal`, `Wait_OperationPredicate_NoInFlight_ReturnsImmediately`, `Wait_WorktreeScope_PreservesWlm6Capabilities` (until: merge + integrationRef; until: idle), `Wait_AllPaths_AppendZeroEvents` (event-count invariance).
+**testingStrategy:** `propertyTests: true` (property: for any transition/liveness event sequence, `wait` resolves iff its predicate is satisfied at precheck or becomes satisfied before timeout — state-machine category); `benchmarks: false`; `characterizationRequired: true` (absorbs shipped worktree kernel).
+**Dependencies:** 001, 002, 004, 008, 019
+**Parallelizable:** Yes (wave 3 — disjoint files within the wave)
 
 #### Task 011: S-6 stuck-executing recovery — acceptance north-star
 
@@ -381,50 +408,54 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Files:**
 - `servers/exarchos-mcp/src/views/lifecycle/s6-recovery.acceptance.test.ts` (new — real store, real handlers, no mocks)
 
-**Verification:** the acceptance walkthrough from DR-5: seed `merge.executing_started` with no terminal (simulated crash); `wait <id> --phase delegate --timeout` resolves on `merge.recovered` and times out (17) without it; `inspect` shows the unpaired start; grep-assert no merge-specific code in `wait.ts`/`operations-fold.ts`.
+**Verification:** the corrected acceptance walkthrough from DR-5: seed `merge.executing_started` with no terminal (simulated crash); `wait <id> --operation merge --timeout` resolves when `merge.recovered` is appended, and returns `WAIT_TIMEOUT` (CLI exit 17) without it; `inspect` shows the unpaired start in flight; grep-assert no merge-specific code in `wait.ts`/`operations-fold.ts` (behavioral assertions carry the adequacy — the grep is a fence, not the proof).
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 008, 010
-**Parallelizable:** No
+**Parallelizable:** Yes (wave 4 — disjoint files within the wave)
 
 #### Task 012: `export.requested` / `export.executed` event schemas
 
-**Risk Tier:** medium
+**Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 015
 **Implements:** DR-6
 
 **Files:**
 - `servers/exarchos-mcp/src/event-store/schemas.ts` (two event types + emission-registry entries, idempotency-keyed per INV-8)
 - `servers/exarchos-mcp/src/event-store/schemas.test.ts`
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `ExportEventSchemas_RequestedExecutedPair_RegisteredWithEmissionSource`, `ExportRequested_CarriesResolvedPathIntent`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (schema surface — mechanically high). Tests: `ExportEventSchemas_RequestedExecutedPair_RegisteredWithEmissionSource`, `ExportRequested_CarriesResolvedPathIntent`.
 **testingStrategy:** `propertyTests: true` (schema-compliance property; serialization category); `benchmarks: false`; `characterizationRequired: false`.
-**Dependencies:** None
-**Parallelizable:** Yes
+**Dependencies:** 003
+**Parallelizable:** Yes (wave 2 — disjoint files within the wave)
 
-#### Task 013: `export` handler — zip bundle + INV-13 precheck + replay round-trip
+#### Task 013: `export` handler — yazl zip bundle + INV-13 precheck + replay round-trip
 
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 015
 **Implements:** DR-6
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/export.ts` (new — events.jsonl / state.json / metadata.json / artifacts/; requested→write→executed; crash precheck)
+- `servers/exarchos-mcp/src/views/lifecycle/export.ts` (new — events.jsonl / state.json / metadata.json / artifacts/; requested→write→executed; crash precheck; fields from `schema-fields.ts`)
 - `servers/exarchos-mcp/src/views/lifecycle/export.test.ts` (new)
 - `servers/exarchos-mcp/src/views/composite.ts` (route `export`)
 - `servers/exarchos-mcp/src/registry.ts` (action def, `task-isolated` posture, `openWorldHint: true`)
+- `servers/exarchos-mcp/package.json` (pin `yazl`)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Export_Bundle_ReplayEventsJsonlEqualsStateJson` (round-trip), `Export_CrashBetweenPair_PrecheckCompletesWithoutDuplicateIntent`, `Export_InvalidOutputPath_SuggestedFixNoEvents`, `Export_UnknownFeatureId_ExpectedShapeNoZip`. Windows: POSIX zip entries, handles closed before temp-dir removal (INV-16).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Export_Bundle_ReplayEventsJsonlEqualsStateJson` (round-trip), `Export_Success_AppendsExactlyRequestedExecutedPair` (idempotency-keyed; re-run creates a new pair, never duplicates a prior intent), `Export_CrashBetweenPair_PrecheckCompletesWithoutDuplicateIntent`, `Export_ArtifactsDir_IncludedAndMissingRefsListedInMetadata`, `Export_InvalidOutputPath_SuggestedFixNoEvents`, `Export_UnknownFeatureId_ExpectedShapeNoZip`. Windows: POSIX zip entries via `path.posix`, handles closed before temp-dir removal (INV-16). Build: `npm run build` single-file bundle includes yazl and export runs from it.
 **testingStrategy:** `propertyTests: true` (property: `replay(export(store)) === projection(store)` for arbitrary event sequences — data-transformation round-trip); `benchmarks: false`; `characterizationRequired: false`.
-**Dependencies:** 012
-**Parallelizable:** No
+**Dependencies:** 007, 012, 019
+**Parallelizable:** Yes (wave 5 — disjoint files within the wave)
 
 #### Task 014: CLI top-level promotion mechanism (`CliActionHints.topLevel`)
 
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 015
 **Implements:** DR-7
 
 **Files:**
@@ -437,11 +468,11 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Dependencies:** None
 **Parallelizable:** Yes
 
-#### Task 015: Stamp promotions + exit-code map + three-path parity fixtures
+#### Task 015: Promotion stamps + exit-code map + three-path parity — acceptance north-star for the CLI surface
 
-**Risk Tier:** medium
+**Risk Tier:** high
 **Boundary Touching:** true
-**Test Layer:** integration
+**Test Layer:** acceptance
 **Implements:** DR-7
 
 **Files:**
@@ -449,43 +480,43 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/adapters/cli.ts` (generic errorCode→exitCode map: `WAIT_TIMEOUT`→17, `WAIT_FAILED`→18 — presentation only)
 - `servers/exarchos-mcp/src/parity/lifecycle-verbs.parity.test.ts` (new)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `Parity_EachPromotedVerb_ByteIdenticalToolResultAcrossThreePaths`, `ExitCodeMap_WaitTimeout_17`, `ExitCodeMap_WaitFailed_18`, `ExitCodeMap_Success_0`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (this task is the DR-7/INV-2 contract check that 014 defers to). Tests: `Parity_EachPromotedVerb_ByteIdenticalToolResultAcrossThreePaths` (volatile fields — `_perf`, timestamps, `ageMs` — normalized per existing parity-harness conventions, injected clock where needed), `ExitCodeMap_WaitTimeout_17`, `ExitCodeMap_WaitFailed_18`, `ExitCodeMap_Success_0`, `Registry_VisibleCompositeCount_RemainsFour` (extend/cite the existing visible-count fence in `registry.test.ts`).
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 007, 008, 010, 013, 014
-**Parallelizable:** No
+**Parallelizable:** Yes (wave 6 — disjoint files within the wave)
 
 #### Task 016: Error-envelope edge cases across the verb surface
 
-**Risk Tier:** medium
-**Boundary Touching:** false
+**Risk Tier:** high
+**Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-8
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (`validTargets` from HSM topology for the workflow's type)
+- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (`validTargets` from HSM topology for the workflow's type; registry surfaces for `--operation`)
 - `servers/exarchos-mcp/src/views/lifecycle/errors.test.ts` (new — consolidated edge-case suite)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `Wait_InvalidPhase_ValidTargetsFromTopologyForWorkflowType`, `Verbs_UnknownFeatureId_SideEffectFreeExpectedShape` (inspect/wait/export; event-count invariance), `Ps_ProbeOutsideWorktreeScope_InvalidInputWithSuggestedFix`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (edits `wait.ts`, a high-tier surface) + `check_contract_drift` (error-envelope contract). Tests: `Wait_InvalidPhase_ValidTargetsFromTopologyForWorkflowType`, `Wait_UnknownOperationSurface_ValidTargetsFromRegistry`, `Verbs_UnknownFeatureId_SideEffectFreeExpectedShape` (inspect/wait/export; event-count invariance), `Ps_ProbeOutsideWorktreeScope_InvalidInputWithSuggestedFix`.
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 007, 008, 010, 013
-**Parallelizable:** Yes (after deps)
+**Parallelizable:** Yes (wave 6 — disjoint files within the wave)
 
-#### Task 017: Subscription lifecycle hardening — disposal, cancellation, concurrency
+#### Task 017: Subscription lifecycle + portability hardening (owns the DR-8 Windows AC)
 
-**Risk Tier:** medium
+**Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-1, DR-8
 
 **Files:**
-- `servers/exarchos-mcp/src/event-store/subscriptions.test.ts` (leak + concurrency suites)
-- `servers/exarchos-mcp/src/cli/follow-loop.ts` (SIGINT disposal)
-- `servers/exarchos-mcp/src/mcp/tasks-methods.ts` (task-cancel disposal)
+- `servers/exarchos-mcp/src/event-store/subscriptions.test.ts` (leak + concurrency + win32 suites)
+- `servers/exarchos-mcp/src/cli/follow-loop.ts` (AbortSignal disposal audit)
+- `servers/exarchos-mcp/src/mcp/tasks-methods.ts` (task-cancel disposal audit)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `Follow_ConsumerDisconnect_HandleDisposedRegistryZero`, `TasksCancel_MidFollow_HandleDisposed`, `Wait_ConcurrentSameStream_BothResolveIndependently`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Follow_ConsumerDisconnect_HandleDisposedRegistryZero`, `TasksCancel_MidFollow_HandleDisposed`, `Wait_ConcurrentSameStream_BothResolveIndependently`. **Windows/INV-16 ownership:** assert the poll floor holds no open SQLite statement across ticks (handle-close class, #1620); audit every new lifecycle test for wall-clock timing and convert to the injected clock (**zero new `skipIf(win32)` entries** — grep-asserted against the diff); confirm two-connection tests carry the `busy_timeout` posture; the `test-windows` CI lane must be green on the integration branch before this task completes.
 **testingStrategy:** `propertyTests: true` (concurrency category — property: any interleaving of N concurrent subscribe/dispose/append operations leaves the registry consistent and delivers each subscriber only its matches); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 009, 010
-**Parallelizable:** Yes (after deps)
+**Parallelizable:** Yes (wave 5 — disjoint files within the wave)
 
 #### Task 018: Documentation — liveness convention + subscription contract + verb surface
 
@@ -495,31 +526,49 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-1, DR-2
 
 **Files:**
-- `docs/architecture/runtime.md` (§6 liveness convention: base schema + pairing rule + registry as enforcement; §L7 verbs updated to the shipped shape)
+- `docs/architecture/runtime.md` (§6 liveness convention: base schema + pairing rule + registry as enforcement; §L7 verbs updated to the shipped shape, including the operation predicate and the corrected S-6 story)
 
 **Verification:** static analysis + `verify_doc_links`. The #1315 subscription contract is this spec's DR-1; runtime.md links here.
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 010
-**Parallelizable:** Yes (after 010)
+**Parallelizable:** Yes (wave 4 — disjoint files within the wave)
+
+#### Task 019: Shared lifecycle field shapes + registration-construction guard
+
+**Risk Tier:** medium
+**Boundary Touching:** true
+**Test Layer:** integration
+**Implements:** DR-8
+
+**Files:**
+- `servers/exarchos-mcp/src/views/lifecycle/schema-fields.ts` (new — one canonical Zod definition per lifecycle field name: `scope`, `status`, `phase`, `workflowType`, `all`, `follow`, `limit`, `output`, `operation`; base types checked against existing view-action fields)
+- `servers/exarchos-mcp/src/registry.construction.test.ts` (new — composes the current `exarchos_view` registration plus a probe action built from every shared shape and asserts `buildRegistrationSchema` does not throw)
+
+**Verification:** scoped tests + `check_test_adequacy` + `check_contract_drift`. Tests: `RegistryConstruction_WithAllLifecycleFieldShapes_DoesNotThrow`, `SchemaFields_BaseTypes_MatchExistingViewFieldsWhereNamesCollide`. Tasks 007/008/010/013 MUST import from this module (grep-asserted in 015's parity suite setup).
+**testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
+**Dependencies:** None
+**Parallelizable:** Yes
 
 ### Parallelization
 
-**Critical path:** 001 → 002 → 010 → 011 (S-6 acceptance) and 010 → 015 (parity closure).
+**Critical path:** 001 → 002 → 010 → 007 → 013 → 015/016 (the `registry.ts`/`composite.ts` serialization chain).
 
-| Wave | Tasks (parallel within wave) |
+| Wave | Tasks (parallel within wave; all same-file edits serialized across waves) |
 |---|---|
-| 1 | 001, 003, 005, 008, 012, 014 |
-| 2 | 002, 004, 013 |
-| 3 | 006, 007 (after 005+006), 009, 010 |
-| 4 | 011, 015, 016, 017, 018 |
+| 1 | 001, 003, 005, 014, 019 |
+| 2 | 002, 004, 008, 012 |
+| 3 | 006, 009, 010 |
+| 4 | 007, 011, 018 |
+| 5 | 013, 017 |
+| 6 | 015, 016 |
 
-No two parallel tasks in the same wave modify the same file (`registry.ts`/`composite.ts`/`cli.ts` touches are serialized across waves 3–4 via dependencies; wave-1 tasks touch disjoint modules).
+**Same-file serialization (total orders across waves):** `registry.ts`: 014 → 008 → 010 → 007 → 013 → 015. `composite.ts`: 008 → 010 → 007 → 013. `worktree/handlers.ts`: 010 → 007. `adapters/cli.ts`: 014 → 009 → 015. `event-store/schemas.ts`: 003 → 012. `subscriptions.ts(.test)`: 001 → 002 → 017. `follow-loop.ts`/`tasks-methods.ts`: 009 → 017. `wait.ts`: 010 → 016. No two tasks within any wave share a file.
 
 ### Completion checklist
 
 - [x] Every DR-N in `## Design & Rationale` maps to at least one task in the matrix
 - [x] Every task `Implements:` a DR-N that exists in this document
-- [x] Every task carries a `riskTier` stamp
+- [x] Every task carries a `riskTier` stamp (six raised to match the mechanical derivation in rev. 1; remaining medium stamps — 004/005/006/019 — are single-new-module tasks the derivation itself classifies medium; `boundaryTouching: true` stamped wherever `testLayer: integration` would derive it)
 - [x] Medium/high-tier tasks carry adequacy-judged tests (test-after); low-tier tasks lean on static analysis
 - [x] Open questions are resolved OR explicitly deferred with rationale
 - [ ] Ready for `plan-review`

--- a/docs/specs/2026-07-07-lifecycle-verbs.md
+++ b/docs/specs/2026-07-07-lifecycle-verbs.md
@@ -93,7 +93,7 @@ Adding a surface to the lifecycle plane = one registry entry, zero verb code.
 New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite projection returning workflow state (via the canonical `resolveWorkflowState`/rehydration path — never `.state.json` presence), recent events (with `operationId`/`correlationId`/`causationId`), artifacts, and task progress. Existence signal is `_meta.workflowExists`; a cold probe of an unknown featureId is side-effect-free. `--follow` consumes DR-1 and streams through two carriers per #1316 Q3: NDJSON frames on the CLI (existing encoder/heartbeat, heartbeats on the injectable timer), MCP Tasks (SEP-1686) on the MCP path — one contract, two presentations (INV-5b). Follow disposal is `AbortSignal`-based (SIGINT wired to abort on POSIX and Windows alike — no POSIX-only signal semantics). The MCP action name avoids the GA'd schema-`describe` (no rename, no Zod-union overload — a known CLI-parity hazard); DR-7 maps the CLI top-level verb `exarchos describe <id>` onto it.
 
 **Acceptance criteria:**
-- Given an unknown featureId, when `inspect` runs, then `_meta.workflowExists: false` with `expectedShape` in the error envelope, and no event is appended.
+- Given an unknown featureId, when `inspect` runs, then it returns `success: true` with `_meta.workflowExists: false` and appends no event — the canonical, side-effect-free cold-probe contract shared with `rehydrate`/`get` (NOT an error envelope).
 - Given `--follow`, when events append to the feature's stream (in-process or cross-process), then they appear as NDJSON `event` frames deduplicated by sequence; heartbeat frames cover silent gaps (injected timer).
 - The MCP path exposes follow via Tasks (`tasks/get`/`tasks/result`), sharing the DR-1 subscription with the CLI carrier.
 - Given abort (CLI SIGINT→AbortSignal, MCP task cancel), the follow loop exits and its subscription handle is disposed.
@@ -151,7 +151,7 @@ Cross-cutting failure contract for the verb surface.
 
 **Acceptance criteria:**
 - Given `wait --phase <invalid>`, then the error envelope's `validTargets` is populated from the HSM topology **for that workflow's type**; given `--operation <unknown-or-non-feature-scoped-surface>`, `validTargets` lists the registry's **feature-scoped** surfaces.
-- Given an unknown featureId on `inspect`/`wait`/`export`, then a side-effect-free error with `expectedShape` returns (cold-probe rule; no stream registration, no events).
+- Given an unknown featureId on the read verbs `inspect`/`export`, then a side-effect-free `success: true` result with `_meta.workflowExists: false` returns — the canonical cold-probe contract shared with `rehydrate`/`get` (NOT an error envelope); no stream registration, no events. `wait` on an unknown featureId is likewise side-effect-free (no stream registration, no events): its predicate simply never holds, resolving through the normal `WAIT_TIMEOUT`/`WAIT_FAILED` path rather than a `workflowExists` envelope.
 - Given a subscription whose consumer disconnects mid-follow (CLI abort, MCP task cancel), then the handle is disposed and the leak test passes.
 - Given concurrent `wait`s on the same stream from two dispatches, then both resolve independently (no shared-handle interference).
 - Cross-process `wait` latency is bounded by one floor interval + one drain — verified at the **verb level** by DR-5's foreign-connection test (Task 010), deterministically via the injected clock; the floor default is documented and surfaced in `_perf`.

--- a/docs/specs/2026-07-07-lifecycle-verbs.md
+++ b/docs/specs/2026-07-07-lifecycle-verbs.md
@@ -1,6 +1,6 @@
 # Spec: Process Lifecycle Verbs — generic ps / describe / wait / export over the event log
 
-**Date:** 2026-07-07 (rev. 1: 2026-07-08) · **Feature:** `lifecycle-verbs` · **Depth:** deep
+**Date:** 2026-07-07 (rev. 2: 2026-07-08) · **Feature:** `lifecycle-verbs` · **Depth:** deep
 **Inputs:** #1316 (design spike, this spec closes it) · #1090 (epic; children #1103–#1106 absorbed here) · #1315 (subscription primitive — contract defined here) · #1599 roadmap (Z2 critical path, coordination rules 2–4) · `docs/specs/2026-07-03-wlm-6-surface-and-workflow-fixes.md` · `docs/specs/2026-06-26-wlm-operational-core.md` · `docs/architecture/runtime.md` §L7/§6 · `.exarchos/invariants.md` (INV-1/2/5a–d/6/7/8/10/12/13/15/16)
 
 > One unified artifact: `## Design & Rationale` is the DR-N source; `## Decomposition` maps tasks → DR-N within this same document.
@@ -15,7 +15,7 @@ Epic #1090 promises generic workflow-lifecycle verbs — `ps` (list), `describe`
 - **The workflow-projection `describe` is absent**; the `describe` name on every composite tool is taken by GA'd schema-introspection.
 - **`export` is absent.**
 - **The #1315 subscription primitive is absent** — every waiter re-folds a projection on a sleep loop.
-- **INV-10 is aspirational**: four surfaces emit `<surface>.executing_started`/terminal pairs (merge, launch, mutation, prune) as ad-hoc per-surface schemas with no shared base and no generic consumer; `mutation` is observable by nothing.
+- **INV-10 is aspirational**: four surfaces emit `<surface>.executing_started`/terminal pairs (merge, launch, mutation, prune) as ad-hoc per-surface schemas with **no shared fields** (three of four record no start time in their data; none carry a uniform instance key) and no generic consumer; `mutation` is observable by nothing. `launch`/`prune` emit to the singleton `worktrees` stream, `merge`/`mutation` to feature streams — any generic design must carry that scoping, not assume it away.
 - **Audit S-6 (stuck-`executing` recovery) remains open**: no generic way to wait out or inspect a crashed long-running operation. Note: the original #1090/#1316 sketch (`wait <id> --phase delegate` resolving merge stalls) is **semantically unsound** against shipped reducer behavior — `merge.recovered` folds into the `mergeOrchestrator` sub-view and never produces a phase transition, and merges run while the workflow is already *in* `delegate`. S-6 closure requires an operation-level predicate (DR-5), not a phase predicate.
 
 Without one design, the four implementation issues (#1103–#1106) would diverge on subscription handling, predicate language, output schemas, and postures — exactly what #1316 was filed to prevent.
@@ -24,12 +24,12 @@ Without one design, the four implementation issues (#1103–#1106) would diverge
 
 **Unify under generic verbs on the two-tier subscription substrate** (Exploration, Option 2 — decided with the owner 2026-07-07):
 
-1. **One subscription primitive (DR-1)** — a **cursor-pump**: each subscription holds a sequence cursor and delivery is always a cursor-driven drain; an in-process post-commit hook and a `PRAGMA data_version` cross-process poll floor are merely *wake signals*. Exactly-once, globally sequence-ordered delivery holds by construction. Subscriptions are ephemeral (per-dispatch), so INV-15's no-daemon frame holds by construction.
-2. **One liveness contract (DR-2)** — `ExecutingStartedBase` + a liveness-pair registry — turns INV-10 from convention into checkable contract, and gives `ps` its generic operations fold and `wait` its operation predicate (adopted from Exploration Option 3, without its row-shape conflation).
+1. **One subscription primitive (DR-1)** — a **cursor-pump**: each subscription holds a sequence cursor and delivery is always a cursor-driven drain; an in-process post-commit hook and a `dataVersion()` cross-process poll floor are merely *wake signals*. Registration atomically captures cursor + floor baseline and schedules an initial drain, so exactly-once, globally sequence-ordered delivery holds by construction. Subscriptions are ephemeral (per-dispatch), so INV-15's no-daemon frame holds by construction.
+2. **One liveness contract (DR-2)** — a **descriptor registry** (`startType`, `terminalTypes`, `streamScope`, `instanceKeyOf`; `startedAt` from the envelope) — turns INV-10 from convention into checkable contract, defines the pairing relation the shipped events never had, and gives `ps` its generic operations fold and `wait` its operation predicate (adopted from Exploration Option 3, without its row-shape conflation).
 3. **The verbs are pure consumers** — `ps`/`inspect`/`wait` are projections or subscriptions (no writes; `wait` emits no events, revising #1316 Q7); `export` is the one emitter and follows INV-13's two-event split.
 4. **CLI promotion (DR-7)** hoists the verbs to `exarchos ps|describe|wait|export` through a registry-driven mechanism, keeping INV-2 parity.
 
-Compatibility posture: **break-in-preview** — the WLM-6 `ps`/`wait` schemas are redesigned freely (no shims); the unified surface lands before v2.12.0 GA. Worktree capabilities (probe/reconcile, merge/idle waits) are preserved as a *scope* of the generic verbs.
+Compatibility posture: **break-in-preview** — the WLM-6 `ps`/`wait` schemas are redesigned freely (no shims); the unified surface lands before v2.12.0 GA. Worktree capabilities (probe/reconcile, merge/idle waits) are preserved as a *scope* of the generic verbs. Event-data changes are **validation-compatible additive only**: every previously stored payload still validates; emitters may gain fields; nothing is migrated.
 
 ### Requirements (DR-N)
 
@@ -37,35 +37,54 @@ The DR-N identifiers below are the single source the decomposition traces agains
 
 #### DR-1: Cursor-pump subscription primitive with two wake tiers (#1315)
 
-The event store exposes `subscribe(filter, onEvent, { fromSequence?, floorMs? }): SubscriptionHandle` where `filter` is `{ streamId?, eventTypes?[] }`. Each subscription holds a **sequence cursor** (initialized to the current head, or `fromSequence`); delivery is always a **cursor-driven drain** — read matching events after the cursor, deliver in global sequence order, advance the cursor. Two wake signals trigger drains: **Tier 1** (in-process): a post-commit hook fires after the append transaction commits **and after the per-stream mutex releases** (never inside the lock — the appender's per-stream Promise mutex is non-reentrant, so a listener that itself appends must not deadlock). **Tier 2** (cross-process): a bounded poll floor re-checks `dataVersion()` (near-free) and drains only when a foreign connection has committed. Because both tiers converge on the same cursor drain, a Tier-1 wake at sequence N+1 delivers a not-yet-seen foreign event at sequence N first — no gaps, no double delivery. Listener failures are isolated (never affect an append result or sibling listeners). INV-8 idempotency cache-hits commit nothing and do **not** wake subscriptions. Subscriptions are ephemeral: registered by a dispatch, disposed when it returns (INV-15). `dataVersion(): number` joins the `StorageBackend` interface — SQLite via `PRAGMA data_version`, memory backend via a monotonic append counter — so Tier-2 behavior is defined on every backend.
+The event store exposes `subscribe(filter, onEvent, { fromSequence?, floorMs? }): SubscriptionHandle` where `filter` is `{ streamId?, eventTypes?[] }`. Each subscription holds a **sequence cursor**; delivery is always a **cursor-driven drain** — read matching events after the cursor, deliver in global sequence order, advance the cursor. **Registration contract:** `subscribe()` atomically captures the cursor position (head, or `fromSequence`) together with the Tier-2 floor baseline and schedules an unconditional **initial drain**, so an event committed at any moment relative to registration is delivered exactly once — by the initial drain or a later wake, never lost to a baseline that already included it. Two wake signals trigger drains: **Tier 1** (in-process): a post-commit hook fires after the append transaction commits **and after the per-stream mutex releases** (never inside the lock — the appender's per-stream Promise mutex is non-reentrant, so a listener that itself appends must not deadlock). **Tier 2** (cross-process): a bounded poll floor re-checks `dataVersion()` (near-free) and drains only when a foreign connection has committed. Because both tiers converge on the same cursor drain, a Tier-1 wake at sequence N+1 delivers a not-yet-seen foreign event at sequence N first — no gaps, no double delivery. Listener failures are isolated (never affect an append result or sibling listeners). INV-8 idempotency cache-hits commit nothing and do **not** wake subscriptions. Subscriptions are ephemeral: registered by a dispatch, disposed when it returns (INV-15). `dataVersion(): number` joins the `StorageBackend` interface with **per-backend semantics**: SQLite (`PRAGMA data_version`) changes iff a *foreign* connection committed — the observer's own commits never bump it; `InMemoryBackend` uses a monotonic append counter (own appends bump it; the resulting spurious drains are idempotent by cursor).
 
 **Acceptance criteria:**
 - Given a subscription with cursor at sequence N, when matching events N+1…N+k are appended in-process, then the drain delivers them post-commit in order; a listener that throws on N+1 does not affect the append result, sibling listeners, or delivery of N+2…N+k.
 - Given interleaved appends from a second connection (sequence N, undrained) and the own process (sequence N+1), then delivery order is N, N+1 — exactly once each (gap-detection property, injectable clock).
+- Given a foreign commit landing at any point relative to `subscribe()` (before the head read, between head read and baseline capture, after registration), then it is delivered exactly once — the registration-timing property test varies the registration point among generated appends; the initial drain covers the baseline-already-included case.
 - Given a listener that appends to the same stream during delivery, then no deadlock occurs (hook fires outside the per-stream mutex) and the new event arrives in a subsequent drain.
 - Given an INV-8 idempotency cache-hit (duplicate append, no new commit), then no wake fires and nothing is re-delivered.
 - Given a dispatch that registered subscriptions, when it returns (success or error), then all its handles are disposed — a leak test asserts the registry count returns to zero.
 - With zero subscribers, the append hot path executes no listener-related work beyond a single guard check (append benchmark: p99 regression < 5% vs baseline).
 - The floor interval has a documented default, honored per-call `floorMs` override (test), and is driven by an injectable clock so floor tests are deterministic (no wall-clock sleeps).
-- `MemoryBackend.dataVersion()` increases on every committed append and is stable otherwise (contract test shared across backends).
+- `dataVersion()` per-backend contract tests: SQLite — foreign-commit-only visibility (second connection bumps it; own commit does not); `InMemoryBackend` — monotonic on every committed append.
 
-#### DR-2: `ExecutingStartedBase` and the liveness-pair registry (INV-10 made checkable)
+#### DR-2: Liveness descriptor registry (INV-10 made checkable)
 
-Extract a shared Zod base `{ surface, instanceId, startedAt, expectedDurationMs? }`; the four existing schemas (`merge`/`launch`/`mutation`/`prune` `.executing_started`) retrofit via `.extend(...)` with **byte-identical event data** (no migration). A liveness-pair registry — one table mapping each `<surface>.executing_started` to its terminal event types — becomes the single source consumed by `ps`'s operations fold and `wait`'s operation predicate. Adding a surface to the lifecycle plane = one registry entry, zero verb code.
+One registry entry per surface defines the whole liveness contract the verbs consume:
+
+```ts
+{ surface, startType, terminalTypes: string[],
+  streamScope: 'feature' | 'worktrees',
+  instanceKeyOf(data): string }
+```
+
+- **`startedAt` derives from the start event's envelope timestamp** — three of four shipped surfaces record no start time in their data; the envelope is the uniform source (no payload change needed).
+- **Pairing relation:** an operation is in flight iff a start event's `instanceKeyOf(data)` has no later terminal event with the same key on the same stream. Concurrent operations on one stream (the *normal* case for `launch` on the singleton `worktrees` stream) pair correctly by key, not by type-level ordering.
+- **Canonical `instanceId` (additive standardization, owner decision 2026-07-08):** all four emitters gain one canonical `instanceId` field on their start *and* terminal emissions — `merge` → `taskId ?? sourceBranch→targetBranch`; `launch` → `worktreeId`; `prune` → its existing `operationId`; `mutation` → a new `operationId`. `instanceKeyOf` therefore reads `data.instanceId ?? legacyFallback(surface, data)` — the per-surface fallback extractors exist only for events stored before this change. **New surfaces MUST emit `instanceId`** (their registry entries carry no fallback; the conformance test enforces it), so the extractor zoo is a shrinking legacy shim, not a permanent design. `surface` and `startedAt` are deliberately NOT standardized into payloads: the former is derivable from the event type, the latter from the envelope — in-payload copies would be redundant.
+- **`streamScope`** records where the surface emits: `merge`/`mutation` → feature streams; `launch`/`prune` → the singleton `worktrees` stream. Verbs use it to decide feature-observability (DR-5).
+- **Retrofit posture: validation-compatible additive, never byte-identical emission.** Every previously stored payload still validates against the retrofit schemas; emitters gain the canonical `instanceId` additively; nothing is migrated. Previously-emitted payload shapes are pinned as fixtures.
+
+Adding a surface to the lifecycle plane = one registry entry, zero verb code.
 
 **Acceptance criteria:**
-- All four existing `*.executing_started` schemas extend the base; snapshot tests prove emitted event data is unchanged.
-- A conformance test fails if any `*.executing_started` event type in the emission catalog lacks a registry entry with ≥1 terminal type.
-- `docs/architecture/runtime.md` §6 documents the convention (base schema + pairing rule) and cites the registry as its enforcement.
+- Fixtures of previously-emitted payload shapes (captured verbatim from the shipped emitters for all four surfaces) validate against the retrofit schemas.
+- All four emitters emit the canonical `instanceId` additively on start and terminal events; events stored before the change still validate and pair via the surface's legacy fallback (legacy `mutation` events without any key: treated as a singleton instance).
+- A conformance test fails if any `*.executing_started` event type in the emission catalog lacks a registry entry with ≥1 terminal type, a `streamScope`, and an `instanceKeyOf`; a registry entry **without** a legacy fallback requires `instanceId` in its start schema (the new-surface rule).
+- Given `start(A)`, `start(B)`, `terminal(B)` on one stream, then A is in flight and B is not (concurrent-pairing property over arbitrary key interleavings).
+- `docs/architecture/runtime.md` §6 documents the convention (descriptor registry + pairing rule + envelope-derived `startedAt`) and cites the registry as its enforcement.
 
 #### DR-3: Generic `ps` — scope-parameterized process listing
 
-`exarchos_view { action: 'ps', scope: 'workflow' | 'worktree' | 'all' }` (default `all`). Output has two honestly-shaped sections, never conflated rows: `workflows` (fold of `workflow_state` joined with `streams.workflow_type`: featureId, workflowType, phase, status, ageMs) and `operations` (generic fold over the DR-2 registry: any `executing_started` without its terminal — including `mutation`, which today nothing surfaces). Filters: `workflowType` (indexed pushdown via `streams.workflow_type`), `status`, `phase`, `all` (include completed/cancelled; default excludes them). The WLM-6 worktree fold (in-flight merges/launches/prunes + `probe` reconciliation) is preserved under `scope: 'worktree' | 'all'`; `probe: true` remains a conditional writer with its existing `LOCAL_MUTATION_IDEMPOTENT` annotation. All new/redesigned action fields come from the shared lifecycle field-shape module (DR-8) so cross-action base types cannot collide.
+`exarchos_view { action: 'ps', scope: 'workflow' | 'worktree' | 'all' }` (default `all`). Output has two honestly-shaped sections, never conflated rows: `workflows` (fold of `workflow_state` joined with `streams.workflow_type`: featureId, workflowType, phase, status, ageMs) and `operations` (generic fold over the DR-2 registry: any start whose instance key lacks a terminal — including `mutation`, which today nothing surfaces; `startedAt`/age from envelope timestamps). Filters: `workflowType` (indexed pushdown via a new `listWorkflowSummaries` backend read joining `workflow_state` × `streams`), `status`, `phase`, `all` (include completed/cancelled; default excludes them). The WLM-6 worktree fold (in-flight merges/launches/prunes + `probe` reconciliation) is preserved under `scope: 'worktree' | 'all'`; `probe: true` remains a conditional writer with its existing `LOCAL_MUTATION_IDEMPOTENT` annotation. All new/redesigned action fields come from the shared lifecycle field-shape module (DR-8) so cross-action base types cannot collide.
 
 **Acceptance criteria:**
-- Given workflows of mixed types and phases, when `ps --workflow-type feature`, then only `feature` rows return, and the query uses the indexed `streams.workflow_type` column.
+- Given workflows of mixed types and phases, when `ps --workflow-type feature`, then only `feature` rows return, and the read goes through `listWorkflowSummaries` with the `streams.workflow_type` index (pushdown asserted, not in-memory filtered).
+- Given `--status <state>` or `--phase <name>`, then only matching workflow rows return (named tests per filter).
 - Given a completed workflow, then default `ps` excludes it and `--all` includes it.
 - Given a synthetic `mutation.executing_started` without terminal, then it appears in `operations` with no mutation-specific code in any verb handler (generic-fold test).
+- Given two concurrent same-surface operations on one stream where only the second has a terminal, then `ps` lists exactly the first as in flight (instance-key pairing).
 - Given `scope: 'workflow'` with `probe: true`, then the input is rejected as `INVALID_INPUT` (probe is a worktree-scope capability).
 - Worktree-scope output preserves every WLM-6 capability (in-flight pairs, launches, prunes, probe reconcile) under the redesigned schema.
 
@@ -78,15 +97,15 @@ New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite proj
 - Given `--follow`, when events append to the feature's stream (in-process or cross-process), then they appear as NDJSON `event` frames deduplicated by sequence; heartbeat frames cover silent gaps (injected timer).
 - The MCP path exposes follow via Tasks (`tasks/get`/`tasks/result`), sharing the DR-1 subscription with the CLI carrier.
 - Given abort (CLI SIGINT→AbortSignal, MCP task cancel), the follow loop exits and its subscription handle is disposed.
-- Schema-introspection `describe` on all four composite tools is byte-unchanged.
+- Schema-introspection `describe` on **all four** composite tools is byte-unchanged (test enumerates the four).
 
 #### DR-5: Generic `wait` — event-driven gate with phase, status, and operation predicates; no self-journaling
 
 `wait(featureId, phase?, status?, operation?, until?, integrationRef?, timeoutMs)`:
 
 - **`phase`** — reached-or-passed semantics: the projection is checked first, returning immediately if the target phase was already reached (idempotent re-runs, #1316 Q2); otherwise a DR-1 subscription on `workflow.transition` resolves it.
-- **`status`** — terminal waits (`completed` / `failed` / `cancelled`).
-- **`operation <surface>`** — the **S-6 predicate**: resolves when the feature's unpaired `<surface>.executing_started` gains a terminal event per the DR-2 registry; resolves immediately if no such operation is in flight. This — not `--phase` — is how a stuck merge is waited out: `merge.recovered` never transitions the workflow phase (it folds into the `mergeOrchestrator` sub-view), so the original epic sketch is explicitly corrected here.
+- **`status`** — terminal waits. Resolves **successfully** when the workflow reaches the *requested* terminal status (`completed` / `failed` / `cancelled`); returns immediately if already in it; resolves `WAIT_FAILED` if a *different* terminal status arrives first; `WAIT_TIMEOUT` otherwise.
+- **`operation <surface>`** — the **S-6 predicate**, valid for **feature-scoped surfaces only** (DR-2 `streamScope: 'feature'`: `merge`, `mutation`): resolves when the feature's unpaired `<surface>.executing_started` (by instance key) gains a terminal event per the registry; resolves immediately if none in flight. Singleton-stream surfaces (`launch`, `prune`) are **not feature-observable** — they emit to the `worktrees` stream — and remain covered by the retained worktree predicates below; requesting them here returns `INVALID_INPUT` with `validTargets` = the feature-scoped surfaces and a `suggestedFix` pointing at `until`. This — not `--phase` — is how a stuck merge is waited out: `merge.recovered` never transitions the workflow phase (it folds into the `mergeOrchestrator` sub-view), so the original epic sketch is explicitly corrected here.
 - **`until: merge|idle` + `integrationRef`** — the WLM-6 worktree predicates, retained as the worktree scope of the same action.
 
 `wait` emits **no events** (revises #1316 Q7): posture read-only, `readOnlyHint: true`, `idempotentHint: true` — the log records domain facts, not observations of them. Timeout/failure return structured `WAIT_TIMEOUT` / `WAIT_FAILED` envelopes; the CLI adapter maps them to exit codes 17/18 as pure presentation (a generic errorCode→exitCode map, INV-2-safe).
@@ -94,9 +113,12 @@ New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite proj
 **Acceptance criteria:**
 - Given a workflow already past `--phase plan-review`, when `wait --phase plan-review` runs, then it returns success immediately (exit 0) without subscribing.
 - Given an in-process `workflow.transition` to the target phase, then `wait` resolves on the Tier-1 wake (injected clock; no floor tick consumed).
+- Given a foreign-connection event satisfying the predicate, then `wait` resolves within one floor tick (injected clock) and the floor interval is surfaced in `_perf` (verb-level Tier-2 test).
 - Given no matching event within `timeoutMs`, then `WAIT_TIMEOUT` is returned and the CLI exits 17.
 - Given the workflow enters `failed`/`cancelled` while waiting on a phase, then `WAIT_FAILED` is returned and the CLI exits 18.
-- Given an unpaired `merge.executing_started`, when `wait --operation merge` runs, then it resolves when any registry terminal for `merge` lands (e.g. `merge.recovered`, `merge.executed`); given none in flight, it returns immediately; given no terminal within `timeoutMs`, exit 17.
+- Given `wait --status completed` on a workflow that later completes, then it resolves successfully; given the workflow is already `completed`, it returns immediately; given the workflow instead reaches `cancelled`, then `WAIT_FAILED` (exit 18); given nothing terminal, `WAIT_TIMEOUT` (exit 17).
+- Given an unpaired `merge.executing_started`, when `wait --operation merge` runs, then it resolves when a registry terminal for that instance key lands (e.g. `merge.recovered`, `merge.executed`); given none in flight, it returns immediately; given no terminal within `timeoutMs`, exit 17.
+- Given `wait <id> --operation launch` (a `worktrees`-scoped surface), then `INVALID_INPUT` with `validTargets` = feature-scoped surfaces and `suggestedFix` referencing `until`.
 - Worktree retention: `Wait_WorktreeScope_PreservesWlm6Capabilities` — `until: merge` (with `integrationRef`) and `until: idle` behave per the WLM-6 contract under the redesigned schema.
 - **S-6 closure walkthrough:** given `merge.executing_started` with no terminal (simulated crash), `wait <id> --operation merge --timeout 10m` resolves when `merge.recovered` lands, or exits 17 on timeout; `inspect` shows the unpaired `executing_started`; no merge-specific code exists in `wait.ts` or `operations-fold.ts` (grep-asserted; behavioral assertions carry the adequacy).
 - `wait` appends zero events across all paths (event-count invariance in tests).
@@ -111,7 +133,7 @@ New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite proj
 - Given a crash simulated between the pair, when export re-runs, then the precheck detects the existing/partial zip and completes without duplicating the `requested` intent.
 - Given referenced artifacts where some paths are missing on disk, then existing ones are bundled under `artifacts/` and missing ones are listed in `metadata.json` without failing the export.
 - Given an invalid `--output` path, then a structured error with `suggestedFix` (default location) returns and no events are appended.
-- Zip entry paths are POSIX-normalized and built with `path.join`; tests close SQLite handles before temp-dir removal (INV-16); `npm run build` still produces a working single-file bundle containing the zip writer.
+- Zip entry names are POSIX-normalized (`path.posix` for entry names; `path.join` only for filesystem paths); tests close SQLite handles before temp-dir removal (INV-16); `npm run build` still produces a working single-file bundle containing the zip writer.
 
 #### DR-7: Registry-driven CLI top-level promotion
 
@@ -128,19 +150,21 @@ New `exarchos_view` action `inspect(featureId, follow?, limit?)`: composite proj
 Cross-cutting failure contract for the verb surface.
 
 **Acceptance criteria:**
-- Given `wait --phase <invalid>`, then the error envelope's `validTargets` is populated from the HSM topology **for that workflow's type**; given `--operation <unknown-surface>`, `validTargets` lists the registry's surfaces.
+- Given `wait --phase <invalid>`, then the error envelope's `validTargets` is populated from the HSM topology **for that workflow's type**; given `--operation <unknown-or-non-feature-scoped-surface>`, `validTargets` lists the registry's **feature-scoped** surfaces.
 - Given an unknown featureId on `inspect`/`wait`/`export`, then a side-effect-free error with `expectedShape` returns (cold-probe rule; no stream registration, no events).
 - Given a subscription whose consumer disconnects mid-follow (CLI abort, MCP task cancel), then the handle is disposed and the leak test passes.
 - Given concurrent `wait`s on the same stream from two dispatches, then both resolve independently (no shared-handle interference).
-- Cross-process wait latency is bounded by one floor interval + one drain: verified deterministically with the injected clock (advance one floor tick → foreign event delivered); the floor default is documented and surfaced in `_perf`.
+- Cross-process `wait` latency is bounded by one floor interval + one drain — verified at the **verb level** by DR-5's foreign-connection test (Task 010), deterministically via the injected clock; the floor default is documented and surfaced in `_perf`.
 - **Registration integrity:** the composed `exarchos_view` registration schema — including every new/redesigned lifecycle field — constructs without `buildRegistrationSchema` throwing (the documented same-field-name/different-base-type THROW class). All lifecycle actions source shared field names from one field-shape module; a construction test guards the composed registry.
-- **Windows (INV-16), owned by Task 017:** the win32 CI lane runs every new path green with **no new `skipIf(win32)` entries**; the poll floor holds no open SQLite statement across ticks (handle-close class, #1620); two-connection tests set an explicit `busy_timeout` posture; follow disposal is AbortSignal-based (no POSIX-only signal semantics); all timing tests use the injectable clock (no wall-clock sleeps — the #1641 nondeterminism class).
+- **Windows (INV-16):** Task 017 owns the hardening mechanics and the mid-feature audit (through wave 5): the poll floor holds no open SQLite statement across ticks (handle-close class, #1620); two-connection tests set an explicit `busy_timeout` posture; follow disposal is AbortSignal-based (no POSIX-only signal semantics); all timing tests use the injectable clock (no wall-clock sleeps — the #1641 nondeterminism class). **Final discharge rides the last wave:** Tasks 015 and 016 each complete only with the `test-windows` CI lane green on the integration tip and a zero-new-`skipIf(win32)` grep over the **full feature diff** (new CLI-path tests are the documented win32 `.cmd`-shim class, #1623).
 
 ### Technical Design
 
-**New substrate:** `servers/exarchos-mcp/src/event-store/subscriptions.ts` — subscription registry, `SubscriptionHandle`, the **cursor pump** (per-subscription `lastDeliveredSeq`; wake → drain matching events after cursor in global order → advance), and the Tier-2 floor loop on an **injectable clock**. The Tier-1 hook point lands in the append path (`store.ts`/`atomic-appender.ts`) and fires **after commit and after the per-stream mutex releases** — listener-initiated appends re-enter the normal append path without deadlock; the hook is a single guard check when no subscribers exist. INV-8 cache-hit short-circuits (pre-transaction, no commit) never wake. `dataVersion()` joins `StorageBackend` (`storage/backend.ts`): SQLite = `PRAGMA data_version`; memory = monotonic append counter.
+**New substrate:** `servers/exarchos-mcp/src/event-store/subscriptions.ts` — subscription registry, `SubscriptionHandle`, the **cursor pump** (per-subscription `lastDeliveredSeq`; wake → drain matching events after cursor in global order → advance), atomic registration (cursor + floor baseline captured together, immediate initial drain), and the Tier-2 floor loop on an **injectable clock**. The Tier-1 hook point lands in the append path (`store.ts`/`atomic-appender.ts`) and fires **after commit and after the per-stream mutex releases** — listener-initiated appends re-enter the normal append path without deadlock; the hook is a single guard check when no subscribers exist. INV-8 cache-hit short-circuits (pre-transaction, no commit) never wake. `dataVersion()` joins `StorageBackend` (`storage/backend.ts`): SQLite = `PRAGMA data_version` (foreign-commit-only visibility); `InMemoryBackend` = monotonic append counter (spurious drains idempotent by cursor).
 
-**Liveness contract:** base schema + pair registry live beside the event schemas (`event-store/schemas.ts`, `event-store/liveness-registry.ts`); the generic "in-flight operations" fold is a small reusable module consumed by `ps` and by `wait --operation` — not a new stored projection table.
+**Liveness contract:** the descriptor registry (`event-store/liveness-registry.ts`) carries `{ startType, terminalTypes, streamScope, instanceKeyOf }` per surface; `startedAt` comes from the start event's **envelope timestamp**. Schema retrofits in `event-store/schemas.ts` are validation-compatible additive (fixtures pin previously-emitted shapes); all four emitters gain the canonical `instanceId` (merge/launch/prune copy their natural keys; mutation mints one), so `instanceKeyOf` is `data.instanceId ?? legacyFallback` and new surfaces need no fallback at all. The generic "in-flight operations" fold pairs starts to terminals **by instance key** and is a small reusable module consumed by `ps` and by `wait --operation` — not a new stored projection table.
+
+**Backend read surface:** `listWorkflowSummaries({ workflowType?, status?, phase?, includeTerminal? })` joins `workflow_state` × `streams` with the `workflow_type` index (SQLite pushdown; in-memory filter on `InMemoryBackend`) — the `ps` workflows fold consumes it instead of loading all states.
 
 **Verbs:** new handlers under `src/views/lifecycle/` (ps/inspect/wait/export), routed via `views/composite.ts`; the WLM-6 worktree fold (`orchestrate/worktree/handlers.ts`) is called by the `ps` worktree scope rather than duplicated; the WLM-6 wait kernel is absorbed by generic `wait`. All lifecycle action schemas import field definitions from `src/views/lifecycle/schema-fields.ts` (one canonical Zod shape per field name — `scope`, `status`, `phase`, `workflowType`, `all`, `follow`, `limit`, `output`, `operation`) so `buildRegistrationSchema`'s same-name/different-base-type THROW is unrepresentable; a registry-construction test enforces it. Registry entries stamp postures, `outputSchema`, annotations, and `cli.topLevel` (#1316 Q7/Q8 land as registration facts, not prose).
 
@@ -153,9 +177,10 @@ Cross-cutting failure contract for the verb surface.
 ### Integration Points
 
 - `servers/exarchos-mcp/src/event-store/store.ts` + `atomic-appender.ts` — post-commit notification hook (outside the per-stream mutex; guarded, zero-cost empty path; no wake on idempotency cache-hits)
-- `servers/exarchos-mcp/src/event-store/subscriptions.ts` — **new**: registry, cursor pump, handle lifecycle, injectable-clock floor
-- `servers/exarchos-mcp/src/storage/backend.ts` + `sqlite-backend.ts` + `memory-backend.ts` — `dataVersion()` contract
-- `servers/exarchos-mcp/src/event-store/schemas.ts` + `liveness-registry.ts` — `ExecutingStartedBase`; four schema retrofits; pair registry; `export.*` events
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` — **new**: registry, cursor pump, atomic registration + initial drain, handle lifecycle, injectable-clock floor
+- `servers/exarchos-mcp/src/storage/backend.ts` + `sqlite-backend.ts` + `memory-backend.ts` — `dataVersion()` contract + `listWorkflowSummaries` read
+- `servers/exarchos-mcp/src/event-store/schemas.ts` + `liveness-registry.ts` — validation-compatible retrofits; descriptor registry; `export.*` events
+- `servers/exarchos-mcp/src/orchestrate/run-mutation.ts` (or the mutation emission site) — additive `operationId`
 - `servers/exarchos-mcp/src/views/composite.ts` — route `ps`(redesigned)/`inspect`(new)/`wait`(redesigned)/`export`(new)
 - `servers/exarchos-mcp/src/views/lifecycle/` — **new**: verb handlers + `schema-fields.ts` shared shapes
 - `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` — worktree fold consumed as `ps` scope; WLM-6 wait kernel absorbed
@@ -177,6 +202,8 @@ Owner decisions converged in one iteration: unify (vs coexist) · full pickup (s
 
 **Plan-review revision 1 (2026-07-08).** A 3-voter fresh-context adversarial panel (coverage / feasibility / adequacy) refuted rev. 0 unanimously. Design-level corrections absorbed: (a) DR-1 re-specified as a **cursor-pump** — the naive "synchronous notify" wording could not jointly satisfy exactly-once and global order across two connections, and left the listener-vs-per-stream-mutex re-entrancy contract undefined; (b) DR-5 gained the **`operation` predicate** after the panel proved the epic's phase-based S-6 walkthrough unsound against shipped reducer semantics (`merge.recovered` never transitions phase); (c) DR-6 pinned the zip dependency (`yazl` — none exists in-repo); (d) DR-8 gained the registration-integrity and Windows/INV-16 criteria with owning tasks (019/017). Decomposition re-waved to eliminate three same-file wave collisions; six tiers raised to match the mechanical derivation.
 
+**Plan-review revision 2 (2026-07-08).** A second fresh 3-voter panel refuted rev. 1 unanimously. Corrections absorbed: (a) DR-2 rebuilt as a **descriptor registry** — the shipped `executing_started` payloads share no fields (no uniform `startedAt`, no instance key), so the rev.-1 required-field base + byte-identical `.extend` retrofit was unimplementable; `startedAt` now derives from the envelope, pairing is by per-surface `instanceKeyOf`, and the retrofit posture is validation-compatible additive (`mutation` gains `operationId`); (b) DR-5's `operation` predicate scoped to **feature-scoped surfaces** (`merge`/`mutation`) — `launch`/`prune` emit to the singleton `worktrees` stream and are not feature-observable (the worktree `until` predicates cover them); (c) DR-1 gained the **registration contract** (atomic cursor+baseline capture, unconditional initial drain) closing a registration-race delivery hole, plus per-backend `dataVersion()` semantics; (d) DR-5's `status` predicate got defined semantics + ACs (it previously shipped as an untested input branch); (e) the `workflowType` pushdown got its missing backend read (`listWorkflowSummaries`) with Task 005 re-sequenced to own it; (f) Windows/INV-16 final discharge moved to the last wave (015/016), Task 019 raised to high (schema-glob surface), the 009→015 `cli.ts` edge added, and benchmark SLAs got numeric targets. **Owner amendment (2026-07-08):** the instance key was standardized — all four emitters gain a canonical additive `instanceId` (not just mutation), demoting the per-surface extractors to a legacy-events-only fallback; `surface`/`startedAt` deliberately stay un-standardized in payloads (derivable from event type and envelope respectively).
+
 ### Alternatives considered
 
 - **Coexist (freeze WLM-6 verbs, add new names)** — rejected: permanently splits the lifecycle surface and squats the #1090 names on worktree semantics.
@@ -187,6 +214,8 @@ Owner decisions converged in one iteration: unify (vs coexist) · full pickup (s
 - **OS-level notification (fs-watch on the SQLite WAL, LISTEN/NOTIFY-style IPC)** — rejected: imports watcher/daemon primitives from outside the INV-15 frame; `data_version` polling floor achieves the cross-process bound within it.
 - **Hand-rolled STORE-method zip writer** — rejected in rev. 1: a bespoke binary format is higher-risk than a pinned, tiny, pure-JS `yazl`; bundle-size impact verified in Task 013.
 - **Phase-based S-6 recovery (`wait --phase delegate`)** — rejected in rev. 1 (see DR-5): unsound against reducer semantics; replaced by the operation predicate.
+- **Required-field `ExecutingStartedBase` + byte-identical `.extend` retrofit** — rejected in rev. 2: the shipped payloads lack the fields (three of four have no start time; none share an instance key); replaced by envelope-derived `startedAt` + the descriptor registry + the additive canonical `instanceId` standard (full payload standardization of `surface`/`startedAt` stays rejected as redundant with the event type and envelope).
+- **Feature-scoped `wait --operation launch|prune`** — rejected in rev. 2: those surfaces emit to the singleton `worktrees` stream and are not feature-observable; the retained worktree `until` predicates are their honest waiting surface.
 
 ### Open Questions
 
@@ -194,6 +223,7 @@ Owner decisions converged in one iteration: unify (vs coexist) · full pickup (s
 - **MCP `resources/subscribe` exposure of DR-1:** deferred to the #1604 MCP-migration tranche (Z3) — the primitive is transport-agnostic; exposing it remotely is a harness-boundary question (#1599 rule 5).
 - **Import/replay tooling for export bundles:** deferred; the round-trip test (DR-6) guarantees replayability, tooling lands with a concrete diagnostic consumer.
 - **`shepherd`/`tdd-swarm` liveness conformance:** out of scope per #1316; the DR-2 registry makes each a one-entry addition tracked on their own issues.
+- **Worktrees-stream operation waits (`wait --operation launch` without a featureId):** deferred — the worktree `until` predicates cover today's consumers; a feature-less operation wait needs a schema change (optional featureId) with its own design pass.
 
 ## Decomposition
 
@@ -209,13 +239,13 @@ The decomposition maps every task to one or more DR-N from the section above.
 | DR | Requirement | Tasks |
 |----|-------------|-------|
 | DR-1 | Cursor-pump subscription primitive (#1315) | 001, 002, 017, 018 |
-| DR-2 | ExecutingStartedBase + liveness-pair registry | 003, 004, 018 |
-| DR-3 | Generic `ps` (scope-parameterized) | 005, 006, 007 |
+| DR-2 | Liveness descriptor registry | 003, 004, 018 |
+| DR-3 | Generic `ps` (scope-parameterized) | 005, 006, 007, 011 |
 | DR-4 | `inspect` workflow-projection describe | 008, 009 |
 | DR-5 | Generic `wait` (phase/status/operation predicates) | 010, 011 |
 | DR-6 | `export` with INV-13 two-event split | 012, 013 |
 | DR-7 | Registry-driven CLI top-level promotion | 014, 015 |
-| DR-8 | Error handling, failure modes, edge cases | 011, 016, 017, 019 |
+| DR-8 | Error handling, failure modes, edge cases | 010, 011, 015, 016, 017, 019 |
 
 ### Tasks
 
@@ -228,13 +258,13 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-1
 
 **Files:**
-- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (new — registry, `SubscriptionHandle`, cursor pump, filter matching, injectable clock seam)
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (new — registry, `SubscriptionHandle`, cursor pump, atomic registration + initial drain, filter matching, injectable clock seam)
 - `servers/exarchos-mcp/src/event-store/subscriptions.test.ts` (new)
 - `servers/exarchos-mcp/src/event-store/store.ts` (post-commit hook point — guarded zero-cost when empty)
 - `servers/exarchos-mcp/src/event-store/atomic-appender.ts` (wake fired after commit AND after per-stream mutex release; no wake on INV-8 cache-hits)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Subscribe_InProcessAppend_CursorDrainDeliversPostCommitInOrder`, `Subscribe_ListenerThrows_AppendUnaffectedSiblingsAndLaterEventsDelivered`, `Subscribe_ListenerAppendsSameStream_NoDeadlockDeliveredNextDrain`, `Subscribe_IdempotencyCacheHit_NoWakeNoRedelivery`, `Subscribe_DispatchReturns_HandleDisposedRegistryZero`, `Append_ZeroSubscribers_GuardCheckOnly`. INV-16: no wall-clock sleeps (injectable clock); SQLite handles closed before temp-dir removal.
-**testingStrategy:** `propertyTests: true` (property: for arbitrary interleavings of matching/non-matching appends and wakes, each subscriber receives exactly its matches, exactly once, in global sequence order — concurrency category); `benchmarks: true` (SLA: append p99 regression < 5% with zero subscribers vs baseline; boundary/offline cadence, not the inner vitest loop); `characterizationRequired: true` (append path is existing code).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Subscribe_InProcessAppend_CursorDrainDeliversPostCommitInOrder`, `Subscribe_RegistrationConcurrentWithAppends_InitialDrainNoLoss`, `Subscribe_ListenerThrows_AppendUnaffectedSiblingsAndLaterEventsDelivered`, `Subscribe_ListenerAppendsSameStream_NoDeadlockDeliveredNextDrain`, `Subscribe_IdempotencyCacheHit_NoWakeNoRedelivery`, `Subscribe_DispatchReturns_HandleDisposedRegistryZero`, `Append_ZeroSubscribers_GuardCheckOnly`. INV-16: no wall-clock sleeps (injectable clock); SQLite handles closed before temp-dir removal.
+**testingStrategy:** `propertyTests: true` (property: for arbitrary interleavings of matching/non-matching appends, wakes, **and the registration point itself**, each subscriber receives exactly its matches after its registration cursor, exactly once, in global sequence order — concurrency category); `benchmarks: true` (`performanceSLAs: [{ operation: 'event-append-zero-subscribers', metric: 'p99_regression_pct', threshold: 5 }]`; boundary/offline cadence, not the inner vitest loop); `characterizationRequired: true` (append path is existing code).
 **Dependencies:** None
 **Parallelizable:** Yes
 
@@ -249,16 +279,16 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Files:**
 - `servers/exarchos-mcp/src/storage/backend.ts` (`dataVersion(): number` joins the interface)
 - `servers/exarchos-mcp/src/storage/sqlite-backend.ts` (`PRAGMA data_version`)
-- `servers/exarchos-mcp/src/storage/memory-backend.ts` (monotonic append counter)
-- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (floor loop on the injectable clock; drain only on version change; no open statement held across ticks)
+- `servers/exarchos-mcp/src/storage/memory-backend.ts` (`InMemoryBackend`: monotonic append counter)
+- `servers/exarchos-mcp/src/event-store/subscriptions.ts` (floor loop on the injectable clock; baseline captured atomically at registration; drain only on version change; no open statement held across ticks)
 - `servers/exarchos-mcp/src/event-store/subscriptions.test.ts`
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Floor_ForeignCommit_DrainedInGlobalOrderNextTick` (injected clock), `Floor_ForeignThenOwnAppend_NoGapNoDoubleDelivery` (foreign seq N + own seq N+1 → delivered N, N+1), `Floor_NoForeignCommit_NoReRead`, `Floor_PerCallIntervalOverride_Honored`, `Floor_DefaultInterval_SurfacedInPerf`, `DataVersion_MemoryBackend_MonotonicOnAppend` (shared backend-contract test). Two-connection tests set explicit `busy_timeout` (INV-16 / SQLITE_BUSY posture).
-**testingStrategy:** `propertyTests: true` (property: for any split of appends across two connections and any wake/tick schedule, the subscriber observes every matching event exactly once in global sequence order); `benchmarks: false`; `characterizationRequired: false`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Floor_ForeignCommit_DrainedInGlobalOrderNextTick` (injected clock), `Floor_ForeignThenOwnAppend_NoGapNoDoubleDelivery` (foreign seq N + own seq N+1 → delivered N, N+1), `Floor_CommitBetweenHeadReadAndBaseline_DeliveredByInitialDrain`, `Floor_NoForeignCommit_NoReRead`, `Floor_PerCallIntervalOverride_Honored`, `Floor_DefaultInterval_SurfacedInPerf`, `DataVersion_Sqlite_ForeignCommitOnlyVisibility` (second connection bumps; own commit does not), `DataVersion_InMemory_MonotonicOnAppend`. Two-connection tests set explicit `busy_timeout` (INV-16 / SQLITE_BUSY posture).
+**testingStrategy:** `propertyTests: true` (property: for any split of appends across two connections, any wake/tick schedule, and any registration point, the subscriber observes every matching post-registration event exactly once in global sequence order); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 001
 **Parallelizable:** No (extends 001's module)
 
-#### Task 003: `ExecutingStartedBase` schema + retrofit of the four surfaces
+#### Task 003: Validation-compatible liveness schema retrofit + canonical `instanceId` on all four emitters
 
 **Risk Tier:** high
 **Boundary Touching:** true
@@ -266,15 +296,19 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-2
 
 **Files:**
-- `servers/exarchos-mcp/src/event-store/schemas.ts` (base + `merge`/`launch`/`mutation`/`prune` `.executing_started` retrofit via `.extend`)
-- `servers/exarchos-mcp/src/event-store/schemas.test.ts` (byte-identity snapshots)
+- `servers/exarchos-mcp/src/event-store/schemas.ts` (retrofit the four `*.executing_started` (+terminal) schemas — validation-compatible additive `instanceId`; shared structural helpers only where payloads actually agree)
+- `servers/exarchos-mcp/src/event-store/schemas.test.ts` (previously-emitted payload fixtures)
+- `servers/exarchos-mcp/src/orchestrate/run-mutation.ts` (new `operationId` → `instanceId` on the mutation emissions)
+- `servers/exarchos-mcp/src/orchestrate/execute-merge.ts` (additive `instanceId` = `taskId ?? sourceBranch→targetBranch`)
+- `servers/exarchos-mcp/src/launcher/liveness.ts` (additive `instanceId` = `worktreeId`)
+- `servers/exarchos-mcp/src/orchestrate/worktree/manager.ts` (prune emissions: additive `instanceId` = existing `operationId`)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite (shared-contract surface — schema glob classifies this high mechanically). Tests: `ExecutingStartedSchemas_Retrofit_EmittedDataByteIdentical` (snapshot per surface), `ExecutingStartedBase_RequiredFields_Validated`.
-**testingStrategy:** `propertyTests: true` (property: schema compliance — every payload accepted by a retrofit schema is accepted by the base's field contract; serialization category); `benchmarks: false`; `characterizationRequired: true` (modifies existing schemas).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (shared-contract surface — schema glob classifies this high mechanically). Tests: `ExecutingStartedSchemas_PreviouslyEmittedPayloadFixtures_StillValidate` (verbatim fixtures per surface), `ExecutingStartedSchemas_RejectMalformedPayload` (negative — carries the revert-probe adequacy), `AllFourEmitters_EmitCanonicalInstanceIdAdditively` (start + terminal emissions), `LegacyPayloadsWithoutInstanceId_StillValidate`.
+**testingStrategy:** `propertyTests: true` (property: schema compliance — every fixture-shaped payload, with and without the additive fields, validates; serialization category); `benchmarks: false`; `characterizationRequired: true` (modifies existing schemas + four emitters).
 **Dependencies:** None
 **Parallelizable:** Yes
 
-#### Task 004: Liveness-pair registry + conformance test
+#### Task 004: Liveness descriptor registry + conformance test
 
 **Risk Tier:** medium
 **Boundary Touching:** true
@@ -282,31 +316,34 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-2
 
 **Files:**
-- `servers/exarchos-mcp/src/event-store/liveness-registry.ts` (new — `{ startType, terminalTypes[] }` per surface)
+- `servers/exarchos-mcp/src/event-store/liveness-registry.ts` (new — `{ surface, startType, terminalTypes[], streamScope, instanceKeyOf }` per surface; envelope-derived `startedAt` helper; legacy-mutation fallback key)
 - `servers/exarchos-mcp/src/event-store/liveness-registry.test.ts` (new)
 
-**Verification:** scoped tests + `check_test_adequacy` + `check_contract_drift` (this registry is the contract `ps` and `wait --operation` consume). Tests: `LivenessRegistry_EveryExecutingStartedInCatalog_HasEntryWithTerminal` (conformance — fails on unregistered `*.executing_started`), `LivenessRegistry_Lookup_ReturnsTerminalTypesForSurface`. (The "adding a surface needs zero verb code" property is proven by 006's generic-fold test and 011's grep — not assertable here before verbs exist.)
-**testingStrategy:** `propertyTests: false` (static table; the conformance test is the guarantee); `benchmarks: false`; `characterizationRequired: false`.
+**Verification:** scoped tests + `check_test_adequacy` + `check_contract_drift` (this registry is the contract `ps` and `wait --operation` consume). Tests: `LivenessRegistry_EveryExecutingStartedInCatalog_HasEntryWithTerminalScopeAndKey` (conformance — fails on any unregistered or under-specified `*.executing_started`), `LivenessRegistry_InstanceKey_PairsConcurrentOpsCorrectly` (start A, start B, terminal B → A in flight, at the pairing-helper level), `LivenessRegistry_Lookup_ReturnsDescriptorForSurface`. (The "adding a surface needs zero verb code" property is proven by 006's generic-fold test and 011's grep — not assertable here before verbs exist.)
+**testingStrategy:** `propertyTests: true` (property: pairing correctness over arbitrary start/terminal key interleavings — state-machine category); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 003
 **Parallelizable:** Yes (within wave 2 — disjoint files)
 
-#### Task 005: `ps` workflows fold (workflow_state ⋈ streams.workflow_type + filters)
+#### Task 005: `listWorkflowSummaries` backend read + `ps` workflows fold
 
-**Risk Tier:** medium
+**Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-3
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/workflow-fold.ts` (new — rows: featureId, workflowType, phase, status, ageMs; filters: workflowType pushdown, status, phase, all)
+- `servers/exarchos-mcp/src/storage/backend.ts` (`listWorkflowSummaries({ workflowType?, status?, phase?, includeTerminal? })`)
+- `servers/exarchos-mcp/src/storage/sqlite-backend.ts` (join `workflow_state` × `streams` using the `workflow_type` index — real pushdown)
+- `servers/exarchos-mcp/src/storage/memory-backend.ts` (in-memory equivalent)
+- `servers/exarchos-mcp/src/views/lifecycle/workflow-fold.ts` (new — rows: featureId, workflowType, phase, status, ageMs)
 - `servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts` (new)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `WorkflowFold_TypeFilter_UsesIndexedStreamsColumn`, `WorkflowFold_Default_ExcludesTerminalStates`, `WorkflowFold_AllFlag_IncludesCompleted`.
-**testingStrategy:** `propertyTests: true` (properties: filter idempotence `filter(filter(rows)) === filter(rows)`; filtered set ⊆ unfiltered set; collections category); `benchmarks: true` (view-materialization category — projection-fold events/sec SLA at boundary/offline cadence); `characterizationRequired: false`.
-**Dependencies:** None
-**Parallelizable:** Yes
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (backend interface change — files ≥ 3, shared contract). Tests: `WorkflowFold_TypeFilter_PushedDownToIndexedColumn` (asserts the SQLite query path, not in-memory filtering), `WorkflowFold_StatusFilter_ReturnsMatchingRows`, `WorkflowFold_PhaseFilter_ReturnsMatchingRows`, `WorkflowFold_Default_ExcludesTerminalStates`, `WorkflowFold_AllFlag_IncludesCompleted`, `ListWorkflowSummaries_BackendContract_SharedAcrossSqliteAndInMemory`.
+**testingStrategy:** `propertyTests: true` (properties: filter idempotence `filter(filter(rows)) === filter(rows)`; filtered set ⊆ unfiltered set — generators enumerate all four filters; collections category); `benchmarks: true` (`performanceSLAs: [{ operation: 'workflow-fold-cold-10k-events', metric: 'p95_ms', threshold: 250 }]`; boundary/offline cadence); `characterizationRequired: false`.
+**Dependencies:** 002
+**Parallelizable:** Yes (wave 3 — disjoint files within the wave)
 
-#### Task 006: `ps` operations fold (generic in-flight over the liveness registry)
+#### Task 006: `ps` operations fold (generic in-flight, paired by instance key)
 
 **Risk Tier:** medium
 **Boundary Touching:** true
@@ -314,19 +351,20 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-3
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/operations-fold.ts` (new — `executing_started` without matching terminal, per registry)
+- `servers/exarchos-mcp/src/views/lifecycle/operations-fold.ts` (new — starts whose `instanceKeyOf` has no later matching terminal, per descriptor registry; envelope-derived age)
 - `servers/exarchos-mcp/src/views/lifecycle/operations-fold.test.ts` (new)
 
-**Verification:** scoped tests + `check_test_adequacy`. Tests: `OperationsFold_StartedWithoutTerminal_ListedInFlight`, `OperationsFold_MutationSurface_ListedGenerically` (DR-3 AC: no mutation-specific code), `OperationsFold_TerminalPresent_Excluded`.
-**testingStrategy:** `propertyTests: true` (property: for any event sequence, an operation is listed iff its start event has no later matching terminal — state-machine category); `benchmarks: true` (view-materialization category — fold throughput SLA at boundary/offline cadence); `characterizationRequired: false`.
+**Verification:** scoped tests + `check_test_adequacy`. Tests: `OperationsFold_StartedWithoutTerminal_ListedInFlight`, `OperationsFold_ConcurrentSameStreamOps_PairsByInstanceKey` (start A, start B, terminal B → exactly A listed), `OperationsFold_MutationSurface_ListedGenerically` (DR-3 AC: no mutation-specific code), `OperationsFold_TerminalPresent_Excluded`.
+**testingStrategy:** `propertyTests: true` (property: for any event sequence, an operation is listed iff its start's instance key has no later matching terminal — state-machine category); `benchmarks: true` (`performanceSLAs: [{ operation: 'operations-fold-cold-10k-events', metric: 'p95_ms', threshold: 250 }]`; boundary/offline cadence); `characterizationRequired: false`.
 **Dependencies:** 004
-**Parallelizable:** Yes (wave 3 — disjoint files)
+**Parallelizable:** Yes (wave 3 — disjoint files within the wave)
 
 #### Task 007: `ps` handler redesign — scope parameter, composition, probe gating
 
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
+**Acceptance Test Ref:** 011
 **Implements:** DR-3
 
 **Files:**
@@ -355,7 +393,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/views/composite.ts` (route `inspect`)
 - `servers/exarchos-mcp/src/registry.ts` (action def + `outputSchema` + `readOnlyHint`)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite (cold-probe side-effect-free invariant is the 2026-05-30 state-source-integrity RCA class). Tests: `Inspect_UnknownFeatureId_WorkflowExistsFalseNoSideEffect` (event-count invariance), `Inspect_KnownWorkflow_ReturnsStateEventsArtifacts`, `Inspect_SchemaDescribe_ByteUnchanged`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (cold-probe side-effect-free invariant is the 2026-05-30 state-source-integrity RCA class). Tests: `Inspect_UnknownFeatureId_WorkflowExistsFalseNoSideEffect` (event-count invariance), `Inspect_KnownWorkflow_ReturnsStateEventsArtifacts`, `Inspect_SchemaDescribe_AllFourCompositeTools_ByteUnchanged`.
 **testingStrategy:** `propertyTests: false` (projection composition; no transformation core); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 014, 019
 **Parallelizable:** Yes (wave 2 — disjoint files within the wave)
@@ -384,34 +422,34 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Boundary Touching:** true
 **Test Layer:** integration
 **Acceptance Test Ref:** 011
-**Implements:** DR-5
+**Implements:** DR-5, DR-8
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (new — projection precheck; DR-1 subscription on `workflow.transition` + registry terminals; `phase`/`status`/`operation`/worktree `until` predicates; structured `WAIT_TIMEOUT`/`WAIT_FAILED`; fields from `schema-fields.ts`)
+- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (new — projection precheck; DR-1 subscription on `workflow.transition` + registry terminals; `phase`/`status`/`operation`/worktree `until` predicates; feature-scope gating for `operation`; structured `WAIT_TIMEOUT`/`WAIT_FAILED`; fields from `schema-fields.ts`)
 - `servers/exarchos-mcp/src/views/lifecycle/wait.test.ts` (new)
 - `servers/exarchos-mcp/src/views/composite.ts` (route redesigned `wait`)
 - `servers/exarchos-mcp/src/registry.ts` (redesigned schema + `readOnlyHint`/`idempotentHint`)
 - `servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts` (WLM-6 wait kernel absorbed)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Wait_PhaseAlreadyPassed_ReturnsImmediatelyWithoutSubscribing`, `Wait_InProcessTransition_ResolvesOnTier1Wake` (injected clock), `Wait_Timeout_StructuredWaitTimeout`, `Wait_WorkflowCancelledMidWait_WaitFailed`, `Wait_OperationPredicate_ResolvesOnRegistryTerminal`, `Wait_OperationPredicate_NoInFlight_ReturnsImmediately`, `Wait_WorktreeScope_PreservesWlm6Capabilities` (until: merge + integrationRef; until: idle), `Wait_AllPaths_AppendZeroEvents` (event-count invariance).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Wait_PhaseAlreadyPassed_ReturnsImmediatelyWithoutSubscribing`, `Wait_InProcessTransition_ResolvesOnTier1Wake` (injected clock), `Wait_ForeignConnectionEvent_ResolvesWithinOneFloorTick_PerfSurfaced` (verb-level Tier-2 bound, DR-8), `Wait_Timeout_StructuredWaitTimeout`, `Wait_WorkflowCancelledMidWait_WaitFailed` (phase wait interrupted), `Wait_StatusPredicate_ResolvesOnRequestedTerminal`, `Wait_StatusPredicate_AlreadyTerminal_ReturnsImmediately`, `Wait_StatusPredicate_DifferentTerminalArrives_WaitFailed`, `Wait_OperationPredicate_ResolvesOnRegistryTerminalByInstanceKey`, `Wait_OperationPredicate_NoInFlight_ReturnsImmediately`, `Wait_OperationPredicate_NonFeatureScopedSurface_InvalidInputWithSuggestedFix`, `Wait_WorktreeScope_PreservesWlm6Capabilities` (until: merge + integrationRef; until: idle), `Wait_AllPaths_AppendZeroEvents` (event-count invariance).
 **testingStrategy:** `propertyTests: true` (property: for any transition/liveness event sequence, `wait` resolves iff its predicate is satisfied at precheck or becomes satisfied before timeout — state-machine category); `benchmarks: false`; `characterizationRequired: true` (absorbs shipped worktree kernel).
 **Dependencies:** 001, 002, 004, 008, 019
 **Parallelizable:** Yes (wave 3 — disjoint files within the wave)
 
-#### Task 011: S-6 stuck-executing recovery — acceptance north-star
+#### Task 011: S-6 stuck-executing recovery — feature acceptance north-star
 
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** acceptance
-**Implements:** DR-5, DR-8
+**Implements:** DR-3, DR-5, DR-8
 
 **Files:**
 - `servers/exarchos-mcp/src/views/lifecycle/s6-recovery.acceptance.test.ts` (new — real store, real handlers, no mocks)
 
-**Verification:** the corrected acceptance walkthrough from DR-5: seed `merge.executing_started` with no terminal (simulated crash); `wait <id> --operation merge --timeout` resolves when `merge.recovered` is appended, and returns `WAIT_TIMEOUT` (CLI exit 17) without it; `inspect` shows the unpaired start in flight; grep-assert no merge-specific code in `wait.ts`/`operations-fold.ts` (behavioral assertions carry the adequacy — the grep is a fence, not the proof).
+**Verification:** the corrected acceptance walkthrough from DR-5: seed `merge.executing_started` with no terminal (simulated crash); `ps` lists the stuck merge in `operations` (DR-3 north-star assertion); `wait <id> --operation merge --timeout` resolves when `merge.recovered` is appended, and returns `WAIT_TIMEOUT` (CLI exit 17) without it; `inspect` shows the unpaired start in flight; grep-assert no merge-specific code in `wait.ts`/`operations-fold.ts` (behavioral assertions carry the adequacy — the grep is a fence, not the proof).
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
-**Dependencies:** 008, 010
-**Parallelizable:** Yes (wave 4 — disjoint files within the wave)
+**Dependencies:** 007, 008, 010
+**Parallelizable:** Yes (wave 5 — disjoint files within the wave)
 
 #### Task 012: `export.requested` / `export.executed` event schemas
 
@@ -445,7 +483,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/registry.ts` (action def, `task-isolated` posture, `openWorldHint: true`)
 - `servers/exarchos-mcp/package.json` (pin `yazl`)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Export_Bundle_ReplayEventsJsonlEqualsStateJson` (round-trip), `Export_Success_AppendsExactlyRequestedExecutedPair` (idempotency-keyed; re-run creates a new pair, never duplicates a prior intent), `Export_CrashBetweenPair_PrecheckCompletesWithoutDuplicateIntent`, `Export_ArtifactsDir_IncludedAndMissingRefsListedInMetadata`, `Export_InvalidOutputPath_SuggestedFixNoEvents`, `Export_UnknownFeatureId_ExpectedShapeNoZip`. Windows: POSIX zip entries via `path.posix`, handles closed before temp-dir removal (INV-16). Build: `npm run build` single-file bundle includes yazl and export runs from it.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Export_Bundle_ReplayEventsJsonlEqualsStateJson` (round-trip), `Export_Success_AppendsExactlyRequestedExecutedPair` (idempotency-keyed; re-run creates a new pair, never duplicates a prior intent), `Export_CrashBetweenPair_PrecheckCompletesWithoutDuplicateIntent`, `Export_ArtifactsDir_IncludedAndMissingRefsListedInMetadata`, `Export_InvalidOutputPath_SuggestedFixNoEvents`, `Export_UnknownFeatureId_ExpectedShapeNoZip`. Windows: zip entry names via `path.posix`, filesystem paths via `path.join`, handles closed before temp-dir removal (INV-16). Build: `npm run build` single-file bundle includes yazl and export runs from it.
 **testingStrategy:** `propertyTests: true` (property: `replay(export(store)) === projection(store)` for arbitrary event sequences — data-transformation round-trip); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 007, 012, 019
 **Parallelizable:** Yes (wave 5 — disjoint files within the wave)
@@ -473,16 +511,16 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** acceptance
-**Implements:** DR-7
+**Implements:** DR-7, DR-8
 
 **Files:**
 - `servers/exarchos-mcp/src/registry.ts` (`ps`→`ps`, `wait`→`wait`, `export`→`export`, `inspect`→`describe`)
 - `servers/exarchos-mcp/src/adapters/cli.ts` (generic errorCode→exitCode map: `WAIT_TIMEOUT`→17, `WAIT_FAILED`→18 — presentation only)
 - `servers/exarchos-mcp/src/parity/lifecycle-verbs.parity.test.ts` (new)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite (this task is the DR-7/INV-2 contract check that 014 defers to). Tests: `Parity_EachPromotedVerb_ByteIdenticalToolResultAcrossThreePaths` (volatile fields — `_perf`, timestamps, `ageMs` — normalized per existing parity-harness conventions, injected clock where needed), `ExitCodeMap_WaitTimeout_17`, `ExitCodeMap_WaitFailed_18`, `ExitCodeMap_Success_0`, `Registry_VisibleCompositeCount_RemainsFour` (extend/cite the existing visible-count fence in `registry.test.ts`).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (this task is the DR-7/INV-2 contract check that 014 defers to). Tests: `Parity_EachPromotedVerb_ByteIdenticalToolResultAcrossThreePaths` (volatile fields — `_perf`, timestamps, `ageMs` — normalized per existing parity-harness conventions, injected clock where needed; setup grep-asserts 007/008/010/013 import `schema-fields.ts`), `ExitCodeMap_WaitTimeout_17`, `ExitCodeMap_WaitFailed_18`, `ExitCodeMap_Success_0`, `Registry_VisibleCompositeCount_RemainsFour` (extend/cite the existing visible-count fence in `registry.test.ts`). **Windows final discharge (DR-8):** completes only with the `test-windows` CI lane green on the integration tip and a zero-new-`skipIf(win32)` grep over the full feature diff.
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
-**Dependencies:** 007, 008, 010, 013, 014
+**Dependencies:** 007, 008, 009, 010, 013, 014
 **Parallelizable:** Yes (wave 6 — disjoint files within the wave)
 
 #### Task 016: Error-envelope edge cases across the verb surface
@@ -493,15 +531,15 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-8
 
 **Files:**
-- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (`validTargets` from HSM topology for the workflow's type; registry surfaces for `--operation`)
+- `servers/exarchos-mcp/src/views/lifecycle/wait.ts` (`validTargets` from HSM topology for the workflow's type; feature-scoped registry surfaces for `--operation`)
 - `servers/exarchos-mcp/src/views/lifecycle/errors.test.ts` (new — consolidated edge-case suite)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite (edits `wait.ts`, a high-tier surface) + `check_contract_drift` (error-envelope contract). Tests: `Wait_InvalidPhase_ValidTargetsFromTopologyForWorkflowType`, `Wait_UnknownOperationSurface_ValidTargetsFromRegistry`, `Verbs_UnknownFeatureId_SideEffectFreeExpectedShape` (inspect/wait/export; event-count invariance), `Ps_ProbeOutsideWorktreeScope_InvalidInputWithSuggestedFix`.
+**Verification:** scoped tests + `check_test_adequacy` + integration suite (edits `wait.ts`, a high-tier surface) + `check_contract_drift` (error-envelope contract). Tests: `Wait_InvalidPhase_ValidTargetsFromTopologyForWorkflowType`, `Wait_UnknownOperationSurface_ValidTargetsListsFeatureScopedSurfaces`, `Verbs_UnknownFeatureId_SideEffectFreeExpectedShape` (inspect/wait/export; event-count invariance), `Ps_ProbeOutsideWorktreeScope_InvalidInputWithSuggestedFix`. **Windows final discharge (DR-8):** completes only with the `test-windows` CI lane green on the integration tip and a zero-new-`skipIf(win32)` grep over the full feature diff.
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 007, 008, 010, 013
 **Parallelizable:** Yes (wave 6 — disjoint files within the wave)
 
-#### Task 017: Subscription lifecycle + portability hardening (owns the DR-8 Windows AC)
+#### Task 017: Subscription lifecycle + portability hardening (owns the DR-8 Windows mechanics)
 
 **Risk Tier:** high
 **Boundary Touching:** true
@@ -513,7 +551,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/cli/follow-loop.ts` (AbortSignal disposal audit)
 - `servers/exarchos-mcp/src/mcp/tasks-methods.ts` (task-cancel disposal audit)
 
-**Verification:** scoped tests + `check_test_adequacy` + integration suite. Tests: `Follow_ConsumerDisconnect_HandleDisposedRegistryZero`, `TasksCancel_MidFollow_HandleDisposed`, `Wait_ConcurrentSameStream_BothResolveIndependently`. **Windows/INV-16 ownership:** assert the poll floor holds no open SQLite statement across ticks (handle-close class, #1620); audit every new lifecycle test for wall-clock timing and convert to the injected clock (**zero new `skipIf(win32)` entries** — grep-asserted against the diff); confirm two-connection tests carry the `busy_timeout` posture; the `test-windows` CI lane must be green on the integration branch before this task completes.
+**Verification:** scoped tests + integration suite. `check_test_adequacy` applies to any source hunks this task produces (disposal fixes); for the test-only portions the revert-probe is inapplicable by construction — adequacy is instead demonstrated by **killing seeded mutations** of the substrate under test (mutate `subscriptions.ts` disposal/registry logic → the new tests must go red). Tests: `Follow_ConsumerDisconnect_HandleDisposedRegistryZero`, `TasksCancel_MidFollow_HandleDisposed`, `Wait_ConcurrentSameStream_BothResolveIndependently`. **Windows/INV-16 mechanics (through wave 5):** assert the poll floor holds no open SQLite statement across ticks (handle-close class, #1620); audit every new lifecycle test for wall-clock timing and convert to the injected clock (**zero new `skipIf(win32)` entries** in the diff-so-far — final full-diff discharge rides 015/016); confirm two-connection tests carry the `busy_timeout` posture; `test-windows` lane green on the integration tip as of this wave.
 **testingStrategy:** `propertyTests: true` (concurrency category — property: any interleaving of N concurrent subscribe/dispose/append operations leaves the registry consistent and delivers each subscriber only its matches); `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** 009, 010
 **Parallelizable:** Yes (wave 5 — disjoint files within the wave)
@@ -526,7 +564,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 **Implements:** DR-1, DR-2
 
 **Files:**
-- `docs/architecture/runtime.md` (§6 liveness convention: base schema + pairing rule + registry as enforcement; §L7 verbs updated to the shipped shape, including the operation predicate and the corrected S-6 story)
+- `docs/architecture/runtime.md` (§6 liveness convention: descriptor registry + pairing rule + envelope-derived `startedAt` + streamScope; §L7 verbs updated to the shipped shape, including the operation predicate, its feature-scope boundary, and the corrected S-6 story)
 
 **Verification:** static analysis + `verify_doc_links`. The #1315 subscription contract is this spec's DR-1; runtime.md links here.
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
@@ -535,7 +573,7 @@ The decomposition maps every task to one or more DR-N from the section above.
 
 #### Task 019: Shared lifecycle field shapes + registration-construction guard
 
-**Risk Tier:** medium
+**Risk Tier:** high
 **Boundary Touching:** true
 **Test Layer:** integration
 **Implements:** DR-8
@@ -544,31 +582,31 @@ The decomposition maps every task to one or more DR-N from the section above.
 - `servers/exarchos-mcp/src/views/lifecycle/schema-fields.ts` (new — one canonical Zod definition per lifecycle field name: `scope`, `status`, `phase`, `workflowType`, `all`, `follow`, `limit`, `output`, `operation`; base types checked against existing view-action fields)
 - `servers/exarchos-mcp/src/registry.construction.test.ts` (new — composes the current `exarchos_view` registration plus a probe action built from every shared shape and asserts `buildRegistrationSchema` does not throw)
 
-**Verification:** scoped tests + `check_test_adequacy` + `check_contract_drift`. Tests: `RegistryConstruction_WithAllLifecycleFieldShapes_DoesNotThrow`, `SchemaFields_BaseTypes_MatchExistingViewFieldsWhereNamesCollide`. Tasks 007/008/010/013 MUST import from this module (grep-asserted in 015's parity suite setup).
+**Verification:** scoped tests + `check_test_adequacy` + integration suite + `check_contract_drift` (this is the shared-contract module every lifecycle verb imports — the schema glob classifies it high mechanically, and its silent breakage is the registry-THROW class). Tests: `RegistryConstruction_WithAllLifecycleFieldShapes_DoesNotThrow`, `SchemaFields_BaseTypes_MatchExistingViewFieldsWhereNamesCollide`. Tasks 007/008/010/013 MUST import from this module (grep-asserted in 015's parity suite setup).
 **testingStrategy:** `propertyTests: false`; `benchmarks: false`; `characterizationRequired: false`.
 **Dependencies:** None
 **Parallelizable:** Yes
 
 ### Parallelization
 
-**Critical path:** 001 → 002 → 010 → 007 → 013 → 015/016 (the `registry.ts`/`composite.ts` serialization chain).
+**Critical path:** 001 → 002 → 005/010 → 007 → 013 → 015/016 (the `registry.ts`/`composite.ts` serialization chain).
 
 | Wave | Tasks (parallel within wave; all same-file edits serialized across waves) |
 |---|---|
-| 1 | 001, 003, 005, 014, 019 |
+| 1 | 001, 003, 014, 019 |
 | 2 | 002, 004, 008, 012 |
-| 3 | 006, 009, 010 |
-| 4 | 007, 011, 018 |
-| 5 | 013, 017 |
+| 3 | 005, 006, 009, 010 |
+| 4 | 007, 018 |
+| 5 | 011, 013, 017 |
 | 6 | 015, 016 |
 
-**Same-file serialization (total orders across waves):** `registry.ts`: 014 → 008 → 010 → 007 → 013 → 015. `composite.ts`: 008 → 010 → 007 → 013. `worktree/handlers.ts`: 010 → 007. `adapters/cli.ts`: 014 → 009 → 015. `event-store/schemas.ts`: 003 → 012. `subscriptions.ts(.test)`: 001 → 002 → 017. `follow-loop.ts`/`tasks-methods.ts`: 009 → 017. `wait.ts`: 010 → 016. No two tasks within any wave share a file.
+**Same-file serialization (total orders across waves, all edge-enforced):** `registry.ts`: 014 → 008 → 010 → 007 → 013 → 015. `composite.ts`: 008 → 010 → 007 → 013. `worktree/handlers.ts`: 010 → 007. `adapters/cli.ts`: 014 → 009 → 015 (015 depends on 009 directly). `event-store/schemas.ts`: 003 → 012. `storage/backend.ts`/`sqlite-backend.ts`/`memory-backend.ts`: 002 → 005. `subscriptions.ts(.test)`: 001 → 002 → 017. `follow-loop.ts`/`tasks-methods.ts`: 009 → 017. `wait.ts`: 010 → 016. No two tasks within any wave share a file.
 
 ### Completion checklist
 
 - [x] Every DR-N in `## Design & Rationale` maps to at least one task in the matrix
 - [x] Every task `Implements:` a DR-N that exists in this document
-- [x] Every task carries a `riskTier` stamp (six raised to match the mechanical derivation in rev. 1; remaining medium stamps — 004/005/006/019 — are single-new-module tasks the derivation itself classifies medium; `boundaryTouching: true` stamped wherever `testLayer: integration` would derive it)
+- [x] Every task carries a `riskTier` stamp (rev. 2: 019 raised to high — `schema-fields.ts` hits the schema glob and is the shared-contract module; remaining medium stamps — 004/006 — are single-new-module tasks the mechanical derivation classifies medium; `boundaryTouching: true` stamped wherever `testLayer: integration` would derive it)
 - [x] Medium/high-tier tasks carry adequacy-judged tests (test-after); low-tier tasks lean on static analysis
 - [x] Open questions are resolved OR explicitly deferred with rationale
 - [ ] Ready for `plan-review`

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -15,7 +15,7 @@
         "patch-package": "^8.0.1",
         "pino": "^10.3.1",
         "yaml": "^2.8.2",
-        "yazl": "^3.3.1",
+        "yazl": "3.3.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "2.12.0-preview.2",
+  "version": "2.12.0-preview.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lvlup-sw/exarchos-mcp",
-      "version": "2.12.0-preview.2",
+      "version": "2.12.0-preview.3",
       "hasInstallScript": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -15,6 +15,7 @@
         "patch-package": "^8.0.1",
         "pino": "^10.3.1",
         "yaml": "^2.8.2",
+        "yazl": "^3.3.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -23,6 +24,8 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/iarna__toml": "^2.0.5",
         "@types/node": "^22.0.0",
+        "@types/yauzl": "^3.4.0",
+        "@types/yazl": "^3.3.1",
         "@vitest/coverage-v8": "^3.0.0",
         "better-sqlite3": "^12.6.2",
         "dependency-cruiser": "^17.4.3",
@@ -30,7 +33,8 @@
         "promptfoo": "^0.120.25",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
-        "vitest": "^3.0.0"
+        "vitest": "^3.0.0",
+        "yauzl": "^3.4.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6257,6 +6261,26 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.3.tgz",
@@ -7122,6 +7146,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -13073,6 +13106,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
@@ -17059,6 +17099,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
       }
     },
     "node_modules/yoctocolors": {

--- a/servers/exarchos-mcp/package.json
+++ b/servers/exarchos-mcp/package.json
@@ -26,7 +26,7 @@
     "patch-package": "^8.0.1",
     "pino": "^10.3.1",
     "yaml": "^2.8.2",
-    "yazl": "^3.3.1",
+    "yazl": "3.3.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/servers/exarchos-mcp/package.json
+++ b/servers/exarchos-mcp/package.json
@@ -26,6 +26,7 @@
     "patch-package": "^8.0.1",
     "pino": "^10.3.1",
     "yaml": "^2.8.2",
+    "yazl": "^3.3.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -34,6 +35,8 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/iarna__toml": "^2.0.5",
     "@types/node": "^22.0.0",
+    "@types/yauzl": "^3.4.0",
+    "@types/yazl": "^3.3.1",
     "@vitest/coverage-v8": "^3.0.0",
     "better-sqlite3": "^12.6.2",
     "dependency-cruiser": "^17.4.3",
@@ -41,7 +44,8 @@
     "promptfoo": "^0.120.25",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "yauzl": "^3.4.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/servers/exarchos-mcp/scripts/cli-vocab-guard.ts
+++ b/servers/exarchos-mcp/scripts/cli-vocab-guard.ts
@@ -140,12 +140,22 @@ const BANNED_FLAGS: readonly BannedFlag[] = [
 //      field, alongside the canonical `--json`. The `format` field is load-
 //      bearing in HandleDoctorArgs/HandleOnboardArgs and their parity tests.
 //      Tracked for collapse onto `--json` as a follow-up.
+//   3. `exarchos vw export --output` — NOT debt and NOT a JSON-carrier alias.
+//      The `--output` ban targets `--output json` (output-FORMAT selection, whose
+//      canonical is `--json`); `export`'s `--output` is a DESTINATION FILE PATH
+//      (DR-6 — the zip bundle's location, default `./<featureId>-export.zip`),
+//      declared by the shared DR-8 `output` field (schema-fields.ts, which
+//      documents it as "a path, NOT a table|json format enum"). The guard keys
+//      on the token STRING and cannot see that semantic split, so the legitimate
+//      path-valued use is excepted surgically — a `--output` on any OTHER command
+//      still fails.
 const KNOWN_EXCEPTIONS: ReadonlySet<string> = new Set([
   'exarchos vw ls::ls',
   'exarchos doctor::--format',
   'exarchos onboard::--format',
   'exarchos orch doctor::--format',
   'exarchos orch onboard::--format',
+  'exarchos vw export::--output',
 ]);
 
 // ─── Surface extraction ───────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/scripts/cli-vocab-guard.ts
+++ b/servers/exarchos-mcp/scripts/cli-vocab-guard.ts
@@ -148,7 +148,10 @@ const BANNED_FLAGS: readonly BannedFlag[] = [
 //      documents it as "a path, NOT a table|json format enum"). The guard keys
 //      on the token STRING and cannot see that semantic split, so the legitimate
 //      path-valued use is excepted surgically — a `--output` on any OTHER command
-//      still fails.
+//      still fails. DR-7 (task-015) promotes `export` to a TOP-LEVEL verb, so the
+//      SAME destination-path `--output` now also surfaces at `exarchos export`;
+//      that promoted path gets the identical surgical exception below (the flag's
+//      semantics are unchanged by the hoist — same action, same schema field).
 const KNOWN_EXCEPTIONS: ReadonlySet<string> = new Set([
   'exarchos vw ls::ls',
   'exarchos doctor::--format',
@@ -156,6 +159,8 @@ const KNOWN_EXCEPTIONS: ReadonlySet<string> = new Set([
   'exarchos orch doctor::--format',
   'exarchos orch onboard::--format',
   'exarchos vw export::--output',
+  // DR-7 top-level promotion of the same DR-6 destination-path flag.
+  'exarchos export::--output',
 ]);
 
 // ─── Surface extraction ───────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -523,7 +523,12 @@ describe('EventTypes', () => {
     // the counted plan-review dispatch emitted by the `prepare_review scope:plan`
     // provisioning seam (folded into `state.planReview.revisionCount` to bound the
     // plan-review loop at its unskippable server action).
-    expect(EventTypes).toHaveLength(146);
+    // DR-6 (lifecycle-verbs task 012): bumped 146 → 148 to include the two-event
+    // `export` contract — `export.requested` (durable intent + RESOLVED path) and
+    // `export.executed` (result + content hash), the INV-13 two-event split for
+    // the non-idempotent zip-bundle write, emitted `auto` by the `export`
+    // composite handler (task 013), idempotency-keyed per INV-8.
+    expect(EventTypes).toHaveLength(148);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('merge.executing_started');
@@ -549,6 +554,8 @@ describe('EventTypes', () => {
     expect(EventTypes).toContain('workflow.plan-revision');
     expect(EventTypes).toContain('prune.executing_started');
     expect(EventTypes).toContain('prune.executed');
+    expect(EventTypes).toContain('export.requested');
+    expect(EventTypes).toContain('export.executed');
     // Retirement guard: init.executed removed in DR-5 (task 018).
     expect(EventTypes as readonly string[]).not.toContain('init.executed');
   });

--- a/servers/exarchos-mcp/src/adapters/cli.test.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.test.ts
@@ -71,7 +71,8 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
 
 import { buildCli, commanderErrorToResult, runCli, CLI_EXIT_CODES } from './cli.js';
 import { dispatch } from '../core/dispatch.js';
-import { TOOL_REGISTRY } from '../registry.js';
+import { TOOL_REGISTRY, getFullRegistry } from '../registry.js';
+import type { CompositeTool } from '../registry.js';
 import type { DispatchContext } from '../core/dispatch.js';
 import { CommanderError } from 'commander';
 
@@ -941,3 +942,126 @@ describe.skipIf(!SMOKE_BINARY)(
     });
   },
 );
+
+// ─── DR-7: top-level CLI promotion mechanism (CliActionHints.topLevel) ────────
+//
+// These tests exercise the GENERIC promotion mechanism + its collision guard
+// over the REAL registry + CLI wiring (no hand-mocked registry): they stamp
+// `cli.topLevel` onto a real registry action and assert `buildCli` hoists it to
+// a top-level command that shares the subcommand's code path + Zod schema. The
+// lifecycle-verb re-map (which actions actually declare `topLevel`) is a
+// follow-on — this task ships only the mechanism.
+describe('CLI top-level promotion (DR-7)', () => {
+  let ctx: DispatchContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createTestContext();
+  });
+
+  // Clone the REAL registry (getFullRegistry) and stamp `cli.topLevel` onto one
+  // action. Everything else — the action's Zod schema, description, dispatch
+  // wiring — stays the real thing, so the mechanism is proven against real
+  // registry data, not a fabricated fixture.
+  function registryWithTopLevel(
+    toolName: string,
+    actionName: string,
+    topLevel: string,
+  ): readonly CompositeTool[] {
+    return getFullRegistry().map((tool) =>
+      tool.name !== toolName
+        ? tool
+        : {
+            ...tool,
+            actions: tool.actions.map((action) =>
+              action.name !== actionName
+                ? action
+                : { ...action, cli: { ...action.cli, topLevel } },
+            ),
+          },
+    );
+  }
+
+  it('Promotion_TopLevelStamp_CommandRegisteredAndDispatches', async () => {
+    // Arrange — promote the real `exarchos_view` `ps` action to top-level `ps`.
+    const registry = registryWithTopLevel('exarchos_view', 'ps', 'ps');
+    const program = buildCli(ctx, { registry });
+
+    // Assert (registration) — a NEW top-level `ps` command exists alongside the
+    // untouched `vw` tool group.
+    const topLevelNames = program.commands.map((c) => c.name());
+    expect(topLevelNames).toContain('ps');
+
+    // Assert (same Zod schema) — the hoisted command's flag set is IDENTICAL to
+    // the `vw ps` subcommand's, and carries the schema-derived `--probe` flag.
+    const topLevelPs = program.commands.find((c) => c.name() === 'ps');
+    const vwPs = program.commands
+      .find((c) => c.name() === 'vw')
+      ?.commands.find((c) => c.name() === 'ps');
+    expect(topLevelPs, 'top-level ps not registered').toBeDefined();
+    expect(vwPs, 'vw ps subcommand not registered').toBeDefined();
+    const topLevelFlags = (topLevelPs?.options ?? []).map((o) => o.flags).sort();
+    const subFlags = (vwPs?.options ?? []).map((o) => o.flags).sort();
+    expect(topLevelFlags).toEqual(subFlags);
+    expect(topLevelFlags.some((f) => f.includes('--probe'))).toBe(true);
+
+    // Assert (same dispatch path) — running `exarchos ps` dispatches the SAME
+    // tool + action the subcommand form would, through the shared handler.
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    await program.parseAsync(['node', 'exarchos', 'ps']);
+    stdoutSpy.mockRestore();
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'exarchos_view',
+      expect.objectContaining({ action: 'ps' }),
+      ctx,
+    );
+  });
+
+  it('Promotion_CollidingName_FailsRegistrationNotRuntime', () => {
+    // A `topLevel` that collides with an existing top-level command must fail at
+    // REGISTRATION (build time) — the throw happens inside `buildCli`, before any
+    // argv is parsed or any command action runs. `wf` is the workflow tool
+    // group's top-level name.
+    const collideName = registryWithTopLevel('exarchos_view', 'ps', 'wf');
+    expect(() => buildCli(ctx, { registry: collideName })).toThrow(
+      /topLevel 'wf'.*collides with the existing top-level command 'wf'/,
+    );
+
+    // The guard also catches a clash with a top-level command's ALIAS, not just
+    // its primary name: `workflow` is registered as an alias of `wf`.
+    const collideAlias = registryWithTopLevel('exarchos_view', 'ps', 'workflow');
+    expect(() => buildCli(ctx, { registry: collideAlias })).toThrow(
+      /topLevel 'workflow'.*collides with the existing top-level command/,
+    );
+
+    // Guard specificity: a non-colliding name must NOT throw (proves the guard
+    // rejects clashes, not every promotion).
+    const noCollide = registryWithTopLevel('exarchos_view', 'ps', 'ps');
+    expect(() => buildCli(ctx, { registry: noCollide })).not.toThrow();
+
+    // Dispatch was never invoked — the failure is at registration, not runtime.
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('Promotion_SubcommandForm_StillWorks', async () => {
+    // Promoting an action to top-level must NOT disturb its `<tool> <action>`
+    // subcommand form: `vw ps` still registers and still dispatches.
+    const registry = registryWithTopLevel('exarchos_view', 'ps', 'ps');
+    const program = buildCli(ctx, { registry });
+
+    const vwCmd = program.commands.find((c) => c.name() === 'vw');
+    const vwPs = vwCmd?.commands.find((c) => c.name() === 'ps');
+    expect(vwPs, 'vw ps subcommand missing after promotion').toBeDefined();
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    await program.parseAsync(['node', 'exarchos', 'vw', 'ps']);
+    stdoutSpy.mockRestore();
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'exarchos_view',
+      expect.objectContaining({ action: 'ps' }),
+      ctx,
+    );
+  });
+});

--- a/servers/exarchos-mcp/src/adapters/cli.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.ts
@@ -933,6 +933,15 @@ function registerActionCommand(
     );
   }
 
+  // DR-4 (task-009): `view inspect --follow` tails ONE workflow's event stream
+  // live as NDJSON frames over the DR-1 cursor-pump subscription (a DIFFERENT
+  // carrier from the `VIEW_FOLLOW_ACTIONS` Tasks-polling loop above). No option
+  // is registered here — inspect's `follow` field is schema-declared (DR-8 SoT),
+  // so `addFlagsFromSchema` already emits `--follow`; this predicate only routes
+  // the dispatch branch below.
+  const isInspectFollow =
+    tool.name === 'exarchos_view' && action.name === 'inspect';
+
   // T5 (#1240): convenience flags on `wf checkpoint` so agents emit a
   // structured handoff payload without having to type nested JSON.
   // The flags map to the `handoff` field on the dispatch surface
@@ -1202,6 +1211,82 @@ function registerActionCommand(
           format,
         );
         process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
+      }
+      return;
+    }
+
+    // ─── DR-4 (task-009): `view inspect --follow` NDJSON carrier ──────
+    //
+    // Tails ONE workflow's event stream live over the DR-1 cursor-pump
+    // subscription, framing each delivered event as an NDJSON `event`
+    // frame (deduped by sequence) with heartbeat frames on silence. The
+    // MCP Tasks arm (`mcp/tasks-methods.ts#tasksFollow`) drives the SAME
+    // `runInspectFollow` core over the SAME subscription contract, so the
+    // two facades stream byte-identical frames (INV-2). Disposal is
+    // AbortSignal-driven: SIGINT aborts the controller → the carrier
+    // disposes the subscription and writes a terminal `end` frame.
+    if (isInspectFollow && follow === true) {
+      // Parse the action args first so a bad/missing featureId surfaces as
+      // INVALID_INPUT before we open a subscription.
+      const followCoerced = coerceFlags(flagOpts, action.schema);
+      const followParse = action.schema.safeParse(followCoerced);
+      if (!followParse.success) {
+        const errCtx = `${tool.name}/${action.name}`;
+        const err = formatValidationError(followParse.error, errCtx);
+        emitResult({ success: false, error: err }, isJson, format);
+        process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+        return;
+      }
+      const featureId =
+        typeof followParse.data.featureId === 'string'
+          ? followParse.data.featureId
+          : undefined;
+      if (!featureId) {
+        const err = buildInvalidInput(
+          `${tool.name}/${action.name}: --follow requires featureId`,
+        );
+        emitResult({ success: false, error: err }, isJson, format);
+        process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+        return;
+      }
+
+      // Wire SIGINT → AbortController (no POSIX-only signal semantics reach
+      // the carrier). The handler MUST NOT call `process.exit` — awaiting
+      // `handle.done` lets the carrier dispose the subscription and flush the
+      // `end` frame, then the action returns and the event loop drains.
+      const controller = new AbortController();
+      const onSigint = (): void => controller.abort();
+      process.once('SIGINT', onSigint);
+      try {
+        const { runInspectFollow, defaultFollowClock } = await import(
+          '../cli/follow-loop.js'
+        );
+        const { NdjsonEncoder } = await import('../ndjson/encoder.js');
+        const encoder = new NdjsonEncoder(process.stdout);
+        const handle = runInspectFollow({
+          subscribe: (filter, onEvent, options) =>
+            ctx.eventStore.subscribe(filter, onEvent, options),
+          featureId,
+          // `0` so the follow stream is self-contained: existing events
+          // (initial drain) followed by the live tail.
+          fromSequence: 0,
+          onFrame: (frame) => encoder.write(frame),
+          signal: controller.signal,
+          clock: defaultFollowClock(),
+        });
+        await handle.done;
+        // Abort (SIGINT) is a clean exit — the user asked for it.
+        process.exitCode = CLI_EXIT_CODES.SUCCESS;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        emitResult(
+          { success: false, error: { code: 'UNCAUGHT_EXCEPTION', message } },
+          isJson,
+          format,
+        );
+        process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
+      } finally {
+        process.off('SIGINT', onSigint);
       }
       return;
     }

--- a/servers/exarchos-mcp/src/adapters/cli.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getFullRegistry } from '../registry.js';
+import type { CompositeTool, ToolAction } from '../registry.js';
 import { dispatch } from '../core/dispatch.js';
 import type { DispatchContext } from '../core/dispatch.js';
 import type { ToolResult } from '../format.js';
@@ -227,6 +228,16 @@ export const VIEW_FOLLOW_ACTIONS: ReadonlySet<string> = new Set([
 export interface BuildCliOptions {
   /** OS-effect / advanced overrides threaded into the `exarchos <harness>` launcher wiring. */
   readonly launcher?: LauncherWiringOverrides;
+  /**
+   * DR-7 test seam — override the composite-tool registry the auto-generated
+   * command tree (and the top-level promotion hoist loop) is built from.
+   * Production callers pass none and the full registry ({@link getFullRegistry})
+   * is used. Tests stamp `cli.topLevel` onto a REAL registry action to exercise
+   * the promotion mechanism + its collision guard without hand-mocking the
+   * registry. Mirrors the `launcher` seam: a DI point at the production boundary,
+   * not a divergent code path.
+   */
+  readonly registry?: readonly CompositeTool[];
 }
 
 /**
@@ -245,7 +256,9 @@ export function buildCli(ctx: DispatchContext, options?: BuildCliOptions): Comma
 
   // ─── Auto-generated tool commands ──────────────────────────────────────────
 
-  for (const tool of getFullRegistry()) {
+  const cliRegistry = options?.registry ?? getFullRegistry();
+
+  for (const tool of cliRegistry) {
     const toolName = tool.name.replace(/^exarchos_/, '');
     const cliName = tool.cli?.alias ?? toolName;
     const toolCmd = program
@@ -261,401 +274,13 @@ export function buildCli(ctx: DispatchContext, options?: BuildCliOptions): Comma
     }
 
     for (const action of tool.actions) {
-      const actionCmd = toolCmd
-        .command(action.cli?.alias ?? action.name)
-        .description(action.description);
-
-      addFlagsFromSchema(actionCmd, action.schema, action.cli?.flags);
-
-      // T042 / DR-9: the `exarchos event query` action gains a streaming
-      // `--follow` mode that emits NDJSON frames via the dedicated
-      // `runEventQueryFollow` handler instead of the one-shot dispatch path.
-      // The flag is intentionally registered outside `addFlagsFromSchema` so
-      // the MCP tool schema (which only describes one-shot query args) is
-      // not affected.
-      const isEventQuery =
-        tool.name === 'exarchos_event' && action.name === 'query';
-      if (isEventQuery) {
-        actionCmd.option('--follow', 'Stream events as NDJSON frames until the source closes');
-      }
-
-      // T33 (#1273) / Wave C PR 3 — the `exarchos view` actions listed in
-      // `VIEW_FOLLOW_ACTIONS` gain a `--follow` flag that drives the
-      // dispatch-core `EventSourcedTaskStore` polling loop (see
-      // `cli/follow-loop.ts`). #1440 Op 1 (T7) expanded the set from the
-      // original two-arm disjunction (workflow_status, shepherd_status) to
-      // include three more pure-projection view actions (pipeline,
-      // convergence, delegation_timeline). Like the event-query `--follow`,
-      // this flag is registered outside `addFlagsFromSchema` so the MCP
-      // tool schema for the underlying action stays one-shot — the
-      // Tasks-augmented branch for the MCP arm is gated by the SDK
-      // `task: { ttl }` request parameter, not by a tool-schema field (C2).
-      const isViewFollow =
-        tool.name === 'exarchos_view' && VIEW_FOLLOW_ACTIONS.has(action.name);
-      if (isViewFollow) {
-        actionCmd.option(
-          '--follow',
-          'Stream task lifecycle transitions to stdout until terminal status or SIGINT',
-        );
-      }
-
-      // T5 (#1240): convenience flags on `wf checkpoint` so agents emit a
-      // structured handoff payload without having to type nested JSON.
-      // The flags map to the `handoff` field on the dispatch surface
-      // (which `addFlagsFromSchema` already exposes as
-      // `--handoff <json-or-csv>` for power-user / scripting parity).
-      // `--context` accepts inline strings only — the `@<path>` substitution
-      // sugar is OUT OF SCOPE here (#1245, scheduled v2.12.0). The
-      // variadic syntax `<step...>` lets agents repeat `--next-steps a
-      // --next-steps b` to build the array, mirroring how the MCP arm
-      // would receive `nextSteps: ['a', 'b']`.
-      const isWorkflowCheckpoint =
-        tool.name === 'exarchos_workflow' && action.name === 'checkpoint';
-      if (isWorkflowCheckpoint) {
-        actionCmd.option(
-          '--context <string>',
-          'Handoff context (single inline string, max 2KB). Maps to handoff.context.',
-        );
-        actionCmd.option(
-          '--next-steps <step...>',
-          'Repeatable handoff next-step entry; pass once per entry. Maps to handoff.nextSteps.',
-        );
-        actionCmd.option(
-          '--suggestions <suggestion...>',
-          'Repeatable handoff suggestion entry; pass once per entry. Maps to handoff.suggestions.',
-        );
-      }
-
-      actionCmd.action(async (opts: Record<string, unknown>) => {
-        const { json, follow, ...flagOpts } = opts;
-        const isJson = Boolean(json);
-        const format = action.cli?.format;
-
-        // ─── T5 (#1240): convenience-flag → handoff reshape ───────────────
-        // Done BEFORE `coerceFlags` / `safeParse` so the synthesised
-        // `handoff` is the value that hits both schema validation and
-        // dispatch. Critical contract: when NONE of the convenience
-        // flags are present, `handoff` MUST stay ABSENT — not be set
-        // to `{ context: undefined, nextSteps: undefined, ... }`. The
-        // C3 (#1241) digest is `sha256(handoff ?? {})`, and an
-        // all-undefined object stringifies to `{}` only by coincidence;
-        // explicit absence keeps the digest stable for pre-T5 callers
-        // and for the parity contract with the MCP arm (which passes
-        // `handoff` undefined when the caller didn't populate it).
-        if (isWorkflowCheckpoint) {
-          const ctxOpt = flagOpts.context;
-          const nextStepsOpt = flagOpts.nextSteps;
-          const suggestionsOpt = flagOpts.suggestions;
-          const hasContext = typeof ctxOpt === 'string';
-          const hasNextSteps = Array.isArray(nextStepsOpt) && nextStepsOpt.length > 0;
-          const hasSuggestions =
-            Array.isArray(suggestionsOpt) && suggestionsOpt.length > 0;
-
-          // Reject the conflict where the operator passes both the raw
-          // `--handoff '{...}'` JSON flag AND any convenience flag. Without
-          // this guard the reshape block below would silently overwrite
-          // the JSON-supplied handoff with the synthesized convenience
-          // object — losing data the operator explicitly supplied. The
-          // two surfaces are mutually exclusive: `--handoff` is the full
-          // shape, the convenience flags are field-level sugar.
-          if (
-            flagOpts.handoff !== undefined &&
-            (hasContext || hasNextSteps || hasSuggestions)
-          ) {
-            const err = buildInvalidInput(
-              `${tool.name}/${action.name}: --handoff is mutually exclusive with --context/--next-steps/--suggestions; pass either the full --handoff JSON or the convenience flags, not both`,
-            );
-            emitResult({ success: false, error: err }, isJson, format);
-            process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
-            return;
-          }
-
-          if (hasContext || hasNextSteps || hasSuggestions) {
-            // Synthesize `handoff` from the convenience flags. Spread-on-
-            // condition keeps the shape minimal so the rehydration
-            // projection's `latestHandoff` snapshot only carries what
-            // the operator actually supplied (e.g. `{ context: 'x' }`
-            // and not `{ context: 'x', nextSteps: undefined,
-            // suggestions: undefined }`). The handler's
-            // `CheckpointInputSchema.handoff` is a Zod object with all
-            // three fields optional, so omitting them is valid input.
-            flagOpts.handoff = {
-              ...(hasContext ? { context: ctxOpt as string } : {}),
-              ...(hasNextSteps ? { nextSteps: nextStepsOpt as string[] } : {}),
-              ...(hasSuggestions
-                ? { suggestions: suggestionsOpt as string[] }
-                : {}),
-            };
-          }
-          // Strip the convenience-flag aliases so they don't leak into
-          // dispatch args (the schema doesn't declare them; they'd be
-          // silently ignored, but cleaning them up here keeps the
-          // dispatched payload shaped exactly like the MCP arm's).
-          delete flagOpts.context;
-          delete flagOpts.nextSteps;
-          delete flagOpts.suggestions;
-        }
-
-        // ─── T33 (#1273): view `--follow` Tasks polling branch ────────────
-        //
-        // Wave C PR 3 — the CLI equivalent of the MCP `tasks/get` polling
-        // loop. The dispatch creates a task via the dispatch-core
-        // `runTasksAugmented` path (synthetic `task: {}` augmentation
-        // threaded through dispatch args), pulls out the resulting
-        // `taskId`, then drives `runFollowLoop` against the same
-        // `EventSourcedTaskStore` the MCP arm consumes (INV-2 facade
-        // equivalence). SIGINT during the loop emits `task.cancelled`
-        // via the dispatch-core `cancelTask` surface.
-        if (isViewFollow && follow === true) {
-          if (!ctx.taskStore) {
-            const err = buildInvalidInput(
-              `${tool.name}/${action.name}: --follow requires a wired EventSourcedTaskStore; none present on this context`,
-            );
-            emitResult({ success: false, error: err }, isJson, format);
-            process.exitCode = CLI_EXIT_CODES.HANDLER_ERROR;
-            return;
-          }
-
-          // Parse the action args first so a `--workflow-id` typo surfaces
-          // as INVALID_INPUT before we cut a task envelope.
-          const followCoerced = coerceFlags(flagOpts, action.schema);
-          const followParse = action.schema.safeParse(followCoerced);
-          if (!followParse.success) {
-            const errCtx = `${tool.name}/${action.name}`;
-            const err = formatValidationError(followParse.error, errCtx);
-            emitResult({ success: false, error: err }, isJson, format);
-            process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
-            return;
-          }
-
-          // Resolve poll cadence: CLI override (none yet — reserved for a
-          // future `--poll-interval-ms` flag) > `.exarchos.yml`
-          // `cli.followPollIntervalMs` > module default. The loader runs
-          // synchronously and tolerates a missing file (returns null).
-          let pollIntervalMs: number | undefined;
-          try {
-            const { loadExarchosConfig } = await import(
-              '../config/load-exarchos-config.js'
-            );
-            const loaded = loadExarchosConfig(process.cwd());
-            pollIntervalMs = loaded?.config.cli?.followPollIntervalMs;
-          } catch {
-            // Malformed `.exarchos.yml` is surfaced by the broader CLI
-            // load path; in `--follow` we degrade to the default cadence
-            // rather than abort the polling session.
-            pollIntervalMs = undefined;
-          }
-
-          // Wire SIGINT → AbortController. The handler MUST NOT call
-          // `process.exit` — the polling loop awaits `cancelTask` before
-          // returning, then we let the action callback fall through to
-          // its normal return so the event-loop drains cleanly (project-
-          // memory caution).
-          const controller = new AbortController();
-          const onSigint = (): void => controller.abort();
-          process.once('SIGINT', onSigint);
-
-          try {
-            const { runFollowLoop } = await import('../cli/follow-loop.js');
-            // #1440 Op 1 (T7): the routing now flows directly from
-            // `action.name` since `VIEW_FOLLOW_ACTIONS` and the
-            // `FollowSubcommand` union are kept in lockstep — both
-            // describe the same five-element set. The cast is the
-            // bridge from the registry's `string` field to the
-            // narrower literal union; the `isViewFollow` guard above
-            // proves membership before we reach this point.
-            const subcommand = action.name as FollowSubcommand;
-
-            // Dispatch the underlying action through the Tasks-augmented
-            // path so the lifecycle is recorded in the same
-            // `EventSourcedTaskStore` projection the MCP arm reads. The
-            // `task: {}` field is the augmentation signal per C1's
-            // `isTaskAugmented` predicate (presence of a plain object is
-            // sufficient; no `ttl` here means an unbounded task lifetime,
-            // appropriate for an interactive CLI follow session).
-            const createResult = await dispatch(
-              tool.name,
-              {
-                action: action.name,
-                ...followParse.data,
-                task: {},
-              },
-              ctx,
-            );
-
-            // Extract taskId from the CreateTaskResult envelope. Dispatch
-            // wraps the Tasks-augmented response under
-            // `{ success: true, data: { task: { taskId, ... } } }` (see
-            // `runTasksAugmented`'s return shape in C1).
-            const dataCandidate = (createResult as { data?: unknown }).data;
-            const taskCandidate =
-              dataCandidate && typeof dataCandidate === 'object'
-                ? (dataCandidate as { task?: { taskId?: unknown } }).task
-                : undefined;
-            const taskId =
-              taskCandidate && typeof taskCandidate.taskId === 'string'
-                ? taskCandidate.taskId
-                : undefined;
-            if (!createResult.success || !taskId) {
-              // The underlying dispatch already serialised a meaningful
-              // error envelope; surface it untouched.
-              emitResult(createResult, isJson, format);
-              process.exitCode = createResult.success
-                ? CLI_EXIT_CODES.HANDLER_ERROR
-                : createResult.error?.code === VALIDATION_ERROR_CODE
-                  ? CLI_EXIT_CODES.INVALID_INPUT
-                  : CLI_EXIT_CODES.HANDLER_ERROR;
-              return;
-            }
-
-            const loopResult = await runFollowLoop({
-              taskStore: ctx.taskStore,
-              taskId,
-              pollIntervalMs,
-              stdout: process.stdout,
-              subcommand,
-              signal: controller.signal,
-            });
-
-            // Cancellation is a clean exit — the user asked for it. Map
-            // it to SUCCESS so a wrapping shell script doesn't treat ^C
-            // as an error (matches `exarchos event query --follow`'s
-            // SIGINT-on-close discipline).
-            process.exitCode =
-              loopResult.terminalStatus === 'failed'
-                ? CLI_EXIT_CODES.HANDLER_ERROR
-                : CLI_EXIT_CODES.SUCCESS;
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            emitResult(
-              { success: false, error: { code: 'UNCAUGHT_EXCEPTION', message } },
-              isJson,
-              format,
-            );
-            process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
-          } finally {
-            process.off('SIGINT', onSigint);
-          }
-          return;
-        }
-
-        // ─── T042: `--follow` streaming branch ─────────────────────────────
-        if (isEventQuery && follow === true) {
-          const streamFlag = typeof flagOpts.stream === 'string' ? flagOpts.stream : undefined;
-          if (!streamFlag) {
-            const err = buildInvalidInput(
-              `${tool.name}/${action.name}: required option(s) not specified: stream`,
-            );
-            emitResult({ success: false, error: err }, isJson, format);
-            process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
-            return;
-          }
-          try {
-            const { runEventQueryFollow, pollingEventSource } = await import(
-              '../cli-commands/event-query.js'
-            );
-            const source = pollingEventSource({
-              store: ctx.eventStore,
-              streamId: streamFlag,
-            });
-            await runEventQueryFollow({ source, sink: process.stdout });
-            process.exitCode = CLI_EXIT_CODES.SUCCESS;
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            emitResult(
-              { success: false, error: { code: 'UNCAUGHT_EXCEPTION', message } },
-              isJson,
-              format,
-            );
-            process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
-          }
-          return;
-        }
-
-        // ─── INVALID_INPUT (exit 1): required-flag check ──────────────────
-        // Commander can't enforce --flag vs --no-flag for required booleans.
-        const missingBools = validateRequiredBooleans(flagOpts, action.schema);
-        if (missingBools.length > 0) {
-          const err = buildInvalidInput(
-            `${tool.name}/${action.name}: required option(s) not specified: ${missingBools.join(', ')}`,
-          );
-          const errResult: ToolResult = { success: false, error: err };
-          emitResult(errResult, isJson, format);
-          process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
-          return;
-        }
-
-        // ─── INVALID_INPUT (exit 1): Zod validation at CLI layer ──────────
-        // Parse coerced args through the action schema so bad inputs are
-        // surfaced before dispatch runs. DR-5: this funnels through the
-        // shared `formatValidationError` so the MCP adapter emits the same
-        // error.code and an equivalent error.message for the same input.
-        const coerced = coerceFlags(flagOpts, action.schema);
-        const parseResult = action.schema.safeParse(coerced);
-        if (!parseResult.success) {
-          const context = `${tool.name}/${action.name}`;
-          const err = formatValidationError(parseResult.error, context);
-          const errResult: ToolResult = { success: false, error: err };
-          emitResult(errResult, isJson, format);
-          process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
-          return;
-        }
-
-        // ─── Dispatch ─────────────────────────────────────────────────────
-        // Dispatch may return a handler-reported error (exit 2) or throw
-        // an unexpected exception (exit 3). Normalize both into ToolResult.
-        //
-        // DR-5: for actions flagged `longRunning` in the registry, emit
-        // stderr heartbeats under --json so a multi-second silence doesn't
-        // look like a hung process.  Interactive pretty-print mode stays
-        // untouched — a progress spinner belongs to a future UX layer.
-        const heartbeatEnabled = isJson && action.longRunning === true;
-        const stopHeartbeat = heartbeatEnabled
-          ? startHeartbeat(action.name)
-          : null;
-        let result: ToolResult;
-        try {
-          try {
-            result = await dispatch(
-              tool.name,
-              { action: action.name, ...parseResult.data },
-              ctx,
-            );
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            // F-024 dead-code: inlined single-use ToolResult shape — was
-            // previously a `toErrorResult(code, message)` helper used only
-            // from this branch.
-            const errResult: ToolResult = {
-              success: false,
-              error: { code: 'UNCAUGHT_EXCEPTION', message },
-            };
-            emitResult(errResult, isJson, format);
-            process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
-            return;
-          }
-        } finally {
-          // F-023-1: cleanup runs on success, handler-reported errors, AND
-          // uncaught exceptions — a single site so future edits can't leak
-          // timers.
-          stopHeartbeat?.();
-        }
-
-        // ─── Emit + map to exit code ──────────────────────────────────────
-        // Preserve INVALID_INPUT when the handler reports a validation
-        // failure — collapsing every non-success into HANDLER_ERROR loses
-        // parity with the pre-dispatch INVALID_INPUT path (e.g. a bad arg
-        // that slips past Zod at the CLI layer but is caught by a handler
-        // guard should still report exit 1, not exit 2).
-        emitResult(result, isJson, format);
-        if (result.success) {
-          process.exitCode = CLI_EXIT_CODES.SUCCESS;
-        } else if (result.error?.code === VALIDATION_ERROR_CODE) {
-          process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
-        } else {
-          process.exitCode = CLI_EXIT_CODES.HANDLER_ERROR;
-        }
-      });
+      registerActionCommand(
+        toolCmd,
+        tool,
+        action,
+        action.cli?.alias ?? action.name,
+        ctx,
+      );
     }
   }
 
@@ -1219,7 +844,454 @@ export function buildCli(ctx: DispatchContext, options?: BuildCliOptions): Comma
       });
   }
 
+  // ─── DR-7: top-level CLI promotion (hoist loop) ──────────────────────────
+  //
+  // For each action carrying `cli.topLevel`, register a TOP-LEVEL command that
+  // dispatches through the SAME `registerActionCommand` path — same Zod schema,
+  // same handler — as its `<tool> <action>` subcommand form (no divergent
+  // parsing). Runs AFTER every other top-level command is registered so the
+  // collision guard below sees the full top-level namespace (tool groups,
+  // standalone verbs, harness launchers) plus any earlier hoist in this loop.
+  //
+  // Collision guard: a `topLevel` name clashing with an existing top-level
+  // command NAME or ALIAS throws HERE, at registration (build time) — never at
+  // runtime — so a bad promotion can't ship silently. The subcommand form is
+  // untouched and keeps working regardless.
+  for (const tool of cliRegistry) {
+    for (const action of tool.actions) {
+      const topLevel = action.cli?.topLevel;
+      if (topLevel === undefined) continue;
+      const clash = program.commands.find(
+        (c) => c.name() === topLevel || c.aliases().includes(topLevel),
+      );
+      if (clash) {
+        throw new Error(
+          `buildCli: CliActionHints.topLevel '${topLevel}' on action ` +
+            `'${tool.name}/${action.name}' collides with the existing top-level ` +
+            `command '${clash.name()}'. Choose a non-colliding top-level name ` +
+            `or drop the promotion.`,
+        );
+      }
+      registerActionCommand(program, tool, action, topLevel, ctx);
+    }
+  }
+
   return program;
+}
+
+/**
+ * Registers a single composite-tool action as a Commander command under
+ * `parent` with `commandName`, wiring flags from the action's Zod schema and
+ * the shared dispatch handler. Extracted (DR-7) so the auto-generated
+ * `<tool> <action>` subcommand form AND the top-level promotion hoist loop go
+ * through ONE code path — same schema, same handler, no divergent parsing.
+ * `parent` is the tool group for a subcommand, or the root `program` for a
+ * promoted top-level command.
+ */
+function registerActionCommand(
+  parent: Command,
+  tool: CompositeTool,
+  action: ToolAction,
+  commandName: string,
+  ctx: DispatchContext,
+): Command {
+  const actionCmd = parent
+    .command(commandName)
+    .description(action.description);
+
+  addFlagsFromSchema(actionCmd, action.schema, action.cli?.flags);
+
+  // T042 / DR-9: the `exarchos event query` action gains a streaming
+  // `--follow` mode that emits NDJSON frames via the dedicated
+  // `runEventQueryFollow` handler instead of the one-shot dispatch path.
+  // The flag is intentionally registered outside `addFlagsFromSchema` so
+  // the MCP tool schema (which only describes one-shot query args) is
+  // not affected.
+  const isEventQuery =
+    tool.name === 'exarchos_event' && action.name === 'query';
+  if (isEventQuery) {
+    actionCmd.option('--follow', 'Stream events as NDJSON frames until the source closes');
+  }
+
+  // T33 (#1273) / Wave C PR 3 — the `exarchos view` actions listed in
+  // `VIEW_FOLLOW_ACTIONS` gain a `--follow` flag that drives the
+  // dispatch-core `EventSourcedTaskStore` polling loop (see
+  // `cli/follow-loop.ts`). #1440 Op 1 (T7) expanded the set from the
+  // original two-arm disjunction (workflow_status, shepherd_status) to
+  // include three more pure-projection view actions (pipeline,
+  // convergence, delegation_timeline). Like the event-query `--follow`,
+  // this flag is registered outside `addFlagsFromSchema` so the MCP
+  // tool schema for the underlying action stays one-shot — the
+  // Tasks-augmented branch for the MCP arm is gated by the SDK
+  // `task: { ttl }` request parameter, not by a tool-schema field (C2).
+  const isViewFollow =
+    tool.name === 'exarchos_view' && VIEW_FOLLOW_ACTIONS.has(action.name);
+  if (isViewFollow) {
+    actionCmd.option(
+      '--follow',
+      'Stream task lifecycle transitions to stdout until terminal status or SIGINT',
+    );
+  }
+
+  // T5 (#1240): convenience flags on `wf checkpoint` so agents emit a
+  // structured handoff payload without having to type nested JSON.
+  // The flags map to the `handoff` field on the dispatch surface
+  // (which `addFlagsFromSchema` already exposes as
+  // `--handoff <json-or-csv>` for power-user / scripting parity).
+  // `--context` accepts inline strings only — the `@<path>` substitution
+  // sugar is OUT OF SCOPE here (#1245, scheduled v2.12.0). The
+  // variadic syntax `<step...>` lets agents repeat `--next-steps a
+  // --next-steps b` to build the array, mirroring how the MCP arm
+  // would receive `nextSteps: ['a', 'b']`.
+  const isWorkflowCheckpoint =
+    tool.name === 'exarchos_workflow' && action.name === 'checkpoint';
+  if (isWorkflowCheckpoint) {
+    actionCmd.option(
+      '--context <string>',
+      'Handoff context (single inline string, max 2KB). Maps to handoff.context.',
+    );
+    actionCmd.option(
+      '--next-steps <step...>',
+      'Repeatable handoff next-step entry; pass once per entry. Maps to handoff.nextSteps.',
+    );
+    actionCmd.option(
+      '--suggestions <suggestion...>',
+      'Repeatable handoff suggestion entry; pass once per entry. Maps to handoff.suggestions.',
+    );
+  }
+
+  actionCmd.action(async (opts: Record<string, unknown>) => {
+    const { json, follow, ...flagOpts } = opts;
+    const isJson = Boolean(json);
+    const format = action.cli?.format;
+
+    // ─── T5 (#1240): convenience-flag → handoff reshape ───────────────
+    // Done BEFORE `coerceFlags` / `safeParse` so the synthesised
+    // `handoff` is the value that hits both schema validation and
+    // dispatch. Critical contract: when NONE of the convenience
+    // flags are present, `handoff` MUST stay ABSENT — not be set
+    // to `{ context: undefined, nextSteps: undefined, ... }`. The
+    // C3 (#1241) digest is `sha256(handoff ?? {})`, and an
+    // all-undefined object stringifies to `{}` only by coincidence;
+    // explicit absence keeps the digest stable for pre-T5 callers
+    // and for the parity contract with the MCP arm (which passes
+    // `handoff` undefined when the caller didn't populate it).
+    if (isWorkflowCheckpoint) {
+      const ctxOpt = flagOpts.context;
+      const nextStepsOpt = flagOpts.nextSteps;
+      const suggestionsOpt = flagOpts.suggestions;
+      const hasContext = typeof ctxOpt === 'string';
+      const hasNextSteps = Array.isArray(nextStepsOpt) && nextStepsOpt.length > 0;
+      const hasSuggestions =
+        Array.isArray(suggestionsOpt) && suggestionsOpt.length > 0;
+
+      // Reject the conflict where the operator passes both the raw
+      // `--handoff '{...}'` JSON flag AND any convenience flag. Without
+      // this guard the reshape block below would silently overwrite
+      // the JSON-supplied handoff with the synthesized convenience
+      // object — losing data the operator explicitly supplied. The
+      // two surfaces are mutually exclusive: `--handoff` is the full
+      // shape, the convenience flags are field-level sugar.
+      if (
+        flagOpts.handoff !== undefined &&
+        (hasContext || hasNextSteps || hasSuggestions)
+      ) {
+        const err = buildInvalidInput(
+          `${tool.name}/${action.name}: --handoff is mutually exclusive with --context/--next-steps/--suggestions; pass either the full --handoff JSON or the convenience flags, not both`,
+        );
+        emitResult({ success: false, error: err }, isJson, format);
+        process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+        return;
+      }
+
+      if (hasContext || hasNextSteps || hasSuggestions) {
+        // Synthesize `handoff` from the convenience flags. Spread-on-
+        // condition keeps the shape minimal so the rehydration
+        // projection's `latestHandoff` snapshot only carries what
+        // the operator actually supplied (e.g. `{ context: 'x' }`
+        // and not `{ context: 'x', nextSteps: undefined,
+        // suggestions: undefined }`). The handler's
+        // `CheckpointInputSchema.handoff` is a Zod object with all
+        // three fields optional, so omitting them is valid input.
+        flagOpts.handoff = {
+          ...(hasContext ? { context: ctxOpt as string } : {}),
+          ...(hasNextSteps ? { nextSteps: nextStepsOpt as string[] } : {}),
+          ...(hasSuggestions
+            ? { suggestions: suggestionsOpt as string[] }
+            : {}),
+        };
+      }
+      // Strip the convenience-flag aliases so they don't leak into
+      // dispatch args (the schema doesn't declare them; they'd be
+      // silently ignored, but cleaning them up here keeps the
+      // dispatched payload shaped exactly like the MCP arm's).
+      delete flagOpts.context;
+      delete flagOpts.nextSteps;
+      delete flagOpts.suggestions;
+    }
+
+    // ─── T33 (#1273): view `--follow` Tasks polling branch ────────────
+    //
+    // Wave C PR 3 — the CLI equivalent of the MCP `tasks/get` polling
+    // loop. The dispatch creates a task via the dispatch-core
+    // `runTasksAugmented` path (synthetic `task: {}` augmentation
+    // threaded through dispatch args), pulls out the resulting
+    // `taskId`, then drives `runFollowLoop` against the same
+    // `EventSourcedTaskStore` the MCP arm consumes (INV-2 facade
+    // equivalence). SIGINT during the loop emits `task.cancelled`
+    // via the dispatch-core `cancelTask` surface.
+    if (isViewFollow && follow === true) {
+      if (!ctx.taskStore) {
+        const err = buildInvalidInput(
+          `${tool.name}/${action.name}: --follow requires a wired EventSourcedTaskStore; none present on this context`,
+        );
+        emitResult({ success: false, error: err }, isJson, format);
+        process.exitCode = CLI_EXIT_CODES.HANDLER_ERROR;
+        return;
+      }
+
+      // Parse the action args first so a `--workflow-id` typo surfaces
+      // as INVALID_INPUT before we cut a task envelope.
+      const followCoerced = coerceFlags(flagOpts, action.schema);
+      const followParse = action.schema.safeParse(followCoerced);
+      if (!followParse.success) {
+        const errCtx = `${tool.name}/${action.name}`;
+        const err = formatValidationError(followParse.error, errCtx);
+        emitResult({ success: false, error: err }, isJson, format);
+        process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+        return;
+      }
+
+      // Resolve poll cadence: CLI override (none yet — reserved for a
+      // future `--poll-interval-ms` flag) > `.exarchos.yml`
+      // `cli.followPollIntervalMs` > module default. The loader runs
+      // synchronously and tolerates a missing file (returns null).
+      let pollIntervalMs: number | undefined;
+      try {
+        const { loadExarchosConfig } = await import(
+          '../config/load-exarchos-config.js'
+        );
+        const loaded = loadExarchosConfig(process.cwd());
+        pollIntervalMs = loaded?.config.cli?.followPollIntervalMs;
+      } catch {
+        // Malformed `.exarchos.yml` is surfaced by the broader CLI
+        // load path; in `--follow` we degrade to the default cadence
+        // rather than abort the polling session.
+        pollIntervalMs = undefined;
+      }
+
+      // Wire SIGINT → AbortController. The handler MUST NOT call
+      // `process.exit` — the polling loop awaits `cancelTask` before
+      // returning, then we let the action callback fall through to
+      // its normal return so the event-loop drains cleanly (project-
+      // memory caution).
+      const controller = new AbortController();
+      const onSigint = (): void => controller.abort();
+      process.once('SIGINT', onSigint);
+
+      try {
+        const { runFollowLoop } = await import('../cli/follow-loop.js');
+        // #1440 Op 1 (T7): the routing now flows directly from
+        // `action.name` since `VIEW_FOLLOW_ACTIONS` and the
+        // `FollowSubcommand` union are kept in lockstep — both
+        // describe the same five-element set. The cast is the
+        // bridge from the registry's `string` field to the
+        // narrower literal union; the `isViewFollow` guard above
+        // proves membership before we reach this point.
+        const subcommand = action.name as FollowSubcommand;
+
+        // Dispatch the underlying action through the Tasks-augmented
+        // path so the lifecycle is recorded in the same
+        // `EventSourcedTaskStore` projection the MCP arm reads. The
+        // `task: {}` field is the augmentation signal per C1's
+        // `isTaskAugmented` predicate (presence of a plain object is
+        // sufficient; no `ttl` here means an unbounded task lifetime,
+        // appropriate for an interactive CLI follow session).
+        const createResult = await dispatch(
+          tool.name,
+          {
+            action: action.name,
+            ...followParse.data,
+            task: {},
+          },
+          ctx,
+        );
+
+        // Extract taskId from the CreateTaskResult envelope. Dispatch
+        // wraps the Tasks-augmented response under
+        // `{ success: true, data: { task: { taskId, ... } } }` (see
+        // `runTasksAugmented`'s return shape in C1).
+        const dataCandidate = (createResult as { data?: unknown }).data;
+        const taskCandidate =
+          dataCandidate && typeof dataCandidate === 'object'
+            ? (dataCandidate as { task?: { taskId?: unknown } }).task
+            : undefined;
+        const taskId =
+          taskCandidate && typeof taskCandidate.taskId === 'string'
+            ? taskCandidate.taskId
+            : undefined;
+        if (!createResult.success || !taskId) {
+          // The underlying dispatch already serialised a meaningful
+          // error envelope; surface it untouched.
+          emitResult(createResult, isJson, format);
+          process.exitCode = createResult.success
+            ? CLI_EXIT_CODES.HANDLER_ERROR
+            : createResult.error?.code === VALIDATION_ERROR_CODE
+              ? CLI_EXIT_CODES.INVALID_INPUT
+              : CLI_EXIT_CODES.HANDLER_ERROR;
+          return;
+        }
+
+        const loopResult = await runFollowLoop({
+          taskStore: ctx.taskStore,
+          taskId,
+          pollIntervalMs,
+          stdout: process.stdout,
+          subcommand,
+          signal: controller.signal,
+        });
+
+        // Cancellation is a clean exit — the user asked for it. Map
+        // it to SUCCESS so a wrapping shell script doesn't treat ^C
+        // as an error (matches `exarchos event query --follow`'s
+        // SIGINT-on-close discipline).
+        process.exitCode =
+          loopResult.terminalStatus === 'failed'
+            ? CLI_EXIT_CODES.HANDLER_ERROR
+            : CLI_EXIT_CODES.SUCCESS;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        emitResult(
+          { success: false, error: { code: 'UNCAUGHT_EXCEPTION', message } },
+          isJson,
+          format,
+        );
+        process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
+      } finally {
+        process.off('SIGINT', onSigint);
+      }
+      return;
+    }
+
+    // ─── T042: `--follow` streaming branch ─────────────────────────────
+    if (isEventQuery && follow === true) {
+      const streamFlag = typeof flagOpts.stream === 'string' ? flagOpts.stream : undefined;
+      if (!streamFlag) {
+        const err = buildInvalidInput(
+          `${tool.name}/${action.name}: required option(s) not specified: stream`,
+        );
+        emitResult({ success: false, error: err }, isJson, format);
+        process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+        return;
+      }
+      try {
+        const { runEventQueryFollow, pollingEventSource } = await import(
+          '../cli-commands/event-query.js'
+        );
+        const source = pollingEventSource({
+          store: ctx.eventStore,
+          streamId: streamFlag,
+        });
+        await runEventQueryFollow({ source, sink: process.stdout });
+        process.exitCode = CLI_EXIT_CODES.SUCCESS;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        emitResult(
+          { success: false, error: { code: 'UNCAUGHT_EXCEPTION', message } },
+          isJson,
+          format,
+        );
+        process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
+      }
+      return;
+    }
+
+    // ─── INVALID_INPUT (exit 1): required-flag check ──────────────────
+    // Commander can't enforce --flag vs --no-flag for required booleans.
+    const missingBools = validateRequiredBooleans(flagOpts, action.schema);
+    if (missingBools.length > 0) {
+      const err = buildInvalidInput(
+        `${tool.name}/${action.name}: required option(s) not specified: ${missingBools.join(', ')}`,
+      );
+      const errResult: ToolResult = { success: false, error: err };
+      emitResult(errResult, isJson, format);
+      process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+      return;
+    }
+
+    // ─── INVALID_INPUT (exit 1): Zod validation at CLI layer ──────────
+    // Parse coerced args through the action schema so bad inputs are
+    // surfaced before dispatch runs. DR-5: this funnels through the
+    // shared `formatValidationError` so the MCP adapter emits the same
+    // error.code and an equivalent error.message for the same input.
+    const coerced = coerceFlags(flagOpts, action.schema);
+    const parseResult = action.schema.safeParse(coerced);
+    if (!parseResult.success) {
+      const context = `${tool.name}/${action.name}`;
+      const err = formatValidationError(parseResult.error, context);
+      const errResult: ToolResult = { success: false, error: err };
+      emitResult(errResult, isJson, format);
+      process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+      return;
+    }
+
+    // ─── Dispatch ─────────────────────────────────────────────────────
+    // Dispatch may return a handler-reported error (exit 2) or throw
+    // an unexpected exception (exit 3). Normalize both into ToolResult.
+    //
+    // DR-5: for actions flagged `longRunning` in the registry, emit
+    // stderr heartbeats under --json so a multi-second silence doesn't
+    // look like a hung process.  Interactive pretty-print mode stays
+    // untouched — a progress spinner belongs to a future UX layer.
+    const heartbeatEnabled = isJson && action.longRunning === true;
+    const stopHeartbeat = heartbeatEnabled
+      ? startHeartbeat(action.name)
+      : null;
+    let result: ToolResult;
+    try {
+      try {
+        result = await dispatch(
+          tool.name,
+          { action: action.name, ...parseResult.data },
+          ctx,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // F-024 dead-code: inlined single-use ToolResult shape — was
+        // previously a `toErrorResult(code, message)` helper used only
+        // from this branch.
+        const errResult: ToolResult = {
+          success: false,
+          error: { code: 'UNCAUGHT_EXCEPTION', message },
+        };
+        emitResult(errResult, isJson, format);
+        process.exitCode = CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
+        return;
+      }
+    } finally {
+      // F-023-1: cleanup runs on success, handler-reported errors, AND
+      // uncaught exceptions — a single site so future edits can't leak
+      // timers.
+      stopHeartbeat?.();
+    }
+
+    // ─── Emit + map to exit code ──────────────────────────────────────
+    // Preserve INVALID_INPUT when the handler reports a validation
+    // failure — collapsing every non-success into HANDLER_ERROR loses
+    // parity with the pre-dispatch INVALID_INPUT path (e.g. a bad arg
+    // that slips past Zod at the CLI layer but is caught by a handler
+    // guard should still report exit 1, not exit 2).
+    emitResult(result, isJson, format);
+    if (result.success) {
+      process.exitCode = CLI_EXIT_CODES.SUCCESS;
+    } else if (result.error?.code === VALIDATION_ERROR_CODE) {
+      process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
+    } else {
+      process.exitCode = CLI_EXIT_CODES.HANDLER_ERROR;
+    }
+  });
+
+  return actionCmd;
 }
 
 // ─── Commander-Error → INVALID_INPUT (DR-5) ────────────────────────────────

--- a/servers/exarchos-mcp/src/adapters/cli.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.ts
@@ -61,6 +61,51 @@ export const CLI_EXIT_CODES = {
 
 export type CliExitCode = (typeof CLI_EXIT_CODES)[keyof typeof CLI_EXIT_CODES];
 
+// ─── DR-7: generic errorCode → exit-code map (presentation only) ─────────────
+
+/**
+ * Generic `errorCode → exit-code` table (DR-7). This is PRESENTATION metadata,
+ * NOT business logic: it lets a shell caller branch on a `wait` outcome by exit
+ * code alone (`$? == 17`) without parsing the JSON envelope. The map is a plain
+ * lookup consulted by {@link resolveExitCode} BEFORE the generic
+ * INVALID_INPUT/HANDLER_ERROR fallback, so it is purely additive — any error
+ * code NOT listed here keeps the pre-DR-7 mapping.
+ *
+ * - `WAIT_TIMEOUT` → 17: the bounded `wait` expired before its predicate held.
+ * - `WAIT_FAILED`  → 18: a terminal that can never satisfy the predicate arrived
+ *   first (e.g. a failed/cancelled workflow while waiting for `completed`).
+ *
+ * The codes ride `result.error.code` from the `wait` handler
+ * (`views/lifecycle/wait.ts`); the exit codes (17/18) sit above the 0-3 generic
+ * band so they never alias SUCCESS/INVALID_INPUT/HANDLER_ERROR/UNCAUGHT.
+ */
+export const ERROR_CODE_EXIT_CODES: Readonly<Record<string, number>> = {
+  WAIT_TIMEOUT: 17,
+  WAIT_FAILED: 18,
+};
+
+/**
+ * Map a dispatched {@link ToolResult} to its process exit code (DR-7).
+ *
+ * Resolution order (presentation only — never consulted for control flow):
+ *   1. success            → SUCCESS (0)
+ *   2. code in the DR-7 map → its mapped value (WAIT_TIMEOUT 17 / WAIT_FAILED 18)
+ *   3. code === INVALID_INPUT (VALIDATION_ERROR_CODE) → INVALID_INPUT (1)
+ *   4. any other handler error → HANDLER_ERROR (2)
+ *
+ * Steps 1/3/4 reproduce the pre-DR-7 mapping exactly, so this is a superset:
+ * only the two `wait` codes gain a distinct exit code.
+ */
+export function resolveExitCode(result: ToolResult): number {
+  if (result.success) return CLI_EXIT_CODES.SUCCESS;
+  const code = result.error?.code;
+  if (code !== undefined && Object.prototype.hasOwnProperty.call(ERROR_CODE_EXIT_CODES, code)) {
+    return ERROR_CODE_EXIT_CODES[code];
+  }
+  if (code === VALIDATION_ERROR_CODE) return CLI_EXIT_CODES.INVALID_INPUT;
+  return CLI_EXIT_CODES.HANDLER_ERROR;
+}
+
 // ─── Error-Shape Helpers ────────────────────────────────────────────────────
 
 /**
@@ -1361,19 +1406,17 @@ function registerActionCommand(
     }
 
     // ─── Emit + map to exit code ──────────────────────────────────────
-    // Preserve INVALID_INPUT when the handler reports a validation
-    // failure — collapsing every non-success into HANDLER_ERROR loses
-    // parity with the pre-dispatch INVALID_INPUT path (e.g. a bad arg
-    // that slips past Zod at the CLI layer but is caught by a handler
-    // guard should still report exit 1, not exit 2).
+    // DR-7: `resolveExitCode` funnels the handler result through the generic
+    // errorCode→exitCode table (WAIT_TIMEOUT→17 / WAIT_FAILED→18) BEFORE the
+    // generic fallback. It preserves the prior mapping exactly — INVALID_INPUT
+    // stays exit 1 when the handler reports a validation failure (collapsing
+    // every non-success into HANDLER_ERROR would lose parity with the
+    // pre-dispatch INVALID_INPUT path), any other handler error stays exit 2 —
+    // so only the two structured `wait` codes gain a distinct exit code. The
+    // SAME site serves both the `vw <verb>` subcommand and the DR-7 top-level
+    // promotion (both route through this one registerActionCommand handler).
     emitResult(result, isJson, format);
-    if (result.success) {
-      process.exitCode = CLI_EXIT_CODES.SUCCESS;
-    } else if (result.error?.code === VALIDATION_ERROR_CODE) {
-      process.exitCode = CLI_EXIT_CODES.INVALID_INPUT;
-    } else {
-      process.exitCode = CLI_EXIT_CODES.HANDLER_ERROR;
-    }
+    process.exitCode = resolveExitCode(result);
   });
 
   return actionCmd;

--- a/servers/exarchos-mcp/src/cli-commands/run-mutation.ts
+++ b/servers/exarchos-mcp/src/cli-commands/run-mutation.ts
@@ -66,6 +66,14 @@ export interface RunMutationDeps {
   eventStore?: RunMutationEventStore;
   /** Stream to emit liveness events on (typically the active featureId). */
   stream?: string;
+  /**
+   * DR-2 — canonical INV-10 liveness instance key for the mutation surface. When
+   * provided it is stamped (additive) as `instanceId` on BOTH liveness events so
+   * a uniform liveness view can correlate the mutation start↔terminal without
+   * per-surface field knowledge. Omitted (no `instanceId` field) when absent, so
+   * a pre-retrofit / operation-less invocation still validates.
+   */
+  operationId?: string;
 }
 
 /** Fire-and-forget emit that never throws into the run path (degrade per INV-4). */
@@ -129,9 +137,15 @@ export function handleRunMutation(argv: readonly string[], deps: RunMutationDeps
   const run: (cmd: string, args: readonly string[], runCwd: string) => number = canEmit
     ? (cmd, args, runCwd) => {
         const command = resolved.mutation ?? cmd;
+        // DR-2 — stamp the canonical liveness instance key (additive) only when
+        // an operationId is supplied; omit the field otherwise so operation-less
+        // invocations stay valid against the additive-optional schema.
+        const instanceIdField =
+          deps.operationId !== undefined ? { instanceId: deps.operationId } : {};
         emitLiveness(deps.eventStore!, deps.stream!, 'mutation.executing_started', {
           command,
           repoRoot: runCwd,
+          ...instanceIdField,
         });
         const exitCode = baseRun(cmd, args, runCwd);
         emitLiveness(deps.eventStore!, deps.stream!, 'mutation.executed', {
@@ -139,6 +153,7 @@ export function handleRunMutation(argv: readonly string[], deps: RunMutationDeps
           repoRoot: runCwd,
           passed: exitCode === 0,
           exitCode,
+          ...instanceIdField,
         });
         return exitCode;
       }

--- a/servers/exarchos-mcp/src/cli/follow-loop.ts
+++ b/servers/exarchos-mcp/src/cli/follow-loop.ts
@@ -385,7 +385,17 @@ export function runInspectFollow(opts: InspectFollowOptions): InspectFollowHandl
         activitySinceTick = false;
         return;
       }
-      opts.onFrame({ type: 'heartbeat', timestamp: new Date(now()).toISOString() });
+      try {
+        opts.onFrame({ type: 'heartbeat', timestamp: new Date(now()).toISOString() });
+      } catch {
+        // Isolate the caller-supplied sink (NDJSON encoder write / MCP
+        // task-update push) from the tick — same gap, and same containment, as
+        // `Subscription.floorTick()` in event-store/subscriptions.ts. This runs
+        // inside `scheduleInterval`, so an escaping throw is an unhandled
+        // process-level exception rather than one dropped frame. A lost
+        // heartbeat is cosmetic: it carries no state, real event frames flow
+        // through the subscription path, and the next tick re-emits.
+      }
     }, heartbeatIntervalMs);
   }
 

--- a/servers/exarchos-mcp/src/cli/follow-loop.ts
+++ b/servers/exarchos-mcp/src/cli/follow-loop.ts
@@ -51,6 +51,15 @@ import {
   formatTransition,
   type FollowSubcommand,
 } from './follow-formatter.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import type {
+  SubscribeOptions,
+  SubscriptionClock,
+  SubscriptionFilter,
+  SubscriptionHandle,
+  SubscriptionListener,
+} from '../event-store/subscriptions.js';
+import type { Frame } from '../ndjson/frames.js';
 
 /**
  * Minimum slice of the SDK `TaskStore` interface the polling loop
@@ -218,4 +227,187 @@ export async function runFollowLoop(
 
     await sleep(pollIntervalMs, signal);
   }
+}
+
+// ─── DR-4: subscription-fed `inspect --follow` carrier ───────────────────────
+//
+// The task-polling loop above (`runFollowLoop`) tails the SDK `TaskStore`
+// projection for the `workflow_status` / `shepherd_status` view actions.
+// `inspect --follow` is a DIFFERENT shape: it tails ONE workflow's raw event
+// stream live over the DR-1 cursor-pump subscription (see
+// `event-store/subscriptions.ts`), framing each delivered event as an NDJSON
+// `event` frame. Both streaming facades — the CLI NDJSON carrier and the MCP
+// Tasks arm (`mcp/tasks-methods.ts`) — drive this SAME core over the SAME
+// subscription contract, so they emit byte-identical frame streams (INV-2).
+//
+// Two invariants shape the core:
+//   • DEDUP BY SEQUENCE (monotonic). A monotonic cursor drops any event whose
+//     sequence is at-or-below the last-emitted one, so the frame stream carries
+//     each sequence EXACTLY ONCE in ascending order. The DR-1 subscription
+//     already guarantees exactly-once in-order delivery; this cursor is
+//     defence-in-depth over that guarantee AND the seam a future snapshot+tail
+//     overlap needs (a snapshot's trailing events re-delivered by the tail's
+//     initial drain collapse to one frame each).
+//   • INJECTED-TIMER HEARTBEAT (INV-16 — no wall-clock). Heartbeat frames on
+//     silence are scheduled through the injected {@link SubscriptionClock}, not
+//     `setInterval` + `Date.now()` directly, so tests drive both the cadence
+//     (`scheduleInterval`) and the frame timestamp (`now`) deterministically.
+//     A tick that follows real event activity RESETS instead of emitting, so a
+//     heartbeat marks a genuine idle gap rather than merely elapsed time.
+//
+// Disposal is AbortSignal-driven (no POSIX-only signal semantics): aborting the
+// signal — SIGINT on the CLI, `tasks/cancel` on the MCP arm — disposes the
+// subscription, cancels the heartbeat, and writes a terminal `end` frame.
+
+/**
+ * The slice of the DR-1 subscription contract the follow carrier drives
+ * (`EventStore.subscribe` satisfies it). Declared structurally so tests can
+ * inject a hermetic subscribe fixture without a real EventStore.
+ */
+export type FollowSubscribe = (
+  filter: SubscriptionFilter,
+  onEvent: SubscriptionListener,
+  options?: SubscribeOptions,
+) => SubscriptionHandle;
+
+/**
+ * Default idle-heartbeat cadence (ms) for the `inspect --follow` carrier —
+ * matches `event query --follow`'s 30s so an HTTP/WS intermediary doesn't tear
+ * down an idle stream.
+ */
+export const DEFAULT_FOLLOW_HEARTBEAT_MS = 30_000;
+
+export interface InspectFollowOptions {
+  /** DR-1 subscription contract (`EventStore.subscribe` in production). */
+  readonly subscribe: FollowSubscribe;
+  /** Workflow to tail — becomes the subscription filter's `streamId`. */
+  readonly featureId: string;
+  /**
+   * Start the cursor here (subscription sees events at-or-after
+   * `fromSequence + 1`). The CLI passes `0` so the follow stream is
+   * self-contained (existing events + live tail); omitting it tails only
+   * events committed after registration.
+   */
+  readonly fromSequence?: number;
+  /** Carrier sink: an NDJSON encoder (CLI) or a task-update pump (MCP). */
+  readonly onFrame: (frame: Frame) => void;
+  /** Disposal handle — abort disposes the subscription and ends the stream. */
+  readonly signal: AbortSignal;
+  /**
+   * Injected heartbeat timer (INV-16). When it omits `scheduleInterval` (a bare
+   * `{ now }` clock) the carrier runs with NO heartbeat; production CLI passes
+   * {@link defaultFollowClock}.
+   */
+  readonly clock?: SubscriptionClock;
+  /** Idle heartbeat interval (ms). Defaults to {@link DEFAULT_FOLLOW_HEARTBEAT_MS}. */
+  readonly heartbeatIntervalMs?: number;
+}
+
+export interface InspectFollowHandle {
+  /** Resolves once the stream has ended (signal aborted or {@link dispose}). */
+  readonly done: Promise<void>;
+  /** True once the underlying DR-1 subscription has been disposed. */
+  disposed(): boolean;
+  /**
+   * Force-dispose (idempotent) — the same teardown the abort path runs. The
+   * MCP `tasks/cancel` arm calls this to turn a task cancellation into a
+   * subscription dispose.
+   */
+  dispose(): void;
+}
+
+/**
+ * A real host-timer clock for the carrier's heartbeat. Unlike the
+ * subscription registry's default clock this interval is deliberately NOT
+ * `unref`'d: the heartbeat is the CLI follow session's keep-alive, holding the
+ * process open until SIGINT aborts the signal (there is no polling loop to do
+ * so). Tests inject a manual clock and never touch this.
+ */
+export function defaultFollowClock(): SubscriptionClock {
+  return {
+    now: () => Date.now(),
+    scheduleInterval: (tick, intervalMs) => {
+      const timer = setInterval(tick, intervalMs);
+      return () => clearInterval(timer);
+    },
+  };
+}
+
+/**
+ * Tail one workflow's event stream as a frame stream over the DR-1
+ * subscription. Returns immediately with a handle; the initial drain (existing
+ * events at-or-after the cursor) is delivered synchronously during
+ * {@link InspectFollowOptions.subscribe}, and live events arrive as the source
+ * commits. The stream ends when the signal aborts or {@link dispose} is called.
+ */
+export function runInspectFollow(opts: InspectFollowOptions): InspectFollowHandle {
+  const heartbeatIntervalMs = opts.heartbeatIntervalMs ?? DEFAULT_FOLLOW_HEARTBEAT_MS;
+
+  // Monotonic dedup cursor. `fromSequence` (when set) is the initial cursor, so
+  // an event re-delivered at or below it is dropped; otherwise start below the
+  // first possible sequence (events are 1-based) so nothing is filtered.
+  let lastEmitted = opts.fromSequence ?? 0;
+  let ended = false;
+  // Set on every emitted event; a heartbeat tick that sees it RESETS instead of
+  // firing, so heartbeats mark genuine idle gaps ("on silence"), not activity.
+  let activitySinceTick = false;
+  let cancelHeartbeat: (() => void) | undefined;
+  let resolveDone!: () => void;
+  const done = new Promise<void>((res) => {
+    resolveDone = res;
+  });
+
+  const handle = opts.subscribe(
+    { streamId: opts.featureId },
+    (event: WorkflowEvent) => {
+      if (ended) return;
+      // DEDUP BY SEQUENCE (monotonic): drop anything not strictly newer.
+      if (event.sequence <= lastEmitted) return;
+      lastEmitted = event.sequence;
+      activitySinceTick = true;
+      opts.onFrame({ type: 'event', event, sequence: event.sequence });
+    },
+    opts.fromSequence !== undefined ? { fromSequence: opts.fromSequence } : undefined,
+  );
+
+  // Call the clock methods as methods (never detach them) so an injected clock
+  // may keep instance state on `this` — matching the subscription registry's
+  // own convention.
+  const clock = opts.clock;
+  const now = (): number => (clock ? clock.now() : Date.now());
+  if (clock?.scheduleInterval) {
+    cancelHeartbeat = clock.scheduleInterval(() => {
+      if (ended) return;
+      // Heartbeat ONLY on silence: a tick that follows real event activity
+      // resets the idle marker rather than emitting a frame (INV-16 timing +
+      // frame timestamp both come from the injected clock — no wall-clock).
+      if (activitySinceTick) {
+        activitySinceTick = false;
+        return;
+      }
+      opts.onFrame({ type: 'heartbeat', timestamp: new Date(now()).toISOString() });
+    }, heartbeatIntervalMs);
+  }
+
+  const end = (reason: string): void => {
+    if (ended) return;
+    ended = true;
+    cancelHeartbeat?.();
+    cancelHeartbeat = undefined;
+    handle.dispose();
+    opts.onFrame({ type: 'end', reason });
+    resolveDone();
+  };
+
+  if (opts.signal.aborted) {
+    end('aborted');
+  } else {
+    opts.signal.addEventListener('abort', () => end('aborted'), { once: true });
+  }
+
+  return {
+    done,
+    disposed: () => handle.disposed,
+    dispose: () => end('disposed'),
+  };
 }

--- a/servers/exarchos-mcp/src/cli/follow-loop.ts
+++ b/servers/exarchos-mcp/src/cli/follow-loop.ts
@@ -389,11 +389,20 @@ export function runInspectFollow(opts: InspectFollowOptions): InspectFollowHandl
     }, heartbeatIntervalMs);
   }
 
+  // Single abort-listener reference so the SAME function can be removed on
+  // teardown — a stream that ends by `dispose()` (never abort) must not leave a
+  // live `abort` listener pinned to a long-lived external AbortSignal (SIGINT
+  // wiring / server session). `{ once: true }` covers the abort-fired case; this
+  // covers the dispose-first case. Both disposal entry points still converge on
+  // the SINGLE `end()` → `handle.dispose()` route.
+  const onAbort = (): void => end('aborted');
+
   const end = (reason: string): void => {
     if (ended) return;
     ended = true;
     cancelHeartbeat?.();
     cancelHeartbeat = undefined;
+    opts.signal.removeEventListener('abort', onAbort);
     handle.dispose();
     opts.onFrame({ type: 'end', reason });
     resolveDone();
@@ -402,7 +411,7 @@ export function runInspectFollow(opts: InspectFollowOptions): InspectFollowHandl
   if (opts.signal.aborted) {
     end('aborted');
   } else {
-    opts.signal.addEventListener('abort', () => end('aborted'), { once: true });
+    opts.signal.addEventListener('abort', onAbort, { once: true });
   }
 
   return {

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -366,6 +366,21 @@ export class AtomicAppender {
   /** Durability posture for lazily-constructed backends (DR-4). */
   private readonly synchronous?: 'normal' | 'full';
 
+  /**
+   * DR-1 Tier-1 post-commit hook (#1315). Fired with the committed stream id
+   * AFTER the append transaction commits AND AFTER the per-stream mutex
+   * releases — never inside the lock, so a listener that itself appends to
+   * the same stream re-enters the normal append path without deadlocking the
+   * non-reentrant Promise-chain mutex. Only fresh commits fire it:
+   * INV-8 idempotency cache-hits (pre-transaction short-circuit) and every
+   * failure branch commit nothing and do NOT wake.
+   *
+   * Wired by `EventStore` to the `SubscriptionRegistry`. Undefined until the
+   * first subscription is registered, so the zero-subscriber hot path costs a
+   * single `undefined` check in {@link notifyCommit}.
+   */
+  private commitHook?: (streamId: string) => void;
+
   constructor(options: AtomicAppenderOptions) {
     this.stateDir = options.stateDir;
     this.sqliteDbFilename = options.sqliteDbFilename ?? STORE_DB_FILENAME;
@@ -383,15 +398,40 @@ export class AtomicAppender {
     }
   }
 
+  /**
+   * Install (or clear) the DR-1 Tier-1 post-commit hook (#1315). Idempotent
+   * setter owned by `EventStore`; passing `undefined` detaches it. See
+   * {@link commitHook}.
+   */
+  setCommitHook(hook: ((streamId: string) => void) | undefined): void {
+    this.commitHook = hook;
+  }
+
+  /**
+   * Fire the Tier-1 hook iff a fresh commit happened. Called by every append
+   * entry point AFTER `runExclusive` has resolved — i.e. after the per-stream
+   * mutex's `finally` released the lock — so the hook runs outside the lock
+   * (deadlock-free re-entrant append) and only for `kind: 'committed'`
+   * (INV-8 cache-hits and failures never wake). Zero-subscriber hot path:
+   * a single `undefined` guard, no allocation, no listener work.
+   */
+  private notifyCommit(streamId: string, result: AppendResult): void {
+    const hook = this.commitHook;
+    if (hook === undefined) return;
+    if (result.ok && result.kind === 'committed') hook(streamId);
+  }
+
   async append(
     streamId: string,
     events: EventInput[],
     idempotencyKey: string,
     options?: AppendOptions,
   ): Promise<AppendResult> {
-    return this.locks.runExclusive(streamId, () =>
+    const result = await this.locks.runExclusive(streamId, () =>
       this.appendSqliteLocked(streamId, events, { idempotencyKey }, options),
     );
+    this.notifyCommit(streamId, result);
+    return result;
   }
 
   /**
@@ -407,9 +447,11 @@ export class AtomicAppender {
     events: EventInput[],
     options?: AppendOptions,
   ): Promise<AppendResult> {
-    return this.locks.runExclusive(streamId, () =>
+    const result = await this.locks.runExclusive(streamId, () =>
       this.appendSqliteLocked(streamId, events, null, options),
     );
+    this.notifyCommit(streamId, result);
+    return result;
   }
 
   /**
@@ -432,7 +474,7 @@ export class AtomicAppender {
     compute: () => Promise<EventInput[]>,
     options?: AppendOptions,
   ): Promise<AppendResult> {
-    return this.locks.runExclusive(streamId, async () => {
+    const result = await this.locks.runExclusive(streamId, async () => {
       const events = await compute();
       return this.appendSqliteLocked(
         streamId,
@@ -441,6 +483,8 @@ export class AtomicAppender {
         options,
       );
     });
+    this.notifyCommit(streamId, result);
+    return result;
   }
 
   /**

--- a/servers/exarchos-mcp/src/event-store/index.ts
+++ b/servers/exarchos-mcp/src/event-store/index.ts
@@ -49,5 +49,6 @@ export {
   type SubscriptionFilter,
   type SubscriptionHandle,
   type SubscriptionListener,
+  type SubscriptionPerf,
   type SubscriptionRegistryOptions,
 } from './subscriptions.js';

--- a/servers/exarchos-mcp/src/event-store/index.ts
+++ b/servers/exarchos-mcp/src/event-store/index.ts
@@ -39,3 +39,15 @@ export {
 export type { InvalidSessionOptionsSuggestedFix } from './session-errors.js';
 
 export { EventStore } from './store.js';
+
+export {
+  SubscriptionRegistry,
+  DEFAULT_FLOOR_MS,
+  type SubscribeOptions,
+  type SubscriptionClock,
+  type SubscriptionEventReader,
+  type SubscriptionFilter,
+  type SubscriptionHandle,
+  type SubscriptionListener,
+  type SubscriptionRegistryOptions,
+} from './subscriptions.js';

--- a/servers/exarchos-mcp/src/event-store/liveness-instance-id.emitters.test.ts
+++ b/servers/exarchos-mcp/src/event-store/liveness-instance-id.emitters.test.ts
@@ -1,0 +1,252 @@
+// ─── DR-2 (task 003): all four liveness emitters stamp a canonical instanceId ─
+//
+// Characterization at the EMISSION boundary. Each of the four INV-10 liveness
+// surfaces — merge / launch / mutation / prune — is driven through its real
+// emission seam and the emitted START + TERMINAL payloads are validated against
+// the REAL exported Zod schemas (not hand-mocked validators), asserting each
+// carries the canonical, additive `instanceId`:
+//   • merge    → taskId ?? `${sourceBranch}→${targetBranch}`
+//   • launch   → worktreeId
+//   • mutation → operationId
+//   • prune    → the existing per-pass operationId
+//
+// merge / launch / prune append to a REAL EventStore (per-test tmp dir); the
+// mutation verb emits through its structural `{append}` seam. `EventStore.append`
+// validates only the envelope, so every emitted `data` is re-parsed here with the
+// surface's exported schema — that is the real validator the boundary note asks
+// for.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from './store.js';
+import {
+  MergeExecutingStartedData,
+  MergeExecutedData,
+  LaunchExecutingStartedData,
+  LaunchExecutedData,
+  MutationExecutingStartedData,
+  MutationExecutedData,
+  PruneExecutingStartedData,
+  PruneExecutedData,
+  type WorkflowEvent,
+} from './schemas.js';
+import { rmrfAsync } from '../test-helpers/temp-dir.js';
+import type { DispatchContext } from '../core/dispatch.js';
+import { handleExecuteMerge } from '../orchestrate/execute-merge.js';
+// Side-effect: register `merge-orchestrator@v1` so the executor's Phase A
+// `decide` closure can resolve the reducer against a real EventStore.
+import '../projections/merge-orchestrator/index.js';
+import {
+  emitLaunchExecutingStarted,
+  emitLaunchExecuted,
+} from '../launcher/liveness.js';
+import { WorktreeManager, WORKTREES_STREAM } from '../orchestrate/worktree/manager.js';
+import { handleRunMutation } from '../cli-commands/run-mutation.js';
+import type { ResolvedVerificationRuntime } from '../config/test-runtime-resolver.js';
+
+const scratchDirs: string[] = [];
+
+async function makeStore(prefix: string): Promise<{ store: EventStore; stateDir: string }> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), prefix));
+  scratchDirs.push(stateDir);
+  await mkdir(path.join(stateDir, 'workflow-state'), { recursive: true });
+  const store = new EventStore(stateDir);
+  await store.initialize();
+  return { store, stateDir };
+}
+
+/** Init a real git repo (one commit, no linked worktrees) — prune's ground truth. */
+async function initRepo(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  scratchDirs.push(dir);
+  const git = (args: readonly string[]): void => {
+    execFileSync('git', args as string[], { cwd: dir, stdio: 'ignore' });
+  };
+  git(['init', '-q', '-b', 'work']);
+  git(['config', 'user.email', 'dr2@example.com']);
+  git(['config', 'user.name', 'DR2 Test']);
+  git(['config', 'commit.gpgsign', 'false']);
+  await writeFile(path.join(dir, 'README.md'), '# dr2 liveness instanceId test\n');
+  git(['add', '.']);
+  git(['commit', '-q', '-m', 'init']);
+  return realpathSync(dir);
+}
+
+function makeCtx(eventStore: EventStore, stateDir: string): DispatchContext {
+  return { stateDir, eventStore, enableTelemetry: false } as unknown as DispatchContext;
+}
+
+/** gitExec stub — `git rev-parse HEAD` yields the recovery-point sha. */
+function makeGitExec(recoverySha: string) {
+  return vi.fn().mockImplementation((_repo: string, args: readonly string[]) => {
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+      return { stdout: `${recoverySha}\n`, exitCode: 0 };
+    }
+    return { stdout: '', exitCode: 0 };
+  });
+}
+
+const RESOLVED_MUTATION: ResolvedVerificationRuntime = {
+  test: null,
+  typecheck: null,
+  install: null,
+  mutation: 'npx stryker run',
+  lint: null,
+  contract: null,
+  source: 'detection',
+};
+
+afterEach(async () => {
+  while (scratchDirs.length > 0) {
+    const dir = scratchDirs.pop();
+    if (dir) await rmrfAsync(dir);
+  }
+});
+
+function findByType(events: readonly WorkflowEvent[], type: string): WorkflowEvent {
+  const hit = events.find((e) => e.type === type);
+  expect(hit, `expected an emitted ${type} event`).toBeDefined();
+  return hit!;
+}
+
+describe('DR-2 liveness emitters', () => {
+  it('AllFourEmitters_EmitCanonicalInstanceIdAdditively', async () => {
+    // ── merge: instanceId = taskId (present) ──────────────────────────────────
+    {
+      const { store, stateDir } = await makeStore('dr2-merge-');
+      const recoverySha = 'b'.repeat(40);
+      const result = await handleExecuteMerge(
+        {
+          featureId: 'feat-merge',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          taskId: 'T11',
+          strategy: 'squash',
+          vcsMerge: vi.fn().mockResolvedValue({ mergeSha: 'a'.repeat(40) }),
+          persistState: vi.fn().mockResolvedValue(undefined),
+          gitExec: makeGitExec(recoverySha),
+        },
+        makeCtx(store, stateDir),
+      );
+      expect(result.success).toBe(true);
+
+      const events = await store.query('feat-merge');
+      const started = MergeExecutingStartedData.parse(
+        findByType(events, 'merge.executing_started').data,
+      );
+      const terminal = MergeExecutedData.parse(findByType(events, 'merge.executed').data);
+      // taskId present → instanceId IS the taskId, on both START and TERMINAL.
+      expect(started.instanceId).toBe('T11');
+      expect(terminal.instanceId).toBe('T11');
+    }
+
+    // ── merge: instanceId = `${sourceBranch}→${targetBranch}` (no taskId) ──────
+    {
+      const { store, stateDir } = await makeStore('dr2-merge-notask-');
+      const result = await handleExecuteMerge(
+        {
+          featureId: 'feat-merge-notask',
+          sourceBranch: 'feat/y',
+          targetBranch: 'integration',
+          strategy: 'merge',
+          vcsMerge: vi.fn().mockResolvedValue({ mergeSha: 'c'.repeat(40) }),
+          persistState: vi.fn().mockResolvedValue(undefined),
+          gitExec: makeGitExec('d'.repeat(40)),
+        },
+        makeCtx(store, stateDir),
+      );
+      expect(result.success).toBe(true);
+
+      const events = await store.query('feat-merge-notask');
+      const started = MergeExecutingStartedData.parse(
+        findByType(events, 'merge.executing_started').data,
+      );
+      const terminal = MergeExecutedData.parse(findByType(events, 'merge.executed').data);
+      // No taskId → the `<source>→<target>` fallback uniquely keys the merge.
+      expect(started.instanceId).toBe('feat/y→integration');
+      expect(terminal.instanceId).toBe('feat/y→integration');
+    }
+
+    // ── launch: instanceId = worktreeId ───────────────────────────────────────
+    {
+      const { store } = await makeStore('dr2-launch-');
+      const worktreeId = '/srv/wt/launch-a';
+      await emitLaunchExecutingStarted(store, {
+        worktreeId,
+        holderPid: 4242,
+        holderStartedAt: 'boot-4242',
+      });
+      await emitLaunchExecuted(store, { worktreeId, exitCode: 0 });
+
+      const events = await store.query(WORKTREES_STREAM);
+      const started = LaunchExecutingStartedData.parse(
+        findByType(events, 'launch.executing_started').data,
+      );
+      const terminal = LaunchExecutedData.parse(findByType(events, 'launch.executed').data);
+      expect(started.instanceId).toBe(worktreeId);
+      expect(terminal.instanceId).toBe(worktreeId);
+    }
+
+    // ── mutation: instanceId = operationId (through the structural seam) ───────
+    {
+      const emitted: Array<{ type: string; data: unknown }> = [];
+      const eventStore = {
+        append: (_stream: string, event: { type: string; data: unknown }) => {
+          emitted.push({ type: event.type, data: event.data });
+        },
+      };
+      const code = handleRunMutation([], {
+        cwd: '/repo',
+        resolve: () => RESOLVED_MUTATION,
+        run: () => 0,
+        stdout: () => {},
+        stderr: () => {},
+        eventStore,
+        stream: 'feat-mutation',
+        operationId: 'op-mutation-run',
+      });
+      expect(code).toBe(0);
+
+      const started = MutationExecutingStartedData.parse(
+        emitted.find((e) => e.type === 'mutation.executing_started')?.data,
+      );
+      const terminal = MutationExecutedData.parse(
+        emitted.find((e) => e.type === 'mutation.executed')?.data,
+      );
+      expect(started.instanceId).toBe('op-mutation-run');
+      expect(terminal.instanceId).toBe('op-mutation-run');
+    }
+
+    // ── prune: instanceId = the existing per-pass operationId ──────────────────
+    {
+      const { store } = await makeStore('dr2-prune-store-');
+      const repoRoot = await initRepo('dr2-prune-repo-');
+      const manager = new WorktreeManager({ eventStore: store });
+      // A repo with no released/orphan worktrees is a clean no-op pass; the
+      // liveness pair still brackets it (started before the ladder, executed in
+      // the finally). Defensive try/catch so an enumeration hiccup still lets us
+      // read the bracketed pair.
+      try {
+        await manager.prune({ repoRoot });
+      } catch {
+        /* liveness pair is emitted regardless — assert on the persisted events */
+      }
+
+      const events = await store.query(WORKTREES_STREAM);
+      const started = PruneExecutingStartedData.parse(
+        findByType(events, 'prune.executing_started').data,
+      );
+      const terminal = PruneExecutedData.parse(findByType(events, 'prune.executed').data);
+      // The prune surface reuses its existing operationId as the instance key,
+      // so START and TERMINAL correlate by the same value.
+      expect(started.instanceId).toBe(started.operationId);
+      expect(terminal.instanceId).toBe(started.operationId);
+      expect(terminal.instanceId).toBe(terminal.operationId);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/liveness-registry.test.ts
+++ b/servers/exarchos-mcp/src/event-store/liveness-registry.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { fc } from '@fast-check/vitest';
-import { EventTypes, type EventType } from './schemas.js';
+import { z } from 'zod';
+import { EventTypes, type EventType, EVENT_DATA_SCHEMAS, livenessInstanceFields } from './schemas.js';
 import {
   LIVENESS_REGISTRY,
   LIVENESS_DESCRIPTORS,
+  MUTATION_LEGACY_SINGLETON_KEY,
   getLivenessDescriptor,
   getLivenessDescriptorByStartType,
   computeInFlightInstances,
+  everyExecutingStartedType,
   livenessStartedAt,
+  type LivenessDescriptor,
   type LivenessEventLike,
 } from './liveness-registry.js';
 
@@ -20,12 +24,33 @@ import {
 // fifth `<surface>.executing_started` type without a matching registry entry
 // fails loudly here rather than silently at the `ps`/`wait` consumer.
 
+/**
+ * Whether a `<surface>.executing_started` data schema REQUIRES a non-optional
+ * `instanceId`. Tests the field in isolation: an optional field admits
+ * `undefined`, a required one rejects it — independent of the schema's other
+ * fields, so it works for any surface's shape (finding 4 / DR-2 new-surface rule).
+ */
+function startSchemaRequiresInstanceId(schema: z.ZodTypeAny): boolean {
+  if (!(schema instanceof z.ZodObject)) return false;
+  const field = (schema.shape as Record<string, z.ZodTypeAny | undefined>).instanceId;
+  if (field === undefined) return false;
+  // Required iff the field itself rejects an omitted (`undefined`) value.
+  return !field.safeParse(undefined).success;
+}
+
 describe('LivenessRegistry conformance', () => {
   it('LivenessRegistry_EveryExecutingStartedInCatalog_HasEntryWithTerminalScopeAndKey', () => {
-    // Drive off the REAL catalog — this is the whole point of the conformance
-    // test: a real unregistered surface (a new `<x>.executing_started` type
-    // added to `EventTypes` with no matching registry entry) must fail here.
-    const startTypesInCatalog = EventTypes.filter((t) => t.endsWith('.executing_started'));
+    // Drive off the REAL catalog via the exported helper (not a re-derived inline
+    // filter) — this is the whole point of the conformance test: a real
+    // unregistered surface (a new `<x>.executing_started` type added to
+    // `EventTypes` with no matching registry entry) must fail here.
+    const startTypesInCatalog = everyExecutingStartedType();
+
+    // The helper agrees with the catalog it is derived from (guards a drift
+    // between `everyExecutingStartedType()` and a raw `EventTypes` filter).
+    expect([...startTypesInCatalog].sort()).toEqual(
+      EventTypes.filter((t) => t.endsWith('.executing_started')).sort(),
+    );
 
     // Sanity: the catalog actually has liveness-start types to check (a
     // vacuous conformance test would silently pass on an empty catalog).
@@ -50,6 +75,19 @@ describe('LivenessRegistry conformance', () => {
       expect(typeof descriptor!.instanceKeyOf).toBe('function');
       expect(() => descriptor!.instanceKeyOf(undefined)).not.toThrow();
       expect(() => descriptor!.instanceKeyOf({})).not.toThrow();
+
+      // New-surface rule (DR-2 AC): a descriptor WITHOUT a legacy fallback has no
+      // pre-retrofit rows to accommodate, so its start schema MUST require a
+      // non-optional `instanceId` (`.min(1)`). A descriptor WITH a fallback may
+      // leave `instanceId` optional (legacy rows pair via the fallback).
+      if (!descriptor!.hasLegacyFallback) {
+        const startSchema = EVENT_DATA_SCHEMAS[startType as EventType];
+        expect(startSchema, `start schema for new surface ${startType}`).toBeDefined();
+        expect(
+          startSchemaRequiresInstanceId(startSchema!),
+          `descriptor '${descriptor!.surface}' has no legacy fallback → its start schema MUST require instanceId (.min(1), non-optional)`,
+        ).toBe(true);
+      }
     }
 
     // Reverse direction: every registered descriptor's startType is itself a
@@ -57,6 +95,36 @@ describe('LivenessRegistry conformance', () => {
     for (const descriptor of LIVENESS_DESCRIPTORS) {
       expect(EventTypes as readonly string[]).toContain(descriptor.startType);
       expect(descriptor.startType.endsWith('.executing_started')).toBe(true);
+    }
+  });
+
+  // ── The new-surface rule's guard is not a no-op (finding 4) ────────────────
+  //
+  // Every SHIPPED surface has a legacy fallback, so the conformance loop's
+  // fallback-less branch is currently vacuous. These focused assertions prove
+  // the `startSchemaRequiresInstanceId` predicate the rule rests on actually
+  // discriminates — so a future fallback-less surface with an OPTIONAL
+  // `instanceId` really would be caught, not silently admitted.
+  it('LivenessRegistry_NewSurfaceRule_RequiresInstanceIdPredicate_Discriminates', () => {
+    // The current shared shape leaves `instanceId` optional (additive retrofit).
+    const optionalShape = z.object({ command: z.string().min(1), ...livenessInstanceFields });
+    expect(startSchemaRequiresInstanceId(optionalShape)).toBe(false);
+
+    // A new-surface shape requires it non-optional (`.min(1)`).
+    const requiredShape = z.object({ command: z.string().min(1), instanceId: z.string().min(1) });
+    expect(startSchemaRequiresInstanceId(requiredShape)).toBe(true);
+
+    // A shape with NO instanceId field at all does not satisfy the rule either.
+    const noneShape = z.object({ command: z.string().min(1) });
+    expect(startSchemaRequiresInstanceId(noneShape)).toBe(false);
+  });
+
+  it('LivenessRegistry_AllShippedSurfaces_DeclareLegacyFallback', () => {
+    // All four INV-10 surfaces accommodate pre-retrofit rows, so each carries a
+    // legacy fallback. (When a genuinely new surface is added it must set
+    // `hasLegacyFallback: false` AND require `instanceId` — enforced above.)
+    for (const descriptor of LIVENESS_DESCRIPTORS) {
+      expect(descriptor.hasLegacyFallback, `${descriptor.surface} legacy fallback`).toBe(true);
     }
   });
 
@@ -114,13 +182,39 @@ describe('LivenessRegistry conformance', () => {
     expect(instanceKeyOf({})).toBeUndefined();
   });
 
-  it('LivenessRegistry_MutationInstanceKey_PrefersInstanceIdThenOperationIdLegacyFallback', () => {
+  it('LivenessRegistry_MutationInstanceKey_PrefersInstanceIdThenOperationIdThenSingleton', () => {
     const { instanceKeyOf } = getLivenessDescriptor('mutation');
     expect(instanceKeyOf({ instanceId: 'op-1', operationId: 'op-legacy' })).toBe('op-1');
     // Legacy-mutation fallback: no instanceId, but an operationId is present.
     expect(instanceKeyOf({ operationId: 'op-legacy' })).toBe('op-legacy');
-    // Neither present (the real `mutation-adequacy.ts` shape today) → undefined.
-    expect(instanceKeyOf({ command: 'npx stryker run', repoRoot: '/repo' })).toBeUndefined();
+    // DR-2 singleton fallback (finding 3): a truly keyless legacy row (neither
+    // field) resolves to the singleton key so a keyless START still pairs with
+    // its keyless TERMINAL, instead of being silently skipped.
+    expect(instanceKeyOf({ command: 'npx stryker run', repoRoot: '/repo' })).toBe(
+      MUTATION_LEGACY_SINGLETON_KEY,
+    );
+    expect(instanceKeyOf({})).toBe(MUTATION_LEGACY_SINGLETON_KEY);
+    expect(instanceKeyOf(undefined)).toBe(MUTATION_LEGACY_SINGLETON_KEY);
+  });
+
+  it('LivenessRegistry_MutationSingleton_KeylessStartPairsWithKeylessTerminal', () => {
+    // The DR-2 "keyless mutation → singleton instance" AC at the fold level:
+    // a keyless start followed by a keyless terminal on the SAME stream pairs
+    // and clears (was: silently skipped → forever "in flight" / never waitable).
+    const descriptor = getLivenessDescriptor('mutation');
+    const paired = computeInFlightInstances(descriptor, [
+      { type: 'mutation.executing_started', data: { command: 'x', repoRoot: '/r' }, streamId: 'feat-a' },
+      { type: 'mutation.executed', data: { command: 'x', repoRoot: '/r' }, streamId: 'feat-a' },
+    ]);
+    expect(paired.size).toBe(0);
+
+    // A keyless start with NO terminal stays in flight (visible), carrying the
+    // singleton instance key.
+    const inFlight = computeInFlightInstances(descriptor, [
+      { type: 'mutation.executing_started', data: { command: 'x', repoRoot: '/r' }, streamId: 'feat-a' },
+    ]);
+    expect(inFlight.size).toBe(1);
+    expect([...inFlight.values()][0]?.instanceKey).toBe(MUTATION_LEGACY_SINGLETON_KEY);
   });
 
   it('LivenessRegistry_PruneInstanceKey_PrefersInstanceIdThenOperationId', () => {
@@ -151,11 +245,36 @@ describe('LivenessRegistry conformance', () => {
     ];
 
     const inFlight = computeInFlightInstances(descriptor, events);
+    const keys = new Set([...inFlight.values()].map((i) => i.instanceKey));
 
-    // B terminated → cleared. A has no terminal → still in flight.
-    expect(inFlight.has('A')).toBe(true);
-    expect(inFlight.has('B')).toBe(false);
-    expect(inFlight.get('A')?.data).toEqual({ worktreeId: 'A' });
+    // B terminated → cleared. A has no terminal → still in flight. `launch` is a
+    // `worktrees`-scope surface, so the pairing key IS the instanceKey.
+    expect(keys.has('A')).toBe(true);
+    expect(keys.has('B')).toBe(false);
+    expect([...inFlight.values()].find((i) => i.instanceKey === 'A')?.startEvent.data).toEqual({
+      worktreeId: 'A',
+    });
+  });
+
+  it('LivenessRegistry_FeatureScope_SameKeyDifferentStreams_PairPerStream', () => {
+    // Finding 1 (S-6): the SAME merge instanceKey on two DIFFERENT feature
+    // streams is two DISTINCT in-flight instances. Terminating one must NOT
+    // clear the other. (`merge` is `feature`-scoped → keyed by (streamId, key).)
+    const descriptor = getLivenessDescriptor('merge');
+    const events: LivenessEventLike[] = [
+      { type: 'merge.executing_started', data: { instanceId: 'T11' }, streamId: 'feat-a' },
+      { type: 'merge.executing_started', data: { instanceId: 'T11' }, streamId: 'feat-b' },
+      // Terminal on feat-b ONLY.
+      { type: 'merge.executed', data: { instanceId: 'T11' }, streamId: 'feat-b' },
+    ];
+
+    const inFlight = computeInFlightInstances(descriptor, events);
+    const survivors = [...inFlight.values()];
+
+    // feat-a's T11 merge is still stuck; feat-b's was cleared.
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0]?.instanceKey).toBe('T11');
+    expect(survivors[0]?.streamId).toBe('feat-a');
   });
 
   it('LivenessRegistry_InstanceKey_TerminalWithNoMatchingStartIsANoop', () => {
@@ -170,12 +289,14 @@ describe('LivenessRegistry conformance', () => {
   it('LivenessRegistry_InstanceKey_RestartAfterTerminalReopensTheInstance', () => {
     const descriptor = getLivenessDescriptor('mutation');
     const events: LivenessEventLike[] = [
-      { type: 'mutation.executing_started', data: { operationId: 'op-1' } },
-      { type: 'mutation.executed', data: { operationId: 'op-1' } },
-      { type: 'mutation.executing_started', data: { operationId: 'op-1' } },
+      { type: 'mutation.executing_started', data: { operationId: 'op-1' }, streamId: 'feat-a' },
+      { type: 'mutation.executed', data: { operationId: 'op-1' }, streamId: 'feat-a' },
+      { type: 'mutation.executing_started', data: { operationId: 'op-1' }, streamId: 'feat-a' },
     ];
     const inFlight = computeInFlightInstances(descriptor, events);
-    expect(inFlight.has('op-1')).toBe(true);
+    // Reopened → exactly one in-flight instance for op-1 on feat-a.
+    expect(inFlight.size).toBe(1);
+    expect([...inFlight.values()][0]?.instanceKey).toBe('op-1');
   });
 
   // ── property test (state-machine): pairing correctness over arbitrary

--- a/servers/exarchos-mcp/src/event-store/liveness-registry.test.ts
+++ b/servers/exarchos-mcp/src/event-store/liveness-registry.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { fc } from '@fast-check/vitest';
+import { EventTypes, type EventType } from './schemas.js';
+import {
+  LIVENESS_REGISTRY,
+  LIVENESS_DESCRIPTORS,
+  getLivenessDescriptor,
+  getLivenessDescriptorByStartType,
+  computeInFlightInstances,
+  livenessStartedAt,
+  type LivenessEventLike,
+} from './liveness-registry.js';
+
+// ─── DR-2 (task 004): liveness descriptor registry conformance ─────────────
+//
+// One registry entry per INV-10 liveness surface (merge / launch / mutation /
+// prune) defines the whole contract `ps` / `wait --operation` (tasks 006/010)
+// will consume. The conformance test below drives its assertion off the REAL
+// `EventTypes` catalog in `schemas.ts` — not a hand-mocked list — so adding a
+// fifth `<surface>.executing_started` type without a matching registry entry
+// fails loudly here rather than silently at the `ps`/`wait` consumer.
+
+describe('LivenessRegistry conformance', () => {
+  it('LivenessRegistry_EveryExecutingStartedInCatalog_HasEntryWithTerminalScopeAndKey', () => {
+    // Drive off the REAL catalog — this is the whole point of the conformance
+    // test: a real unregistered surface (a new `<x>.executing_started` type
+    // added to `EventTypes` with no matching registry entry) must fail here.
+    const startTypesInCatalog = EventTypes.filter((t) => t.endsWith('.executing_started'));
+
+    // Sanity: the catalog actually has liveness-start types to check (a
+    // vacuous conformance test would silently pass on an empty catalog).
+    expect(startTypesInCatalog.length).toBeGreaterThanOrEqual(4);
+
+    for (const startType of startTypesInCatalog) {
+      const descriptor = getLivenessDescriptorByStartType(startType);
+      expect(descriptor, `expected a registry entry for real type ${startType}`).toBeDefined();
+
+      // Terminal: at least one terminal type, and every declared terminal is
+      // itself a real, registered `EventType` (catches a typo'd terminal).
+      expect(descriptor!.terminalTypes.length).toBeGreaterThan(0);
+      for (const terminal of descriptor!.terminalTypes) {
+        expect(EventTypes as readonly string[]).toContain(terminal);
+      }
+
+      // Scope: declared and one of the two known stream families.
+      expect(['feature', 'worktrees']).toContain(descriptor!.streamScope);
+
+      // Key: instanceKeyOf is present and callable without throwing, even on
+      // an empty/undefined payload (the "never throws" contract).
+      expect(typeof descriptor!.instanceKeyOf).toBe('function');
+      expect(() => descriptor!.instanceKeyOf(undefined)).not.toThrow();
+      expect(() => descriptor!.instanceKeyOf({})).not.toThrow();
+    }
+
+    // Reverse direction: every registered descriptor's startType is itself a
+    // real catalog type (no stale/renamed entry lingering in the registry).
+    for (const descriptor of LIVENESS_DESCRIPTORS) {
+      expect(EventTypes as readonly string[]).toContain(descriptor.startType);
+      expect(descriptor.startType.endsWith('.executing_started')).toBe(true);
+    }
+  });
+
+  it('LivenessRegistry_Lookup_ReturnsDescriptorForSurface', () => {
+    const merge = getLivenessDescriptor('merge');
+    expect(merge.startType).toBe('merge.executing_started');
+    expect(merge.terminalTypes).toEqual(['merge.executed', 'merge.recovered']);
+    expect(merge.streamScope).toBe('feature');
+
+    const launch = getLivenessDescriptor('launch');
+    expect(launch.startType).toBe('launch.executing_started');
+    expect(launch.terminalTypes).toEqual(['launch.executed']);
+    expect(launch.streamScope).toBe('worktrees');
+
+    const mutation = getLivenessDescriptor('mutation');
+    expect(mutation.startType).toBe('mutation.executing_started');
+    expect(mutation.terminalTypes).toEqual(['mutation.executed']);
+    expect(mutation.streamScope).toBe('feature');
+
+    const prune = getLivenessDescriptor('prune');
+    expect(prune.startType).toBe('prune.executing_started');
+    expect(prune.terminalTypes).toEqual(['prune.executed']);
+    expect(prune.streamScope).toBe('worktrees');
+
+    // getLivenessDescriptorByStartType is the reverse lookup and must agree.
+    expect(getLivenessDescriptorByStartType('merge.executing_started')).toBe(
+      LIVENESS_REGISTRY.merge,
+    );
+    expect(getLivenessDescriptorByStartType('unknown.executing_started')).toBeUndefined();
+  });
+
+  // ── instanceKeyOf canonical-key derivations (mirrors task 003's emitters) ──
+
+  it('LivenessRegistry_MergeInstanceKey_PrefersInstanceIdThenTaskIdThenBranchPair', () => {
+    const { instanceKeyOf } = getLivenessDescriptor('merge');
+    // instanceId present → wins over everything else.
+    expect(
+      instanceKeyOf({ instanceId: 'T11', taskId: 'T99', sourceBranch: 'a', targetBranch: 'b' }),
+    ).toBe('T11');
+    // No instanceId, taskId present → taskId.
+    expect(instanceKeyOf({ taskId: 'T11', sourceBranch: 'a', targetBranch: 'b' })).toBe('T11');
+    // Neither → `<source>→<target>` fallback (pre-retrofit shape, DR-2/INV-10).
+    expect(instanceKeyOf({ sourceBranch: 'feat/y', targetBranch: 'integration' })).toBe(
+      'feat/y→integration',
+    );
+    // Nothing resolvable → undefined, never throws.
+    expect(instanceKeyOf({})).toBeUndefined();
+    expect(instanceKeyOf(undefined)).toBeUndefined();
+  });
+
+  it('LivenessRegistry_LaunchInstanceKey_PrefersInstanceIdThenWorktreeId', () => {
+    const { instanceKeyOf } = getLivenessDescriptor('launch');
+    expect(instanceKeyOf({ instanceId: '/wt/a', worktreeId: '/wt/b' })).toBe('/wt/a');
+    expect(instanceKeyOf({ worktreeId: '/wt/b' })).toBe('/wt/b');
+    expect(instanceKeyOf({})).toBeUndefined();
+  });
+
+  it('LivenessRegistry_MutationInstanceKey_PrefersInstanceIdThenOperationIdLegacyFallback', () => {
+    const { instanceKeyOf } = getLivenessDescriptor('mutation');
+    expect(instanceKeyOf({ instanceId: 'op-1', operationId: 'op-legacy' })).toBe('op-1');
+    // Legacy-mutation fallback: no instanceId, but an operationId is present.
+    expect(instanceKeyOf({ operationId: 'op-legacy' })).toBe('op-legacy');
+    // Neither present (the real `mutation-adequacy.ts` shape today) → undefined.
+    expect(instanceKeyOf({ command: 'npx stryker run', repoRoot: '/repo' })).toBeUndefined();
+  });
+
+  it('LivenessRegistry_PruneInstanceKey_PrefersInstanceIdThenOperationId', () => {
+    const { instanceKeyOf } = getLivenessDescriptor('prune');
+    expect(instanceKeyOf({ instanceId: 'op-1', operationId: 'op-1' })).toBe('op-1');
+    expect(instanceKeyOf({ operationId: 'op-1' })).toBe('op-1');
+    expect(instanceKeyOf({})).toBeUndefined();
+  });
+
+  // ── envelope-derived startedAt ──────────────────────────────────────────
+
+  it('LivenessRegistry_StartedAt_DerivesFromEnvelopeTimestamp', () => {
+    expect(livenessStartedAt({ timestamp: '2026-07-13T00:00:00.000Z' })).toBe(
+      '2026-07-13T00:00:00.000Z',
+    );
+    expect(livenessStartedAt({})).toBeUndefined();
+    expect(livenessStartedAt({ timestamp: '' })).toBeUndefined();
+  });
+
+  // ── pairing helper: concurrent-instance correlation ─────────────────────
+
+  it('LivenessRegistry_InstanceKey_PairsConcurrentOpsCorrectly', () => {
+    const descriptor = getLivenessDescriptor('launch');
+    const events: LivenessEventLike[] = [
+      { type: 'launch.executing_started', data: { worktreeId: 'A' } },
+      { type: 'launch.executing_started', data: { worktreeId: 'B' } },
+      { type: 'launch.executed', data: { worktreeId: 'B' } },
+    ];
+
+    const inFlight = computeInFlightInstances(descriptor, events);
+
+    // B terminated → cleared. A has no terminal → still in flight.
+    expect(inFlight.has('A')).toBe(true);
+    expect(inFlight.has('B')).toBe(false);
+    expect(inFlight.get('A')?.data).toEqual({ worktreeId: 'A' });
+  });
+
+  it('LivenessRegistry_InstanceKey_TerminalWithNoMatchingStartIsANoop', () => {
+    const descriptor = getLivenessDescriptor('prune');
+    const events: LivenessEventLike[] = [
+      { type: 'prune.executed', data: { operationId: 'op-orphan' } },
+    ];
+    const inFlight = computeInFlightInstances(descriptor, events);
+    expect(inFlight.size).toBe(0);
+  });
+
+  it('LivenessRegistry_InstanceKey_RestartAfterTerminalReopensTheInstance', () => {
+    const descriptor = getLivenessDescriptor('mutation');
+    const events: LivenessEventLike[] = [
+      { type: 'mutation.executing_started', data: { operationId: 'op-1' } },
+      { type: 'mutation.executed', data: { operationId: 'op-1' } },
+      { type: 'mutation.executing_started', data: { operationId: 'op-1' } },
+    ];
+    const inFlight = computeInFlightInstances(descriptor, events);
+    expect(inFlight.has('op-1')).toBe(true);
+  });
+
+  // ── property test (state-machine): pairing correctness over arbitrary
+  //    start/terminal key interleavings ──────────────────────────────────
+  //
+  // An independent reference model (a plain `Set<string>` mutated by the same
+  // start-adds / terminal-removes semantics) is compared against
+  // `computeInFlightInstances` over hundreds of randomly generated start/
+  // terminal event sequences drawn from a small key alphabet — exercising
+  // interleavings a hand-written example test would never enumerate (repeated
+  // starts, terminals-before-starts, restarts after termination, etc).
+  it('LivenessRegistry_InstanceKey_PairingMatchesReferenceModelOverArbitraryInterleavings', () => {
+    const keyAlphabet = ['A', 'B', 'C'] as const;
+    const opArb = fc.record({
+      op: fc.constantFrom<'start' | 'terminal'>('start', 'terminal'),
+      key: fc.constantFrom(...keyAlphabet),
+    });
+
+    fc.assert(
+      fc.property(fc.array(opArb, { minLength: 0, maxLength: 50 }), (ops) => {
+        const descriptor = getLivenessDescriptor('prune');
+        const events: LivenessEventLike[] = ops.map(({ op, key }) => ({
+          type: op === 'start' ? descriptor.startType : descriptor.terminalTypes[0],
+          data: { operationId: key },
+        }));
+
+        const actual = computeInFlightInstances(descriptor, events);
+
+        // Reference model: independent from the implementation under test —
+        // a bare Set mutated by the same start-adds/terminal-removes rule.
+        const expected = new Set<string>();
+        for (const { op, key } of ops) {
+          if (op === 'start') expected.add(key);
+          else expected.delete(key);
+        }
+
+        expect(new Set(actual.keys())).toEqual(expected);
+      }),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ── Type-level guard: registry stays keyed by every LivenessSurface ────────
+// (compile-time only — `LIVENESS_REGISTRY` is `Record<LivenessSurface, ...>`,
+// so a surface added to the union without a registry entry is a TS error.)
+void ((): void => {
+  const _surfaces: readonly EventType[] = LIVENESS_DESCRIPTORS.map((d) => d.startType);
+  void _surfaces;
+});

--- a/servers/exarchos-mcp/src/event-store/liveness-registry.ts
+++ b/servers/exarchos-mcp/src/event-store/liveness-registry.ts
@@ -20,11 +20,11 @@
  *
  *   • merge    → `data.instanceId ?? data.taskId ?? \`${sourceBranch}→${targetBranch}\``
  *   • launch   → `data.instanceId ?? data.worktreeId`
- *   • mutation → `data.instanceId ?? data.operationId` (legacy fallback: the
- *     older `mutation-adequacy.ts` emission path predates the instanceId
- *     retrofit and stamps neither field on some rows; the operationId fallback
- *     is defensive so a future/foreign row that carries a bare `operationId`
- *     still resolves)
+ *   • mutation → `data.instanceId ?? data.operationId ?? MUTATION_LEGACY_SINGLETON_KEY`
+ *     (both live emitters — `orchestrate/mutation-adequacy.ts` and
+ *     `cli-commands/run-mutation.ts` — now stamp `instanceId`; the `operationId`
+ *     fallback is defensive, and a truly keyless legacy row resolves to the DR-2
+ *     singleton instance so it still pairs rather than being dropped)
  *   • prune    → `data.instanceId ?? data.operationId`
  *
  * `instanceKeyOf` is intentionally permissive about its input: any pre-
@@ -62,6 +62,16 @@ export type LivenessStreamScope = 'feature' | 'worktrees';
 export interface LivenessEventLike {
   readonly type: string;
   readonly data?: Record<string, unknown> | undefined;
+  /**
+   * The stream this event was persisted on. Load-bearing for the DR-2 "same
+   * stream" pairing relation: two `feature`-scoped workflows whose merge
+   * `instanceKey` collides (recurring `taskId`s, a shared branch pair) must NOT
+   * cross-contaminate — a terminal on workflow B's stream may only clear an
+   * in-flight START on B's stream, never A's. Real `WorkflowEvent` rows carry it;
+   * fixtures should set it for `feature`-scoped surfaces. Absent → treated as the
+   * empty stream (the degenerate single-namespace fallback).
+   */
+  readonly streamId?: string | undefined;
 }
 
 /** One registry entry: the whole liveness contract for a single surface. */
@@ -75,6 +85,17 @@ export interface LivenessDescriptor {
   readonly terminalTypes: readonly EventType[];
   /** Which stream family the pair rides on. */
   readonly streamScope: LivenessStreamScope;
+  /**
+   * Whether this surface has a LEGACY key fallback — a way to derive an instance
+   * key from rows emitted BEFORE the canonical `instanceId` retrofit (task 003).
+   * All four shipped surfaces do (merge → `taskId`/branch-pair, launch →
+   * `worktreeId`, mutation → `operationId`/singleton, prune → `operationId`), so
+   * their start schemas may leave `instanceId` optional and still pair legacy
+   * rows. A NEW surface has no legacy rows to accommodate, so it carries
+   * `hasLegacyFallback: false` and MUST require a non-optional `instanceId` in
+   * its start schema — the DR-2 new-surface rule the conformance test enforces.
+   */
+  readonly hasLegacyFallback: boolean;
   /**
    * Derive the canonical per-instance liveness key from a raw event `data`
    * payload. Returns `undefined` when no key can be derived (e.g. `data` is
@@ -114,12 +135,28 @@ function launchInstanceKeyOf(data: Record<string, unknown> | undefined): string 
   return readStringField(data, 'instanceId') ?? readStringField(data, 'worktreeId');
 }
 
+/**
+ * DR-2 singleton fallback key for a keyless legacy `mutation` row. The
+ * pre-retrofit `orchestrate/mutation-adequacy.ts` liveness path stamped neither
+ * `instanceId` nor `operationId`, so such a start would resolve to `undefined`
+ * and be SKIPPED by the pairing fold — leaving a stuck mutation invisible to
+ * `ps` / un-waitable, which contradicts DR-2's "keyless mutation → singleton
+ * instance" AC. Resolving a constant key instead lets a keyless START pair with
+ * its keyless TERMINAL (per stream, since `mutation` is `feature`-scoped). The
+ * value is namespaced so it can never collide with a real emitter-minted key.
+ */
+export const MUTATION_LEGACY_SINGLETON_KEY = 'mutation:legacy-singleton';
+
 function mutationInstanceKeyOf(data: Record<string, unknown> | undefined): string | undefined {
-  // Legacy-mutation fallback: rows from the pre-retrofit `mutation-adequacy.ts`
-  // liveness path carry neither `instanceId` nor `operationId` today, but the
-  // fallback stays defensive against any row (present or future) that carries
-  // a bare `operationId` with no `instanceId`.
-  return readStringField(data, 'instanceId') ?? readStringField(data, 'operationId');
+  // Canonical key (post-retrofit) → the emitter-minted `instanceId`. Defensive
+  // fallback for any row carrying a bare `operationId`. A truly keyless legacy
+  // row (neither field) resolves to the DR-2 singleton so it still pairs rather
+  // than being silently dropped.
+  return (
+    readStringField(data, 'instanceId') ??
+    readStringField(data, 'operationId') ??
+    MUTATION_LEGACY_SINGLETON_KEY
+  );
 }
 
 function pruneInstanceKeyOf(data: Record<string, unknown> | undefined): string | undefined {
@@ -160,6 +197,7 @@ export const LIVENESS_REGISTRY: Readonly<Record<LivenessSurface, LivenessDescrip
     // merge.executed / merge.recovered events drive the phase").
     terminalTypes: ['merge.executed', 'merge.recovered'],
     streamScope: 'feature',
+    hasLegacyFallback: true,
     instanceKeyOf: mergeInstanceKeyOf,
   },
   launch: {
@@ -167,6 +205,7 @@ export const LIVENESS_REGISTRY: Readonly<Record<LivenessSurface, LivenessDescrip
     startType: 'launch.executing_started',
     terminalTypes: ['launch.executed'],
     streamScope: 'worktrees',
+    hasLegacyFallback: true,
     instanceKeyOf: launchInstanceKeyOf,
   },
   mutation: {
@@ -174,6 +213,7 @@ export const LIVENESS_REGISTRY: Readonly<Record<LivenessSurface, LivenessDescrip
     startType: 'mutation.executing_started',
     terminalTypes: ['mutation.executed'],
     streamScope: 'feature',
+    hasLegacyFallback: true,
     instanceKeyOf: mutationInstanceKeyOf,
   },
   prune: {
@@ -181,6 +221,7 @@ export const LIVENESS_REGISTRY: Readonly<Record<LivenessSurface, LivenessDescrip
     startType: 'prune.executing_started',
     terminalTypes: ['prune.executed'],
     streamScope: 'worktrees',
+    hasLegacyFallback: true,
     instanceKeyOf: pruneInstanceKeyOf,
   },
 };
@@ -212,43 +253,87 @@ export function everyExecutingStartedType(): readonly string[] {
 
 // ─── Pairing helper ──────────────────────────────────────────────────────────
 
+/** One surviving in-flight instance: its resolved key, the stream it rides, and
+ *  the START event that opened it (for envelope-derived `startedAt`). */
+export interface InFlightInstance {
+  /** The descriptor's own resolved `instanceKeyOf(startEvent.data)`. */
+  readonly instanceKey: string;
+  /** The stream the START event was persisted on (`undefined` for keyless
+   *  fixtures). For `feature`-scoped surfaces this is the workflow's featureId. */
+  readonly streamId: string | undefined;
+  /** The `<surface>.executing_started` event that opened this instance. */
+  readonly startEvent: LivenessEventLike;
+}
+
+/** NUL separator for the composite `(streamId, instanceKey)` pairing key — a
+ *  byte neither a stream id nor an instance key ever contains, so the composite
+ *  is unambiguous (`(streamId='a', key='b→c')` never collides with
+ *  `(streamId='a→b', key='c')`). */
+const PAIRING_KEY_SEP = String.fromCharCode(0);
+
+/**
+ * The DR-2 pairing key. `feature`-scoped surfaces pair PER STREAM — the same
+ * `instanceKey` on two different feature streams is two DISTINCT instances, so a
+ * terminal on one stream can never clear the other (the S-6 cross-stream
+ * mis-pairing this feature exists to prevent). The singleton `worktrees` stream
+ * pairs by `instanceKey` alone: concurrent launches/prunes on that one shared
+ * stream are the NORMAL case, so cross-instance concurrency there is expected.
+ */
+function pairingKey(
+  descriptor: LivenessDescriptor,
+  instanceKey: string,
+  streamId: string | undefined,
+): string {
+  return descriptor.streamScope === 'feature'
+    ? `${streamId ?? ''}${PAIRING_KEY_SEP}${instanceKey}`
+    : instanceKey;
+}
+
 /**
  * Fold an ordered event list into the set of liveness instances still IN
  * FLIGHT for one surface: a START with no paired TERMINAL (yet) after it in
- * the given order. Applies the pairing purely at the instance-key level —
- * caller supplies whichever events are relevant to the descriptor's stream
- * scope (a `ps`/`wait` consumer filters to the right stream before calling
- * this).
+ * the given order. For `feature`-scoped surfaces the pairing is keyed by
+ * `(streamId, instanceKey)` so events from different workflow streams never
+ * cross-contaminate; for the singleton `worktrees` scope it is keyed by
+ * `instanceKey` alone (see {@link pairingKey}).
  *
  * Semantics, applied left-to-right over `events`:
  *   - a START event whose key resolves is recorded as in-flight (re-starting
- *     an already in-flight key overwrites — the latest START wins, matching
- *     an idempotent-retry re-emission of the same key);
+ *     an already in-flight `(stream,key)` overwrites — the latest START wins,
+ *     matching an idempotent-retry re-emission of the same key);
  *   - a TERMINAL event (any of `descriptor.terminalTypes`) whose key resolves
- *     clears that key from the in-flight set (a terminal for an unknown/
- *     already-cleared key is a no-op, never a throw);
+ *     clears that `(stream,key)` from the in-flight set (a terminal for an
+ *     unknown/already-cleared key is a no-op, never a throw);
  *   - events whose key cannot be derived (`instanceKeyOf` returns `undefined`)
  *     are skipped — an unresolvable row can never be paired.
  *
- * Returns a map of `instanceKey -> the START event that opened it`, so a
- * caller can report `startedAt` (via {@link livenessStartedAt}) alongside the
- * surviving in-flight set.
+ * Returns a map keyed by the internal pairing key; each value is the surviving
+ * {@link InFlightInstance} (resolved `instanceKey`, `streamId`, and the START
+ * event) so a caller can report the true key, "which workflow is stuck?", and
+ * `startedAt` (via {@link livenessStartedAt}). `.size` is the count of distinct
+ * in-flight instances — the `wait --operation` predicate reads exactly this.
  */
 export function computeInFlightInstances(
   descriptor: LivenessDescriptor,
   events: readonly LivenessEventLike[],
-): ReadonlyMap<string, LivenessEventLike> {
-  const inFlight = new Map<string, LivenessEventLike>();
+): ReadonlyMap<string, InFlightInstance> {
+  const inFlight = new Map<string, InFlightInstance>();
   const terminalTypes: readonly string[] = descriptor.terminalTypes;
   for (const event of events) {
     if (event.type === descriptor.startType) {
-      const key = descriptor.instanceKeyOf(event.data);
-      if (key !== undefined) inFlight.set(key, event);
+      const instanceKey = descriptor.instanceKeyOf(event.data);
+      if (instanceKey === undefined) continue;
+      inFlight.set(pairingKey(descriptor, instanceKey, event.streamId), {
+        instanceKey,
+        streamId: event.streamId,
+        startEvent: event,
+      });
       continue;
     }
     if (terminalTypes.includes(event.type)) {
-      const key = descriptor.instanceKeyOf(event.data);
-      if (key !== undefined) inFlight.delete(key);
+      const instanceKey = descriptor.instanceKeyOf(event.data);
+      if (instanceKey === undefined) continue;
+      inFlight.delete(pairingKey(descriptor, instanceKey, event.streamId));
     }
   }
   return inFlight;

--- a/servers/exarchos-mcp/src/event-store/liveness-registry.ts
+++ b/servers/exarchos-mcp/src/event-store/liveness-registry.ts
@@ -1,0 +1,255 @@
+/**
+ * Liveness descriptor registry (DR-2, task 004).
+ *
+ * The four INV-10 liveness surfaces — merge / launch / mutation / prune — each
+ * emit a `<surface>.executing_started` CLAIM paired with one or more TERMINAL
+ * event types. Tasks 003 (this task's prerequisite, merged) retrofitted a
+ * canonical `instanceId` onto every payload so a uniform liveness view can
+ * correlate a START with its TERMINAL without per-surface field knowledge.
+ * This module is that uniform view: ONE registry entry per surface, declaring
+ * the whole contract a consumer needs — which event starts the instance, which
+ * event(s) terminate it, which stream it lives on, and how to derive its
+ * instance key from a raw event payload.
+ *
+ * Downstream consumers (`ps`, `wait --operation` — tasks 006/010) read this
+ * registry rather than re-deriving per-surface knowledge, so a fifth liveness
+ * surface only has to add ONE entry here (and the conformance test below
+ * fails loudly if it doesn't).
+ *
+ * ## Canonical keys (mirrors task 003's real emitters exactly)
+ *
+ *   • merge    → `data.instanceId ?? data.taskId ?? \`${sourceBranch}→${targetBranch}\``
+ *   • launch   → `data.instanceId ?? data.worktreeId`
+ *   • mutation → `data.instanceId ?? data.operationId` (legacy fallback: the
+ *     older `mutation-adequacy.ts` emission path predates the instanceId
+ *     retrofit and stamps neither field on some rows; the operationId fallback
+ *     is defensive so a future/foreign row that carries a bare `operationId`
+ *     still resolves)
+ *   • prune    → `data.instanceId ?? data.operationId`
+ *
+ * `instanceKeyOf` is intentionally permissive about its input: any pre-
+ * retrofit row (no `instanceId`) or partially-shaped row still resolves via
+ * the fallback chain when possible, and returns `undefined` (never throws)
+ * when no key can be derived at all — an unresolvable row cannot be paired,
+ * but it must not crash a `ps`/`wait` scan.
+ *
+ * ## `startedAt`
+ *
+ * Rather than reading a surface-specific data field (only `merge` carries its
+ * own `data.startedAt`; the other three do not), {@link livenessStartedAt}
+ * derives the instant uniformly from the event ENVELOPE's `timestamp` — the
+ * one field every persisted event carries regardless of surface.
+ */
+
+import type { EventType } from './schemas.js';
+import { EventTypes } from './schemas.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** The four INV-10 liveness surfaces this registry describes. */
+export type LivenessSurface = 'merge' | 'launch' | 'mutation' | 'prune';
+
+/**
+ * Which stream family a surface's liveness pair rides on. `'feature'` means
+ * the workflow's own feature stream (a different stream id per workflow, so
+ * the registry does not — and cannot — pin a literal stream name); `'worktrees'`
+ * means the fixed singleton `worktrees` stream shared across every workflow.
+ */
+export type LivenessStreamScope = 'feature' | 'worktrees';
+
+/** A minimal event shape the pairing helper operates on — real `WorkflowEvent`
+ * rows satisfy this, as do hand-built fixtures in tests. */
+export interface LivenessEventLike {
+  readonly type: string;
+  readonly data?: Record<string, unknown> | undefined;
+}
+
+/** One registry entry: the whole liveness contract for a single surface. */
+export interface LivenessDescriptor {
+  /** The surface this descriptor describes. */
+  readonly surface: LivenessSurface;
+  /** The `<surface>.executing_started` CLAIM event type. */
+  readonly startType: EventType;
+  /** The paired TERMINAL event type(s) — one or more; e.g. merge has two
+   * (`merge.executed` success path, `merge.recovered` rollback path). */
+  readonly terminalTypes: readonly EventType[];
+  /** Which stream family the pair rides on. */
+  readonly streamScope: LivenessStreamScope;
+  /**
+   * Derive the canonical per-instance liveness key from a raw event `data`
+   * payload. Returns `undefined` when no key can be derived (e.g. `data` is
+   * absent or missing every fallback field) — never throws.
+   */
+  readonly instanceKeyOf: (data: Record<string, unknown> | undefined) => string | undefined;
+}
+
+// ─── Field-reading helpers ───────────────────────────────────────────────────
+
+/** Read a non-empty string field off a raw event payload, or `undefined`. */
+function readStringField(
+  data: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  if (!data) return undefined;
+  const value = data[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+// ─── Per-surface instanceKeyOf derivations ──────────────────────────────────
+
+function mergeInstanceKeyOf(data: Record<string, unknown> | undefined): string | undefined {
+  const instanceId = readStringField(data, 'instanceId');
+  if (instanceId !== undefined) return instanceId;
+  const taskId = readStringField(data, 'taskId');
+  if (taskId !== undefined) return taskId;
+  const sourceBranch = readStringField(data, 'sourceBranch');
+  const targetBranch = readStringField(data, 'targetBranch');
+  if (sourceBranch !== undefined && targetBranch !== undefined) {
+    return `${sourceBranch}→${targetBranch}`;
+  }
+  return undefined;
+}
+
+function launchInstanceKeyOf(data: Record<string, unknown> | undefined): string | undefined {
+  return readStringField(data, 'instanceId') ?? readStringField(data, 'worktreeId');
+}
+
+function mutationInstanceKeyOf(data: Record<string, unknown> | undefined): string | undefined {
+  // Legacy-mutation fallback: rows from the pre-retrofit `mutation-adequacy.ts`
+  // liveness path carry neither `instanceId` nor `operationId` today, but the
+  // fallback stays defensive against any row (present or future) that carries
+  // a bare `operationId` with no `instanceId`.
+  return readStringField(data, 'instanceId') ?? readStringField(data, 'operationId');
+}
+
+function pruneInstanceKeyOf(data: Record<string, unknown> | undefined): string | undefined {
+  return readStringField(data, 'instanceId') ?? readStringField(data, 'operationId');
+}
+
+// ─── Envelope-derived startedAt ──────────────────────────────────────────────
+
+/**
+ * Derive the instant a liveness instance started from the event ENVELOPE
+ * (`timestamp`) rather than a surface-specific data field — the one field
+ * every persisted event carries uniformly, regardless of surface. Returns
+ * `undefined` when the envelope carries no usable timestamp (defensive; real
+ * `WorkflowEvent` rows always have one via the schema's default).
+ */
+export function livenessStartedAt(event: { readonly timestamp?: string }): string | undefined {
+  return typeof event.timestamp === 'string' && event.timestamp.length > 0
+    ? event.timestamp
+    : undefined;
+}
+
+// ─── The registry ────────────────────────────────────────────────────────────
+
+/**
+ * One entry per INV-10 liveness surface. See the module doc for the full
+ * canonical-key contract each `instanceKeyOf` mirrors from task 003's real
+ * emitters (`orchestrate/execute-merge.ts`, `launcher/liveness.ts`,
+ * `cli-commands/run-mutation.ts`, `orchestrate/worktree/manager.ts`).
+ */
+export const LIVENESS_REGISTRY: Readonly<Record<LivenessSurface, LivenessDescriptor>> = {
+  merge: {
+    surface: 'merge',
+    startType: 'merge.executing_started',
+    // The INV-10 `<surface>.executing_started` + paired terminal pattern for
+    // merge: `merge.executed` (success path) / `merge.recovered` (INV-14
+    // recovery-ladder path) — per the `merge.executing_started` schema doc and
+    // the `workflow-state-projection.ts` fold comment ("the terminal
+    // merge.executed / merge.recovered events drive the phase").
+    terminalTypes: ['merge.executed', 'merge.recovered'],
+    streamScope: 'feature',
+    instanceKeyOf: mergeInstanceKeyOf,
+  },
+  launch: {
+    surface: 'launch',
+    startType: 'launch.executing_started',
+    terminalTypes: ['launch.executed'],
+    streamScope: 'worktrees',
+    instanceKeyOf: launchInstanceKeyOf,
+  },
+  mutation: {
+    surface: 'mutation',
+    startType: 'mutation.executing_started',
+    terminalTypes: ['mutation.executed'],
+    streamScope: 'feature',
+    instanceKeyOf: mutationInstanceKeyOf,
+  },
+  prune: {
+    surface: 'prune',
+    startType: 'prune.executing_started',
+    terminalTypes: ['prune.executed'],
+    streamScope: 'worktrees',
+    instanceKeyOf: pruneInstanceKeyOf,
+  },
+};
+
+/** All registered descriptors, in declaration order. */
+export const LIVENESS_DESCRIPTORS: readonly LivenessDescriptor[] =
+  Object.values(LIVENESS_REGISTRY);
+
+/** Look up a descriptor by surface. */
+export function getLivenessDescriptor(surface: LivenessSurface): LivenessDescriptor {
+  return LIVENESS_REGISTRY[surface];
+}
+
+/**
+ * Look up a descriptor by its `startType` (the `<surface>.executing_started`
+ * event type) — the reverse lookup a generic event-driven scanner uses.
+ * Returns `undefined` for any type not registered as a liveness START.
+ */
+export function getLivenessDescriptorByStartType(
+  startType: string,
+): LivenessDescriptor | undefined {
+  return LIVENESS_DESCRIPTORS.find((d) => d.startType === startType);
+}
+
+/** Every `<surface>.executing_started` type in the real event catalog. */
+export function everyExecutingStartedType(): readonly string[] {
+  return EventTypes.filter((t): t is EventType => t.endsWith('.executing_started'));
+}
+
+// ─── Pairing helper ──────────────────────────────────────────────────────────
+
+/**
+ * Fold an ordered event list into the set of liveness instances still IN
+ * FLIGHT for one surface: a START with no paired TERMINAL (yet) after it in
+ * the given order. Applies the pairing purely at the instance-key level —
+ * caller supplies whichever events are relevant to the descriptor's stream
+ * scope (a `ps`/`wait` consumer filters to the right stream before calling
+ * this).
+ *
+ * Semantics, applied left-to-right over `events`:
+ *   - a START event whose key resolves is recorded as in-flight (re-starting
+ *     an already in-flight key overwrites — the latest START wins, matching
+ *     an idempotent-retry re-emission of the same key);
+ *   - a TERMINAL event (any of `descriptor.terminalTypes`) whose key resolves
+ *     clears that key from the in-flight set (a terminal for an unknown/
+ *     already-cleared key is a no-op, never a throw);
+ *   - events whose key cannot be derived (`instanceKeyOf` returns `undefined`)
+ *     are skipped — an unresolvable row can never be paired.
+ *
+ * Returns a map of `instanceKey -> the START event that opened it`, so a
+ * caller can report `startedAt` (via {@link livenessStartedAt}) alongside the
+ * surviving in-flight set.
+ */
+export function computeInFlightInstances(
+  descriptor: LivenessDescriptor,
+  events: readonly LivenessEventLike[],
+): ReadonlyMap<string, LivenessEventLike> {
+  const inFlight = new Map<string, LivenessEventLike>();
+  const terminalTypes: readonly string[] = descriptor.terminalTypes;
+  for (const event of events) {
+    if (event.type === descriptor.startType) {
+      const key = descriptor.instanceKeyOf(event.data);
+      if (key !== undefined) inFlight.set(key, event);
+      continue;
+    }
+    if (terminalTypes.includes(event.type)) {
+      const key = descriptor.instanceKeyOf(event.data);
+      if (key !== undefined) inFlight.delete(key);
+    }
+  }
+  return inFlight;
+}

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -621,7 +621,12 @@ describe('EventTypes', () => {
     //   plan-review dispatch emitted by the `prepare_review scope:plan` provisioning
     //   seam; folded into state.planReview.revisionCount to bound the plan-review
     //   loop at its one unskippable server action, closing the skippable-edge bypass).
-    expect(EventTypes).toHaveLength(146);
+    // Bumped 146 → 148: DR-6 (lifecycle-verbs task 012) — export.requested +
+    //   export.executed (the two-event `export` contract, INV-13 two-event split /
+    //   INV-8 idempotency; export.requested carries the RESOLVED path intent before
+    //   the zip write, export.executed carries the written bundle's content hash
+    //   after, emitted `auto` by the `export` composite handler in task 013).
+    expect(EventTypes).toHaveLength(148);
     expect(EventTypes).toContain('merge.recovered');
     expect(EventTypes).toContain('merge.retry_attempt');
     expect(EventTypes).toContain('merge.executing_started');
@@ -640,6 +645,8 @@ describe('EventTypes', () => {
     expect(EventTypes).toContain('workflow.plan-revision');
     expect(EventTypes).toContain('prune.executing_started');
     expect(EventTypes).toContain('prune.executed');
+    expect(EventTypes).toContain('export.requested');
+    expect(EventTypes).toContain('export.executed');
     // Retirement guard: init.executed removed in DR-5 (task 018).
     expect(EventTypes as readonly string[]).not.toContain('init.executed');
   });
@@ -4125,17 +4132,18 @@ describe('WLM operational-core merge lease schemas', () => {
     expect(EventTypes).toContain('worktree.merge_executed');
   });
 
-  it('EventTypes_CountPins_146_AllThreeSites', () => {
+  it('EventTypes_CountPins_148_AllThreeSites', () => {
     // The single canonical count after adding the two operational-core merge
     // types (136 foundation → 138), main's `workflow.plan-revision` merged in
     // (138 → 139), the harness-launcher (DR-2) create pair + launch liveness
     // pair (139 → 143), the WLM slice 3 (DR-3) prune-run liveness pair
-    // prune.executing_started / prune.executed (143 → 145), and WLM-6 (DR-2)
-    // `workflow.plan-review-dispatched` (145 → 146). The pinned literal at ALL
-    // THREE toHaveLength sites (this file at two sites plus the mirror
-    // __tests__/event-store/schemas.test.ts) must agree with this — a divergence
-    // means one pin was missed.
-    expect(EventTypes).toHaveLength(146);
+    // prune.executing_started / prune.executed (143 → 145), WLM-6 (DR-2)
+    // `workflow.plan-review-dispatched` (145 → 146), and the DR-6 (lifecycle-verbs
+    // task 012) two-event `export` contract export.requested / export.executed
+    // (146 → 148). The pinned literal at ALL THREE toHaveLength sites (this file
+    // at two sites plus the mirror __tests__/event-store/schemas.test.ts) must
+    // agree with this — a divergence means one pin was missed.
+    expect(EventTypes).toHaveLength(148);
     // No duplicate slipped in while bumping the count.
     expect(new Set(EventTypes).size).toBe(EventTypes.length);
   });
@@ -4516,6 +4524,133 @@ describe('DR-2 liveness instanceId retrofit', () => {
       const terminalShape = (f.terminalSchema as unknown as { shape: Record<string, unknown> }).shape;
       expect(startedShape, `${f.startedType} shape must carry instanceId`).toHaveProperty('instanceId');
       expect(terminalShape, `${f.terminalType} shape must carry instanceId`).toHaveProperty('instanceId');
+    }
+  });
+});
+
+// ─── DR-6 (lifecycle-verbs task 012) — export two-event contract ─────────────
+//
+// `export` writes a zip bundle to a path OUTSIDE `.exarchos/` — a non-idempotent
+// external side effect — so it follows the INV-13 two-event split:
+// `export.requested` (durable intent + RESOLVED path) journaled BEFORE the
+// write; `export.executed` (result + content hash) journaled AFTER. Both are
+// `auto` (the composite handler owns the appends) and idempotency-keyed (INV-8).
+//
+// Schemas are read from EVENT_DATA_SCHEMAS (the live registry) rather than the
+// direct exports, so the revert-probe (which reverts the schemas.ts hunks that
+// register + define them) makes these assertions a CLEAN red: the map has no
+// `export.*` key, so the schema is undefined and the required-field pins below
+// fail — not an import artifact.
+describe('Export event contract (DR-6, lifecycle-verbs task 012)', () => {
+  const requestedSchema = () => EVENT_DATA_SCHEMAS['export.requested'];
+  const executedSchema = () => EVENT_DATA_SCHEMAS['export.executed'];
+
+  const validRequested = () => ({
+    featureId: 'feat-export-1',
+    outputPath: '/repo/feat-export-1-export.zip',
+    idempotencyKey: 'feat-export-1:export:/repo/feat-export-1-export.zip',
+  });
+
+  const validExecuted = () => ({
+    featureId: 'feat-export-1',
+    outputPath: '/repo/feat-export-1-export.zip',
+    contentHash: 'sha256:'.concat('a'.repeat(64)),
+    eventCount: 42,
+    idempotencyKey: 'feat-export-1:export:/repo/feat-export-1-export.zip',
+  });
+
+  it('ExportEventSchemas_RequestedExecutedPair_RegisteredWithEmissionSource', () => {
+    // The pair is registered as first-class event types, both classified `auto`
+    // (the `export` composite handler owns both appends — never model-emitted),
+    // and both carry a data schema. Registration is the substrate task 013's
+    // handler emits onto.
+    expect(EventTypes).toContain('export.requested');
+    expect(EventTypes).toContain('export.executed');
+
+    expect(EVENT_EMISSION_REGISTRY['export.requested']).toBe('auto');
+    expect(EVENT_EMISSION_REGISTRY['export.executed']).toBe('auto');
+
+    expect(requestedSchema()).toBeDefined();
+    expect(executedSchema()).toBeDefined();
+
+    // And the serialized catalog surfaces both under bySource.auto with a schema.
+    const catalog = serializeEventCatalog();
+    expect(catalog.bySource.auto).toContain('export.requested');
+    expect(catalog.bySource.auto).toContain('export.executed');
+    expect(catalog.types['export.requested']).toEqual({ source: 'auto', isBuiltIn: true, hasSchema: true });
+    expect(catalog.types['export.executed']).toEqual({ source: 'auto', isBuiltIn: true, hasSchema: true });
+  });
+
+  it('ExportRequested_CarriesResolvedPathIntent', () => {
+    // REVERT-PROBE ANCHOR: `export.requested` pins the RESOLVED destination path
+    // as a REQUIRED, typed, non-empty field — the intent the timeline needs to
+    // reconstruct where the bundle was meant to land after a mid-write crash
+    // (INV-13). With the schemas.ts hunks reverted the schema is unregistered
+    // (undefined) and these required-field pins go red.
+    const schema = requestedSchema();
+    expect(schema).toBeDefined();
+
+    // A fully-formed intent (resolved path + feature + idempotency key) validates.
+    expect(schema!.safeParse(validRequested()).success).toBe(true);
+
+    // The resolved path IS carried through on parse (not stripped).
+    const parsed = schema!.parse(validRequested()) as { outputPath: string };
+    expect(parsed.outputPath).toBe('/repo/feat-export-1-export.zip');
+
+    // Missing the resolved path — rejected (the intent is meaningless without it).
+    expect(schema!.safeParse({ featureId: 'f', idempotencyKey: 'k' }).success).toBe(false);
+    // Empty path — rejected by `.min(1)`.
+    expect(schema!.safeParse({ ...validRequested(), outputPath: '' }).success).toBe(false);
+    // Wrong-typed path (number) — rejected because outputPath is a typed string.
+    expect(schema!.safeParse({ ...validRequested(), outputPath: 123 }).success).toBe(false);
+    // Missing featureId / idempotencyKey — both required.
+    expect(schema!.safeParse({ outputPath: '/x.zip', idempotencyKey: 'k' }).success).toBe(false);
+    expect(schema!.safeParse({ featureId: 'f', outputPath: '/x.zip' }).success).toBe(false);
+    // Empty idempotency key — rejected (INV-8: an empty key would collapse
+    // unrelated exports into one).
+    expect(schema!.safeParse({ ...validRequested(), idempotencyKey: '' }).success).toBe(false);
+  });
+
+  it('ExportEventSchemas_Serialization_ValidPayloadsValidate_MalformedReject', () => {
+    // Property (serialization category): every valid payload survives a JSON
+    // persistence round-trip and re-validates; every malformed payload is
+    // rejected. Exercises BOTH events of the pair.
+    const requested = requestedSchema();
+    const executed = executedSchema();
+    expect(requested).toBeDefined();
+    expect(executed).toBeDefined();
+
+    const validCases: Array<{ label: string; schema: z.ZodSchema; payload: Record<string, unknown> }> = [
+      { label: 'export.requested (minimal)', schema: requested!, payload: validRequested() },
+      { label: 'export.executed (minimal)', schema: executed!, payload: validExecuted() },
+      {
+        label: 'export.executed (with tolerated missingArtifacts)',
+        schema: executed!,
+        payload: { ...validExecuted(), missingArtifacts: ['artifacts/plan.md', 'artifacts/review.json'] },
+      },
+      {
+        label: 'export.executed (empty missingArtifacts — nothing missing)',
+        schema: executed!,
+        payload: { ...validExecuted(), missingArtifacts: [] },
+      },
+    ];
+    for (const c of validCases) {
+      const roundTripped = JSON.parse(JSON.stringify(c.payload));
+      expect(c.schema.safeParse(roundTripped).success, c.label).toBe(true);
+    }
+
+    const malformedCases: Array<{ label: string; schema: z.ZodSchema; payload: Record<string, unknown> }> = [
+      { label: 'requested: missing outputPath', schema: requested!, payload: { featureId: 'f', idempotencyKey: 'k' } },
+      { label: 'requested: empty idempotencyKey', schema: requested!, payload: { ...validRequested(), idempotencyKey: '' } },
+      { label: 'executed: missing contentHash', schema: executed!, payload: (() => { const p = validExecuted() as Record<string, unknown>; delete p.contentHash; return p; })() },
+      { label: 'executed: empty contentHash', schema: executed!, payload: { ...validExecuted(), contentHash: '' } },
+      { label: 'executed: fractional eventCount', schema: executed!, payload: { ...validExecuted(), eventCount: 4.5 } },
+      { label: 'executed: negative eventCount', schema: executed!, payload: { ...validExecuted(), eventCount: -1 } },
+      { label: 'executed: missingArtifacts wrong element type', schema: executed!, payload: { ...validExecuted(), missingArtifacts: [123] } },
+    ];
+    for (const c of malformedCases) {
+      const roundTripped = JSON.parse(JSON.stringify(c.payload));
+      expect(c.schema.safeParse(roundTripped).success, c.label).toBe(false);
     }
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -88,6 +88,13 @@ import {
   WorktreeCreateExecutedData,
   LaunchExecutingStartedData,
   LaunchExecutedData,
+  // DR-2 (task 003) — the four INV-10 liveness pairs retrofitted with a
+  // canonical additive `instanceId` (merge / launch / mutation / prune).
+  MergeExecutingStartedData,
+  MutationExecutingStartedData,
+  MutationExecutedData,
+  PruneExecutingStartedData,
+  PruneExecutedData,
   type WorkflowEvent,
 } from './schemas.js';
 import { workflowStateProjection } from '../views/workflow-state-projection.js';
@@ -4320,5 +4327,195 @@ describe('harness-launcher event schemas (DR-2)', () => {
     expect(
       WorktreeCreateExecutedData.parse({ operationId: opId, worktreePath: '/abs/launch-worktree', created: true }).created,
     ).toBe(true);
+  });
+});
+
+// ─── DR-2 (task 003): validation-compatible liveness `instanceId` retrofit ───
+//
+// The four INV-10 liveness pairs — merge / launch / mutation / prune
+// `<surface>.executing_started` + paired terminal — gained a canonical,
+// ADDITIVE `instanceId` field via the shared `livenessInstanceFields` mixin.
+// These tests pin the two halves of the contract:
+//   1. every VERBATIM payload each surface emitted BEFORE the retrofit still
+//      validates (backward-compatibility / nothing migrated), and
+//   2. the additive field is TYPED — a malformed (wrong-typed / empty)
+//      `instanceId` is now rejected at the boundary. This second property is
+//      what the DR-2 revert-probe pins: with the schema change reverted,
+//      `instanceId` is no longer a known key, so a wrong-typed value is
+//      silently stripped and the malformed payload wrongly validates.
+
+describe('DR-2 liveness instanceId retrofit', () => {
+  // VERBATIM shapes captured from the four emitters' emission sites BEFORE the
+  // retrofit (characterization). NONE carries `instanceId`, mirroring every
+  // previously-persisted row. `instanceId` is the canonical key each emitter
+  // now stamps additively.
+  const LIVENESS_PAIR_FIXTURES = [
+    {
+      surface: 'merge',
+      startedType: 'merge.executing_started',
+      startedSchema: MergeExecutingStartedData,
+      started: {
+        taskId: 'T11',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        recoveryPointSha: 'b'.repeat(40),
+        startedAt: '2026-06-21T00:00:00.000Z',
+      },
+      terminalType: 'merge.executed',
+      terminalSchema: MergeExecutedData,
+      terminal: {
+        taskId: 'T11',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        strategy: 'squash',
+        mergeSha: 'a'.repeat(40),
+        rollbackSha: 'b'.repeat(40),
+      },
+      instanceId: 'T11',
+    },
+    {
+      surface: 'launch',
+      startedType: 'launch.executing_started',
+      startedSchema: LaunchExecutingStartedData,
+      started: {
+        worktreeId: '/srv/wt/launch-a',
+        holderPid: 4242,
+        holderStartedAt: 'boot-4242',
+      },
+      terminalType: 'launch.executed',
+      terminalSchema: LaunchExecutedData,
+      terminal: { worktreeId: '/srv/wt/launch-a', exitCode: 0 },
+      instanceId: '/srv/wt/launch-a',
+    },
+    {
+      surface: 'mutation',
+      startedType: 'mutation.executing_started',
+      startedSchema: MutationExecutingStartedData,
+      started: { command: 'npx stryker run', repoRoot: '/repo' },
+      terminalType: 'mutation.executed',
+      terminalSchema: MutationExecutedData,
+      terminal: { command: 'npx stryker run', repoRoot: '/repo', passed: true, exitCode: 0 },
+      instanceId: 'op-mutation-1',
+    },
+    {
+      surface: 'prune',
+      startedType: 'prune.executing_started',
+      startedSchema: PruneExecutingStartedData,
+      started: { operationId: 'op-prune-1', repoRoot: '/repo', holderPid: 7777, holderStartedAt: null },
+      terminalType: 'prune.executed',
+      terminalSchema: PruneExecutedData,
+      terminal: { operationId: 'op-prune-1', deletedCount: 0 },
+      instanceId: 'op-prune-1',
+    },
+  ] as const;
+
+  it('ExecutingStartedSchemas_PreviouslyEmittedPayloadFixtures_StillValidate', () => {
+    // Every verbatim pre-retrofit payload (no instanceId) must still parse under
+    // the additive schema — the additive change never breaks a persisted row.
+    for (const f of LIVENESS_PAIR_FIXTURES) {
+      const started = f.startedSchema.safeParse(f.started);
+      expect(started.success, `${f.startedType}: ${JSON.stringify(started)}`).toBe(true);
+      const terminal = f.terminalSchema.safeParse(f.terminal);
+      expect(terminal.success, `${f.terminalType}: ${JSON.stringify(terminal)}`).toBe(true);
+
+      // And the schema is also registered against the live event-type key.
+      expect(EVENT_DATA_SCHEMAS[f.startedType as typeof EventTypes[number]]).toBeDefined();
+      expect(EVENT_DATA_SCHEMAS[f.terminalType as typeof EventTypes[number]]).toBeDefined();
+    }
+  });
+
+  it('LegacyPayloadsWithoutInstanceId_StillValidate', () => {
+    // The additive field is OPTIONAL: a payload with NO instanceId key (every
+    // legacy row) validates, and the parsed shape leaves instanceId undefined —
+    // no default is injected, so replay is byte-stable.
+    for (const f of LIVENESS_PAIR_FIXTURES) {
+      expect(Object.prototype.hasOwnProperty.call(f.started, 'instanceId')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(f.terminal, 'instanceId')).toBe(false);
+
+      const startedParsed = f.startedSchema.parse(f.started) as { instanceId?: string };
+      const terminalParsed = f.terminalSchema.parse(f.terminal) as { instanceId?: string };
+      expect(startedParsed.instanceId).toBeUndefined();
+      expect(terminalParsed.instanceId).toBeUndefined();
+
+      // The additive-widened shape ALSO accepts an explicit instanceId.
+      expect(f.startedSchema.safeParse({ ...f.started, instanceId: f.instanceId }).success).toBe(true);
+      expect(f.terminalSchema.safeParse({ ...f.terminal, instanceId: f.instanceId }).success).toBe(true);
+    }
+  });
+
+  it('ExecutingStartedSchemas_RejectMalformedPayload', () => {
+    // REVERT-PROBE ADEQUACY: the additive `instanceId` is a TYPED string field,
+    // not a stripped unknown. A wrong-typed (number) or empty (`min(1)`) value
+    // is rejected. With the schema retrofit reverted, `instanceId` is no longer
+    // a known key → the wrong-typed value is silently stripped and these
+    // payloads wrongly validate → this test goes red (the kill-probe trigger).
+    for (const f of LIVENESS_PAIR_FIXTURES) {
+      // A well-formed instanceId is accepted — establishes the field IS honored.
+      expect(f.startedSchema.safeParse({ ...f.started, instanceId: f.instanceId }).success).toBe(true);
+      expect(f.terminalSchema.safeParse({ ...f.terminal, instanceId: f.instanceId }).success).toBe(true);
+
+      // Wrong type (number) — rejected only because instanceId is a typed field.
+      expect(
+        f.startedSchema.safeParse({ ...f.started, instanceId: 123 }).success,
+        `${f.startedType}: number instanceId must be rejected`,
+      ).toBe(false);
+      expect(
+        f.terminalSchema.safeParse({ ...f.terminal, instanceId: 123 }).success,
+        `${f.terminalType}: number instanceId must be rejected`,
+      ).toBe(false);
+
+      // Empty string — rejected by `.min(1)` (an empty instance key is meaningless).
+      expect(
+        f.startedSchema.safeParse({ ...f.started, instanceId: '' }).success,
+        `${f.startedType}: empty instanceId must be rejected`,
+      ).toBe(false);
+      expect(
+        f.terminalSchema.safeParse({ ...f.terminal, instanceId: '' }).success,
+        `${f.terminalType}: empty instanceId must be rejected`,
+      ).toBe(false);
+    }
+  });
+
+  it('LivenessPairSchemas_SerializationRoundTrip_ValidateWithAndWithoutInstanceId', () => {
+    // Property (serialization): every fixture-shaped payload, JSON round-tripped
+    // as it would be after persistence, validates BOTH with and without the
+    // additive instanceId — the two states the event log can hold across the
+    // retrofit boundary.
+    for (const f of LIVENESS_PAIR_FIXTURES) {
+      const variants: Array<{ label: string; started: unknown; terminal: unknown }> = [
+        { label: 'without instanceId (legacy)', started: f.started, terminal: f.terminal },
+        {
+          label: 'with instanceId (retrofit)',
+          started: { ...f.started, instanceId: f.instanceId },
+          terminal: { ...f.terminal, instanceId: f.instanceId },
+        },
+      ];
+      for (const v of variants) {
+        const started = JSON.parse(JSON.stringify(v.started));
+        const terminal = JSON.parse(JSON.stringify(v.terminal));
+        expect(
+          f.startedSchema.safeParse(started).success,
+          `${f.startedType} ${v.label}`,
+        ).toBe(true);
+        expect(
+          f.terminalSchema.safeParse(terminal).success,
+          `${f.terminalType} ${v.label}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('LivenessInstanceFields_SharedMixin_IsAppliedToAllEightSchemas', () => {
+    // The shared structural helper is applied to EXACTLY the eight liveness
+    // schemas (4 starts + 4 terminals) — the only place the payloads agree. Each
+    // exposes `instanceId` in its Zod shape. (Asserted against the schema shape
+    // rather than importing the mixin, so this is a clean assertion-level red
+    // when the retrofit is reverted — not an import artifact.)
+    for (const f of LIVENESS_PAIR_FIXTURES) {
+      const startedShape = (f.startedSchema as unknown as { shape: Record<string, unknown> }).shape;
+      const terminalShape = (f.terminalSchema as unknown as { shape: Record<string, unknown> }).shape;
+      expect(startedShape, `${f.startedType} shape must carry instanceId`).toHaveProperty('instanceId');
+      expect(terminalShape, `${f.terminalType} shape must carry instanceId`).toHaveProperty('instanceId');
+    }
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -352,6 +352,22 @@ export const EventTypes = [
   // deterministic plumbing: the WorktreeManager owns both appends around the pass.
   'prune.executing_started',
   'prune.executed',
+  // DR-6 (lifecycle-verbs, task 012) — the two-event `export` contract (INV-13
+  // two-event split, INV-8 idempotency). `export` writes a zip bundle
+  // (events.jsonl + state.json + metadata.json + artifacts/) to a path OUTSIDE
+  // `.exarchos/` — a non-idempotent external side effect. `export.requested` is
+  // the durable INTENT carrying the RESOLVED destination path, journaled BEFORE
+  // the write; `export.executed` is the RESULT carrying the written bundle's
+  // content hash, journaled AFTER. A crash between the two is recoverable: the
+  // next invocation observes `export.requested` without `export.executed` and
+  // runs an idempotent precheck (zip exists + hash matches the recorded
+  // `contentHash`) to re-emit or redo. Both are `auto` — the `export` composite
+  // handler owns both appends deterministically (task 013), so the model is
+  // never asked to hand-emit them. Keyed on the payload's `idempotencyKey`
+  // (INV-8): a crash-retry of the SAME logical export collapses onto one intent,
+  // while a fresh export invocation mints a distinct key and a new pair.
+  'export.requested',
+  'export.executed',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -750,6 +766,13 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // so the model is never asked to hand-emit them.
   'prune.executing_started': 'auto',
   'prune.executed': 'auto',
+
+  // DR-6 (lifecycle-verbs, task 012) — the two-event `export` contract. Both
+  // `auto`: the `export` composite handler owns both appends deterministically
+  // (task 013 — `export.requested` before the zip write, `export.executed`
+  // after), so the model is never nagged to hand-emit them.
+  'export.requested': 'auto',
+  'export.executed': 'auto',
 };
 
 // ─── Base Event Schema ──────────────────────────────────────────────────────
@@ -2939,6 +2962,81 @@ export const PruneExecutedData = z.object({
   ...livenessInstanceFields,
 });
 
+// ─── Export event contract (DR-6, lifecycle-verbs task 012 / INV-13 / INV-8) ─
+//
+// `export` writes a zip bundle (events.jsonl + state.json + metadata.json +
+// artifacts/) to a path OUTSIDE `.exarchos/` — a non-idempotent external side
+// effect, so it follows the INV-13 two-event split. `export.requested` is the
+// durable INTENT (carrying the RESOLVED destination path) journaled BEFORE the
+// write; `export.executed` is the RESULT (carrying the written bundle's content
+// hash) journaled AFTER. On a crash between the two, the next invocation
+// observes `export.requested` without `export.executed` and runs an idempotent
+// precheck (the zip exists AND its hash matches the recorded `contentHash`) to
+// decide whether to re-emit `export.executed` or redo the write.
+//
+// Both payloads carry `idempotencyKey` (INV-8) — the emitter (task 013) derives
+// the storage key from it so a crash-retry of the SAME logical export collapses
+// onto one intent, while a fresh export invocation mints a distinct key and a
+// new pair. The schema's only contract is that the field is present + non-empty;
+// the emitter owns the key's construction.
+
+/**
+ * `export.requested` — durable INTENT recorded BEFORE the non-idempotent zip
+ * write (INV-13). Carries the RESOLVED destination `outputPath` so the timeline
+ * reconstructs exactly WHERE the bundle was intended to land even if the write
+ * crashes mid-flight (the default `./<featureId>-export.zip` is resolved to an
+ * absolute path by the handler before this event is emitted). `idempotencyKey`
+ * (INV-8) lets a crash-retry collapse onto the same logical request.
+ */
+export const ExportRequestedData = z.object({
+  featureId: z.string().min(1).describe('The workflow/feature stream being exported'),
+  outputPath: z
+    .string()
+    .min(1)
+    .describe(
+      'RESOLVED absolute destination path for the zip bundle — the intent recorded before the write (default ./<featureId>-export.zip, resolved by the handler before emit)',
+    ),
+  idempotencyKey: z
+    .string()
+    .min(1)
+    .describe(
+      'Stable key (INV-8) collapsing crash-retries of the same logical export onto one intent; a fresh export invocation mints a distinct key',
+    ),
+});
+
+/**
+ * `export.executed` — the RESULT recorded AFTER the zip write succeeds
+ * (INV-13). Carries the written bundle's `contentHash` (the INV-13 crash
+ * precheck compares it against the on-disk zip to decide re-emit vs redo), the
+ * `eventCount` in the exported stream extract, the OPTIONAL `missingArtifacts`
+ * (referenced artifact paths that did not exist on disk — tolerated and listed
+ * in the bundle metadata), and the SAME `idempotencyKey` that paired it to its
+ * `export.requested` intent.
+ */
+export const ExportExecutedData = z.object({
+  featureId: z.string().min(1).describe('The workflow/feature stream that was exported'),
+  outputPath: z.string().min(1).describe('Path the zip bundle was written to (matches the requested event)'),
+  contentHash: z
+    .string()
+    .min(1)
+    .describe(
+      'Content hash of the written zip bundle — the INV-13 crash precheck compares it against the on-disk manifest to decide re-emit vs redo',
+    ),
+  eventCount: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Number of events in the exported stream extract (recorded in metadata.json)'),
+  missingArtifacts: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Referenced artifact paths that did not exist on disk — tolerated, listed in the bundle metadata'),
+  idempotencyKey: z
+    .string()
+    .min(1)
+    .describe('Same key as the paired export.requested intent (INV-8)'),
+});
+
 // ─── Event Data Schemas Map ─────────────────────────────────────────────────
 
 export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
@@ -3168,6 +3266,10 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   // WLM slice 3 (DR-3 / INV-10) — prune-run liveness pair.
   'prune.executing_started': PruneExecutingStartedData,
   'prune.executed': PruneExecutedData,
+
+  // DR-6 (lifecycle-verbs task 012) — export two-event contract (INV-13 / INV-8).
+  'export.requested': ExportRequestedData,
+  'export.executed': ExportExecutedData,
 };
 
 // ─── TypeScript Types ───────────────────────────────────────────────────────
@@ -3323,6 +3425,10 @@ export type FeedbackRecorded = z.infer<typeof FeedbackRecordedData>;
 export type PruneExecutingStarted = z.infer<typeof PruneExecutingStartedData>;
 export type PruneExecuted = z.infer<typeof PruneExecutedData>;
 
+// DR-6 (lifecycle-verbs task 012) — export two-event contract (INV-13 / INV-8).
+export type ExportRequested = z.infer<typeof ExportRequestedData>;
+export type ExportExecuted = z.infer<typeof ExportExecutedData>;
+
 // ─── Event Data Map ─────────────────────────────────────────────────────────
 
 export type EventDataMap = {
@@ -3466,6 +3572,9 @@ export type EventDataMap = {
   // WLM slice 3 (DR-3 / INV-10) — prune-run liveness pair.
   'prune.executing_started': PruneExecutingStarted;
   'prune.executed': PruneExecuted;
+  // DR-6 (lifecycle-verbs task 012) — export two-event contract (INV-13 / INV-8).
+  'export.requested': ExportRequested;
+  'export.executed': ExportExecuted;
 };
 
 // ─── Event Catalog Serialization ────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1767,6 +1767,39 @@ export const MergeRequestedData = z.object({
     .describe('Feature stream id; useful for cross-stream observability'),
 });
 
+// ─── Shared liveness instance key (DR-2 / INV-10) ────────────────────────────
+//
+// The SINGLE field the four INV-10 liveness pairs — merge / launch / mutation /
+// prune `<surface>.executing_started` + paired terminal — agree on. `instanceId`
+// is a canonical per-instance key so a uniform liveness view can correlate a
+// START event with its TERMINAL without per-surface knowledge of which native
+// field is the instance discriminator. Each emitter derives it from its own key:
+//   • merge    → taskId ?? `${sourceBranch}→${targetBranch}`
+//   • launch   → worktreeId
+//   • mutation → operationId
+//   • prune    → operationId
+//
+// This is ADDITIVE, not a uniform-shape rewrite: the surface-native fields
+// (sourceBranch, worktreeId, operationId, holderPid, …) are DELIBERATELY kept
+// as-is. Only this one field is shared — the payloads otherwise stay their own
+// distinct shapes (do not force a uniform shape where the real payloads differ).
+//
+// OPTIONAL + additive (INV-5b widening): every payload emitted BEFORE this
+// retrofit carried NO `instanceId`, so historical rows MUST still validate — no
+// migration, no schemaVersion bump. The emitters populate it going forward and
+// legacy rows fold as instanceId-absent. `.min(1)` rejects an empty/blank key:
+// an empty instance id is meaningless, and a wrong-typed value is a malformed
+// payload the boundary now rejects — the field the DR-2 revert-probe pins.
+export const livenessInstanceFields = {
+  instanceId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Canonical per-instance liveness key correlating a `<surface>.executing_started` event with its paired terminal (DR-2 / INV-10). Additive: absent on pre-retrofit rows.',
+    ),
+} as const;
+
 /**
  * merge.executed — records that a merge has been performed. `mergeSha` is
  * the resulting commit on the target branch; `rollbackSha` is the parent
@@ -1783,6 +1816,8 @@ export const MergeExecutedData = z.object({
   strategy: z.enum(['squash', 'rebase', 'merge']).optional(),
   mergeSha: z.string().min(1),
   rollbackSha: z.string().min(1),
+  // DR-2 — canonical liveness instance key (merge: taskId ?? `src→tgt`).
+  ...livenessInstanceFields,
 });
 
 /**
@@ -1910,6 +1945,8 @@ export const MergeExecutingStartedData = z.object({
   targetBranch: z.string().min(1),
   recoveryPointSha: z.string().min(1),
   startedAt: z.string().min(1),
+  // DR-2 — canonical liveness instance key (merge: taskId ?? `src→tgt`).
+  ...livenessInstanceFields,
 });
 
 // ─── Wave B Two-Event Split Schemas (#1342) ──────────────────────────────────
@@ -2264,6 +2301,8 @@ export const LaunchExecutingStartedData = z.object({
     .describe(
       'Supervisor process start time (ISO 8601) — disambiguates PID reuse; non-empty when resolved, or null when the platform cannot resolve create-time (DR-6, never the empty string)',
     ),
+  // DR-2 — canonical liveness instance key (launch: worktreeId).
+  ...livenessInstanceFields,
 });
 
 /**
@@ -2276,6 +2315,8 @@ export const LaunchExecutingStartedData = z.object({
 export const LaunchExecutedData = z.object({
   worktreeId: z.string().min(1).describe('Canonical worktrees@v1 key of the launch top-level worktree'),
   exitCode: z.number().int().nullable().describe('Child process exit code, or null when signalled / not captured'),
+  // DR-2 — canonical liveness instance key (launch: worktreeId).
+  ...livenessInstanceFields,
 });
 
 // ─── Command Resolver Event Data (#1199 T15) ────────────────────────────────
@@ -2817,6 +2858,8 @@ export const MutationExecutingStartedData = z.object({
   command: z.string().min(1),
   /** Repo root the command runs in. */
   repoRoot: z.string().min(1),
+  // DR-2 — canonical liveness instance key (mutation: operationId).
+  ...livenessInstanceFields,
 });
 
 /** Paired terminal event: the mutation run completed (pass/fail + exit code). */
@@ -2827,6 +2870,8 @@ export const MutationExecutedData = z.object({
   passed: z.boolean(),
   /** The child process exit code. */
   exitCode: z.number().int(),
+  // DR-2 — canonical liveness instance key (mutation: operationId).
+  ...livenessInstanceFields,
 });
 
 /**
@@ -2881,6 +2926,8 @@ export const PruneExecutingStartedData = z.object({
    * null-ready contract.
    */
   holderStartedAt: z.string().min(1).nullable(),
+  // DR-2 — canonical liveness instance key (prune: the existing operationId).
+  ...livenessInstanceFields,
 });
 
 /** Paired TERMINAL: the `prune_worktrees` GC pass completed (DR-3). */
@@ -2888,6 +2935,8 @@ export const PruneExecutedData = z.object({
   operationId: z.string().min(1),
   /** How many worktrees the pass deleted (0 on a dry-run or a no-op pass). */
   deletedCount: z.number().int().nonnegative(),
+  // DR-2 — canonical liveness instance key (prune: the existing operationId).
+  ...livenessInstanceFields,
 });
 
 // ─── Event Data Schemas Map ─────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -719,11 +719,22 @@ describe('EventStore Query Sequence Pre-filter', () => {
 
   it('Query_SequenceRegex_HandlesMultiDigitSequences', async () => {
     const store = new EventStore(tempDir);
-    // Append 1050 events to get multi-digit sequences
-    for (let i = 0; i < 1050; i++) {
-      const type = i % 3 === 0 ? 'task.completed' : 'task.assigned';
-      await store.append('my-workflow', { type });
-    }
+    // 1050 events, so sequences cross into 4 digits — the point of the test is
+    // the QUERY's sequence pre-filter, not the append path.
+    //
+    // Seeded via ONE batchAppend rather than 1050 awaited appends: sequence
+    // assignment and types are identical, but the batch commits in a single
+    // transaction instead of paying a per-append fsync. That is what makes this
+    // test's runtime independent of host disk throughput — the loop took ~121ms
+    // on Linux but ~35.6s on a Windows runner (NTFS fsync per append), which
+    // blew the 30s budget and reds the required `Windows Unit (MCP)` lane
+    // nondeterministically depending on how fast the runner happens to be.
+    await store.batchAppend(
+      'my-workflow',
+      Array.from({ length: 1050 }, (_, i) => ({
+        type: i % 3 === 0 ? 'task.completed' : 'task.assigned',
+      })),
+    );
 
     // Query with sinceSequence=1000 and type filter
     const events = await store.query('my-workflow', {

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -715,13 +715,15 @@ export class EventStore {
    * unconditional initial drain, so an event committed at any moment relative
    * to registration is delivered exactly once.
    *
-   * THIS is the Tier-1 (in-process) surface: an append committing in this
-   * process wakes the subscription via the appender's post-commit hook, fired
-   * after the transaction commits AND after the per-stream mutex releases (so
-   * an `onEvent` that itself appends does not deadlock). INV-8 idempotency
-   * cache-hits commit nothing and do not wake. The Tier-2 cross-process poll
-   * floor (`dataVersion()`) is task-002 — the registry already carries the
-   * injectable-clock + `floorMs` seam it binds to.
+   * Two wake tiers converge on the same cursor drain. Tier-1 (in-process):
+   * an append committing in this process wakes the subscription via the
+   * appender's post-commit hook, fired after the transaction commits AND
+   * after the per-stream mutex releases (so an `onEvent` that itself appends
+   * does not deadlock). INV-8 idempotency cache-hits commit nothing and do
+   * not wake. Tier-2 (cross-process poll floor): a loop on the injectable
+   * clock re-reads `dataVersion()` every `floorMs` and drains only when a
+   * FOREIGN process committed, so cross-process events are delivered within a
+   * bounded latency without re-scanning the log every tick.
    *
    * Subscriptions are ephemeral (INV-15): the returned handle MUST be
    * disposed by the dispatch that registered it; `close()` disposes any that
@@ -755,6 +757,11 @@ export class EventStore {
             this.getReadBackend().queryEvents(streamId, { sinceSequence: afterSequence }),
           ),
         listStreams: () => this.getReadBackend().listStreams(),
+        // Tier-2 poll-floor change token: reads through the SAME backend
+        // handle the appender writes to, so `PRAGMA data_version` reports a
+        // FOREIGN process's commit (never this process's own — those the
+        // Tier-1 hook already delivered).
+        dataVersion: () => this.getReadBackend().dataVersion(),
       };
       this.subscriptions = new SubscriptionRegistry(reader, registryOptions);
       // Wire the Tier-1 hook only now — the zero-subscriber append path never

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -7,6 +7,15 @@ import { validateStreamId } from '../shared/validation.js';
 import { AtomicAppender } from './atomic-appender.js';
 import { migrateEvents } from './event-migration.js';
 import { getDispatchContext } from '../dispatch/dispatch-context.js';
+import {
+  SubscriptionRegistry,
+  type SubscribeOptions,
+  type SubscriptionEventReader,
+  type SubscriptionFilter,
+  type SubscriptionHandle,
+  type SubscriptionListener,
+  type SubscriptionRegistryOptions,
+} from './subscriptions.js';
 
 // ─── #1291 — Dispatch-boundary correlation stamping ─────────────────────────
 //
@@ -185,6 +194,15 @@ export class EventStore {
   /** Durability posture threaded to the lazily-created appender (DR-4). */
   private synchronous?: 'normal' | 'full';
 
+  /**
+   * DR-1 subscription registry (#1315). Lazily created on the first
+   * `subscribe()` call so the append hot path pays nothing until a
+   * subscription exists — the Tier-1 commit hook on the appender is wired at
+   * the same moment, leaving `appendSqliteLocked` a single `undefined` guard
+   * on the zero-subscriber path.
+   */
+  private subscriptions?: SubscriptionRegistry;
+
   constructor(private readonly stateDir: string, options?: EventStoreOptions) {
     this.backend = options?.backend;
     this.synchronous = options?.synchronous;
@@ -293,6 +311,11 @@ export class EventStore {
    * (INV-1); `close()` only releases the live connection.
    */
   close(): void {
+    // Dispose every live subscription (INV-15) and detach the Tier-1 hook
+    // before the appender goes away.
+    this.subscriptions?.disposeAll();
+    this.atomicAppender?.setCommitHook(undefined);
+    this.subscriptions = undefined;
     this.atomicAppender?.close();
     this.atomicAppender = undefined;
     this.backend?.close();
@@ -680,6 +703,74 @@ export class EventStore {
    */
   async tailSequence(streamId: string): Promise<number> {
     return this.getReadBackend().getSequence(streamId);
+  }
+
+  /**
+   * DR-1 cursor-pump subscription primitive (#1315).
+   *
+   * Registers a subscription whose cursor drains committed events matching
+   * `filter` (`{ streamId?, eventTypes? }`) and delivers them to `onEvent` in
+   * global sequence order, exactly once. Registration atomically captures the
+   * cursor (stream head, or `options.fromSequence`) and schedules an
+   * unconditional initial drain, so an event committed at any moment relative
+   * to registration is delivered exactly once.
+   *
+   * THIS is the Tier-1 (in-process) surface: an append committing in this
+   * process wakes the subscription via the appender's post-commit hook, fired
+   * after the transaction commits AND after the per-stream mutex releases (so
+   * an `onEvent` that itself appends does not deadlock). INV-8 idempotency
+   * cache-hits commit nothing and do not wake. The Tier-2 cross-process poll
+   * floor (`dataVersion()`) is task-002 — the registry already carries the
+   * injectable-clock + `floorMs` seam it binds to.
+   *
+   * Subscriptions are ephemeral (INV-15): the returned handle MUST be
+   * disposed by the dispatch that registered it; `close()` disposes any that
+   * leak. `registryOptions` (injectable clock, floor default) is an optional
+   * test/wiring seam.
+   */
+  subscribe(
+    filter: SubscriptionFilter,
+    onEvent: SubscriptionListener,
+    options?: SubscribeOptions,
+    registryOptions?: SubscriptionRegistryOptions,
+  ): SubscriptionHandle {
+    return this.ensureSubscriptions(registryOptions).subscribe(filter, onEvent, options);
+  }
+
+  /**
+   * Lazily construct the subscription registry and wire the appender's
+   * Tier-1 commit hook. The registry reads through this store's read backend
+   * — the same SQLite handle the appender writes to (production wiring), so a
+   * commit is visible to the drain the wake triggers. Reads route through
+   * `migrateEvents` for parity with `query()` (identity today).
+   */
+  private ensureSubscriptions(
+    registryOptions?: SubscriptionRegistryOptions,
+  ): SubscriptionRegistry {
+    if (!this.subscriptions) {
+      const reader: SubscriptionEventReader = {
+        headSequence: (streamId) => this.getReadBackend().getSequence(streamId),
+        readStreamAfter: (streamId, afterSequence) =>
+          migrateEvents(
+            this.getReadBackend().queryEvents(streamId, { sinceSequence: afterSequence }),
+          ),
+        listStreams: () => this.getReadBackend().listStreams(),
+      };
+      this.subscriptions = new SubscriptionRegistry(reader, registryOptions);
+      // Wire the Tier-1 hook only now — the zero-subscriber append path never
+      // pays for a hook that is undefined.
+      const registry = this.subscriptions;
+      this.getAppender().setCommitHook((streamId) => registry.wake(streamId));
+    }
+    return this.subscriptions;
+  }
+
+  /**
+   * Dispose every live subscription (dispatch teardown — INV-15). Idempotent;
+   * safe to call whether or not any subscription was ever registered.
+   */
+  disposeSubscriptions(): void {
+    this.subscriptions?.disposeAll();
   }
 
   /**

--- a/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { fc } from '@fast-check/vitest';
+import { join } from 'node:path';
 
 import { EventStore } from './store.js';
 import { AtomicAppender } from './atomic-appender.js';
@@ -10,6 +11,8 @@ import {
   type SubscriptionEventReader,
 } from './subscriptions.js';
 import type { WorkflowEvent } from './schemas.js';
+import { SqliteBackend } from '../storage/sqlite-backend.js';
+import { InMemoryBackend } from '../storage/memory-backend.js';
 import { makeTempDir, rmrf } from '../test-helpers/temp-dir.js';
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
@@ -26,8 +29,16 @@ const fixedClock: SubscriptionClock = { now: () => 0 };
 class FakeLog implements SubscriptionEventReader {
   private readonly streams = new Map<string, WorkflowEvent[]>();
   private tick = 0;
+  /**
+   * Tier-2 change token (models `PRAGMA data_version`). Only a FOREIGN commit
+   * bumps it — SQLite's data_version is unchanged for the observer's own
+   * connection, which the Tier-1 hook already covers. {@link commit} models
+   * an own commit (bumps NOTHING but the log); {@link commitForeign} models a
+   * different connection's commit (bumps the token, fires no wake).
+   */
+  private version = 0;
 
-  /** Append (no wake) and return the committed event. */
+  /** Own commit (this connection): appends, does NOT bump dataVersion. */
   commit(streamId: string, type: string): WorkflowEvent {
     const arr = this.streams.get(streamId) ?? [];
     const event = {
@@ -38,6 +49,13 @@ class FakeLog implements SubscriptionEventReader {
     } as WorkflowEvent;
     arr.push(event);
     this.streams.set(streamId, arr);
+    return event;
+  }
+
+  /** Foreign commit (another connection): appends AND bumps dataVersion. */
+  commitForeign(streamId: string, type: string): WorkflowEvent {
+    const event = this.commit(streamId, type);
+    this.version++;
     return event;
   }
 
@@ -52,6 +70,10 @@ class FakeLog implements SubscriptionEventReader {
   listStreams(): readonly string[] {
     return [...this.streams.keys()];
   }
+
+  dataVersion(): number {
+    return this.version;
+  }
 }
 
 /** Call-counting decorator over a reader — pins the zero-subscriber guard. */
@@ -59,6 +81,8 @@ class SpyReader implements SubscriptionEventReader {
   headCalls = 0;
   readCalls = 0;
   listCalls = 0;
+  /** Counts cheap Tier-2 token reads separately from event-log work. */
+  versionCalls = 0;
   constructor(private readonly inner: SubscriptionEventReader) {}
   headSequence(streamId: string): number {
     this.headCalls++;
@@ -72,8 +96,46 @@ class SpyReader implements SubscriptionEventReader {
     this.listCalls++;
     return this.inner.listStreams();
   }
+  dataVersion(): number {
+    this.versionCalls++;
+    return this.inner.dataVersion();
+  }
+  /** Event-log work only — the cheap dataVersion token is tracked separately. */
   get totalCalls(): number {
     return this.headCalls + this.readCalls + this.listCalls;
+  }
+}
+
+/**
+ * Manually-driven clock (INV-16) for deterministic Tier-2 floor tests. Records
+ * every scheduled floor loop and its interval; {@link fireAll} fires one tick
+ * on every live loop with no wall-clock sleep. A cancelled loop (disposed
+ * subscription) drops out of {@link scheduledIntervals} and stops ticking.
+ */
+class ManualClock implements SubscriptionClock {
+  time = 0;
+  private readonly loops: Array<{ tick: () => void; intervalMs: number }> = [];
+  now(): number {
+    return this.time;
+  }
+  scheduleInterval(tick: () => void, intervalMs: number): () => void {
+    const entry = { tick, intervalMs };
+    this.loops.push(entry);
+    return () => {
+      const i = this.loops.indexOf(entry);
+      if (i >= 0) this.loops.splice(i, 1);
+    };
+  }
+  /** Fire one tick on every currently-scheduled floor loop. */
+  fireAll(): void {
+    for (const { tick } of [...this.loops]) tick();
+  }
+  /** Intervals of the currently-live floor loops (in schedule order). */
+  get scheduledIntervals(): number[] {
+    return this.loops.map((l) => l.intervalMs);
+  }
+  get loopCount(): number {
+    return this.loops.length;
   }
 }
 
@@ -396,5 +458,333 @@ describe('SubscriptionRegistry (DR-1 invariants)', () => {
 
     expect(received).toEqual(['other#2', 'fresh#1']);
     handle.dispose();
+  });
+});
+
+// ─── Tier-2 dataVersion() backend contract (real backends, boundary) ─────────
+
+/** Minimal valid event for direct backend appends. */
+function makeEvent(streamId: string, sequence: number, type: string): WorkflowEvent {
+  return {
+    streamId,
+    sequence,
+    type,
+    timestamp: new Date(sequence).toISOString(),
+    schemaVersion: '1.0',
+  } as WorkflowEvent;
+}
+
+describe('StorageBackend.dataVersion (DR-1 Tier-2 change token)', () => {
+  it('DataVersion_Sqlite_ForeignCommitOnlyVisibility', () => {
+    // Two REAL SQLite connections on one db file (WAL). SqliteBackend applies
+    // busy_timeout=5000 on every connection (INV-16 / SQLITE_BUSY posture),
+    // so a foreign commit under contention is absorbed at the C layer rather
+    // than surfacing as SQLITE_BUSY. This is the boundary the poll floor
+    // stands on — a hand-mock could not reproduce PRAGMA data_version's
+    // own-vs-foreign asymmetry.
+    const dir = makeTempDir('dataversion-sqlite-');
+    const dbPath = join(dir, 'exarchos.db');
+    const observer = new SqliteBackend(dbPath);
+    const foreign = new SqliteBackend(dbPath);
+    observer.initialize();
+    foreign.initialize();
+    try {
+      const baseline = observer.dataVersion();
+
+      // The observer's OWN commit must NOT bump its data_version — Tier-1
+      // already delivers own commits, so the floor must not re-fire for them.
+      observer.appendEvent('feat-1', makeEvent('feat-1', 1, T1));
+      expect(observer.dataVersion()).toBe(baseline);
+
+      // A FOREIGN connection's commit MUST bump the observer's data_version.
+      foreign.appendEvent('feat-1', makeEvent('feat-1', 2, T2));
+      const afterForeign = observer.dataVersion();
+      expect(afterForeign).not.toBe(baseline);
+
+      // Stable across a second own commit (own writes never bump it).
+      observer.appendEvent('feat-1', makeEvent('feat-1', 3, T3));
+      expect(observer.dataVersion()).toBe(afterForeign);
+
+      // A second foreign commit bumps it again (change detection is repeatable).
+      foreign.appendEvent('feat-1', makeEvent('feat-1', 4, T1));
+      expect(observer.dataVersion()).not.toBe(afterForeign);
+    } finally {
+      observer.close();
+      foreign.close();
+      rmrf(dir);
+    }
+  });
+
+  it('DataVersion_InMemory_MonotonicOnAppend', () => {
+    // In-memory has no cross-process notion, so "foreign" collapses to "any
+    // append": the counter bumps on the observer's own appends and is stable
+    // between them.
+    const backend = new InMemoryBackend();
+    backend.initialize();
+    try {
+      const v0 = backend.dataVersion();
+      backend.appendEvent('s', makeEvent('s', 1, T1));
+      const v1 = backend.dataVersion();
+      backend.appendEvent('s', makeEvent('s', 2, T2));
+      const v2 = backend.dataVersion();
+
+      expect(v1).toBeGreaterThan(v0);
+      expect(v2).toBeGreaterThan(v1);
+      // A read with no intervening append is stable.
+      expect(backend.dataVersion()).toBe(v2);
+    } finally {
+      backend.close();
+    }
+  });
+});
+
+// ─── Tier-2 poll floor over the real store (boundary: real SQLite) ───────────
+
+describe('EventStore.subscribe Tier-2 poll floor (DR-1, real backends)', () => {
+  let dir: string;
+  let store: EventStore;
+  let foreign: EventStore;
+
+  beforeEach(async () => {
+    dir = makeTempDir('floor-');
+    store = new EventStore(dir);
+    foreign = new EventStore(dir);
+    await store.initialize();
+    await foreign.initialize();
+  });
+
+  afterEach(() => {
+    store.close();
+    foreign.close();
+    rmrf(dir);
+  });
+
+  it('Floor_ForeignCommit_DrainedInGlobalOrderNextTick', async () => {
+    const clock = new ManualClock();
+    const received: number[] = [];
+    // Inject the manual clock on the FIRST subscribe (the registry is created
+    // lazily and caches it) so the floor loop is driven tick-by-tick.
+    const handle = store.subscribe(
+      { streamId: STREAM },
+      (e) => received.push(e.sequence),
+      undefined,
+      { clock },
+    );
+
+    // Foreign commits AFTER registration → no Tier-1 wake reaches `store`.
+    await foreign.append(STREAM, { type: T1, data: {} }); // seq 1
+    await foreign.append(STREAM, { type: T2, data: {} }); // seq 2
+
+    // Nothing delivered yet: only the poll floor can pull a foreign commit.
+    expect(received).toEqual([]);
+
+    // One tick: dataVersion changed → single cursor drain delivers both in
+    // ascending global sequence order.
+    clock.fireAll();
+    expect(received).toEqual([1, 2]);
+
+    handle.dispose();
+  });
+
+  it('Floor_ForeignThenOwnAppend_NoGapNoDoubleDelivery', async () => {
+    const clock = new ManualClock();
+    const received: number[] = [];
+    const handle = store.subscribe(
+      { streamId: STREAM },
+      (e) => received.push(e.sequence),
+      undefined,
+      { clock },
+    );
+
+    // Foreign seq N (=1): no wake to `store`; bumps its data_version.
+    await foreign.append(STREAM, { type: T1, data: {} });
+    // A floor tick pulls the foreign event via the cursor drain.
+    clock.fireAll();
+    expect(received).toEqual([1]);
+
+    // Own seq N+1 (=2): Tier-1 wake → drain from cursor 1 → delivers 2.
+    await store.append(STREAM, { type: T2, data: {} });
+    expect(received).toEqual([1, 2]);
+
+    // Another tick: the foreign bump is already consumed and the cursor is at
+    // 2 — no gap, and NO double delivery of seq 1 or 2.
+    clock.fireAll();
+    expect(received).toEqual([1, 2]);
+
+    handle.dispose();
+  });
+});
+
+// ─── Tier-2 poll floor registry-level invariants (owned fixtures) ────────────
+
+describe('SubscriptionRegistry Tier-2 poll floor (DR-1 invariants)', () => {
+  it('Floor_CommitBetweenHeadReadAndBaseline_DeliveredByInitialDrain', () => {
+    // A foreign commit landing in the window between the registration
+    // head-read (cursor) and the dataVersion baseline capture must be
+    // delivered by the INITIAL DRAIN (its seq > cursor) and NOT re-delivered
+    // by a later tick (the baseline already reflects its version bump). An
+    // instrumented reader fires the foreign commit at exactly that seam.
+    const log = new FakeLog();
+    const clock = new ManualClock();
+    let injected = false;
+    const seam: SubscriptionEventReader = {
+      headSequence: (s) => {
+        const head = log.headSequence(s); // cursor = pre-commit head (0)
+        if (!injected) {
+          injected = true;
+          // Lands AFTER the cursor read, BEFORE dataVersion() → folded into
+          // the baseline yet still ahead of the cursor.
+          log.commitForeign(STREAM, T1);
+        }
+        return head;
+      },
+      readStreamAfter: (s, after) => log.readStreamAfter(s, after),
+      listStreams: () => log.listStreams(),
+      dataVersion: () => log.dataVersion(),
+    };
+    const registry = new SubscriptionRegistry(seam, { clock });
+    const received: number[] = [];
+    const handle = registry.subscribe({ streamId: STREAM }, (e) => received.push(e.sequence));
+
+    // Initial drain covers it (seq 1 > cursor 0).
+    expect(received).toEqual([1]);
+    // Ticks see dataVersion unchanged since baseline → no re-delivery.
+    clock.fireAll();
+    clock.fireAll();
+    expect(received).toEqual([1]);
+
+    handle.dispose();
+  });
+
+  it('Floor_NoForeignCommit_NoReRead', () => {
+    // A tick with no dataVersion change is near-free: it reads the cheap
+    // token and short-circuits WITHOUT re-scanning the event log.
+    const spy = new SpyReader(new FakeLog());
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(spy, { clock });
+    const handle = registry.subscribe({ streamId: STREAM }, () => {});
+
+    const readsAfterInit = spy.readCalls;
+    const versionAfterInit = spy.versionCalls;
+
+    clock.fireAll();
+    clock.fireAll();
+    clock.fireAll();
+
+    expect(spy.readCalls).toBe(readsAfterInit); // event log never re-scanned
+    expect(spy.versionCalls).toBeGreaterThan(versionAfterInit); // token still polled
+    expect(handle.perf().floorTicks).toBe(3);
+    expect(handle.perf().floorDrains).toBe(0);
+
+    handle.dispose();
+  });
+
+  it('Floor_PerCallIntervalOverride_Honored', () => {
+    const log = new FakeLog();
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(log, { clock, defaultFloorMs: 250 });
+
+    // Per-call floorMs override wins over the registry default and is the
+    // interval the floor loop is actually scheduled at.
+    const handle = registry.subscribe({ streamId: STREAM }, () => {}, { floorMs: 40 });
+    expect(clock.scheduledIntervals).toEqual([40]);
+    expect(handle.perf().floorMs).toBe(40);
+
+    handle.dispose();
+    // Disposal cancels the loop — no live interval remains.
+    expect(clock.scheduledIntervals).toEqual([]);
+    expect(clock.loopCount).toBe(0);
+  });
+
+  it('Floor_DefaultInterval_SurfacedInPerf', () => {
+    const log = new FakeLog();
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(log, { clock });
+
+    const handle = registry.subscribe({ streamId: STREAM }, () => {});
+    // No override → the documented default interval is used, surfaced in
+    // perf, and used to schedule the floor loop.
+    expect(handle.perf().floorMs).toBe(DEFAULT_FLOOR_MS);
+    expect(clock.scheduledIntervals).toEqual([DEFAULT_FLOOR_MS]);
+
+    handle.dispose();
+  });
+
+  it('Floor_ArbitrarySplitAndSchedule_ExactlyOnceInOrder', () => {
+    // Concurrency property: for ANY split of appends across two connections
+    // (own = Tier-1 wake; foreign = dataVersion bump, no wake), ANY tick
+    // schedule, and ANY registration point, the subscriber observes every
+    // matching post-registration event exactly once in global sequence order.
+    // A single trailing flush tick models the floor's forever-poll. This goes
+    // red without the floor loop: a trailing foreign commit with no following
+    // own wake is delivered ONLY by a tick.
+    fc.assert(
+      fc.property(
+        fc.record({
+          ops: fc.array(
+            fc.record({
+              type: fc.constantFrom(T1, T2, T3),
+              foreign: fc.boolean(),
+              tickAfter: fc.boolean(),
+            }),
+            { minLength: 0, maxLength: 16 },
+          ),
+          regNat: fc.nat(),
+          filterTypes: fc.subarray([T1, T2, T3]),
+        }),
+        ({ ops, regNat, filterTypes }) => {
+          const log = new FakeLog();
+          const clock = new ManualClock();
+          const registry = new SubscriptionRegistry(log, { clock });
+          const k = regNat % (ops.length + 1); // registration point in [0, n]
+
+          // Ops BEFORE registration: committed, but no subscription exists to
+          // wake or tick.
+          for (let i = 0; i < k; i++) {
+            const op = ops[i];
+            if (op.foreign) log.commitForeign(STREAM, op.type);
+            else log.commit(STREAM, op.type);
+          }
+
+          const received: WorkflowEvent[] = [];
+          const filter =
+            filterTypes.length > 0
+              ? { streamId: STREAM, eventTypes: filterTypes }
+              : { streamId: STREAM };
+          const handle = registry.subscribe(filter, (e) => received.push(e));
+
+          // Ops AFTER registration: own commit fires a Tier-1 wake; foreign
+          // commit fires none (only a tick pulls it). A tick may follow any op.
+          for (let i = k; i < ops.length; i++) {
+            const op = ops[i];
+            if (op.foreign) {
+              log.commitForeign(STREAM, op.type);
+            } else {
+              log.commit(STREAM, op.type);
+              registry.wake(STREAM);
+            }
+            if (op.tickAfter) clock.fireAll();
+          }
+          // Trailing flush: the real floor polls forever; the test polls once
+          // more so any trailing foreign commit is observed.
+          clock.fireAll();
+
+          const matches = (t: string) =>
+            filterTypes.length === 0 || filterTypes.includes(t);
+          const expectedSeqs: number[] = [];
+          for (let i = k; i < ops.length; i++) {
+            if (matches(ops[i].type)) expectedSeqs.push(i + 1); // seq is 1-based op index
+          }
+
+          const gotSeqs = received.map((e) => e.sequence);
+          expect(gotSeqs).toEqual(expectedSeqs); // every post-reg match, in order, no gap
+          expect(new Set(gotSeqs).size).toBe(gotSeqs.length); // exactly once
+
+          handle.dispose();
+          expect(registry.size).toBe(0);
+        },
+      ),
+      { numRuns: 300 },
+    );
   });
 });

--- a/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { fc } from '@fast-check/vitest';
 import { join } from 'node:path';
+import { Database } from 'bun:sqlite';
 
 import { EventStore } from './store.js';
 import { AtomicAppender } from './atomic-appender.js';
@@ -14,6 +15,11 @@ import type { WorkflowEvent } from './schemas.js';
 import { SqliteBackend } from '../storage/sqlite-backend.js';
 import { InMemoryBackend } from '../storage/memory-backend.js';
 import { makeTempDir, rmrf } from '../test-helpers/temp-dir.js';
+import { runInspectFollow, type FollowSubscribe } from '../cli/follow-loop.js';
+import { tasksFollow } from '../mcp/tasks-methods.js';
+import { handleViewWait, type WaitDeps } from '../views/lifecycle/wait.js';
+import type { DispatchContext } from '../core/dispatch.js';
+import type { Frame } from '../ndjson/frames.js';
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
@@ -786,5 +792,434 @@ describe('SubscriptionRegistry Tier-2 poll floor (DR-1 invariants)', () => {
       ),
       { numRuns: 300 },
     );
+  });
+});
+
+// ─── DR-1/DR-8: disposal lifecycle across the two entry points (task-017) ─────
+//
+// Both disposal entry points — the CLI AbortSignal (SIGINT) and the MCP
+// task-cancel — MUST converge on the SINGLE `SubscriptionHandle.dispose()` so
+// the DR-1 registry returns to size 0 with NO leak (INV-15: no daemon, the
+// dispatch disposes what it registered). These suites drive the REAL follow
+// carriers (`runInspectFollow` / `tasksFollow`) over a REAL `SubscriptionRegistry`
+// so the leak assertion is `registry.size`, not merely `handle.disposed`.
+// Determinism is INV-16: the injected `ManualClock` — no per-test win32 skips.
+
+/** Bind a `SubscriptionRegistry` as the DR-1 subscribe contract the carriers drive. */
+function registryFollowSubscribe(registry: SubscriptionRegistry): FollowSubscribe {
+  return (filter, onEvent, options) => registry.subscribe(filter, onEvent, options);
+}
+
+/**
+ * An AbortSignal that counts its LIVE `abort` listeners so a leak of the
+ * disposal listener (a dispose-first teardown that never removes the listener
+ * it added to a long-lived signal) is observable. `{ once: true }` auto-removal
+ * on a fired abort bypasses `removeEventListener`, so this probe is only used on
+ * the dispose-BEFORE-abort paths (where abort never fires).
+ */
+function countingAbortSignal(): {
+  signal: AbortSignal;
+  liveAbortListeners: () => number;
+} {
+  const controller = new AbortController();
+  let live = 0;
+  const wrapper = {
+    get aborted(): boolean {
+      return controller.signal.aborted;
+    },
+    addEventListener(type: string, cb: EventListenerOrEventListenerObject, opts?: AddEventListenerOptions | boolean): void {
+      if (type === 'abort') live++;
+      controller.signal.addEventListener(type, cb, opts);
+    },
+    removeEventListener(type: string, cb: EventListenerOrEventListenerObject, opts?: EventListenerOptions | boolean): void {
+      if (type === 'abort') live--;
+      controller.signal.removeEventListener(type, cb, opts);
+    },
+  };
+  return { signal: wrapper as unknown as AbortSignal, liveAbortListeners: () => live };
+}
+
+describe('Subscription disposal lifecycle — AbortSignal + task-cancel (DR-1/DR-8)', () => {
+  it('Follow_ConsumerDisconnect_HandleDisposedRegistryZero', () => {
+    const log = new FakeLog();
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(log, { clock });
+    const frames: Frame[] = [];
+    const controller = new AbortController();
+
+    // CLI `inspect --follow` over a REAL DR-1 registry. The CLI wires SIGINT →
+    // this AbortController (the "consumer disconnect" entry point).
+    const handle = runInspectFollow({
+      subscribe: registryFollowSubscribe(registry),
+      featureId: STREAM,
+      fromSequence: 0,
+      onFrame: (f) => frames.push(f),
+      signal: controller.signal,
+      clock,
+    });
+    expect(registry.size).toBe(1); // one live subscription while following
+    expect(handle.disposed()).toBe(false);
+
+    // Consumer disconnects (^C). The AbortSignal route MUST reach the single
+    // handle.dispose() and drain the registry.
+    controller.abort();
+
+    expect(handle.disposed()).toBe(true);
+    expect(registry.size).toBe(0); // NO leak — sole disposal route reached dispose()
+    expect(frames.at(-1)).toEqual({ type: 'end', reason: 'aborted' });
+
+    // Idempotent: a redundant teardown after abort neither throws nor resurrects.
+    handle.dispose();
+    expect(registry.size).toBe(0);
+  });
+
+  it('Follow_DisposeBeforeAbort_AbortListenerRemovedNoSignalLeak', async () => {
+    // Disposal source hardening (follow-loop.ts): a stream ended by dispose()
+    // (never abort) must not leave a live `abort` listener pinned to a
+    // long-lived external signal. The registry sub is disposed either way; this
+    // pins the SIGNAL-listener half of "NO leak".
+    const log = new FakeLog();
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(log, { clock });
+    const probe = countingAbortSignal();
+
+    const handle = runInspectFollow({
+      subscribe: registryFollowSubscribe(registry),
+      featureId: STREAM,
+      fromSequence: 0,
+      onFrame: () => {},
+      signal: probe.signal,
+      clock,
+    });
+    expect(registry.size).toBe(1);
+    expect(probe.liveAbortListeners()).toBe(1); // listener armed while following
+
+    // End via dispose() — the OTHER convergence into the single end() route,
+    // with NO abort ever firing on the external signal.
+    handle.dispose();
+    await handle.done;
+
+    expect(handle.disposed()).toBe(true);
+    expect(registry.size).toBe(0); // subscription disposed
+    expect(probe.liveAbortListeners()).toBe(0); // abort listener removed — no signal leak
+  });
+
+  it('TasksCancel_MidFollow_HandleDisposed', () => {
+    const log = new FakeLog();
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(log, { clock });
+    const frames: Frame[] = [];
+
+    // MCP Tasks arm — the disposal entry point is `tasks/cancel` (no POSIX
+    // signal; the SDK cancel folds into the carrier's internal AbortController).
+    const handle = tasksFollow({
+      subscribe: registryFollowSubscribe(registry),
+      featureId: STREAM,
+      fromSequence: 0,
+      onFrame: (f) => frames.push(f),
+      clock,
+    });
+    expect(registry.size).toBe(1);
+
+    // Mid-follow: an in-process commit is delivered as an event frame BEFORE the
+    // cancel — the disposal happens partway through a live tail.
+    log.commit(STREAM, T1);
+    registry.wake(STREAM);
+    const eventSeqs = frames
+      .filter((f) => f.type === 'event')
+      .map((f) => (f as { sequence: number }).sequence);
+    expect(eventSeqs).toEqual([1]);
+
+    // tasks/cancel → cancel() → controller.abort() + inner.dispose(), both
+    // folding into the ONE handle.dispose() (task-009 single disposal route).
+    handle.cancel();
+    expect(handle.disposed()).toBe(true);
+    expect(registry.size).toBe(0); // disposed, NOT leaked
+    expect(frames.at(-1)).toEqual({ type: 'end', reason: 'aborted' });
+
+    // Idempotent — a repeat cancel neither re-disposes nor resurrects the sub.
+    handle.cancel();
+    expect(registry.size).toBe(0);
+  });
+
+  it('TasksFollow_EndsBeforeExternalAbort_ExternalListenerRemovedNoSignalLeak', async () => {
+    // Disposal source hardening (tasks-methods.ts): an external (server/session)
+    // signal folded into the carrier must have its `abort` listener dropped once
+    // the follow ends by cancel/dispose, so a long-lived signal does not retain
+    // it after the follow is gone. The registry sub is disposed either way.
+    const log = new FakeLog();
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(log, { clock });
+    const probe = countingAbortSignal();
+
+    const handle = tasksFollow({
+      subscribe: registryFollowSubscribe(registry),
+      featureId: STREAM,
+      fromSequence: 0,
+      onFrame: () => {},
+      clock,
+      signal: probe.signal, // external abort folded into the internal controller
+    });
+    expect(registry.size).toBe(1);
+    expect(probe.liveAbortListeners()).toBe(1); // external listener armed
+
+    // End via cancel() — the external signal itself NEVER aborts, so `{ once }`
+    // auto-removal does not apply; only the explicit teardown removes it.
+    handle.cancel();
+    await handle.done;
+
+    expect(handle.disposed()).toBe(true);
+    expect(registry.size).toBe(0);
+    expect(probe.liveAbortListeners()).toBe(0); // external listener removed — no signal leak
+  });
+});
+
+// ─── DR-1/DR-8: concurrent waits + N-way registry concurrency (task-017) ──────
+//
+// Concurrent consumers on ONE stream each own an INDEPENDENT DR-1 subscription
+// (task-010: each `wait` owns its own handle), so one resolving/disposing never
+// settles or starves another, and each subscriber sees ONLY its own matches.
+// The named case drives the REAL `handleViewWait`; the property generalizes to
+// N concurrent subscribe/dispose/append interleavings over the registry.
+
+/** Reach the store's lazily-created registry to observe/assert leak state. */
+function registryOf(store: EventStore): SubscriptionRegistry | undefined {
+  return (store as unknown as { subscriptions?: SubscriptionRegistry }).subscriptions;
+}
+
+/** Yield (macrotask) until the store's registry reaches `n` live subscriptions. */
+async function waitForRegistrySize(store: EventStore, n: number): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if ((registryOf(store)?.size ?? 0) === n) return;
+    await new Promise((r) => setImmediate(r));
+  }
+  throw new Error(`registry size never reached ${n} (was ${registryOf(store)?.size ?? 0})`);
+}
+
+describe('Concurrent waits on one stream resolve independently (DR-1/DR-8)', () => {
+  it('Wait_ConcurrentSameStream_BothResolveIndependently', async () => {
+    const dir = makeTempDir('wait-concurrent-');
+    const store = new EventStore(dir);
+    await store.initialize();
+    const ctx = { stateDir: dir, eventStore: store, enableTelemetry: false } as unknown as DispatchContext;
+    const clock = new ManualClock();
+    // Deterministic deps (INV-16): injected floor clock + a deadline that never
+    // fires (both waits resolve on Tier-1 in-process wakes).
+    const deps: WaitDeps = {
+      now: () => 1000,
+      scheduleTimeout: () => () => {},
+      subscriptionOptions: { clock },
+    };
+    const featureId = 'feat-concurrent';
+    try {
+      await store.append(featureId, {
+        type: 'workflow.started',
+        data: { featureId, workflowType: 'feature' },
+      });
+
+      // Two concurrent waits on the SAME stream, DIFFERENT phase targets — each
+      // registers its own DR-1 subscription on one registry.
+      const w1 = handleViewWait({ featureId, phase: 'plan-review', timeoutMs: 60_000 }, ctx, deps);
+      const w2 = handleViewWait({ featureId, phase: 'delegate', timeoutMs: 60_000 }, ctx, deps);
+      await waitForRegistrySize(store, 2); // both subscribed: two live handles, one stream
+
+      // First transition: the Tier-1 wake fans out to BOTH subscriptions, but
+      // only w1's predicate is satisfied — w2 stays pending (independence).
+      await store.append(featureId, {
+        type: 'workflow.transition',
+        data: { from: 'plan', to: 'plan-review', featureId },
+      });
+      const r1 = await w1;
+      expect(r1.success).toBe(true);
+      expect((r1.data as { phase?: string }).phase).toBe('plan-review');
+      // Resolved via its OWN subscription (perf surfaced) on a Tier-1 wake.
+      expect((r1.data as { perf?: { floorTicks: number } }).perf?.floorTicks).toBe(0);
+
+      // w1 disposed its handle; w2's subscription is untouched (size 2 → 1).
+      await waitForRegistrySize(store, 1);
+      const PENDING = Symbol('pending');
+      expect(await Promise.race([w2, Promise.resolve(PENDING)])).toBe(PENDING); // w2 still pending
+
+      // Second transition: now w2 resolves — independently, on the SAME stream.
+      await store.append(featureId, {
+        type: 'workflow.transition',
+        data: { from: 'plan-review', to: 'delegate', featureId },
+      });
+      const r2 = await w2;
+      expect(r2.success).toBe(true);
+      expect((r2.data as { phase?: string }).phase).toBe('delegate');
+
+      // Both waits disposed their handles → registry drained to zero (no leak).
+      await waitForRegistrySize(store, 0);
+    } finally {
+      store.close();
+      rmrf(dir);
+    }
+  });
+
+  it('Registry_ConcurrentSubscribeDisposeAppendInterleavings_ConsistentAndScoped', () => {
+    // Property: for ANY set of concurrent subscribers on one stream (each with
+    // its own filter and its own disposal point) and ANY interleaving of own
+    // (Tier-1 wake) / foreign (Tier-2 tick) appends, the registry stays
+    // consistent (returns to size 0 once all dispose) and every subscriber
+    // receives EXACTLY its own matching events committed while it was alive —
+    // exactly once, in ascending sequence order, with no cross-talk between
+    // siblings.
+    fc.assert(
+      fc.property(
+        fc.record({
+          ops: fc.array(
+            fc.record({ type: fc.constantFrom(T1, T2, T3), foreign: fc.boolean() }),
+            { minLength: 0, maxLength: 16 },
+          ),
+          subs: fc.array(
+            fc.record({ filterTypes: fc.subarray([T1, T2, T3]), disposeAt: fc.nat() }),
+            { minLength: 1, maxLength: 5 },
+          ),
+        }),
+        ({ ops, subs }) => {
+          const log = new FakeLog();
+          const clock = new ManualClock();
+          const registry = new SubscriptionRegistry(log, { clock });
+          const n = ops.length;
+
+          const state = subs.map((s) => {
+            const received: WorkflowEvent[] = [];
+            const filter =
+              s.filterTypes.length > 0
+                ? { streamId: STREAM, eventTypes: s.filterTypes }
+                : { streamId: STREAM };
+            const handle = registry.subscribe(filter, (e) => received.push(e));
+            return {
+              s,
+              received,
+              handle,
+              disposeBefore: s.disposeAt % (n + 1), // dispose just before this op index
+              disposed: false,
+            };
+          });
+          expect(registry.size).toBe(subs.length); // all concurrently live at op 0
+
+          for (let i = 0; i < n; i++) {
+            // Any subscriber scheduled to end before op i disposes now — it must
+            // not observe op i onward.
+            for (const st of state) {
+              if (!st.disposed && st.disposeBefore === i) {
+                st.handle.dispose();
+                st.disposed = true;
+              }
+            }
+            const op = ops[i];
+            if (op.foreign) {
+              log.commitForeign(STREAM, op.type); // no Tier-1 wake — only a tick pulls it
+            } else {
+              log.commit(STREAM, op.type);
+              registry.wake(STREAM);
+            }
+            clock.fireAll(); // tick each op so foreign commits are flushed deterministically
+          }
+          // Dispose the survivors.
+          for (const st of state) {
+            if (!st.disposed) {
+              st.handle.dispose();
+              st.disposed = true;
+            }
+          }
+          expect(registry.size).toBe(0); // consistent — every handle removed, no leak
+
+          for (const st of state) {
+            const matches = (t: string) =>
+              st.s.filterTypes.length === 0 || st.s.filterTypes.includes(t);
+            const expected: number[] = [];
+            for (let i = 0; i < st.disposeBefore; i++) {
+              if (matches(ops[i].type)) expected.push(i + 1); // seq is 1-based op index
+            }
+            const got = st.received.map((e) => e.sequence);
+            expect(got).toEqual(expected); // only its matches, in order, none post-dispose
+            expect(new Set(got).size).toBe(got.length); // exactly once
+          }
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+});
+
+// ─── DR-8: Windows handle-close / INV-16 poll-floor mechanics (task-017) ──────
+//
+// The Tier-2 poll floor stands on a real SQLite connection. On Windows an open
+// statement pins the handle so the DB cannot close and the file cannot be
+// deleted (#1620 handle-close class). These tests assert the floor holds NO
+// open statement across ticks: every foreign commit stays visible tick-over-tick
+// (no pinned read snapshot) AND both connections close cleanly afterwards
+// (better-sqlite3 throws on close with an open statement — the portable stand-in
+// for the Windows handle pin). Two-connection contention is made safe by the
+// explicit `busy_timeout` the test verifies on BOTH connections. The injected
+// `ManualClock` drives the floor deterministically — no per-test win32 skips.
+
+/** Read a SqliteBackend connection's `busy_timeout` (per-handle pragma). */
+function readBusyTimeout(backend: SqliteBackend): number {
+  const db = (backend as unknown as { db: Database }).db;
+  const rows = db.query('PRAGMA busy_timeout').all() as Array<Record<string, number>>;
+  const row = rows[0];
+  const value = row.timeout ?? row.busy_timeout ?? row[''];
+  return typeof value === 'number' ? value : Number(value);
+}
+
+describe('Tier-2 poll floor over real SQLite — Windows handle-close (DR-8/INV-16)', () => {
+  it('Floor_RealSqlite_NoOpenStatementAcrossTicks_ClosesCleanBusyTimeout', () => {
+    const dir = makeTempDir('floor-win32-');
+    const dbPath = join(dir, 'exarchos.db');
+    const observer = new SqliteBackend(dbPath);
+    const foreign = new SqliteBackend(dbPath);
+    observer.initialize();
+    foreign.initialize();
+    const clock = new ManualClock();
+    try {
+      // Explicit busy_timeout on BOTH connections — the C-layer silent-absorption
+      // tier that makes two-connection floor contention Windows-safe (the
+      // anti-SQLITE_BUSY posture the poll floor stands on).
+      expect(readBusyTimeout(observer)).toBe(5000);
+      expect(readBusyTimeout(foreign)).toBe(5000);
+
+      // Registry floor over the observer's REAL SQLite reader — the same reader
+      // shape `EventStore.subscribe` wires in production.
+      const reader: SubscriptionEventReader = {
+        headSequence: (s) => observer.getSequence(s),
+        readStreamAfter: (s, after) => observer.queryEvents(s, { sinceSequence: after }),
+        listStreams: () => observer.listStreams(),
+        dataVersion: () => observer.dataVersion(),
+      };
+      const registry = new SubscriptionRegistry(reader, { clock });
+      const received: number[] = [];
+      const handle = registry.subscribe({ streamId: STREAM }, (e) => received.push(e.sequence));
+
+      // Drive many floor ticks, each after a FOREIGN commit. If the floor pinned
+      // a read snapshot (an open statement held across ticks), the observer would
+      // stop seeing new foreign rows — so full delivery witnesses "no open
+      // statement across ticks".
+      const TICKS = 8;
+      for (let seq = 1; seq <= TICKS; seq++) {
+        foreign.appendEvent(STREAM, makeEvent(STREAM, seq, T1));
+        clock.fireAll();
+      }
+      expect(received).toEqual([1, 2, 3, 4, 5, 6, 7, 8]); // every foreign commit visible
+
+      handle.dispose();
+      expect(registry.size).toBe(0);
+
+      // #1620 handle-close: no statement pinned across the ticks ⇒ both handles
+      // close cleanly (better-sqlite3 throws on close if a statement is still
+      // open) and the dir is removable — the Windows teardown guarantee.
+      expect(() => observer.close()).not.toThrow();
+      expect(() => foreign.close()).not.toThrow();
+      expect(() => rmrf(dir)).not.toThrow();
+    } catch (err) {
+      // Best-effort teardown on assertion failure (close() is idempotent).
+      observer.close();
+      foreign.close();
+      rmrf(dir);
+      throw err;
+    }
   });
 });

--- a/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
@@ -137,6 +137,30 @@ class ThrowOnStreamReader implements SubscriptionEventReader {
 }
 
 /**
+ * Wraps a reader so `dataVersion()` throws on demand — models the transient
+ * storage read failure a Tier-2 floor tick must CONTAIN. The tick body runs
+ * inside a native `setInterval` callback, so an escaping throw is an unhandled
+ * process-level exception, not a contained per-subscription failure.
+ */
+class ThrowOnDataVersionReader implements SubscriptionEventReader {
+  throwNext = false;
+  constructor(private readonly inner: SubscriptionEventReader) {}
+  headSequence(streamId: string): number {
+    return this.inner.headSequence(streamId);
+  }
+  readStreamAfter(streamId: string, afterSequence: number): readonly WorkflowEvent[] {
+    return this.inner.readStreamAfter(streamId, afterSequence);
+  }
+  listStreams(): readonly string[] {
+    return this.inner.listStreams();
+  }
+  dataVersion(): number {
+    if (this.throwNext) throw new Error('dataVersion boom');
+    return this.inner.dataVersion();
+  }
+}
+
+/**
  * Manually-driven clock (INV-16) for deterministic Tier-2 floor tests. Records
  * every scheduled floor loop and its interval; {@link fireAll} fires one tick
  * on every live loop with no wall-clock sleep. A cancelled loop (disposed
@@ -487,6 +511,35 @@ describe('SubscriptionRegistry (DR-1 invariants)', () => {
     registry.wake('fresh');
 
     expect(received).toEqual(['other#2', 'fresh#1']);
+    handle.dispose();
+  });
+
+  it('FloorTick_DataVersionThrows_ContainedAndLaterTickStillDeliversForeignCommit', () => {
+    // The Tier-2 floor tick runs inside a native setInterval callback, so a
+    // transient `dataVersion()` failure must be contained the same way `wake()`
+    // contains a Tier-1 drain — otherwise it escapes as an unhandled
+    // process-level exception and takes the server down.
+    const log = new FakeLog();
+    const reader = new ThrowOnDataVersionReader(log);
+    const clock = new ManualClock();
+    const registry = new SubscriptionRegistry(reader, { clock });
+    const received: number[] = [];
+    const handle = registry.subscribe({ streamId: STREAM }, (e) => received.push(e.sequence));
+
+    // A FOREIGN commit: no Tier-1 wake fires, so only the floor can observe it.
+    log.commitForeign(STREAM, T1);
+
+    // The tick that would have observed it fails mid-read.
+    reader.throwNext = true;
+    expect(() => clock.fireAll()).not.toThrow(); // contained, not process-level
+    expect(received).toEqual([]); // nothing delivered by the failed tick
+
+    // …and the failure did NOT fold the commit into the baseline: the next
+    // healthy tick still drains it (the no-gap guarantee survives the throw).
+    reader.throwNext = false;
+    clock.fireAll();
+    expect(received).toEqual([1]);
+
     handle.dispose();
   });
 

--- a/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fc } from '@fast-check/vitest';
+
+import { EventStore } from './store.js';
+import { AtomicAppender } from './atomic-appender.js';
+import {
+  SubscriptionRegistry,
+  DEFAULT_FLOOR_MS,
+  type SubscriptionClock,
+  type SubscriptionEventReader,
+} from './subscriptions.js';
+import type { WorkflowEvent } from './schemas.js';
+import { makeTempDir, rmrf } from '../test-helpers/temp-dir.js';
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+/** Injectable clock (INV-16) — deterministic, never reads wall time. */
+const fixedClock: SubscriptionClock = { now: () => 0 };
+
+/**
+ * Hermetic in-memory event log implementing the registry's read seam. Owned
+ * by the test (a fixture I own, per boundary discipline) so registry-logic
+ * tests can drive precise interleavings — foreign appends without a wake,
+ * varying registration points — without spinning real SQLite.
+ */
+class FakeLog implements SubscriptionEventReader {
+  private readonly streams = new Map<string, WorkflowEvent[]>();
+  private tick = 0;
+
+  /** Append (no wake) and return the committed event. */
+  commit(streamId: string, type: string): WorkflowEvent {
+    const arr = this.streams.get(streamId) ?? [];
+    const event = {
+      streamId,
+      sequence: arr.length + 1,
+      type,
+      timestamp: new Date(this.tick++).toISOString(),
+    } as WorkflowEvent;
+    arr.push(event);
+    this.streams.set(streamId, arr);
+    return event;
+  }
+
+  headSequence(streamId: string): number {
+    return this.streams.get(streamId)?.length ?? 0;
+  }
+
+  readStreamAfter(streamId: string, afterSequence: number): readonly WorkflowEvent[] {
+    return (this.streams.get(streamId) ?? []).filter((e) => e.sequence > afterSequence);
+  }
+
+  listStreams(): readonly string[] {
+    return [...this.streams.keys()];
+  }
+}
+
+/** Call-counting decorator over a reader — pins the zero-subscriber guard. */
+class SpyReader implements SubscriptionEventReader {
+  headCalls = 0;
+  readCalls = 0;
+  listCalls = 0;
+  constructor(private readonly inner: SubscriptionEventReader) {}
+  headSequence(streamId: string): number {
+    this.headCalls++;
+    return this.inner.headSequence(streamId);
+  }
+  readStreamAfter(streamId: string, afterSequence: number): readonly WorkflowEvent[] {
+    this.readCalls++;
+    return this.inner.readStreamAfter(streamId, afterSequence);
+  }
+  listStreams(): readonly string[] {
+    this.listCalls++;
+    return this.inner.listStreams();
+  }
+  get totalCalls(): number {
+    return this.headCalls + this.readCalls + this.listCalls;
+  }
+}
+
+const STREAM = 'feat-1';
+const T1 = 'task.progressed';
+const T2 = 'task.completed';
+const T3 = 'workflow.transition';
+
+// ─── Real-store integration suite (across the store/appender seam) ───────────
+
+describe('EventStore.subscribe (DR-1 cursor-pump, Tier-1)', () => {
+  let dir: string;
+  let store: EventStore;
+
+  beforeEach(async () => {
+    dir = makeTempDir('subscriptions-');
+    store = new EventStore(dir);
+    await store.initialize();
+  });
+
+  afterEach(() => {
+    // Close SQLite handles before temp-dir removal (INV-16 / Windows).
+    store.close();
+    rmrf(dir);
+  });
+
+  it('Subscribe_InProcessAppend_CursorDrainDeliversPostCommitInOrder', async () => {
+    const received: WorkflowEvent[] = [];
+    const handle = store.subscribe({ streamId: STREAM }, (e) => received.push(e));
+
+    await store.append(STREAM, { type: T1, data: {} });
+    await store.append(STREAM, { type: T2, data: {} });
+    await store.append(STREAM, { type: T3, data: {} });
+
+    // Delivered synchronously post-commit (each carries its committed
+    // sequence), in ascending global sequence order.
+    expect(received.map((e) => e.sequence)).toEqual([1, 2, 3]);
+    expect(received.map((e) => e.type)).toEqual([T1, T2, T3]);
+    handle.dispose();
+  });
+
+  it('Subscribe_ForeignThenOwnCommit_DeliversInGlobalSequenceOrder', async () => {
+    // A second EventStore on the same stateDir models a foreign connection:
+    // its commit does NOT wake this store's registry (Tier-1 is in-process),
+    // so the own commit's wake must drain the undrained foreign event first.
+    const foreign = new EventStore(dir);
+    await foreign.initialize();
+    try {
+      const received: WorkflowEvent[] = [];
+      const handle = store.subscribe({ streamId: STREAM }, (e) => received.push(e));
+
+      await foreign.append(STREAM, { type: T1, data: {} }); // seq 1 — no wake here
+      await store.append(STREAM, { type: T2, data: {} }); // seq 2 — wake → drain [1,2]
+
+      expect(received.map((e) => e.sequence)).toEqual([1, 2]);
+      handle.dispose();
+    } finally {
+      foreign.close();
+    }
+  });
+
+  it('Subscribe_ListenerThrows_AppendUnaffectedSiblingsAndLaterEventsDelivered', async () => {
+    const good: number[] = [];
+    const bad: number[] = [];
+    const hGood = store.subscribe({ streamId: STREAM }, (e) => good.push(e.sequence));
+    const hBad = store.subscribe({ streamId: STREAM }, (e) => {
+      bad.push(e.sequence);
+      if (e.sequence === 1) throw new Error('listener boom on N+1');
+    });
+
+    // One transaction, three events → one wake → one batch drain. The throw
+    // on seq 1 must not drop seq 2/3 from the SAME (throwing) subscription,
+    // must not affect the sibling, and must not reach the append result.
+    const result = await store.batchAppend(STREAM, [
+      { type: T1, data: {} },
+      { type: T2, data: {} },
+      { type: T3, data: {} },
+    ]);
+
+    expect(result.map((e) => e.sequence)).toEqual([1, 2, 3]); // append unaffected
+    expect(good).toEqual([1, 2, 3]); // sibling unaffected
+    expect(bad).toEqual([1, 2, 3]); // later events still delivered despite throw
+
+    // A subsequent append still commits and delivers — the throw did not
+    // poison the append path.
+    const after = await store.append(STREAM, { type: T1, data: {} });
+    expect(after.sequence).toBe(4);
+    expect(good).toEqual([1, 2, 3, 4]);
+    hGood.dispose();
+    hBad.dispose();
+  });
+
+  it('Subscribe_ListenerAppendsSameStream_NoDeadlockDeliveredNextDrain', async () => {
+    const received: string[] = [];
+    const nested: Array<Promise<unknown>> = [];
+    let reentered = false;
+    const handle = store.subscribe({ streamId: STREAM }, (e) => {
+      received.push(e.type);
+      if (e.type === T1 && !reentered) {
+        reentered = true;
+        // Re-enter the append path from inside delivery. The Tier-1 hook
+        // fires AFTER the per-stream mutex releases, so this must NOT
+        // deadlock the non-reentrant per-stream lock.
+        nested.push(store.append(STREAM, { type: T2, data: {} }));
+      }
+    });
+
+    await store.append(STREAM, { type: T1, data: {} }); // delivers T1 → triggers nested append
+    await Promise.all(nested); // nested append commits → its wake delivers T2
+
+    expect(received).toEqual([T1, T2]);
+    handle.dispose();
+  });
+
+  it('Subscribe_IdempotencyCacheHit_NoWakeNoRedelivery', async () => {
+    // Store-level: a cache-hit re-append delivers nothing new.
+    const received: WorkflowEvent[] = [];
+    const handle = store.subscribe({ streamId: STREAM }, (e) => received.push(e));
+    const key = 'idem-key-1';
+    await store.append(STREAM, { type: T1, data: {} }, { idempotencyKey: key });
+    expect(received).toHaveLength(1);
+    await store.append(STREAM, { type: T1, data: {} }, { idempotencyKey: key }); // INV-8 cache-hit
+    expect(received).toHaveLength(1);
+    handle.dispose();
+
+    // Appender-level: the hook fires for the fresh commit but NOT for the
+    // cache-hit (proves "no wake", independent of the cursor no-redelivery).
+    const wakes: string[] = [];
+    const appenderDir = makeTempDir('appender-');
+    const appender = new AtomicAppender({ stateDir: appenderDir });
+    appender.setCommitHook((s) => wakes.push(s));
+    try {
+      const first = await appender.append('s', [{ type: T1 }], 'k1');
+      const second = await appender.append('s', [{ type: T1 }], 'k1');
+      expect(first.ok && first.kind).toBe('committed');
+      expect(second.ok && second.kind).toBe('cache-hit');
+      expect(wakes).toEqual(['s']); // exactly one wake — cache-hit did not fire
+    } finally {
+      appender.close();
+      rmrf(appenderDir);
+    }
+  });
+
+  it('Subscribe_EventTypesFilter_DeliversOnlyMatchingTypes', async () => {
+    const received: string[] = [];
+    const handle = store.subscribe(
+      { streamId: STREAM, eventTypes: [T2] },
+      (e) => received.push(e.type),
+    );
+    await store.append(STREAM, { type: T1, data: {} });
+    await store.append(STREAM, { type: T2, data: {} });
+    await store.append(STREAM, { type: T1, data: {} });
+    await store.append(STREAM, { type: T2, data: {} });
+    expect(received).toEqual([T2, T2]);
+    handle.dispose();
+  });
+
+  it('Subscribe_FromSequence_SkipsBaselineDeliversAfterCursor', async () => {
+    await store.append(STREAM, { type: T1, data: {} }); // seq 1 (baseline)
+    await store.append(STREAM, { type: T1, data: {} }); // seq 2 (baseline)
+    const received: number[] = [];
+    // Cursor pinned at 2 → only seq > 2 delivered.
+    const handle = store.subscribe({ streamId: STREAM }, (e) => received.push(e.sequence), {
+      fromSequence: 2,
+    });
+    expect(received).toEqual([]); // initial drain: nothing after cursor 2
+    await store.append(STREAM, { type: T1, data: {} }); // seq 3
+    expect(received).toEqual([3]);
+    handle.dispose();
+  });
+
+  it('Subscribe_DispatchReturns_HandleDisposedStopsDelivery', async () => {
+    const received: number[] = [];
+    const handle = store.subscribe({ streamId: STREAM }, (e) => received.push(e.sequence));
+    await store.append(STREAM, { type: T1, data: {} });
+    expect(received).toEqual([1]);
+    handle.dispose();
+    expect(handle.disposed).toBe(true);
+    await store.append(STREAM, { type: T1, data: {} }); // after disposal — no delivery
+    expect(received).toEqual([1]);
+  });
+
+  it('Append_CharacterizationBaseline_UnchangedWithHook', async () => {
+    // Pins append semantics with NO subscriber (hook never wired): a fresh
+    // commit returns the sequence; an idempotent retry returns the cached
+    // shape (same sequence); the stream holds exactly one event. Adding the
+    // Tier-1 hook must not perturb this.
+    const key = 'char-key';
+    const first = await store.append(STREAM, { type: T1, data: {} }, { idempotencyKey: key });
+    const retry = await store.append(STREAM, { type: T1, data: {} }, { idempotencyKey: key });
+    expect(first.sequence).toBe(1);
+    expect(retry.sequence).toBe(first.sequence);
+    const all = await store.query(STREAM);
+    expect(all).toHaveLength(1);
+  });
+});
+
+// ─── Registry-level suite (INV-15 leak, zero-subscriber guard, property) ─────
+
+describe('SubscriptionRegistry (DR-1 invariants)', () => {
+  it('Subscribe_DispatchReturns_HandleDisposedRegistryZero', () => {
+    const log = new FakeLog();
+    const registry = new SubscriptionRegistry(log, { clock: fixedClock });
+    const handles = [
+      registry.subscribe({ streamId: STREAM }, () => {}),
+      registry.subscribe({ streamId: STREAM }, () => {}),
+      registry.subscribe({ eventTypes: [T1] }, () => {}),
+    ];
+    expect(registry.size).toBe(3);
+
+    // Dispatch returns → dispose all handles (INV-15).
+    for (const h of handles) h.dispose();
+    expect(handles.every((h) => h.disposed)).toBe(true);
+    expect(registry.size).toBe(0);
+
+    // Idempotent + disposeAll safe on an already-empty registry.
+    handles[0].dispose();
+    registry.disposeAll();
+    expect(registry.size).toBe(0);
+  });
+
+  it('Append_ZeroSubscribers_GuardCheckOnly', () => {
+    const spy = new SpyReader(new FakeLog());
+    const registry = new SubscriptionRegistry(spy, { clock: fixedClock });
+    expect(registry.size).toBe(0);
+
+    // Zero subscribers: a wake does no listener-related work beyond the size
+    // guard — the reader is never touched.
+    registry.wake(STREAM);
+    expect(spy.totalCalls).toBe(0);
+
+    // Contrast: with one subscriber, a wake DOES drain (guard is live, not
+    // dead code).
+    const handle = registry.subscribe({ streamId: STREAM }, () => {});
+    const before = spy.totalCalls;
+    registry.wake(STREAM);
+    expect(spy.totalCalls).toBeGreaterThan(before);
+    handle.dispose();
+  });
+
+  it('exposes the injectable-clock + floor seam for task-002 (Tier-2)', () => {
+    const log = new FakeLog();
+    const registry = new SubscriptionRegistry(log, { clock: fixedClock });
+    expect(registry.clock).toBe(fixedClock);
+    expect(registry.defaultFloorMs).toBe(DEFAULT_FLOOR_MS);
+    const custom = new SubscriptionRegistry(log, { clock: fixedClock, defaultFloorMs: 40 });
+    expect(custom.defaultFloorMs).toBe(40);
+  });
+
+  it('Subscribe_RegistrationConcurrentWithAppends_InitialDrainNoLoss', () => {
+    // Property: for arbitrary append sequences, an arbitrary registration
+    // point among them, and an arbitrary type filter, the subscriber receives
+    // EXACTLY its matching events committed after its registration cursor —
+    // exactly once, in global (ascending-sequence) order. Pre-registration
+    // events are never delivered; post-registration matches are never lost.
+    fc.assert(
+      fc.property(
+        fc.record({
+          types: fc.array(fc.constantFrom(T1, T2, T3), { minLength: 0, maxLength: 14 }),
+          regNat: fc.nat(),
+          filterTypes: fc.subarray([T1, T2, T3]),
+        }),
+        ({ types, regNat, filterTypes }) => {
+          const log = new FakeLog();
+          const registry = new SubscriptionRegistry(log, { clock: fixedClock });
+          const k = regNat % (types.length + 1); // registration point in [0, n]
+
+          // Appends BEFORE registration: committed, but no wake reaches a
+          // subscription that does not yet exist.
+          for (let i = 0; i < k; i++) log.commit(STREAM, types[i]);
+
+          const received: WorkflowEvent[] = [];
+          const filter =
+            filterTypes.length > 0
+              ? { streamId: STREAM, eventTypes: filterTypes }
+              : { streamId: STREAM };
+          const handle = registry.subscribe(filter, (e) => received.push(e));
+
+          // Appends AFTER registration: each commit is followed by its
+          // Tier-1 wake.
+          for (let i = k; i < types.length; i++) {
+            log.commit(STREAM, types[i]);
+            registry.wake(STREAM);
+          }
+
+          const matches = (t: string) => filterTypes.length === 0 || filterTypes.includes(t);
+          const expectedSeqs: number[] = [];
+          for (let i = k; i < types.length; i++) {
+            if (matches(types[i])) expectedSeqs.push(i + 1); // seq is 1-based index
+          }
+
+          const gotSeqs = received.map((e) => e.sequence);
+          expect(gotSeqs).toEqual(expectedSeqs); // exact set, in order, no loss
+          expect(new Set(gotSeqs).size).toBe(gotSeqs.length); // exactly once
+
+          handle.dispose();
+          expect(registry.size).toBe(0);
+        },
+      ),
+      { numRuns: 250 },
+    );
+  });
+
+  it('cross-stream subscription delivers new-stream events post-registration', () => {
+    // A stream that did not exist at registration starts at cursor 0, so all
+    // its events are (correctly) post-registration and delivered exactly once.
+    const log = new FakeLog();
+    log.commit('other', T1); // pre-existing on a different stream — baseline
+    const registry = new SubscriptionRegistry(log, { clock: fixedClock });
+    const received: string[] = [];
+    const handle = registry.subscribe({}, (e) => received.push(`${e.streamId}#${e.sequence}`));
+
+    // 'other' was at head 1 at registration → its seq-1 is baseline, not
+    // delivered; a new event on it IS.
+    log.commit('other', T2);
+    registry.wake('other');
+    // A brand-new stream: every event delivered.
+    log.commit('fresh', T1);
+    registry.wake('fresh');
+
+    expect(received).toEqual(['other#2', 'fresh#1']);
+    handle.dispose();
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.test.ts
@@ -113,6 +113,30 @@ class SpyReader implements SubscriptionEventReader {
 }
 
 /**
+ * Wraps a reader so a configured stream's `readStreamAfter` throws — models a
+ * mid-loop read failure during a cross-stream drain (DR-1 "no gaps"): the drain
+ * must not leave an EARLIER stream's cursor advanced past events discarded when
+ * a LATER stream's read throws. `throwOn` is armed/cleared per phase.
+ */
+class ThrowOnStreamReader implements SubscriptionEventReader {
+  throwOn: string | null = null;
+  constructor(private readonly inner: SubscriptionEventReader) {}
+  headSequence(streamId: string): number {
+    return this.inner.headSequence(streamId);
+  }
+  readStreamAfter(streamId: string, afterSequence: number): readonly WorkflowEvent[] {
+    if (this.throwOn === streamId) throw new Error(`read boom on ${streamId}`);
+    return this.inner.readStreamAfter(streamId, afterSequence);
+  }
+  listStreams(): readonly string[] {
+    return this.inner.listStreams();
+  }
+  dataVersion(): number {
+    return this.inner.dataVersion();
+  }
+}
+
+/**
  * Manually-driven clock (INV-16) for deterministic Tier-2 floor tests. Records
  * every scheduled floor loop and its interval; {@link fireAll} fires one tick
  * on every live loop with no wall-clock sleep. A cancelled loop (disposed
@@ -464,6 +488,46 @@ describe('SubscriptionRegistry (DR-1 invariants)', () => {
 
     expect(received).toEqual(['other#2', 'fresh#1']);
     handle.dispose();
+  });
+
+  it('Drain_CrossStreamLaterReadThrows_EarlierCursorNotAdvanced_Redelivered', () => {
+    // DR-1 "no gaps": for a cross-stream subscription the per-stream cursors must
+    // advance only AFTER the whole batch is assembled. If a LATER stream's read
+    // throws mid-loop, the assembled batch is discarded — so an EARLIER stream's
+    // cursor must NOT have advanced past its (undelivered) events, or the next
+    // drain would silently skip them. Insertion order fixes the union scan:
+    // 'stream-a' (has a new event) is read before 'stream-z' (throws).
+    const log = new FakeLog();
+    log.commit('stream-a', T1); // baseline seq 1 — cursor pinned here at registration
+    log.commit('stream-z', T1); // baseline seq 1 on the later-scanned stream
+    const reader = new ThrowOnStreamReader(log);
+    const registry = new SubscriptionRegistry(reader, { clock: fixedClock });
+
+    const received: string[] = [];
+    // Cross-stream subscription (no streamId filter). Registration pins both
+    // cursors to their heads (a=1, z=1); baselines are not delivered.
+    const handle = registry.subscribe({}, (e) => received.push(`${e.streamId}#${e.sequence}`));
+    expect(received).toEqual([]);
+
+    // A NEW event on the earlier stream (seq 2), then arm the later stream to
+    // throw. The wake drains cross-stream: reads stream-a (new event), then
+    // stream-z (throws). The registry isolates the throw (wake swallows it), so
+    // the assembled batch is discarded and NOTHING is delivered this pass.
+    log.commit('stream-a', T2); // seq 2 — the event at risk of silent loss
+    reader.throwOn = 'stream-z';
+    registry.wake('stream-a');
+    expect(received).toEqual([]); // batch discarded on the throw — no partial delivery
+
+    // Heal the later stream and drain again. The earlier stream's cursor must
+    // still be at 1 (NOT advanced past the undelivered seq 2), so seq 2 is
+    // redelivered exactly once. A premature per-stream advance would lose it
+    // forever (received would stay empty).
+    reader.throwOn = null;
+    registry.wake('stream-a');
+    expect(received).toEqual(['stream-a#2']);
+
+    handle.dispose();
+    expect(registry.size).toBe(0);
   });
 });
 

--- a/servers/exarchos-mcp/src/event-store/subscriptions.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.ts
@@ -354,16 +354,30 @@ class Subscription {
         ? [this.filter.streamId]
         : this.unionStreams();
 
+    // Assemble the FULL cross-stream batch BEFORE mutating any cursor. For a
+    // cross-stream subscription a later stream's `readStreamAfter` throwing must
+    // not leave EARLIER streams' cursors advanced past events that were never
+    // delivered (DR-1 "no gaps"): the assembled batch is discarded on a mid-loop
+    // throw, so any cursor already advanced would silently skip its events on the
+    // next drain. Stage each stream's cursor target and apply the advances only
+    // once every read has succeeded — a throw leaves every cursor untouched, so
+    // the next drain re-reads from the same positions and redelivers.
     const batch: WorkflowEvent[] = [];
+    const pendingCursors: Array<[streamId: string, tailSequence: number]> = [];
     for (const streamId of streams) {
       const cursor = this.cursors.get(streamId) ?? 0;
       const events = this.reader.readStreamAfter(streamId, cursor);
       if (events.length === 0) continue;
       for (const event of events) batch.push(event);
-      // Advance the cursor PAST every event read (matching or not) so
-      // trailing non-matching events never force a re-scan. Contiguous
+      // STAGE (do not yet apply) the advance PAST every event read (matching or
+      // not) so trailing non-matching events never force a re-scan. Contiguous
       // per-stream sequences make the tail the last element.
-      this.cursors.set(streamId, events[events.length - 1].sequence);
+      pendingCursors.push([streamId, events[events.length - 1].sequence]);
+    }
+
+    // Every read succeeded — now it is safe to commit the cursor advances.
+    for (const [streamId, tailSequence] of pendingCursors) {
+      this.cursors.set(streamId, tailSequence);
     }
 
     if (batch.length === 0) return;

--- a/servers/exarchos-mcp/src/event-store/subscriptions.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.ts
@@ -1,0 +1,341 @@
+import { randomUUID } from 'node:crypto';
+import type { WorkflowEvent } from './schemas.js';
+
+/**
+ * DR-1 — Cursor-pump subscription primitive (#1315).
+ *
+ * A subscription is a cursor over the committed event log. Delivery is
+ * ALWAYS a cursor-driven drain: read matching events after the cursor,
+ * deliver them in global sequence order, advance the cursor. The cursor is
+ * the load-bearing invariant — every wake signal (Tier-1 in-process
+ * post-commit hook here; the Tier-2 `dataVersion()` poll floor in task-002)
+ * merely triggers the SAME drain, so exactly-once, in-order delivery holds
+ * by construction regardless of which signal fired or how many fired.
+ *
+ * Scope of THIS module (task-001): registration + the cursor drain + the
+ * Tier-1 wake plumbing. The Tier-2 cross-process poll floor is deliberately
+ * NOT implemented here — {@link SubscriptionClock} and the per-subscription
+ * `floorMs` are captured as the seam task-002 binds the floor loop to.
+ */
+
+// ─── Public contract ─────────────────────────────────────────────────────────
+
+/**
+ * Match predicate for a subscription.
+ *
+ * - `streamId` — when set, the subscription observes exactly one stream and
+ *   its cursor is that stream's per-stream sequence (the clean, common case
+ *   consumed by `wait`/`inspect`, which are always feature-scoped). When
+ *   omitted, the subscription observes every stream (cross-stream fold).
+ * - `eventTypes` — when set, only events whose `type` is in the list are
+ *   delivered. Non-matching events still advance the cursor (they are read,
+ *   just not delivered) so a stream dense with non-matching events never
+ *   re-scans.
+ */
+export interface SubscriptionFilter {
+  readonly streamId?: string;
+  readonly eventTypes?: readonly string[];
+}
+
+/** Delivery callback. Invoked once per matching event, in global order. */
+export type SubscriptionListener = (event: WorkflowEvent) => void;
+
+export interface SubscribeOptions {
+  /**
+   * Start the cursor at this sequence instead of the stream head, so a
+   * subscriber sees events committed AT OR AFTER `fromSequence + 1`. Only
+   * meaningful for a single-stream filter (`filter.streamId` set); ignored
+   * for cross-stream filters, whose baseline is the current head of every
+   * known stream.
+   */
+  readonly fromSequence?: number;
+  /**
+   * Per-call override of the Tier-2 poll-floor interval (task-002). Captured
+   * at registration; unused by the Tier-1 path in this module.
+   */
+  readonly floorMs?: number;
+}
+
+/**
+ * Ephemeral handle returned by {@link SubscriptionRegistry.subscribe}.
+ *
+ * INV-15: subscriptions are per-dispatch and are disposed by the dispatch
+ * that registered them — there is no daemon. `dispose()` is idempotent.
+ */
+export interface SubscriptionHandle {
+  readonly id: string;
+  readonly disposed: boolean;
+  dispose(): void;
+}
+
+/**
+ * Read seam the drain pulls committed events through. Kept deliberately
+ * narrow (and synchronous — the SQLite backend reads are synchronous) so the
+ * registry has no dependency on `EventStore` internals and is trivially
+ * driven by a hermetic fixture in unit tests. The production wiring in
+ * `EventStore.subscribe()` implements this over its read backend.
+ */
+export interface SubscriptionEventReader {
+  /** Highest committed sequence on `streamId`, or 0 when empty/unknown. */
+  headSequence(streamId: string): number;
+  /**
+   * Committed events on `streamId` with `sequence > afterSequence`, in
+   * ascending sequence order. MUST include events of every type (not only
+   * the subscription's `eventTypes`) so the cursor can advance past
+   * non-matching events.
+   */
+  readStreamAfter(streamId: string, afterSequence: number): readonly WorkflowEvent[];
+  /** Every stream id known to the backend (for cross-stream subscriptions). */
+  listStreams(): readonly string[];
+}
+
+/**
+ * Injectable clock seam (INV-16). Task-001 uses NO wall-clock time — the
+ * Tier-1 drain is signal-driven, not timed. This interface exists so the
+ * task-002 Tier-2 poll floor is deterministic (no `Date.now()`, no
+ * `setTimeout` sleeps) the moment it lands.
+ */
+export interface SubscriptionClock {
+  now(): number;
+}
+
+/** Documented default poll-floor interval (task-002 consumes it). */
+export const DEFAULT_FLOOR_MS = 250;
+
+export interface SubscriptionRegistryOptions {
+  readonly clock?: SubscriptionClock;
+  readonly defaultFloorMs?: number;
+}
+
+// ─── Global-order comparator ────────────────────────────────────────────────
+
+/**
+ * Deterministic global ordering for a merged drain batch.
+ *
+ * Within a single stream the per-stream `sequence` is the authoritative
+ * total order, so same-stream events compare purely by sequence — this makes
+ * the single-stream delivery guarantee (the only ordering the DR-1
+ * acceptance criteria assert) exact and independent of timestamp ties. Across
+ * streams there is no shared sequence space, so `(timestamp, streamId,
+ * sequence)` is the deterministic global proxy; exactly-once is guaranteed by
+ * the per-stream cursor advance regardless, so the cross-stream order only
+ * affects presentation.
+ */
+function compareGlobalOrder(a: WorkflowEvent, b: WorkflowEvent): number {
+  if (a.streamId === b.streamId) return a.sequence - b.sequence;
+  const byTs = a.timestamp.localeCompare(b.timestamp);
+  if (byTs !== 0) return byTs;
+  const byStream = a.streamId.localeCompare(b.streamId);
+  if (byStream !== 0) return byStream;
+  return a.sequence - b.sequence;
+}
+
+// ─── Subscription ────────────────────────────────────────────────────────────
+
+class Subscription {
+  readonly id = randomUUID();
+  disposed = false;
+
+  /** Per-stream last-delivered sequence — the cursor. */
+  private readonly cursors = new Map<string, number>();
+  /** Re-entrancy guard so at most one drain runs at a time per subscription. */
+  private draining = false;
+  /** Set when a wake arrives mid-drain; coalesces into a single re-run. */
+  private rerun = false;
+
+  constructor(
+    private readonly filter: SubscriptionFilter,
+    private readonly listener: SubscriptionListener,
+    private readonly reader: SubscriptionEventReader,
+    /** Captured for task-002's Tier-2 floor; unused by the Tier-1 path. */
+    readonly floorMs: number,
+    fromSequence: number | undefined,
+    private readonly onDispose: (sub: Subscription) => void,
+  ) {
+    // Registration is atomic: capture the baseline cursor(s) synchronously
+    // (single-threaded JS — no gap between reading head and recording it),
+    // THEN schedule the unconditional initial drain. Any event committed
+    // after this point is delivered by the initial drain or a later wake,
+    // never lost to a baseline that already covered it.
+    if (this.filter.streamId !== undefined) {
+      this.cursors.set(
+        this.filter.streamId,
+        fromSequence ?? this.reader.headSequence(this.filter.streamId),
+      );
+    } else {
+      for (const streamId of this.reader.listStreams()) {
+        this.cursors.set(streamId, this.reader.headSequence(streamId));
+      }
+    }
+    // Unconditional initial drain — covers an event that committed at the
+    // exact registration instant (the baseline-already-included case is a
+    // no-op; nothing is after the cursor).
+    this.requestDrain();
+  }
+
+  /** True when a commit on `streamId` could produce a matching event. */
+  matchesStream(streamId: string): boolean {
+    return this.filter.streamId === undefined || this.filter.streamId === streamId;
+  }
+
+  private matchesEvent(event: WorkflowEvent): boolean {
+    if (this.filter.streamId !== undefined && event.streamId !== this.filter.streamId) {
+      return false;
+    }
+    if (this.filter.eventTypes !== undefined && !this.filter.eventTypes.includes(event.type)) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Trigger a drain. Serialized per subscription: if a drain is already
+   * running (a wake arrived mid-delivery), flag a re-run and return so the
+   * initial drain and a concurrent wake never double-deliver. The loop
+   * drains-until-quiescent so a wake that lands during delivery is not lost.
+   */
+  requestDrain(): void {
+    if (this.disposed) return;
+    if (this.draining) {
+      this.rerun = true;
+      return;
+    }
+    this.draining = true;
+    try {
+      do {
+        this.rerun = false;
+        this.drainOnce();
+      } while (this.rerun && !this.disposed);
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  private drainOnce(): void {
+    const streams =
+      this.filter.streamId !== undefined
+        ? [this.filter.streamId]
+        : this.unionStreams();
+
+    const batch: WorkflowEvent[] = [];
+    for (const streamId of streams) {
+      const cursor = this.cursors.get(streamId) ?? 0;
+      const events = this.reader.readStreamAfter(streamId, cursor);
+      if (events.length === 0) continue;
+      for (const event of events) batch.push(event);
+      // Advance the cursor PAST every event read (matching or not) so
+      // trailing non-matching events never force a re-scan. Contiguous
+      // per-stream sequences make the tail the last element.
+      this.cursors.set(streamId, events[events.length - 1].sequence);
+    }
+
+    if (batch.length === 0) return;
+    batch.sort(compareGlobalOrder);
+
+    for (const event of batch) {
+      if (this.disposed) return;
+      if (!this.matchesEvent(event)) continue;
+      // Listener isolation: a throw on one event must not drop the rest of
+      // the batch, affect sibling subscriptions, or reach the appender.
+      try {
+        this.listener(event);
+      } catch {
+        // Intentionally swallowed — delivery is best-effort observation.
+      }
+    }
+  }
+
+  /** Streams to scan for a cross-stream drain: backend streams ∪ cursor keys. */
+  private unionStreams(): string[] {
+    const streams = new Set<string>(this.reader.listStreams());
+    for (const streamId of this.cursors.keys()) streams.add(streamId);
+    return [...streams];
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.onDispose(this);
+  }
+}
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+/**
+ * Owns the set of live subscriptions and routes Tier-1 wakes to them.
+ *
+ * The registry is the single guard on the append hot path: {@link wake}
+ * early-returns on an empty registry, so a zero-subscriber append does no
+ * listener work beyond one size check.
+ */
+export class SubscriptionRegistry {
+  private readonly subscriptions = new Map<string, Subscription>();
+  private readonly reader: SubscriptionEventReader;
+  /** Injectable clock (INV-16) — retained for the task-002 Tier-2 floor. */
+  readonly clock: SubscriptionClock;
+  /** Default poll-floor interval — retained for the task-002 Tier-2 floor. */
+  readonly defaultFloorMs: number;
+
+  constructor(reader: SubscriptionEventReader, options?: SubscriptionRegistryOptions) {
+    this.reader = reader;
+    this.clock = options?.clock ?? { now: () => Date.now() };
+    this.defaultFloorMs = options?.defaultFloorMs ?? DEFAULT_FLOOR_MS;
+  }
+
+  /** Number of live subscriptions (INV-15 leak assertions read this). */
+  get size(): number {
+    return this.subscriptions.size;
+  }
+
+  subscribe(
+    filter: SubscriptionFilter,
+    listener: SubscriptionListener,
+    options?: SubscribeOptions,
+  ): SubscriptionHandle {
+    const sub = new Subscription(
+      filter,
+      listener,
+      this.reader,
+      options?.floorMs ?? this.defaultFloorMs,
+      options?.fromSequence,
+      (s) => {
+        this.subscriptions.delete(s.id);
+      },
+    );
+    this.subscriptions.set(sub.id, sub);
+    return {
+      id: sub.id,
+      get disposed() {
+        return sub.disposed;
+      },
+      dispose: () => sub.dispose(),
+    };
+  }
+
+  /**
+   * Tier-1 wake. Called by the append path AFTER the transaction commits and
+   * AFTER the per-stream mutex releases (never inside the lock). Fans out to
+   * every subscription whose filter could match `streamId`, each drain
+   * isolated so one failing subscription cannot affect siblings or the
+   * append that triggered the wake.
+   */
+  wake(streamId: string): void {
+    if (this.subscriptions.size === 0) return;
+    // Snapshot: a listener that appends may register/dispose subscriptions
+    // synchronously mid-iteration.
+    for (const sub of [...this.subscriptions.values()]) {
+      if (sub.disposed || !sub.matchesStream(streamId)) continue;
+      try {
+        sub.requestDrain();
+      } catch {
+        // Isolate subscription-level failures from the append result.
+      }
+    }
+  }
+
+  /** Dispose every live subscription (dispatch teardown — INV-15). */
+  disposeAll(): void {
+    for (const sub of [...this.subscriptions.values()]) sub.dispose();
+    this.subscriptions.clear();
+  }
+}

--- a/servers/exarchos-mcp/src/event-store/subscriptions.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.ts
@@ -290,15 +290,33 @@ class Subscription {
   private floorTick(): void {
     if (this.disposed) return;
     this.floorTicks++;
-    const current = this.reader.dataVersion();
-    if (current === this.floorVersion) return; // no foreign commit → no re-read
-    // Advance the baseline BEFORE draining: a commit that lands during this
-    // drain bumps the token past `current`, so the next tick still fires for
-    // it (an extra harmless, cursor-guarded drain) rather than being folded
-    // into the baseline and lost. Never a gap; at worst one redundant tick.
-    this.floorVersion = current;
-    this.floorDrains++;
-    this.requestDrain();
+    // Isolate tick-level failures exactly as `wake()` isolates Tier-1 drains.
+    // This body runs inside a native `setInterval` callback (see
+    // `defaultSubscriptionClock`), so an escaping throw — a transient
+    // `dataVersion()` read error, or a listener that throws through
+    // `requestDrain()` (which is try/FINALLY, not try/catch, so it propagates)
+    // — would surface as an unhandled process-level exception rather than
+    // being contained to this one subscription.
+    const baseline = this.floorVersion;
+    try {
+      const current = this.reader.dataVersion();
+      if (current === baseline) return; // no foreign commit → no re-read
+      // Advance the baseline BEFORE draining: a commit that lands during this
+      // drain bumps the token past `current`, so the next tick still fires for
+      // it (an extra harmless, cursor-guarded drain) rather than being folded
+      // into the baseline and lost. Never a gap; at worst one redundant tick.
+      this.floorVersion = current;
+      this.floorDrains++;
+      this.requestDrain();
+    } catch {
+      // Contained. Roll the baseline back so the commit this tick failed to
+      // drain is retried by the next tick instead of being folded into the
+      // baseline and lost — preserving the same no-gap guarantee the
+      // constructor's T1/T2/T3 ordering establishes. The retry is safe: the
+      // per-stream cursor advance still guarantees exactly-once, so a
+      // re-drain never double-delivers events the failed drain did emit.
+      this.floorVersion = baseline;
+    }
   }
 
   /** Snapshot of this subscription's Tier-2 floor telemetry. */

--- a/servers/exarchos-mcp/src/event-store/subscriptions.ts
+++ b/servers/exarchos-mcp/src/event-store/subscriptions.ts
@@ -8,14 +8,29 @@ import type { WorkflowEvent } from './schemas.js';
  * ALWAYS a cursor-driven drain: read matching events after the cursor,
  * deliver them in global sequence order, advance the cursor. The cursor is
  * the load-bearing invariant — every wake signal (Tier-1 in-process
- * post-commit hook here; the Tier-2 `dataVersion()` poll floor in task-002)
- * merely triggers the SAME drain, so exactly-once, in-order delivery holds
- * by construction regardless of which signal fired or how many fired.
+ * post-commit hook; the Tier-2 `dataVersion()` poll floor) merely triggers
+ * the SAME drain, so exactly-once, in-order delivery holds by construction
+ * regardless of which signal fired or how many fired.
  *
- * Scope of THIS module (task-001): registration + the cursor drain + the
- * Tier-1 wake plumbing. The Tier-2 cross-process poll floor is deliberately
- * NOT implemented here — {@link SubscriptionClock} and the per-subscription
- * `floorMs` are captured as the seam task-002 binds the floor loop to.
+ * Two wake tiers converge on {@link Subscription.requestDrain}:
+ *  - Tier-1 (in-process): the appender's post-commit hook fans out through
+ *    {@link SubscriptionRegistry.wake} the instant this process commits.
+ *  - Tier-2 (cross-process poll floor): a loop on the injectable
+ *    {@link SubscriptionClock} re-reads {@link SubscriptionEventReader.dataVersion}
+ *    every `floorMs` and drains ONLY when the token changed — i.e. when a
+ *    FOREIGN process committed (SQLite's `PRAGMA data_version` ignores the
+ *    observer's own commits, which Tier-1 already delivers). The floor
+ *    guarantees a bounded worst-case latency for events this process did not
+ *    itself write; the cursor guarantees those events are never delivered
+ *    twice even when both tiers fire for the same commit.
+ *
+ * No-gap / no-double across the tiers: the baseline `dataVersion()` is
+ * captured at registration BEFORE the initial drain, so any commit not
+ * covered by the initial drain necessarily bumps the token above baseline
+ * and is picked up by a later tick; and because every signal re-enters the
+ * same per-stream cursor drain, a Tier-1 wake at seq N+1 that sweeps up a
+ * not-yet-seen foreign event at seq N delivers N before N+1, and a
+ * subsequent tick for that same foreign commit re-drains to a no-op.
  */
 
 // ─── Public contract ─────────────────────────────────────────────────────────
@@ -66,6 +81,8 @@ export interface SubscriptionHandle {
   readonly id: string;
   readonly disposed: boolean;
   dispose(): void;
+  /** Snapshot of this subscription's Tier-2 floor telemetry (see {@link SubscriptionPerf}). */
+  perf(): SubscriptionPerf;
 }
 
 /**
@@ -87,20 +104,80 @@ export interface SubscriptionEventReader {
   readStreamAfter(streamId: string, afterSequence: number): readonly WorkflowEvent[];
   /** Every stream id known to the backend (for cross-stream subscriptions). */
   listStreams(): readonly string[];
+  /**
+   * Tier-2 poll-floor change token (see `StorageBackend.dataVersion`). The
+   * floor loop compares successive reads: an unchanged value means no
+   * foreign commit and the loop skips the (more expensive) cursor drain
+   * entirely. MUST be near-free and MUST NOT retain an open read cursor
+   * across calls, or it would pin a snapshot that hides the very foreign
+   * commit it is polling for.
+   */
+  dataVersion(): number;
 }
 
 /**
- * Injectable clock seam (INV-16). Task-001 uses NO wall-clock time — the
- * Tier-1 drain is signal-driven, not timed. This interface exists so the
- * task-002 Tier-2 poll floor is deterministic (no `Date.now()`, no
- * `setTimeout` sleeps) the moment it lands.
+ * Injectable clock seam (INV-16). The Tier-1 drain is signal-driven and uses
+ * no wall-clock time; the Tier-2 poll floor schedules its ticks through
+ * {@link scheduleInterval} so tests drive them deterministically (no
+ * `Date.now()`, no real `setTimeout` sleeps).
  */
 export interface SubscriptionClock {
   now(): number;
+  /**
+   * Schedule `tick` to run every `intervalMs` until the returned canceller
+   * is invoked. This is the ONLY timing seam the Tier-2 floor uses.
+   *
+   * OPTIONAL by design: when a clock omits it, the subscription runs with NO
+   * Tier-2 floor (Tier-1 only). The registry's auto-created default clock
+   * supplies a real, `unref`'d host-timer implementation so production
+   * subscriptions get the floor; a test that injects a bare `{ now }` clock
+   * opts out of real timers, and a test that injects a manual scheduler
+   * drives the floor tick-by-tick.
+   *
+   * The canceller MUST be idempotent and stop all further ticks.
+   */
+  scheduleInterval?(tick: () => void, intervalMs: number): () => void;
 }
 
-/** Documented default poll-floor interval (task-002 consumes it). */
+/** Documented default poll-floor interval (ms) for the Tier-2 wake tier. */
 export const DEFAULT_FLOOR_MS = 250;
+
+/**
+ * The registry's default clock when none is injected. Wall-clock `now` plus a
+ * host-timer `scheduleInterval` whose handle is `unref`'d so the Tier-2 floor
+ * never keeps the process alive on its own (the dispatch that owns the
+ * subscription is what keeps the process live; the floor is a passive poll).
+ */
+function defaultSubscriptionClock(): SubscriptionClock {
+  return {
+    now: () => Date.now(),
+    scheduleInterval: (tick, intervalMs) => {
+      const timer = setInterval(tick, intervalMs);
+      // `unref` exists on Node/Bun timer handles but not in the DOM lib types;
+      // guard so this stays portable across the type surfaces.
+      (timer as unknown as { unref?: () => void }).unref?.();
+      return () => clearInterval(timer);
+    },
+  };
+}
+
+/**
+ * Per-subscription Tier-2 floor telemetry, surfaced on
+ * {@link SubscriptionHandle.perf}. Lets callers/perf harnesses observe the
+ * effective poll interval and how much drain work the floor actually did.
+ */
+export interface SubscriptionPerf {
+  /** Effective poll-floor interval (ms) — per-call override or registry default. */
+  readonly floorMs: number;
+  /** Total floor-loop ticks observed so far. */
+  readonly floorTicks: number;
+  /**
+   * Ticks that saw a `dataVersion()` change and therefore triggered a cursor
+   * drain. `floorTicks - floorDrains` ticks were near-free no-ops (no foreign
+   * commit, no event-log re-read).
+   */
+  readonly floorDrains: number;
+}
 
 export interface SubscriptionRegistryOptions {
   readonly clock?: SubscriptionClock;
@@ -143,20 +220,45 @@ class Subscription {
   /** Set when a wake arrives mid-drain; coalesces into a single re-run. */
   private rerun = false;
 
+  /**
+   * Last-observed Tier-2 change token. Captured at registration BEFORE the
+   * initial drain (see the constructor ordering note) and advanced by each
+   * tick that drains, so a tick fires the cursor drain only on a real change.
+   */
+  private floorVersion = 0;
+  /** Cancels the Tier-2 floor loop; undefined when no floor loop is active. */
+  private cancelFloor?: () => void;
+  /** Tier-2 telemetry (surfaced via {@link perf}). */
+  private floorTicks = 0;
+  private floorDrains = 0;
+
   constructor(
     private readonly filter: SubscriptionFilter,
     private readonly listener: SubscriptionListener,
     private readonly reader: SubscriptionEventReader,
-    /** Captured for task-002's Tier-2 floor; unused by the Tier-1 path. */
+    /** Injectable clock (INV-16) — drives the Tier-2 poll floor. */
+    private readonly clock: SubscriptionClock,
+    /** Effective Tier-2 poll-floor interval (per-call override or registry default). */
     readonly floorMs: number,
     fromSequence: number | undefined,
     private readonly onDispose: (sub: Subscription) => void,
   ) {
-    // Registration is atomic: capture the baseline cursor(s) synchronously
-    // (single-threaded JS — no gap between reading head and recording it),
-    // THEN schedule the unconditional initial drain. Any event committed
-    // after this point is delivered by the initial drain or a later wake,
-    // never lost to a baseline that already covered it.
+    // Registration is atomic AND ordered: cursor first, THEN the Tier-2
+    // baseline, THEN the initial drain, THEN the floor loop. The ordering is
+    // load-bearing for the no-gap guarantee across the two wake tiers:
+    //
+    //   1. Capture the cursor(s) (T1). headSequence is read synchronously.
+    //   2. Capture the dataVersion baseline (T2) — AFTER the cursor so a
+    //      foreign commit landing between T1 and T2 is reflected in the
+    //      baseline (its event has seq > cursor, so the initial drain still
+    //      delivers it, and no future tick re-delivers it). If the baseline
+    //      were captured BEFORE the cursor, such a commit would be past the
+    //      cursor yet above no future token — a gap.
+    //   3. Run the unconditional initial drain (T3) — covers everything with
+    //      seq > cursor committed by now. Because T2 < T3, any commit not
+    //      covered by the drain necessarily bumps the token above the
+    //      baseline and is caught by a later tick — no gap.
+    //   4. Start the floor loop (if the clock can schedule one).
     if (this.filter.streamId !== undefined) {
       this.cursors.set(
         this.filter.streamId,
@@ -167,10 +269,45 @@ class Subscription {
         this.cursors.set(streamId, this.reader.headSequence(streamId));
       }
     }
-    // Unconditional initial drain — covers an event that committed at the
-    // exact registration instant (the baseline-already-included case is a
-    // no-op; nothing is after the cursor).
+    this.floorVersion = this.reader.dataVersion();
     this.requestDrain();
+    // The Tier-2 floor is opt-in on the clock: a bare `{ now }` clock (no
+    // scheduler) runs Tier-1 only. Guard the schedule with the disposed flag
+    // in case an initial-drain listener disposed synchronously.
+    if (!this.disposed) {
+      this.cancelFloor = this.clock.scheduleInterval?.(() => this.floorTick(), this.floorMs);
+    }
+  }
+
+  /**
+   * One Tier-2 poll-floor tick. Near-free by design: a single
+   * {@link SubscriptionEventReader.dataVersion} read (no open statement held
+   * across ticks) that re-enters the cursor drain ONLY when the token
+   * changed — i.e. a foreign process committed. Own commits are delivered by
+   * the Tier-1 hook and (for SQLite) do not bump the token, so a
+   * no-foreign-commit tick never touches the event log.
+   */
+  private floorTick(): void {
+    if (this.disposed) return;
+    this.floorTicks++;
+    const current = this.reader.dataVersion();
+    if (current === this.floorVersion) return; // no foreign commit → no re-read
+    // Advance the baseline BEFORE draining: a commit that lands during this
+    // drain bumps the token past `current`, so the next tick still fires for
+    // it (an extra harmless, cursor-guarded drain) rather than being folded
+    // into the baseline and lost. Never a gap; at worst one redundant tick.
+    this.floorVersion = current;
+    this.floorDrains++;
+    this.requestDrain();
+  }
+
+  /** Snapshot of this subscription's Tier-2 floor telemetry. */
+  perf(): SubscriptionPerf {
+    return {
+      floorMs: this.floorMs,
+      floorTicks: this.floorTicks,
+      floorDrains: this.floorDrains,
+    };
   }
 
   /** True when a commit on `streamId` could produce a matching event. */
@@ -255,6 +392,10 @@ class Subscription {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    // Stop the Tier-2 floor loop first so no tick fires after disposal
+    // (INV-15: a subscription does no work past the dispatch that owns it).
+    this.cancelFloor?.();
+    this.cancelFloor = undefined;
     this.onDispose(this);
   }
 }
@@ -278,7 +419,10 @@ export class SubscriptionRegistry {
 
   constructor(reader: SubscriptionEventReader, options?: SubscriptionRegistryOptions) {
     this.reader = reader;
-    this.clock = options?.clock ?? { now: () => Date.now() };
+    // The default clock supplies a real, unref'd `scheduleInterval` so
+    // production subscriptions get the Tier-2 floor. An injected clock is
+    // used verbatim — a bare `{ now }` clock opts out of the floor entirely.
+    this.clock = options?.clock ?? defaultSubscriptionClock();
     this.defaultFloorMs = options?.defaultFloorMs ?? DEFAULT_FLOOR_MS;
   }
 
@@ -296,6 +440,7 @@ export class SubscriptionRegistry {
       filter,
       listener,
       this.reader,
+      this.clock,
       options?.floorMs ?? this.defaultFloorMs,
       options?.fromSequence,
       (s) => {
@@ -309,6 +454,7 @@ export class SubscriptionRegistry {
         return sub.disposed;
       },
       dispose: () => sub.dispose(),
+      perf: () => sub.perf(),
     };
   }
 

--- a/servers/exarchos-mcp/src/launcher/liveness.ts
+++ b/servers/exarchos-mcp/src/launcher/liveness.ts
@@ -102,6 +102,8 @@ export async function emitLaunchExecutingStarted(
           worktreeId: input.worktreeId,
           holderPid: input.holderPid,
           holderStartedAt: input.holderStartedAt,
+          // DR-2 — canonical liveness instance key (launch: worktreeId).
+          instanceId: input.worktreeId,
         },
       },
       { idempotencyKey: `${LAUNCH_EXECUTING_STARTED}:${input.worktreeId}` },
@@ -128,7 +130,12 @@ export async function emitLaunchExecuted(
   await withStateRetry(() =>
     eventStore.append(
       WORKTREES_STREAM,
-      { type: LAUNCH_EXECUTED, data: { worktreeId, exitCode } },
+      {
+        type: LAUNCH_EXECUTED,
+        // DR-2 — canonical liveness instance key (launch: worktreeId), paired
+        // to the `launch.executing_started` START by the same value.
+        data: { worktreeId, exitCode, instanceId: worktreeId },
+      },
       { idempotencyKey: `${LAUNCH_EXECUTED}:${worktreeId}` },
     ),
   );

--- a/servers/exarchos-mcp/src/mcp/tasks-methods.ts
+++ b/servers/exarchos-mcp/src/mcp/tasks-methods.ts
@@ -162,9 +162,11 @@ export function tasksFollow(opts: TasksFollowOptions): TasksFollowHandle {
   const controller = new AbortController();
   // Fold an external signal (server teardown) into the same abort the cancel
   // path uses, so there is ONE disposal route regardless of trigger.
-  if (opts.signal) {
-    if (opts.signal.aborted) controller.abort();
-    else opts.signal.addEventListener('abort', () => controller.abort(), { once: true });
+  const onExternalAbort = (): void => controller.abort();
+  const externalSignal = opts.signal;
+  if (externalSignal) {
+    if (externalSignal.aborted) controller.abort();
+    else externalSignal.addEventListener('abort', onExternalAbort, { once: true });
   }
 
   const inner = runInspectFollow({
@@ -176,6 +178,14 @@ export function tasksFollow(opts: TasksFollowOptions): TasksFollowHandle {
     clock: opts.clock,
     heartbeatIntervalMs: opts.heartbeatIntervalMs,
   });
+
+  // When the carrier ends by ANY route (cancel / dispose / inner abort), drop the
+  // external-signal listener so a long-lived server/session signal does not
+  // retain it after this follow is gone (`{ once: true }` only covers the
+  // abort-fired case). No new disposal route — purely leak hygiene.
+  if (externalSignal) {
+    void inner.done.then(() => externalSignal.removeEventListener('abort', onExternalAbort));
+  }
 
   return {
     done: inner.done,

--- a/servers/exarchos-mcp/src/mcp/tasks-methods.ts
+++ b/servers/exarchos-mcp/src/mcp/tasks-methods.ts
@@ -24,6 +24,13 @@ import type {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import type { EventSourcedTaskStore } from '../task-store/event-sourced-task-store.js';
+import {
+  runInspectFollow,
+  type FollowSubscribe,
+  type InspectFollowHandle,
+} from '../cli/follow-loop.js';
+import type { SubscriptionClock } from '../event-store/subscriptions.js';
+import type { Frame } from '../ndjson/frames.js';
 
 /**
  * `tasks/get` — return the SDK `Task` projection for `taskId`. Mirrors
@@ -105,4 +112,81 @@ export async function tasksCancel(
     throw new Error(`Task not found after cancellation: ${taskId}`);
   }
   return updated;
+}
+
+// ─── DR-4: MCP Tasks arm of `inspect --follow` ───────────────────────────────
+//
+// The Tasks facade of the streaming `inspect --follow` carrier. It drives the
+// SAME `runInspectFollow` core (see `cli/follow-loop.ts`) over the SAME DR-1
+// subscription contract the CLI NDJSON arm uses, so both facades stream
+// byte-identical frames from one subscription (INV-2). The one facade-specific
+// wire is cancellation: an MCP `tasks/cancel` disposes the subscription. This
+// arm owns an internal `AbortController` so a single {@link TasksFollowHandle.cancel}
+// call (invoked from the cancel path) folds into the carrier's abort teardown
+// — subscription disposed, heartbeat cancelled, terminal `end` frame written.
+
+export interface TasksFollowOptions {
+  /** DR-1 subscription contract — the SAME one the CLI arm drives. */
+  readonly subscribe: FollowSubscribe;
+  /** Workflow to tail. */
+  readonly featureId: string;
+  /** Carrier sink — the MCP transport pushes each frame as a task update. */
+  readonly onFrame: (frame: Frame) => void;
+  /** Initial cursor (see {@link runInspectFollow}). */
+  readonly fromSequence?: number;
+  /** Injected heartbeat timer (INV-16). */
+  readonly clock?: SubscriptionClock;
+  /** Idle heartbeat interval (ms). */
+  readonly heartbeatIntervalMs?: number;
+  /**
+   * Optional external abort (e.g. server teardown / session close) folded into
+   * the same disposal path as {@link TasksFollowHandle.cancel}.
+   */
+  readonly signal?: AbortSignal;
+}
+
+export interface TasksFollowHandle extends InspectFollowHandle {
+  /**
+   * MCP `tasks/cancel` seam — dispose the underlying DR-1 subscription and end
+   * the frame stream. Idempotent; mirrors the abort path exactly.
+   */
+  cancel(): void;
+}
+
+/**
+ * `tasks/follow` — register the MCP Tasks arm of `inspect --follow` over the
+ * DR-1 subscription. Returns a handle whose {@link TasksFollowHandle.cancel}
+ * (wired from the `tasks/cancel` method) disposes the subscription.
+ */
+export function tasksFollow(opts: TasksFollowOptions): TasksFollowHandle {
+  const controller = new AbortController();
+  // Fold an external signal (server teardown) into the same abort the cancel
+  // path uses, so there is ONE disposal route regardless of trigger.
+  if (opts.signal) {
+    if (opts.signal.aborted) controller.abort();
+    else opts.signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  const inner = runInspectFollow({
+    subscribe: opts.subscribe,
+    featureId: opts.featureId,
+    fromSequence: opts.fromSequence,
+    onFrame: opts.onFrame,
+    signal: controller.signal,
+    clock: opts.clock,
+    heartbeatIntervalMs: opts.heartbeatIntervalMs,
+  });
+
+  return {
+    done: inner.done,
+    disposed: () => inner.disposed(),
+    dispose: () => inner.dispose(),
+    cancel: () => {
+      // task-cancel → subscription dispose. Abort drives the carrier's abort
+      // teardown; the explicit dispose covers the (already-aborted) idempotent
+      // case where the signal fired before this call.
+      controller.abort();
+      inner.dispose();
+    },
+  };
 }

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.test.ts
@@ -152,6 +152,8 @@ describe('handleExecuteMerge (T15)', () => {
           targetBranch: 'main',
           recoveryPointSha: ROLLBACK_SHA,
           startedAt: expect.any(String),
+          // DR-2 — canonical liveness instance key (taskId present).
+          instanceId: 'T11',
         },
       },
       {
@@ -171,6 +173,8 @@ describe('handleExecuteMerge (T15)', () => {
           strategy: 'squash',
           mergeSha: MERGE_SHA,
           rollbackSha: ROLLBACK_SHA,
+          // DR-2 — canonical liveness instance key (taskId present).
+          instanceId: 'T11',
         },
       },
       // #1303: idempotencyKey + expectedSequence wired on merge.executed.
@@ -388,6 +392,8 @@ describe('handleExecuteMerge rollback (T16)', () => {
           targetBranch: 'main',
           recoveryPointSha: ROLLBACK_SHA,
           startedAt: expect.any(String),
+          // DR-2 — canonical liveness instance key (taskId present).
+          instanceId: 'T11',
         },
       },
       {

--- a/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
+++ b/servers/exarchos-mcp/src/orchestrate/execute-merge.ts
@@ -223,6 +223,14 @@ export async function handleExecuteMerge(
   }
   const args = parsed.data;
 
+  // DR-2 — canonical liveness instance key for the merge surface. Stamped
+  // (additive) on both the `merge.executing_started` START and the
+  // `merge.executed` terminal so a uniform INV-10 liveness view can correlate
+  // the pair without merge-specific field knowledge. Prefer the task id; fall
+  // back to the `<sourceBranch>→<targetBranch>` pair for CLI direct-invocation
+  // (no task context), which uniquely identifies the merge in flight.
+  const instanceId = args.taskId ?? `${args.sourceBranch}→${args.targetBranch}`;
+
   const gitExec = input.gitExec ?? defaultGitExec;
   const vcsMerge = input.vcsMerge ?? buildDefaultVcsMerge(input, gitExec);
   const rawPersistState =
@@ -266,6 +274,8 @@ export async function handleExecuteMerge(
             targetBranch: args.targetBranch,
             recoveryPointSha,
             startedAt: new Date().toISOString(),
+            // DR-2 — canonical liveness instance key (additive).
+            instanceId,
           },
         },
         {
@@ -545,6 +555,9 @@ export async function handleExecuteMerge(
             strategy: args.strategy,
             mergeSha: result.mergeSha,
             rollbackSha: result.recoveryPointSha,
+            // DR-2 — canonical liveness instance key (additive), paired to the
+            // `merge.executing_started` START by the same value.
+            instanceId,
           },
         },
         appendOptionsExecuted,

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
@@ -719,6 +719,43 @@ describe("mutation-adequacy repoRoot:'auto' resolution (PR #1541 Seer)", () => {
 // ─── Task 004: liveness + gate.executed ──────────────────────────────────────
 
 describe('mutation-adequacy liveness + gate emission', () => {
+  it('MutationAdequacy_RunMutationRejects_StillEmitsPairedTerminalExecuted', async () => {
+    // `defaultRunMutation` handles its own sync failures, but the INJECTED
+    // seam can reject. The terminal event must still land: an unpaired
+    // `mutation.executing_started` pins the run in-flight forever — `ps`
+    // reports a phantom executing mutation and `wait --operation mutation`
+    // blocks to timeout, because DR-2 pairing resolves an instance only when
+    // its terminal event arrives.
+    const { stateDir, eventStore } = await newStore();
+    const ctx = makeCtx(stateDir, eventStore);
+
+    await expect(
+      handleOrchestrate(
+        {
+          action: 'mutation-adequacy',
+          featureId: 'feat-mutadq',
+          base: 'main',
+          resolve: () => runtimeWith('npx stryker run'),
+          detectToolchainId: () => 'node',
+          runMutation: () => Promise.reject(new Error('runner exploded')),
+        },
+        ctx,
+      ),
+    ).rejects.toThrow('runner exploded');
+
+    const events = await eventStore.query('feat-mutadq');
+    const started = events.find((e) => e.type === 'mutation.executing_started');
+    const executed = events.find((e) => e.type === 'mutation.executed');
+    expect(started).toBeDefined();
+    // The pair is CLOSED despite the rejection — no phantom in-flight instance.
+    expect(executed).toBeDefined();
+    // …and it closes THIS instance (same instanceId) as a failure.
+    const startedData = started!.data as { instanceId?: string };
+    const executedData = executed!.data as { instanceId?: string; passed?: boolean };
+    expect(executedData.instanceId).toBe(startedData.instanceId);
+    expect(executedData.passed).toBe(false);
+  });
+
   it('MutationAdequacy_Run_EmitsExecutingStartedThenExecuted', async () => {
     const { stateDir, eventStore } = await newStore();
     await dispatchMutation({ eventStore, stateDir });

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
@@ -29,6 +29,7 @@ import { resolveConfig } from '../config/resolve.js';
 import type { ProjectConfig } from '../config/yaml-schema.js';
 import type { MutationRunResult, RunDiff } from './mutation-adequacy.js';
 import { composeScopedCommand } from './mutation-adequacy.js';
+import { foldInFlightOperations, type OperationEventLike } from '../views/lifecycle/operations-fold.js';
 import { resolveMutationDiffScope } from '../config/toolchains.js';
 import { rmrf } from '../test-helpers/temp-dir.js';
 
@@ -728,6 +729,52 @@ describe('mutation-adequacy liveness + gate emission', () => {
     const endIdx = types.indexOf('mutation.executed');
     expect(startIdx).toBeGreaterThanOrEqual(0);
     expect(endIdx).toBeGreaterThan(startIdx);
+  });
+
+  it('MutationAdequacy_LivenessPair_CarriesCanonicalInstanceId_AndFoldsToPaired', async () => {
+    // Finding 3: the LIVE emitter (mutation-adequacy) must stamp a canonical
+    // `instanceId` on BOTH liveness emissions so a stuck mutation run is visible
+    // to `ps` and waitable — not an anonymous keyless row collapsed to the DR-2
+    // singleton. Passing an operationId correlates the instanceId with the gate.
+    const { stateDir, eventStore } = await newStore();
+    await dispatchMutation({ eventStore, stateDir, operationId: 'op-mut-42' });
+
+    const events = await eventStore.query('feat-mutadq');
+    const start = events.find((e) => e.type === 'mutation.executing_started');
+    const end = events.find((e) => e.type === 'mutation.executed');
+    const startId = (start?.data as { instanceId?: unknown } | undefined)?.instanceId;
+    const endId = (end?.data as { instanceId?: unknown } | undefined)?.instanceId;
+
+    // Both emissions carry a non-empty instanceId, equal to each other and to
+    // the supplied operationId (the correlation contract, mirroring run-mutation).
+    expect(typeof startId).toBe('string');
+    expect((startId as string).length).toBeGreaterThan(0);
+    expect(endId).toBe(startId);
+    expect(startId).toBe('op-mut-42');
+
+    // And the pair folds cleanly: the terminal clears the start → nothing stuck.
+    const rows = foldInFlightOperations(events as unknown as OperationEventLike[]);
+    expect(rows.some((r) => r.surface === 'mutation')).toBe(false);
+  });
+
+  it('MutationAdequacy_StuckRun_VisibleToOperationsFold_WithFeatureAttribution', async () => {
+    // The S-6 case at the LIVE-emitter level: if the terminal never lands (a
+    // crashed run — simulated by dropping the `mutation.executed` event), the
+    // unpaired start is surfaced by the fold, keyed by the canonical instanceId
+    // and attributed to the feature stream — exactly what `ps operations` /
+    // `wait --operation mutation` consume.
+    const { stateDir, eventStore } = await newStore();
+    await dispatchMutation({ eventStore, stateDir, operationId: 'op-stuck' });
+
+    const events = (await eventStore.query('feat-mutadq')).filter(
+      (e) => e.type !== 'mutation.executed',
+    );
+    const rows = foldInFlightOperations(events as unknown as OperationEventLike[]);
+    const stuck = rows.find((r) => r.surface === 'mutation');
+    expect(stuck).toBeDefined();
+    expect(stuck?.instanceKey).toBe('op-stuck');
+    expect(stuck?.streamId).toBe('feat-mutadq');
+    expect(stuck?.featureId).toBe('feat-mutadq');
   });
 
   it('MutationAdequacy_Result_EmitsGateExecutedWithScore', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.test.ts
@@ -16,12 +16,13 @@
 //   reinvented).
 // ────────────────────────────────────────────────────────────────────────────
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { EventStore } from '../event-store/store.js';
+import { orchestrateLogger } from '../logger.js';
 import type { DispatchContext } from '../core/dispatch.js';
 import { handleOrchestrate } from './composite.js';
 import type { ResolvedVerificationRuntime } from '../config/test-runtime-resolver.js';
@@ -719,6 +720,43 @@ describe("mutation-adequacy repoRoot:'auto' resolution (PR #1541 Seer)", () => {
 // ─── Task 004: liveness + gate.executed ──────────────────────────────────────
 
 describe('mutation-adequacy liveness + gate emission', () => {
+  it('MutationAdequacy_TerminalLivenessEmitFails_DegradesWithoutThrowingButLogsTrail', async () => {
+    // The no-throw degrade is deliberate (INV-4): a liveness-emission failure
+    // must not fail a mutation run that actually succeeded. But an empty
+    // `catch {}` also discarded the only breadcrumb — and a lost TERMINAL event
+    // is the consequential case: `computeInFlightInstances` has no TTL, so the
+    // unpaired start reports in-flight to `ps` until an S-6 registry terminal
+    // lands. Degrade, but leave a diagnostic trail (RVC-R4).
+    const { stateDir, eventStore } = await newStore();
+    const ctx = makeCtx(stateDir, eventStore);
+    const warn = vi.spyOn(orchestrateLogger, 'warn').mockImplementation(() => undefined);
+
+    // Fail ONLY the terminal append; the opening one must still land.
+    const realAppend = eventStore.append.bind(eventStore);
+    vi.spyOn(eventStore, 'append').mockImplementation(
+      async (stream: string, event: { type: string }) => {
+        if (event.type === 'mutation.executed') throw new Error('append boom');
+        return realAppend(stream, event);
+      },
+    );
+
+    // The run still completes — the emission failure does not surface as a throw.
+    await expect(dispatchMutation({ eventStore, stateDir })).resolves.toBeDefined();
+
+    // …and the failure is no longer silent: the trail names the terminal type
+    // and the instance an operator would otherwise reverse-engineer from `ps`.
+    const terminalWarn = warn.mock.calls.find(
+      (c) => (c[0] as { type?: string })?.type === 'mutation.executed',
+    );
+    expect(terminalWarn).toBeDefined();
+    expect((terminalWarn![0] as { instanceId?: string }).instanceId).toBeDefined();
+    expect((terminalWarn![0] as { consequence?: string }).consequence).toBe(
+      'unpaired-start-reports-in-flight',
+    );
+
+    vi.restoreAllMocks();
+  });
+
   it('MutationAdequacy_RunMutationRejects_StillEmitsPairedTerminalExecuted', async () => {
     // `defaultRunMutation` handles its own sync failures, but the INJECTED
     // seam can reject. The terminal event must still land: an unpaired

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.ts
@@ -17,6 +17,7 @@
 // that to a Warning carrier rather than failing the gate closed-with-an-error.
 // ────────────────────────────────────────────────────────────────────────────
 
+import { randomUUID } from 'node:crypto';
 import { runCommandSync } from '../utils/process.js';
 import { z } from 'zod';
 
@@ -651,10 +652,20 @@ export async function handleMutationAdequacy(
         })();
 
   // ── Run (injected seam). Bracket with the INV-10 liveness pair. ────────────
+  //
+  // DR-2 / DR-3: stamp a canonical `instanceId` on BOTH the start and terminal
+  // liveness emissions (mirroring `cli-commands/run-mutation.ts`) so a stuck
+  // mutation run is visible to `ps` and waitable via `wait --operation mutation`.
+  // Without it the live emitter emitted keyless rows that `computeInFlightInstances`
+  // could only pair via the DR-2 legacy singleton — one indistinguishable slot per
+  // stream. Reuse the gate `operationId` when present (correlating the liveness
+  // pair with the gate.executed row); otherwise mint a fresh per-pass id.
   const runMutation = args.runMutation ?? defaultRunMutation;
+  const instanceId = args.operationId ?? randomUUID();
   await emitLiveness(eventStore, args.featureId, 'mutation.executing_started', {
     command: scoped.command,
     repoRoot,
+    instanceId,
   });
   const runResult = await runMutation({ command: scoped.command, repoRoot, base: args.base });
   await emitLiveness(eventStore, args.featureId, 'mutation.executed', {
@@ -662,6 +673,7 @@ export async function handleMutationAdequacy(
     repoRoot,
     passed: runResult.ok,
     exitCode: runResult.ok ? 0 : 1,
+    instanceId,
   });
 
   // ── Run-level degrade (no parseable report) → Warning, never a throw. ──────

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.ts
@@ -667,7 +667,25 @@ export async function handleMutationAdequacy(
     repoRoot,
     instanceId,
   });
-  const runResult = await runMutation({ command: scoped.command, repoRoot, base: args.base });
+  // The terminal event must land on EVERY exit path. `defaultRunMutation`
+  // handles its own sync failures, but the injected `runMutation` seam can
+  // still reject — and an unpaired `mutation.executing_started` pins the run
+  // in-flight forever: `ps` reports a phantom executing mutation and
+  // `wait --operation mutation` blocks to timeout, because DR-2 liveness
+  // pairing resolves an instance only when its terminal event arrives.
+  let runResult: MutationRunResult;
+  try {
+    runResult = await runMutation({ command: scoped.command, repoRoot, base: args.base });
+  } catch (err) {
+    await emitLiveness(eventStore, args.featureId, 'mutation.executed', {
+      command: scoped.command,
+      repoRoot,
+      passed: false,
+      exitCode: 1,
+      instanceId,
+    });
+    throw err;
+  }
   await emitLiveness(eventStore, args.featureId, 'mutation.executed', {
     command: scoped.command,
     repoRoot,

--- a/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.ts
+++ b/servers/exarchos-mcp/src/orchestrate/mutation-adequacy.ts
@@ -846,7 +846,27 @@ function warningCarrier(reason: string, scopeWarning?: string): ToolResult {
   };
 }
 
-/** Fire-and-forget liveness emit that never throws into the run path (INV-4 degrade). */
+/**
+ * Fire-and-forget liveness emit that never throws into the run path (INV-4
+ * degrade) — but never silently, either.
+ *
+ * The no-throw is deliberate and stays: a liveness-emission failure must not
+ * fail a mutation run that actually succeeded, and throwing would not close the
+ * gap anyway (a crash between the pair produces the identical unpaired state).
+ *
+ * The two events are NOT symmetric, though, and the asymmetry is why this logs:
+ *   - a lost `mutation.executing_started` is self-healing — no start is
+ *     recorded, so no instance is ever considered in-flight;
+ *   - a lost `mutation.executed` is NOT — `computeInFlightInstances` is a pure
+ *     left-fold with no TTL or age eviction, so the unpaired start reports as
+ *     in-flight to `ps` / `wait --operation mutation` until a registry terminal
+ *     for its `instanceId` is appended (the S-6 recovery path).
+ *
+ * That end state is designed-observable and recoverable, not corruption — but an
+ * empty `catch {}` threw away the one breadcrumb explaining WHY an instance is
+ * stuck. Log it instead, matching the `gate.executed` degrade path's diagnostic
+ * trail (RVC-R4) in this same file.
+ */
 async function emitLiveness(
   store: EventStore,
   stream: string,
@@ -855,7 +875,21 @@ async function emitLiveness(
 ): Promise<void> {
   try {
     await store.append(stream, { type, data });
-  } catch {
-    /* degrade — liveness emission failure must not break the run */
+  } catch (err) {
+    // Terminal-event loss is the consequential one — say so, and name the
+    // instance an operator would otherwise have to reverse-engineer from `ps`.
+    const terminal = type === 'mutation.executed';
+    orchestrateLogger.warn(
+      {
+        stream,
+        type,
+        instanceId: data.instanceId,
+        err: err instanceof Error ? err.message : String(err),
+        ...(terminal ? { consequence: 'unpaired-start-reports-in-flight' } : {}),
+      },
+      terminal
+        ? 'mutation-adequacy: failed to emit terminal mutation.executed — `ps`/`wait --operation mutation` will report this instance in-flight until a registry terminal is appended for it (S-6 recovery)'
+        : 'mutation-adequacy: failed to emit mutation.executing_started — run proceeds untracked',
+    );
   }
 }

--- a/servers/exarchos-mcp/src/orchestrate/worktree/handlers.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/handlers.test.ts
@@ -322,6 +322,11 @@ async function seedReserved(
   );
 }
 
+// DR-3 (task 007): `ps` became scope-parameterized (default `scope: 'all'`
+// composes the workflows + operations folds). The WLM-6 worktree liveness fold
+// these tests characterize is now the `scope: 'worktree'` path — CONSUMED, not
+// changed. Every call below passes `scope: 'worktree'` so it exercises the exact
+// same kernel behavior, re-pointed at its preserved address.
 describe('ps — in-flight liveness read (DR-4)', () => {
   it('HandleView_Ps_ListsInFlightFromInFlightMerges_NoProcessScan', async () => {
     const arm = await createArm();
@@ -337,7 +342,7 @@ describe('ps — in-flight liveness read (DR-4)', () => {
     const listSpy = vi.fn((): readonly ProcessRecord[] => []);
     const table: ProcessTableSource = { list: listSpy };
 
-    const result = await handleView({ action: 'ps' }, arm.ctx, {
+    const result = await handleView({ action: 'ps', scope: 'worktree' }, arm.ctx, {
       processTableSource: table,
       realpath: (p) => p,
     });
@@ -376,7 +381,7 @@ describe('ps — in-flight liveness read (DR-4)', () => {
       list: () => [{ pid: 777, ppid: 1, cwd: '/wlm/orphan-wt/sub', startTime: 'b777' }],
     };
 
-    const result = await handleView({ action: 'ps', probe: true }, arm.ctx, {
+    const result = await handleView({ action: 'ps', scope: 'worktree', probe: true }, arm.ctx, {
       processTableSource: table,
       realpath: (p) => p,
       selfPid: 999999,
@@ -415,7 +420,7 @@ describe('ps — in-flight liveness read (DR-4)', () => {
 
     // ps surfaces the launch straight from events — no process scan.
     const listSpy = vi.fn((): readonly ProcessRecord[] => []);
-    const inFlightResult = await handleView({ action: 'ps' }, arm.ctx, {
+    const inFlightResult = await handleView({ action: 'ps', scope: 'worktree' }, arm.ctx, {
       processTableSource: { list: listSpy },
       realpath: (p) => p,
     });
@@ -437,7 +442,7 @@ describe('ps — in-flight liveness read (DR-4)', () => {
       worktreeId: '/wlm/launch-wt',
       exitCode: 0,
     });
-    const clearedResult = await handleView({ action: 'ps' }, arm.ctx, {
+    const clearedResult = await handleView({ action: 'ps', scope: 'worktree' }, arm.ctx, {
       realpath: (p) => p,
     });
     const clearedData = clearedResult.data as {
@@ -476,7 +481,7 @@ describe('ps — in-flight liveness read (DR-4)', () => {
     );
     expect(before).toHaveLength(0);
 
-    const result = await handleView({ action: 'ps', probe: true }, arm.ctx, {
+    const result = await handleView({ action: 'ps', scope: 'worktree', probe: true }, arm.ctx, {
       processTableSource: table,
       realpath: (p) => p,
       selfPid: 999999,
@@ -509,7 +514,7 @@ describe('ps — in-flight liveness read (DR-4)', () => {
     expect(after[0].data?.worktreeId).toBe('/wlm/phantom-launch-wt');
 
     // A follow-up ps shows the launch column cleared — no permanent phantom.
-    const cleared = await handleView({ action: 'ps' }, arm.ctx, { realpath: (p) => p });
+    const cleared = await handleView({ action: 'ps', scope: 'worktree' }, arm.ctx, { realpath: (p) => p });
     expect((cleared.data as { launchCount: number }).launchCount).toBe(0);
   });
 });
@@ -662,7 +667,7 @@ describe('ps — in-flight prune surface (DR-3)', () => {
     // Without `probe` the prune column is a pure fold — the process table (a spy)
     // must NEVER be enumerated.
     const listSpy = vi.fn((): readonly ProcessRecord[] => []);
-    const result = await handleView({ action: 'ps' }, arm.ctx, {
+    const result = await handleView({ action: 'ps', scope: 'worktree' }, arm.ctx, {
       processTableSource: { list: listSpy },
       realpath: (p) => p,
     });
@@ -678,7 +683,7 @@ describe('ps — in-flight prune surface (DR-3)', () => {
     // After the paired terminal folds, ps reports a cleared prune column — the
     // pair can never surface as a permanent phantom.
     await seedPruneExecuted(arm, { operationId: 'op-prune', deletedCount: 0 });
-    const cleared = await handleView({ action: 'ps' }, arm.ctx, { realpath: (p) => p });
+    const cleared = await handleView({ action: 'ps', scope: 'worktree' }, arm.ctx, { realpath: (p) => p });
     const clearedData = cleared.data as { prunes: InFlightPrune[]; pruneCount: number };
     expect(clearedData.pruneCount).toBe(0);
     expect(clearedData.prunes).toEqual([]);

--- a/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
@@ -744,3 +744,15 @@ export async function handleViewWait(
   }
   return waitTimeout(integrationRef, timeoutMs, result.holder);
 }
+
+/**
+ * The WLM-6 worktree `until: merge|idle` wait kernel, ABSORBED as the WORKTREE
+ * SCOPE of the generic `wait` verb (DR-5). The generic router in
+ * `views/lifecycle/wait.ts` delegates here whenever `until` is present; the
+ * feature-scoped phase / status / operation predicates live in that module. This
+ * is the SAME function as {@link handleViewWait} — re-exported under an
+ * intention-revealing name for the generic router — so the frozen WLM-6
+ * characterization/parity suites (which import `handleViewWait`) keep pinning the
+ * unchanged worktree behavior.
+ */
+export const handleWorktreeUntilWait = handleViewWait;

--- a/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/handlers.ts
@@ -756,3 +756,15 @@ export async function handleViewWait(
  * unchanged worktree behavior.
  */
 export const handleWorktreeUntilWait = handleViewWait;
+
+/**
+ * The WLM-6 worktree liveness fold ({@link handleViewPs}), ABSORBED as the
+ * WORKTREE SCOPE of the generic `ps` verb (DR-3, task 007). The scope-
+ * parameterized router in `views/lifecycle/ps.ts` delegates here whenever
+ * `scope: 'worktree'` is selected — so the worktree fold (inFlightMerges /
+ * launches / inFlightPrunes + the `probe: true` reclaim/reconcile write path) is
+ * CONSUMED, never duplicated in the new module. Re-exported under an intention-
+ * revealing name so the frozen WLM-6 characterization/parity/schema suites (which
+ * import `handleViewPs`) keep pinning the unchanged worktree behavior directly.
+ */
+export const handleWorktreeScopePs = handleViewPs;

--- a/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/manager.ts
@@ -1083,7 +1083,9 @@ export class WorktreeManager {
         WORKTREES_STREAM,
         {
           type: 'prune.executing_started',
-          data: { operationId, repoRoot, holderPid, holderStartedAt },
+          // DR-2 — canonical liveness instance key (prune: the existing
+          // per-pass operationId). Additive; paired to `prune.executed`.
+          data: { operationId, repoRoot, holderPid, holderStartedAt, instanceId: operationId },
         },
         { idempotencyKey: `prune.executing_started:${operationId}` },
       ),
@@ -1105,7 +1107,9 @@ export class WorktreeManager {
         WORKTREES_STREAM,
         {
           type: 'prune.executed',
-          data: { operationId, deletedCount },
+          // DR-2 — canonical liveness instance key (prune: the existing
+          // per-pass operationId), paired to `prune.executing_started`.
+          data: { operationId, deletedCount, instanceId: operationId },
         },
         { idempotencyKey: `prune.executed:${operationId}` },
       ),

--- a/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/recovery.test.ts
@@ -244,7 +244,7 @@ describe('DR-3 — crash-mid-merge reconciled from the ps --probe production ent
     });
 
     const result = await handleView(
-      { action: 'ps', probe: true },
+      { action: 'ps', scope: 'worktree', probe: true },
       arm.ctx,
       { processTableSource: EMPTY_TABLE, selfPid: 999999, realpath: (p) => p },
     );
@@ -286,7 +286,7 @@ describe('DR-3 — crash-mid-merge reconciled from the ps --probe production ent
     });
 
     const result = await handleView(
-      { action: 'ps', probe: true },
+      { action: 'ps', scope: 'worktree', probe: true },
       arm.ctx,
       {
         processTableSource: liveTable([{ pid: 7777, startTime: 'alive-7777' }]),

--- a/servers/exarchos-mcp/src/orchestrate/worktree/schemas.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/schemas.ts
@@ -168,7 +168,7 @@ const InFlightOperationSchema = z
     streamScope: z.string(),
     startType: z.string(),
     startedAt: z.string().optional(),
-    ageMs: z.number().optional(),
+    ageMs: z.number().nullable(),
   })
   .passthrough();
 

--- a/servers/exarchos-mcp/src/orchestrate/worktree/schemas.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/schemas.ts
@@ -147,23 +147,63 @@ const SerializeMergeData = z
   })
   .passthrough();
 
+/** One folded workflow-summary row (mirrors `views/lifecycle/workflow-fold.ts`
+ *  `WorkflowFoldRow`) — the `ps` scope:'workflow'|'all' workflows section. */
+const WorkflowFoldRowSchema = z
+  .object({
+    featureId: z.string(),
+    workflowType: z.string(),
+    phase: z.string(),
+    status: z.string(),
+    ageMs: z.number().nullable(),
+  })
+  .passthrough();
+
+/** One folded in-flight liveness instance (mirrors `views/lifecycle/operations-fold.ts`
+ *  `InFlightOperation`) — the `ps` scope:'all' operations section. */
+const InFlightOperationSchema = z
+  .object({
+    surface: z.string(),
+    instanceKey: z.string(),
+    streamScope: z.string(),
+    startType: z.string(),
+    startedAt: z.string().optional(),
+    ageMs: z.number().optional(),
+  })
+  .passthrough();
+
 /**
- * `ps` success — the live liveness-pair fold. `probe`/`reconcile`/`mergeReconcile`
- * are present ONLY on a `probe: true` invocation, so they are optional; their
- * inner shapes are left loose (typed as objects) to avoid coupling this schema
- * to the reconciler result types.
+ * `ps` success — the DR-3 scope-parameterized fold. THREE shapes ride ONE
+ * `.passthrough()` schema, selected by `scope`:
+ *   - scope:'worktree' (WLM-6, unchanged): inFlight/count/launches/launchCount/
+ *     prunes/pruneCount, plus probe/reconcile/mergeReconcile on `probe: true`;
+ *   - scope:'workflow': workflows/workflowCount (+ echoed `scope`);
+ *   - scope:'all' (default): workflows/workflowCount + operations/operationCount.
+ * Every field is therefore optional — no single scope carries all of them — so a
+ * response for any scope validates against this one schema (the MCP adapter
+ * safeParses real output against it; an over-strict shape would break production).
  */
 const PsData = z
   .object({
-    inFlight: z.array(InFlightMergeSchema),
-    count: z.number(),
-    launches: z.array(WorktreeEntrySchema),
-    launchCount: z.number(),
-    prunes: z.array(InFlightPruneSchema),
-    pruneCount: z.number(),
+    // Scope discriminator (echoed on the workflow/all shapes; absent on the raw
+    // WLM-6 worktree shape, which predates the scope field).
+    scope: z.string().optional(),
+    // Worktree scope (WLM-6) — now optional, present only for scope:'worktree'.
+    inFlight: z.array(InFlightMergeSchema).optional(),
+    count: z.number().optional(),
+    launches: z.array(WorktreeEntrySchema).optional(),
+    launchCount: z.number().optional(),
+    prunes: z.array(InFlightPruneSchema).optional(),
+    pruneCount: z.number().optional(),
     probe: z.record(z.string(), z.unknown()).optional(),
     reconcile: z.record(z.string(), z.unknown()).optional(),
     mergeReconcile: z.record(z.string(), z.unknown()).optional(),
+    // Workflows section (scope:'workflow'|'all').
+    workflows: z.array(WorkflowFoldRowSchema).optional(),
+    workflowCount: z.number().optional(),
+    // Operations section (scope:'all').
+    operations: z.array(InFlightOperationSchema).optional(),
+    operationCount: z.number().optional(),
   })
   .passthrough();
 

--- a/servers/exarchos-mcp/src/orchestrate/worktree/schemas.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree/schemas.ts
@@ -168,8 +168,12 @@ const PsData = z
   .passthrough();
 
 /**
- * `wait` success — the resolved bounded-poll outcome for either mode
- * (`until: 'merge'` carries `integrationRef`, `until: 'idle'` carries `until`).
+ * `wait` success — the resolved outcome (DR-5). ALWAYS carries `resolved: true`
+ * + `waitedMs`. The worktree scope stamps `until`/`integrationRef`; the generic
+ * feature-scoped predicates stamp `predicate` (`phase`/`status`/`operation`) with
+ * the matched target, plus an optional `perf` snapshot of the DR-1 subscription's
+ * Tier-2 floor telemetry (surfaced when resolution rode a floor tick). All
+ * optional + passthrough so every success shape validates against one schema.
  */
 const WaitData = z
   .object({
@@ -177,6 +181,11 @@ const WaitData = z
     waitedMs: z.number(),
     until: z.string().optional(),
     integrationRef: z.string().optional(),
+    predicate: z.string().optional(),
+    phase: z.string().optional(),
+    status: z.string().optional(),
+    operation: z.string().optional(),
+    perf: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough();
 

--- a/servers/exarchos-mcp/src/parity/lifecycle-verbs.parity.test.ts
+++ b/servers/exarchos-mcp/src/parity/lifecycle-verbs.parity.test.ts
@@ -1,0 +1,358 @@
+// ─── Lifecycle-verb three-path CLI parity (DR-7 / DR-8, task-015) ────────────
+//
+// Task-014 shipped the generic top-level-promotion MECHANISM (`cli.topLevel` +
+// the `adapters/cli.ts` hoist loop + its build-time collision guard). Task-015
+// STAMPS the four lifecycle reads/writes onto it and proves the promotion is
+// carrier-transparent:
+//
+//   ps      → `exarchos ps`        (== `exarchos vw ps`)
+//   wait    → `exarchos wait`      (== `exarchos vw wait`)
+//   export  → `exarchos export`    (== `exarchos vw export`)
+//   inspect → `exarchos describe`  (== `exarchos vw inspect`)  ← name re-map
+//
+// The `inspect → describe` re-map is deliberate: `describe` is the natural
+// top-level verb for "project one workflow", and it does NOT collide with the
+// schema-introspection `describe`, which is a per-tool ACTION subcommand
+// (`vw describe`, `wf describe`), NEVER a top-level command. The task-014 hoist
+// guard re-checks the whole top-level namespace at build time; the parity test
+// below exercises that the four promotions register without a collision throw.
+//
+// Three assertions ride here:
+//   1. THREE-PATH PARITY — each promoted verb returns a BYTE-IDENTICAL
+//      ToolResult across the MCP tool-call, the `vw <verb>` subcommand, and the
+//      top-level `<verb>` command. All three route through the ONE stubbed
+//      `exarchos_view` composite handler (fixed clock injected for `wait`'s
+//      `waitedMs`), so a divergence can only come from carrier-specific arg
+//      parsing or exit/emit handling — exactly what DR-7 must not introduce.
+//   2. EXIT-CODE MAP (DR-7) — the generic `errorCode→exitCode` table:
+//      WAIT_TIMEOUT→17, WAIT_FAILED→18, success→0.
+//   3. VISIBLE COMPOSITE COUNT — promotion adds top-level CLI VERBS, never new
+//      composite TOOLS; the visible count stays 4 (INV-5d). Cites the existing
+//      `registry.test.ts` fence `Registry_VisibleToolCount_UnchangedByPhaseKind`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { CommanderError } from 'commander';
+
+import { EventStore } from '../event-store/store.js';
+import type { DispatchContext, CompositeHandler } from '../core/dispatch.js';
+import { stubCompositeHandler } from '../core/dispatch.js';
+import type { ToolResult } from '../format.js';
+import { TOOL_REGISTRY, type ToolAction } from '../registry.js';
+import {
+  buildCli,
+  applyExitOverrideRecursively,
+  resolveExitCode,
+  ERROR_CODE_EXIT_CODES,
+  CLI_EXIT_CODES,
+} from '../adapters/cli.js';
+import {
+  callCli as harnessCallCli,
+  callMcp as harnessCallMcp,
+  normalize as harnessNormalize,
+} from '../__tests__/parity-harness.js';
+import { rmrfAsync } from '../test-helpers/temp-dir.js';
+
+import { handleViewPs } from '../views/lifecycle/ps.js';
+import { handleViewWait, type WaitDeps } from '../views/lifecycle/wait.js';
+import { handleViewInspect } from '../views/lifecycle/inspect.js';
+import { handleViewExport } from '../views/lifecycle/export.js';
+
+// ─── Deterministic injected deps (fixed clock → wait `waitedMs` folds to 0) ──
+
+/** Fixed monotone clock so the `wait` deadline arithmetic is byte-stable. */
+const VIEW_DEPS: WaitDeps = { now: () => 1_000 };
+
+// ─── The four promoted verbs, their fixtures, and their expected top-level names ─
+//
+// `topLevelExpected` is what the promotion MUST stamp; the test reads the ACTUAL
+// stamp from the registry (registry-driven) and asserts it equals this, so a
+// dropped or mis-typed `cli.topLevel` fails here rather than silently skipping a
+// path. Fixtures are chosen to be side-effect-free and byte-deterministic:
+//   - ps `{}`             — pure read of an empty store (no probe, no age).
+//   - wait until:'idle'   — resolves immediately on an empty store; fixed clock.
+//   - inspect/export cold — an unknown featureId → workflowExists:false, ZERO
+//     events, no file write (the CB-2 no-phantom-stream guarantee).
+interface VerbSpec {
+  readonly action: string;
+  readonly topLevelExpected: string;
+  readonly flags: Record<string, unknown>;
+}
+
+const VERBS: readonly VerbSpec[] = [
+  { action: 'ps', topLevelExpected: 'ps', flags: {} },
+  { action: 'wait', topLevelExpected: 'wait', flags: { until: 'idle', timeoutMs: 1_000 } },
+  { action: 'inspect', topLevelExpected: 'describe', flags: { featureId: 'nonexistent-parity-feature' } },
+  { action: 'export', topLevelExpected: 'export', flags: { featureId: 'nonexistent-parity-feature' } },
+];
+
+// ─── Stub: route every promoted verb through the lifecycle handler with the ──
+// injected deterministic deps, so all three carriers fold identical output.
+const viewStub: CompositeHandler = async (args, ctx): Promise<ToolResult> => {
+  const { action, ...rest } = args;
+  switch (action) {
+    case 'ps':
+      return handleViewPs(rest, ctx, VIEW_DEPS);
+    case 'wait':
+      return handleViewWait(rest, ctx, VIEW_DEPS);
+    case 'inspect':
+      return handleViewInspect(rest, ctx);
+    case 'export':
+      return handleViewExport(rest, ctx);
+    default:
+      return {
+        success: false,
+        error: {
+          code: 'UNEXPECTED_ACTION',
+          message: `lifecycle-verbs parity stub: unexpected view action "${String(action)}"`,
+        },
+      };
+  }
+};
+
+// ─── Arm + normalization helpers ─────────────────────────────────────────────
+
+async function createContext(prefix: string): Promise<{ stateDir: string; ctx: DispatchContext }> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), prefix));
+  const eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+  return { stateDir, ctx: { stateDir, eventStore, enableTelemetry: false } };
+}
+
+/** Strip wall-clock / telemetry / tmp-path fields so two carriers are byte-equal. */
+function normalize(value: unknown): unknown {
+  return harnessNormalize(value, {
+    timestampPlaceholder: '<TS>',
+    uuidPlaceholder: '<UUID>',
+    tmpPathPlaceholder: '<TMP>',
+    dropKeys: new Set(['_perf', '_meta']),
+  });
+}
+
+/** The lifecycle-verb action descriptor from `exarchos_view`. */
+function viewAction(name: string): ToolAction {
+  const view = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
+  const action = view?.actions.find((a) => a.name === name);
+  if (!action) throw new Error(`test setup: exarchos_view has no '${name}' action`);
+  return action;
+}
+
+// ─── Top-level `exarchos <verb>` caller ──────────────────────────────────────
+//
+// Mirrors the shared harness `callCli` (same stdout capture + first-`{` JSON
+// slice + exit-code read-back) but drives the ROOT-LEVEL promoted command —
+// `['node','exarchos', <verb>, ...flags, '--json']` — with NO tool-alias/action
+// prefix. That is the third invocation path DR-7 introduces; the harness's
+// `callCli` only speaks the `<alias> <action>` subcommand shape.
+async function callTopLevel(
+  ctx: DispatchContext,
+  topLevelName: string,
+  flags: Record<string, unknown>,
+): Promise<{ result: unknown; exitCode: number }> {
+  const program = buildCli(ctx);
+  applyExitOverrideRecursively(program);
+
+  const capturedStdout: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    capturedStdout.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+  const savedExitCode = process.exitCode;
+  process.exitCode = undefined;
+
+  const argv: string[] = ['node', 'exarchos', topLevelName];
+  for (const [key, value] of Object.entries(flags)) {
+    if (value === undefined) continue;
+    const kebab = key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+    if (typeof value === 'boolean') {
+      argv.push(value ? `--${kebab}` : `--no-${kebab}`);
+    } else if (typeof value === 'object' && value !== null) {
+      argv.push(`--${kebab}`, JSON.stringify(value));
+    } else {
+      argv.push(`--${kebab}`, String(value));
+    }
+  }
+  argv.push('--json');
+
+  try {
+    await program.parseAsync(argv);
+  } catch (err) {
+    process.exitCode = savedExitCode;
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    if (err instanceof CommanderError) {
+      throw new Error(`top-level '${topLevelName}' raised CommanderError: ${err.message}`);
+    }
+    throw err;
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  process.exitCode = savedExitCode;
+
+  const stdoutText = capturedStdout.join('').trim();
+  const firstBrace = stdoutText.indexOf('{');
+  if (firstBrace < 0) {
+    throw new Error(`top-level '${topLevelName}' produced non-JSON stdout: ${stdoutText}`);
+  }
+  return { result: JSON.parse(stdoutText.slice(firstBrace)), exitCode };
+}
+
+// ─── DR-8 shared-field SoT grep-assert (setup) ───────────────────────────────
+//
+// Proves the parity below is not accidental: all four verbs (007 ps / 008
+// inspect / 010 wait / 013 export) bind their shared filter/limit/output fields
+// from ONE `schema-fields.ts` SoT, so the flattened `exarchos_view` registration
+// cannot drift a shared field's base type apart across verbs. The binding seam
+// is `registry.ts` (where the four action schemas reference the imported
+// `lifecycle*Field` / `followField` shapes); reading that source and asserting
+// the import + each verb's binding is the load-bearing DR-8 check.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REGISTRY_SRC = readFileSync(path.join(HERE, '..', 'registry.ts'), 'utf8');
+
+function assertSharedSchemaFieldsSoT(): void {
+  // The SoT import itself.
+  expect(
+    REGISTRY_SRC.includes(`from './views/lifecycle/schema-fields.js'`),
+    'registry.ts must import the shared lifecycle schema-fields SoT',
+  ).toBe(true);
+
+  // Each promoted verb binds at least one shared field from that SoT.
+  const bindings: Readonly<Record<string, string>> = {
+    ps: 'scope: lifecycleScopeField', // 007
+    inspect: 'follow: followField', // 008 (+ limit: lifecycleLimitField)
+    wait: 'operation: lifecycleOperationField', // 010
+    export: 'output: lifecycleOutputField', // 013
+  };
+  for (const [verb, needle] of Object.entries(bindings)) {
+    expect(
+      REGISTRY_SRC.includes(needle),
+      `${verb} (task-0${verb === 'ps' ? '07' : verb === 'inspect' ? '08' : verb === 'wait' ? '10' : '13'}) must bind the shared schema-fields SoT via \`${needle}\``,
+    ).toBe(true);
+  }
+}
+
+// ─── Three-path parity ───────────────────────────────────────────────────────
+
+describe('lifecycle-verb three-path CLI parity (DR-7 / DR-8, task-015)', () => {
+  let cleanups: string[] = [];
+  let restores: Array<() => void> = [];
+
+  afterEach(async () => {
+    for (const r of restores) r();
+    restores = [];
+    for (const dir of cleanups) await rmrfAsync(dir);
+    cleanups = [];
+    vi.restoreAllMocks();
+  });
+
+  it('Parity_EachPromotedVerb_ByteIdenticalToolResultAcrossThreePaths', async () => {
+    // Setup: DR-8 shared-field SoT grep-assert (007/008/010/013).
+    assertSharedSchemaFieldsSoT();
+
+    restores.push(stubCompositeHandler('exarchos_view', viewStub));
+
+    for (const { action, topLevelExpected, flags } of VERBS) {
+      // The promotion stamp is registry-driven, not hardcoded here: read the
+      // ACTUAL `cli.topLevel` and assert it equals the expected top-level name.
+      const actual = viewAction(action).cli?.topLevel;
+      expect(actual, `${action} must carry a cli.topLevel stamp`).toBe(topLevelExpected);
+
+      // One shared empty-store context: every fixture is side-effect-free, so the
+      // three carriers read identical state (and the stub's fixed clock removes
+      // the only wall-clock variance, `wait.waitedMs`).
+      const { stateDir, ctx } = await createContext(`lifecycle-parity-${action}-`);
+      cleanups.push(stateDir);
+
+      // Path 1 — MCP tool-call.
+      const mcp = await harnessCallMcp(ctx, 'exarchos_view', { action, ...flags });
+      // Path 2 — `vw <verb>` subcommand.
+      const { result: sub, exitCode: subExit } = await harnessCallCli(ctx, 'vw', action, flags);
+      // Path 3 — top-level `<verb>` (the DR-7 promotion; `describe` for inspect).
+      const { result: top, exitCode: topExit } = await callTopLevel(ctx, topLevelExpected, flags);
+
+      const nMcp = normalize(mcp);
+      const nSub = normalize(sub);
+      const nTop = normalize(top);
+
+      // Byte-identical across ALL THREE carriers (deep-equal + stringified).
+      expect(nSub, `${action}: subcommand ≡ MCP`).toEqual(nMcp);
+      expect(nTop, `${action}: top-level ≡ MCP`).toEqual(nMcp);
+      expect(JSON.stringify(nTop), `${action}: top-level byte-equal MCP`).toEqual(
+        JSON.stringify(nMcp),
+      );
+      expect(JSON.stringify(nSub), `${action}: subcommand byte-equal top-level`).toEqual(
+        JSON.stringify(nTop),
+      );
+
+      // The read-only fixtures all succeed → exit 0 on both CLI carriers.
+      expect(subExit, `${action}: subcommand exit`).toBe(0);
+      expect(topExit, `${action}: top-level exit`).toBe(0);
+    }
+  });
+
+  // ─── DR-7 exit-code map (presentation only) ────────────────────────────────
+
+  it('ExitCodeMap_WaitTimeout_17', () => {
+    const result: ToolResult = { success: false, error: { code: 'WAIT_TIMEOUT', message: 'expired' } };
+    expect(resolveExitCode(result)).toBe(17);
+    expect(ERROR_CODE_EXIT_CODES.WAIT_TIMEOUT).toBe(17);
+  });
+
+  it('ExitCodeMap_WaitFailed_18', () => {
+    const result: ToolResult = { success: false, error: { code: 'WAIT_FAILED', message: 'terminal reached' } };
+    expect(resolveExitCode(result)).toBe(18);
+    expect(ERROR_CODE_EXIT_CODES.WAIT_FAILED).toBe(18);
+  });
+
+  it('ExitCodeMap_Success_0', () => {
+    const result: ToolResult = { success: true, data: { ok: true } };
+    expect(resolveExitCode(result)).toBe(CLI_EXIT_CODES.SUCCESS);
+    expect(resolveExitCode(result)).toBe(0);
+    // The two DR-7 exit codes sit above the generic 0-3 band so they never alias
+    // SUCCESS / INVALID_INPUT / HANDLER_ERROR / UNCAUGHT_EXCEPTION.
+    expect(ERROR_CODE_EXIT_CODES.WAIT_TIMEOUT).toBeGreaterThan(3);
+    expect(ERROR_CODE_EXIT_CODES.WAIT_FAILED).toBeGreaterThan(3);
+    // A code NOT in the map keeps the pre-DR-7 mapping (additive, not a rewrite).
+    expect(resolveExitCode({ success: false, error: { code: 'INVALID_INPUT', message: 'x' } })).toBe(
+      CLI_EXIT_CODES.INVALID_INPUT,
+    );
+    expect(resolveExitCode({ success: false, error: { code: 'SOME_OTHER', message: 'x' } })).toBe(
+      CLI_EXIT_CODES.HANDLER_ERROR,
+    );
+  });
+
+  // ─── Visible composite count fence (INV-5d) ────────────────────────────────
+
+  it('Registry_VisibleCompositeCount_RemainsFour', () => {
+    // Extends the `registry.test.ts` fence `Registry_VisibleToolCount_
+    // UnchangedByPhaseKind`: promoting the four lifecycle verbs to TOP-LEVEL CLI
+    // commands must add zero visible composite TOOLS — the promotion is a
+    // `cli.topLevel` stamp on existing exarchos_view ACTIONS, not a new tool.
+    const visible = TOOL_REGISTRY.filter((t) => !t.hidden);
+    expect(visible.length).toBe(4);
+    expect(visible.map((t) => t.name).sort()).toEqual([
+      'exarchos_event',
+      'exarchos_orchestrate',
+      'exarchos_view',
+      'exarchos_workflow',
+    ]);
+    // `exarchos_sync` stays the sole hidden composite — total unchanged at 5.
+    expect(TOOL_REGISTRY).toHaveLength(5);
+
+    // The four promoted verbs remain ACTIONS on exarchos_view (INV-5d), each
+    // carrying a `cli.topLevel` stamp — never new composites.
+    for (const { action, topLevelExpected } of VERBS) {
+      expect(viewAction(action).cli?.topLevel).toBe(topLevelExpected);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/registry.construction.test.ts
+++ b/servers/exarchos-mcp/src/registry.construction.test.ts
@@ -45,7 +45,11 @@ function viewTool(): CompositeTool {
  * `name` + `schema.shape`) sees the probe's fields against the real registry.
  */
 function probeAction(name: string, shape: z.ZodRawShape): ToolAction {
-  const template = viewTool().actions[0]; // `pipeline` — carries every required field
+  // Look the template up BY NAME: `actions[0]` assumed `pipeline` sits first, so
+  // a reordering would silently swap in another action's metadata instead of
+  // failing loudly.
+  const template = viewTool().actions.find((a) => a.name === 'pipeline');
+  if (!template) throw new Error('exarchos_view.pipeline action missing — probe template invalid');
   return { ...template, name, surface: undefined, schema: z.object(shape) };
 }
 

--- a/servers/exarchos-mcp/src/registry.construction.test.ts
+++ b/servers/exarchos-mcp/src/registry.construction.test.ts
@@ -1,0 +1,158 @@
+// ─── DR-8: registration-construction guard for the shared lifecycle field shapes ──
+//
+// `buildRegistrationSchema` flattens every action of a composite tool into one
+// strict object and THROWS when two actions declare the same field name with a
+// divergent contract (base kind / enum value set / default). The lifecycle
+// verbs (`ps`/`wait`/`inspect`/`export`) all source their shared field names
+// from `views/lifecycle/schema-fields.ts`; this contract test composes the REAL
+// `exarchos_view` registration PLUS a probe action carrying every shared shape
+// and asserts registration constructs without throwing — and that the shapes
+// whose names ALSO exist on shipped view actions match the existing base type
+// exactly (with negative controls proving the guard is live, not vacuous).
+//
+// No mocks: the real `buildRegistrationSchema` and the real `TOOL_REGISTRY`
+// view actions are the subjects under test.
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { buildRegistrationSchema, TOOL_REGISTRY } from './registry.js';
+import type { ToolAction, CompositeTool } from './registry.js';
+import {
+  LIFECYCLE_FIELD_SHAPES,
+  scopeField,
+  statusField,
+  phaseField,
+  workflowTypeField,
+  allField,
+  followField,
+  limitField,
+  outputField,
+  operationField,
+  type LifecycleFieldName,
+} from './views/lifecycle/schema-fields.js';
+
+/** The real, un-mocked `exarchos_view` composite tool. */
+function viewTool(): CompositeTool {
+  const tool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
+  if (!tool) throw new Error('exarchos_view tool missing from TOOL_REGISTRY');
+  return tool;
+}
+
+/**
+ * A structurally valid probe `ToolAction` reusing a real view action's
+ * non-schema metadata (phases/roles/outputSchema/annotations) and overriding
+ * only `name` + `schema` — so `buildRegistrationSchema` (which reads only
+ * `name` + `schema.shape`) sees the probe's fields against the real registry.
+ */
+function probeAction(name: string, shape: z.ZodRawShape): ToolAction {
+  const template = viewTool().actions[0]; // `pipeline` — carries every required field
+  return { ...template, name, surface: undefined, schema: z.object(shape) };
+}
+
+/** Field names the shared module defines that ALSO exist on a shipped view action. */
+const COLLIDING_NAMES: readonly LifecycleFieldName[] = ['scope', 'phase', 'workflowType', 'limit'];
+
+describe('DR-8 shared lifecycle field shapes — registration construction', () => {
+  it('RegistryConstruction_WithAllLifecycleFieldShapes_DoesNotThrow', () => {
+    const actions = viewTool().actions;
+    const probe = probeAction('__lifecycle_field_probe__', {
+      scope: scopeField.optional(),
+      status: statusField.optional(),
+      phase: phaseField.optional(),
+      workflowType: workflowTypeField.optional(),
+      all: allField.optional(),
+      follow: followField.optional(),
+      limit: limitField.optional(),
+      output: outputField.optional(),
+      operation: operationField.optional(),
+    });
+
+    expect(() => buildRegistrationSchema([...actions, probe])).not.toThrow();
+
+    // Sanity: the composed schema is real and carries the probe's fields.
+    const schema = buildRegistrationSchema([...actions, probe]);
+    for (const name of Object.keys(LIFECYCLE_FIELD_SHAPES)) {
+      expect(name in schema.shape).toBe(true);
+    }
+  });
+
+  it('SchemaFields_BaseTypes_MatchExistingViewFieldsWhereNamesCollide', () => {
+    const actions = viewTool().actions;
+
+    // Premise guard: each colliding name is genuinely declared by ≥1 shipped
+    // view action, so the alignment below is meaningful (not vacuously green if
+    // an upstream action drops the field).
+    for (const name of COLLIDING_NAMES) {
+      const declaredBy = actions.filter((a) => name in a.schema.shape);
+      expect(
+        declaredBy.length,
+        `expected an existing exarchos_view action to declare '${name}'`,
+      ).toBeGreaterThan(0);
+    }
+
+    // Each shared shape composes with the real registration without throwing —
+    // proving its base type matches the existing inline declaration exactly.
+    for (const name of COLLIDING_NAMES) {
+      const probe = probeAction(`__probe_${name}__`, {
+        [name]: LIFECYCLE_FIELD_SHAPES[name].optional(),
+      });
+      expect(
+        () => buildRegistrationSchema([...actions, probe]),
+        `shared '${name}' shape must match the existing exarchos_view base type`,
+      ).not.toThrow();
+    }
+
+    // Negative controls — a WRONG base type for a colliding name DOES throw,
+    // proving the guard discriminates and the alignment is load-bearing.
+    expect(
+      () => buildRegistrationSchema([...actions, probeAction('__wrong_scope_kind__', { scope: z.string().optional() })]),
+      'scope as z.string() must collide with pipeline.scope (enum vs string)',
+    ).toThrow();
+    expect(
+      () => buildRegistrationSchema([...actions, probeAction('__wrong_limit_kind__', { limit: z.string().optional() })]),
+      'limit as z.string() must collide with the shared numeric limit',
+    ).toThrow();
+    // The DR-3 hazard specifically: a scope enum with the wrong VALUE SET (base
+    // kind matches, values diverge) also throws — this is why the shared scope
+    // is pinned to ['repo','all'] rather than ['workflow','worktree','all'].
+    expect(
+      () =>
+        buildRegistrationSchema([
+          ...actions,
+          probeAction('__wrong_scope_values__', {
+            scope: z.enum(['workflow', 'worktree', 'all']).optional(),
+          }),
+        ]),
+      "scope value set ['workflow','worktree','all'] must collide with pipeline.scope ['repo','all']",
+    ).toThrow();
+  });
+
+  it('SchemaFields_BaseTypes_ArePinnedStructurally', () => {
+    // Direct base-type assertions on every shared shape — a mutation to any
+    // field's base type (colliding or not) flips one of these red, so the
+    // adequacy guard has teeth beyond the collision oracle above.
+
+    // enum ['repo','all'] — accepts exactly those members, rejects others.
+    expect(scopeField.safeParse('repo').success).toBe(true);
+    expect(scopeField.safeParse('all').success).toBe(true);
+    expect(scopeField.safeParse('workflow').success).toBe(false);
+
+    // string base type.
+    for (const s of [statusField, phaseField, workflowTypeField, outputField, operationField]) {
+      expect(s).toBeInstanceOf(z.ZodString);
+    }
+
+    // boolean base type.
+    for (const b of [allField, followField]) {
+      expect(b).toBeInstanceOf(z.ZodBoolean);
+    }
+
+    // coerced positive integer — coerces numeric strings, rejects non-positive
+    // and non-numeric (matches the shared `coercedPositiveInt()` `limit`).
+    expect(limitField.parse('5')).toBe(5);
+    expect(limitField.parse(10)).toBe(10);
+    expect(limitField.safeParse('-1').success).toBe(false);
+    expect(limitField.safeParse('0').success).toBe(false);
+    expect(limitField.safeParse('abc').success).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/registry.construction.test.ts
+++ b/servers/exarchos-mcp/src/registry.construction.test.ts
@@ -113,8 +113,10 @@ describe('DR-8 shared lifecycle field shapes — registration construction', () 
       'limit as z.string() must collide with the shared numeric limit',
     ).toThrow();
     // The DR-3 hazard specifically: a scope enum with the wrong VALUE SET (base
-    // kind matches, values diverge) also throws — this is why the shared scope
-    // is pinned to ['repo','all'] rather than ['workflow','worktree','all'].
+    // kind matches, values diverge) still throws — proving the guard discriminates
+    // on the value set, not just the base kind. Task 007 widened the shared scope
+    // to the UNION ['repo','all','workflow','worktree'] (4 members); a probe
+    // declaring only a 3-member subset diverges from that union and collides.
     expect(
       () =>
         buildRegistrationSchema([
@@ -123,7 +125,7 @@ describe('DR-8 shared lifecycle field shapes — registration construction', () 
             scope: z.enum(['workflow', 'worktree', 'all']).optional(),
           }),
         ]),
-      "scope value set ['workflow','worktree','all'] must collide with pipeline.scope ['repo','all']",
+      "scope value set ['workflow','worktree','all'] must collide with the widened union scope ['repo','all','workflow','worktree']",
     ).toThrow();
   });
 
@@ -132,10 +134,14 @@ describe('DR-8 shared lifecycle field shapes — registration construction', () 
     // field's base type (colliding or not) flips one of these red, so the
     // adequacy guard has teeth beyond the collision oracle above.
 
-    // enum ['repo','all'] — accepts exactly those members, rejects others.
+    // enum ['repo','all','workflow','worktree'] (the task-007 widened union) —
+    // accepts every member of BOTH the pipeline (`repo`/`all`) and ps
+    // (`workflow`/`worktree`/`all`) subsets, and rejects a non-member.
     expect(scopeField.safeParse('repo').success).toBe(true);
     expect(scopeField.safeParse('all').success).toBe(true);
-    expect(scopeField.safeParse('workflow').success).toBe(false);
+    expect(scopeField.safeParse('workflow').success).toBe(true);
+    expect(scopeField.safeParse('worktree').success).toBe(true);
+    expect(scopeField.safeParse('bogus-scope').success).toBe(false);
 
     // string base type.
     for (const s of [statusField, phaseField, workflowTypeField, outputField, operationField]) {

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -2981,6 +2981,7 @@ const EXPECTED_EFFECTIVE_BUDGETS: Readonly<Record<string, number>> = {
   'exarchos_view.worktrees': 2000,
   'exarchos_view.ps': 2000,
   'exarchos_view.wait': 2000,
+  'exarchos_view.inspect': 2000,
   'exarchos_view.describe': 8000,
   'exarchos_sync.now': 2000,
 };
@@ -3168,6 +3169,12 @@ describe('Task 022 — registry schema batch (DR-1/DR-3/DR-8)', () => {
       inFlight: [], count: 0, launches: [], launchCount: 0, prunes: [], pruneCount: 0,
     },
     'exarchos_view.wait': { resolved: true, waitedMs: 5 },
+    // The `inspect` cold-probe projection is its minimal valid baseline: the
+    // exists-branch fields (state/artifacts/taskProgress/correlation) are all
+    // optional, so the workflowExists:false shape is the floor.
+    'exarchos_view.inspect': {
+      featureId: 'f', workflowExists: false, recentEvents: [], eventCount: 0,
+    },
   };
   function baselineEnvelope(data: Record<string, unknown>): Record<string, unknown> {
     return {
@@ -3315,9 +3322,10 @@ describe('Task 022 — registry schema batch (DR-1/DR-3/DR-8)', () => {
     it('every typed-output action validates a {summary,counts,firstPage} capped envelope', () => {
       const actions = typedOutputActions();
       // Enumerated from code, not assumed — the spec claims 10; the post-002
-      // base carries 8 (the two exarchos_workflow LCD schemas wrap
-      // EnvelopeSchema(z.unknown()) and are NOT typed).
-      expect(actions.length).toBe(8);
+      // base carried 8 (the two exarchos_workflow LCD schemas wrap
+      // EnvelopeSchema(z.unknown()) and are NOT typed). The worktree-lifecycle
+      // `inspect` verb (DR-4) adds a 9th typed-output view action.
+      expect(actions.length).toBe(9);
       for (const { tool, action } of actions) {
         const parsed = action.outputSchema.safeParse(cappedEnvelope());
         expect(

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -2982,6 +2982,7 @@ const EXPECTED_EFFECTIVE_BUDGETS: Readonly<Record<string, number>> = {
   'exarchos_view.ps': 2000,
   'exarchos_view.wait': 2000,
   'exarchos_view.inspect': 2000,
+  'exarchos_view.export': 2000,
   'exarchos_view.describe': 8000,
   'exarchos_sync.now': 2000,
 };
@@ -3175,6 +3176,12 @@ describe('Task 022 — registry schema batch (DR-1/DR-3/DR-8)', () => {
     'exarchos_view.inspect': {
       featureId: 'f', workflowExists: false, recentEvents: [], eventCount: 0,
     },
+    // The `export` cold-probe shape is its minimal valid baseline: the
+    // exported-branch fields (outputPath/contentHash/eventCount/...) are all
+    // optional, so the workflowExists:false / exported:false shape is the floor.
+    'exarchos_view.export': {
+      featureId: 'f', workflowExists: false, exported: false,
+    },
   };
   function baselineEnvelope(data: Record<string, unknown>): Record<string, unknown> {
     return {
@@ -3321,11 +3328,11 @@ describe('Task 022 — registry schema batch (DR-1/DR-3/DR-8)', () => {
   describe('registrySchemas_TypedOutputActions_AcceptCappedShape', () => {
     it('every typed-output action validates a {summary,counts,firstPage} capped envelope', () => {
       const actions = typedOutputActions();
-      // Enumerated from code, not assumed — the spec claims 10; the post-002
-      // base carried 8 (the two exarchos_workflow LCD schemas wrap
-      // EnvelopeSchema(z.unknown()) and are NOT typed). The worktree-lifecycle
-      // `inspect` verb (DR-4) adds a 9th typed-output view action.
-      expect(actions.length).toBe(9);
+      // Enumerated from code, not assumed — the post-002 base carried 8 (the two
+      // exarchos_workflow LCD schemas wrap EnvelopeSchema(z.unknown()) and are
+      // NOT typed). The worktree-lifecycle `inspect` verb (DR-4) added a 9th
+      // typed-output view action; the `export` verb (DR-6) adds the 10th.
+      expect(actions.length).toBe(10);
       for (const { tool, action } of actions) {
         const parsed = action.outputSchema.safeParse(cappedEnvelope());
         expect(

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -27,6 +27,18 @@ export interface CliActionHints {
     readonly description?: string;
   }>>;
   readonly format?: 'table' | 'json' | 'tree';
+  /**
+   * DR-7 — hoist this action to a TOP-LEVEL CLI command in addition to its
+   * `<tool> <action>` subcommand form. When set to (say) `'ps'`, the CLI
+   * adapter registers `exarchos ps` alongside `exarchos view ps`; both forms
+   * dispatch through the same code path and derive their flags from the same
+   * Zod schema (no divergent parsing). A `topLevel` name that collides with an
+   * existing top-level command fails at registration (build time), not at
+   * runtime — see the hoist loop in `adapters/cli.ts`. This task ships only the
+   * generic mechanism + its guard; the lifecycle-verb re-map (which actions
+   * declare `topLevel`, the exit-code map, and parity) is a follow-on.
+   */
+  readonly topLevel?: string;
 }
 
 export interface CliToolHints {

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -25,8 +25,10 @@ import {
   workflowTypeField as lifecycleWorkflowTypeField,
   allField as lifecycleAllField,
   operationField as lifecycleOperationField,
+  outputField as lifecycleOutputField,
 } from './views/lifecycle/schema-fields.js';
 import { InspectOutputSchema } from './views/lifecycle/inspect.js';
+import { ExportOutputSchema } from './views/lifecycle/export.js';
 import type { AgentPosture } from './agents/spec.js';
 export { coercedRecord, coercedPositiveInt, coercedNonnegativeInt, coercedStringArray, coercedIntArray } from './coerce.js';
 import { coercedRecord, coercedPositiveInt, coercedNonnegativeInt, coercedStringArray, coercedIntArray } from './coerce.js';
@@ -395,6 +397,20 @@ const LOCAL_MUTATION_IDEMPOTENT: ActionAnnotations = {
   destructive: false,
   idempotent: true,
   openWorld: false,
+};
+
+// DR-6 (lifecycle-verbs) — a local-mutation whose side effect is a FILE written
+// OUTSIDE the managed `.exarchos/` store (the `export` diagnostic zip bundle),
+// so `openWorld` is true. Non-destructive (a diagnostic write, not a workflow
+// mutation) and NOT idempotent at the event level (a fresh invocation mints a
+// new INV-13 pair). `local-mutation` leaves `openWorld` free (the annotation
+// schema only pins it for `remote-mutation`), so this tuple is valid.
+const LOCAL_MUTATION_OPEN_WORLD: ActionAnnotations = {
+  safety: 'local-mutation',
+  readOnly: false,
+  destructive: false,
+  idempotent: false,
+  openWorld: true,
 };
 
 const COMPENSABLE_LOCAL: ActionAnnotations = {
@@ -3795,6 +3811,48 @@ const viewActions: readonly ToolAction[] = [
     // {summary,counts,firstPage} envelope, keeping it total over emittable shapes.
     outputSchema: withCappedShape(InspectOutputSchema),
     annotations: READ_ONLY_LOCAL,
+  },
+  // ─── Worktree-lifecycle diagnostic bundle (DR-6) ──────────────────────────
+  // The `export` WRITE leg of the lifecycle verbs (the last verb): writes a
+  // portable zip bundle (events.jsonl / state.json / metadata.json / artifacts/)
+  // of one workflow to a path OUTSIDE `.exarchos/`. Unlike the pure-read `ps` /
+  // `wait` / `inspect` legs it has an unconditional external side effect (a file
+  // write), so it declares the `task-isolated` posture (the capability resolver
+  // mints fs:write from it, containing the blast radius to the caller's
+  // worktree) and an openWorld annotation (writes outside the managed store).
+  // It still rides `exarchos_view` as an ACTION (INV-5d — no new visible tool;
+  // the composite count stays 4), like `ps`'s conditional probe-write path.
+  // The write is journaled as the INV-13 export.requested → export.executed
+  // pair, the storage idempotency key is derived from a logical key (INV-8), a
+  // crashed pair is completed without duplicating the intent, and a cold probe
+  // of an unknown featureId writes nothing + emits zero events. The CLI verb
+  // promotion (`export`→top-level) is task-015.
+  {
+    name: 'export',
+    description:
+      "Write a portable diagnostic zip bundle of ONE workflow to disk: events.jsonl (the domain event stream, one JSON event/line), state.json (fold(events.jsonl) via the canonical projection — replaying events.jsonl reconstructs it), metadata.json (featureId / eventCount / phase / workflowType / artifacts + missingArtifacts), and artifacts/ (every referenced artifact FILE that exists; missing references are tolerated and listed). Default destination ./<featureId>-export.zip; override with output. Writes to a path OUTSIDE .exarchos/ (openWorld) and journals the INV-13 export.requested → export.executed pair around the write, so a crash between the two is completed WITHOUT duplicating the intent and a fresh invocation mints a new pair (INV-8). Cold-probe safe: an unknown featureId returns workflowExists:false, writes no zip and emits no events. Use for: capturing a self-contained, replayable snapshot of a workflow for diagnosis or handoff. Do NOT use for: a live status snapshot (use inspect); advancing or mutating the workflow (use exarchos_workflow).",
+    schema: z.object({
+      featureId: featureIdSchema,
+      // DR-8 shared shape — imported from the schema-fields SoT (z.string(), a
+      // destination FILE PATH, not a table|json format enum) so the flattened
+      // exarchos_view registration cannot drift the `output` field's base type.
+      output: lifecycleOutputField.optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+    // #1305 — task-isolated trust tier: the resolver mints fs:write for the
+    // bundle write, contained to the caller's worktree. The last worktree verb.
+    posture: 'task-isolated',
+    cli: {
+      flags: { featureId: { alias: 'f' }, output: { alias: 'o' } },
+      examples: ['exarchos vw export -f my-feature -o ./my-feature-export.zip'],
+    },
+    // Typed-output totality (DR-1): union the generic capped-fallback shape so
+    // the schema admits BOTH the bundle-write result AND a dispatch-core-capped
+    // envelope.
+    outputSchema: withCappedShape(ExportOutputSchema),
+    // openWorldHint: true — writes a file outside the managed store.
+    annotations: LOCAL_MUTATION_OPEN_WORLD,
   },
   makeDescribeAction(),
 ];

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -3281,10 +3281,11 @@ const viewActions: readonly ToolAction[] = [
       // DR-3 (task 007) — `scope` migrated onto the shared `schema-fields.ts`
       // shape so `pipeline` and `ps` declare ONE `scope` definition on this tool
       // (no flattener collision). The shared shape is the UNION
-      // `['repo','all','workflow','worktree']`; `pipeline` acts on `repo`/`all`
-      // and ignores the `ps`-only members at the handler (see `views/tools.ts`
-      // scope-resolution: anything not `all`/`repo` falls through to the default
-      // caller-key / unscoped branch).
+      // `['repo','all','workflow','worktree']`; `pipeline` acts ONLY on the
+      // `{repo, all}` subset and REJECTS the `ps`-only members (`workflow`/
+      // `worktree`) at the handler with a structured `INVALID_INPUT` (mirroring
+      // how `ps` rejects the pipeline-only `repo` member) — never a silent
+      // coerce to unscoped (see the subset guard in `views/tools.ts`).
       scope: lifecycleScopeField.optional(),
     }),
     phases: ALL_PHASES,
@@ -3763,8 +3764,10 @@ const viewActions: readonly ToolAction[] = [
       // Worktree-scope selector (WLM-6, absorbed). 'merge' polls the serialized-
       // merge terminal; 'idle' polls until the prune liveness pair clears. New
       // field name — no other action declares `until`, so no field-collision at
-      // the flattener. NB: NOT a `scope` field (task-019 pins `scope` to
-      // z.enum(['repo','all']) to match pipeline.scope) — the axis rides `until`.
+      // the flattener. NB: `wait` declares NO `scope` field at all — the worktree
+      // scope axis rides `until` (the feature scope rides `phase`/`status`/
+      // `operation`). (The shared `scopeField` is the 4-member union since task
+      // 007; `wait` simply does not use it.)
       until: z.enum(['merge', 'idle']).optional(),
       // Bounded-wait budget. Same base type (ZodNumber) as serialize_merge /
       // doctor `timeoutMs` so the MCP-registration flattener sees no divergent

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -18,9 +18,12 @@ import {
 // type apart across verbs (DR-8).
 import {
   followField,
+  scopeField as lifecycleScopeField,
   limitField as lifecycleLimitField,
   phaseField as lifecyclePhaseField,
   statusField as lifecycleStatusField,
+  workflowTypeField as lifecycleWorkflowTypeField,
+  allField as lifecycleAllField,
   operationField as lifecycleOperationField,
 } from './views/lifecycle/schema-fields.js';
 import { InspectOutputSchema } from './views/lifecycle/inspect.js';
@@ -3259,7 +3262,14 @@ const viewActions: readonly ToolAction[] = [
       // `repoRoot` scopes to an arbitrary repo (normalized before compare);
       // `scope` forces 'all' (unfiltered) or 'repo' (requires a resolvable key).
       repoRoot: z.string().optional(),
-      scope: z.enum(['repo', 'all']).optional(),
+      // DR-3 (task 007) — `scope` migrated onto the shared `schema-fields.ts`
+      // shape so `pipeline` and `ps` declare ONE `scope` definition on this tool
+      // (no flattener collision). The shared shape is the UNION
+      // `['repo','all','workflow','worktree']`; `pipeline` acts on `repo`/`all`
+      // and ignores the `ps`-only members at the handler (see `views/tools.ts`
+      // scope-resolution: anything not `all`/`repo` falls through to the default
+      // caller-key / unscoped branch).
+      scope: lifecycleScopeField.optional(),
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
@@ -3676,17 +3686,36 @@ const viewActions: readonly ToolAction[] = [
     name: 'ps',
     surface: 'worktree',
     description:
-      'List the live worktree-layer liveness pairs as a pure fold, NO process scan: the worktrees@v1 inFlightMerges (each: integrationRef, operationId, sourceBranch, holder pid/start-time), the in-flight launcher launches, AND the inFlightPrunes — live prune_worktrees GC passes (each: operationId, repoRoot, holder pid/start-time; DR-3). Pass probe:true to additionally run the on-demand DR-5 process probe and emit worktree.released (owner dead, idle) / worktree.orphan_detected (owner dead, still occupied) — the orphan emitter, a conditional write path. Idempotent: without probe it is a pure read; with probe the heals re-converge on re-run. Use for: seeing which merges/launches/prunes are in flight, or (probe:true) reconciling dead holders on demand. Do NOT use for: the governed worktree set (use worktrees); blocking until a merge/prune completes (use wait).',
+      "Scope-parameterized process-plane lister composing three folds (DR-3). scope:'all' (DEFAULT) returns a workflows section (every tracked workflow: featureId, workflowType, phase, status, age) PLUS an operations section (every IN-FLIGHT liveness instance across merge/launch/mutation/prune — a started-without-terminal pair, surface-generic). scope:'workflow' returns the workflows section only; filter it with status/phase/workflowType and all:true to include terminal workflows. scope:'worktree' preserves the WLM-6 worktree capabilities: the worktrees@v1 inFlightMerges/launches/inFlightPrunes fold, and probe:true (valid ONLY in this scope) runs the on-demand DR-5 process probe emitting worktree.released / worktree.orphan_detected + reconciling dead holders. probe on a non-worktree scope is INVALID_INPUT. Idempotent: a pure read except scope:'worktree' probe:true, whose heals re-converge. Use for: a snapshot of what workflows exist and what operations are in flight. Do NOT use for: the governed worktree set (use worktrees); blocking until a condition holds (use wait).",
     schema: z.object({
+      // DR-3 (task 007) — the process-plane axis. Imported from the shared
+      // schema-fields SoT (widened to the union `['repo','all','workflow',
+      // 'worktree']` so `pipeline` and `ps` share ONE `scope` definition on this
+      // tool). `ps` accepts the `workflow|worktree|all` subset and rejects `repo`
+      // at the handler; default `all`.
+      scope: lifecycleScopeField.optional(),
+      // Worktree-scope-only: the on-demand DR-5 process probe. Rejected (INVALID_INPUT)
+      // for any non-worktree scope at the handler.
       probe: z.boolean().optional(),
+      // Workflows-section filters (scope workflow|all). Base types imported from
+      // the DR-8 schema-fields SoT so the flattened registration cannot drift them:
+      // `phase`/`workflowType` collide with invariants_effective (both z.string());
+      // `status` is new; `all` is a new boolean; `limit` reuses the shared coerced int.
+      status: lifecycleStatusField.optional(),
+      phase: lifecyclePhaseField.optional(),
+      workflowType: lifecycleWorkflowTypeField.optional(),
+      all: lifecycleAllField.optional(),
+      limit: lifecycleLimitField.optional(),
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
     outputSchema: withCappedShape(PsOutputSchema),
-    // `ps probe:true` can append worktree.released / worktree.orphan_detected, so
-    // it is NOT readOnly. The heals are idempotent (re-running a probe over an
-    // already-reconciled set emits nothing) and non-destructive → idempotent
-    // local-mutation. `wait` / `worktrees` stay genuinely READ_ONLY_LOCAL.
+    // `ps scope:'worktree' probe:true` can append worktree.released /
+    // worktree.orphan_detected, so the action is NOT readOnly. The heals are
+    // idempotent (re-running a probe over an already-reconciled set emits nothing)
+    // and non-destructive → idempotent local-mutation. Every non-probe scope path
+    // is a pure read; the conservative annotation covers the sole write path.
+    // `wait` / `worktrees` stay genuinely READ_ONLY_LOCAL.
     annotations: LOCAL_MUTATION_IDEMPOTENT,
   },
   {

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -16,7 +16,13 @@ import {
 // task-008 `inspect` typed output schema. Import shapes from the SoT module so
 // the flattened `exarchos_view` registration cannot drift a shared field's base
 // type apart across verbs (DR-8).
-import { followField, limitField as lifecycleLimitField } from './views/lifecycle/schema-fields.js';
+import {
+  followField,
+  limitField as lifecycleLimitField,
+  phaseField as lifecyclePhaseField,
+  statusField as lifecycleStatusField,
+  operationField as lifecycleOperationField,
+} from './views/lifecycle/schema-fields.js';
 import { InspectOutputSchema } from './views/lifecycle/inspect.js';
 import type { AgentPosture } from './agents/spec.js';
 export { coercedRecord, coercedPositiveInt, coercedNonnegativeInt, coercedStringArray, coercedIntArray } from './coerce.js';
@@ -3687,17 +3693,29 @@ const viewActions: readonly ToolAction[] = [
     name: 'wait',
     surface: 'worktree',
     description:
-      "Block on a worktree-layer condition (caller-bounded poll, re-folding worktrees@v1 each iteration; structured wait-timeout on expiry; never hangs, no background timer, emits no events). until:'merge' (default) blocks until the serialized merge on integrationRef reaches its terminal worktree.merge_executed (integrationRef required). until:'idle' blocks until no in-flight prune_worktrees GC pass remains (the prune terminal cleared inFlightPrunes). timeoutMs bounds the wait. Use for: gating on a serialized merge terminal (until:'merge') or on prune-idle (until:'idle') before proceeding. Do NOT use for: a point-in-time liveness snapshot (use ps); running the merge itself (use serialize_merge).",
+      "Block until an event-log predicate holds; PURE CONSUMER — emits NO events, never hangs (structured WAIT_TIMEOUT on expiry). Feature-scoped (needs featureId, pick one): phase resolves on entering the target phase (already-passed ⇒ immediate; a failed/cancelled terminal first ⇒ WAIT_FAILED); status resolves on the requested terminal (completed/failed/cancelled; a DIFFERENT terminal ⇒ WAIT_FAILED); operation <surface> is the S-6 predicate for feature-scoped surfaces (merge, mutation), resolving when the unpaired executing_started gains its registry terminal by instance key (none in flight ⇒ immediate; launch/prune ⇒ INVALID_INPUT → use until). Worktree scope: until:'merge' (default) awaits the serialized merge on integrationRef, until:'idle' awaits prune-idle; timeoutMs bounds it. Use for: gating on a phase/status/operation/merge/idle condition. Do NOT use for: a snapshot (use ps/inspect); running a merge (use serialize_merge).",
     schema: z.object({
-      // Optional: required only in the default until:'merge' mode (the handler
+      // Feature-scoped predicate target. Required by every feature-scoped
+      // predicate (phase/status/operation); the worktree `until` scope ignores it.
+      featureId: featureIdSchema.optional(),
+      // DR-8 shared field shapes — imported from the schema-fields SoT so the
+      // flattened exarchos_view registration cannot drift these names' base types
+      // across lifecycle verbs. `phase` collides with invariants_effective.phase
+      // (both z.string()); `status`/`operation` are new to exarchos_view.
+      phase: lifecyclePhaseField.optional(),
+      status: lifecycleStatusField.optional(),
+      operation: lifecycleOperationField.optional(),
+      // Optional: required only in the worktree until:'merge' mode (the handler
       // rejects a missing ref there). until:'idle' does not consult it. Base
       // type (ZodString) is unchanged, so the MCP-registration flattener sees no
       // divergent shape vs serialize_merge's required integrationRef (optionality
       // drift is allowed; base-type/enum/default drift is not).
       integrationRef: z.string().min(1).optional(),
-      // Mode selector (DR-3/DR-4). 'merge' polls the serialized-merge terminal;
-      // 'idle' polls until the prune liveness pair clears. New field name — no
-      // other action declares `until`, so no field-collision at the flattener.
+      // Worktree-scope selector (WLM-6, absorbed). 'merge' polls the serialized-
+      // merge terminal; 'idle' polls until the prune liveness pair clears. New
+      // field name — no other action declares `until`, so no field-collision at
+      // the flattener. NB: NOT a `scope` field (task-019 pins `scope` to
+      // z.enum(['repo','all']) to match pipeline.scope) — the axis rides `until`.
       until: z.enum(['merge', 'idle']).optional(),
       // Bounded-wait budget. Same base type (ZodNumber) as serialize_merge /
       // doctor `timeoutMs` so the MCP-registration flattener sees no divergent
@@ -3707,6 +3725,9 @@ const viewActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
     outputSchema: withCappedShape(WaitOutputSchema),
+    // Pure read: appends nothing on every path → readOnlyHint + idempotentHint
+    // (the MCP-annotation hints derive from `readOnly`/`idempotent` here). DR-5
+    // revises #1316 Q7 — the log records domain facts, not observations of them.
     annotations: READ_ONLY_LOCAL,
   },
   // ─── Worktree-lifecycle single-workflow projection (DR-4) ─────────────────

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -12,6 +12,12 @@ import {
   WorktreesOutputSchema,
   extractEnvelopeDataSchema,
 } from './orchestrate/worktree/schemas.js';
+// Lifecycle verbs (worktree-lifecycle-verbs) — task-019 shared field shapes +
+// task-008 `inspect` typed output schema. Import shapes from the SoT module so
+// the flattened `exarchos_view` registration cannot drift a shared field's base
+// type apart across verbs (DR-8).
+import { followField, limitField as lifecycleLimitField } from './views/lifecycle/schema-fields.js';
+import { InspectOutputSchema } from './views/lifecycle/inspect.js';
 import type { AgentPosture } from './agents/spec.js';
 export { coercedRecord, coercedPositiveInt, coercedNonnegativeInt, coercedStringArray, coercedIntArray } from './coerce.js';
 import { coercedRecord, coercedPositiveInt, coercedNonnegativeInt, coercedStringArray, coercedIntArray } from './coerce.js';
@@ -3701,6 +3707,43 @@ const viewActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
     outputSchema: withCappedShape(WaitOutputSchema),
+    annotations: READ_ONLY_LOCAL,
+  },
+  // ─── Worktree-lifecycle single-workflow projection (DR-4) ─────────────────
+  // The `inspect` read leg of the lifecycle verbs: folds ONE feature stream and
+  // projects state (via the canonical event-store-first `resolveWorkflowState` —
+  // SQLite is the only source of truth), recent events + the correlation tuple,
+  // artifacts, and task progress. Pure read — appends nothing on any path — so it
+  // sits on the wholesale-read-only exarchos_view tool as an ACTION (INV-5d: NO
+  // new visible tool; the visible composite count stays 4). A cold probe of an
+  // unknown featureId returns `workflowExists:false` and emits ZERO events (the
+  // CB-2 no-phantom-stream guarantee). The CLI verb re-map (`inspect`→`describe`)
+  // is task-015; the `--follow` streaming behavior is task-009 — the `follow`
+  // field is schema-declared here (imported from the DR-8 SoT) so its CLI flag
+  // auto-emits ahead of that handler work.
+  {
+    name: 'inspect',
+    description:
+      'Project a single workflow in one read: state (phase / workflowType / timestamps via the canonical event-store-first resolveWorkflowState — SQLite is the only source of truth, NEVER .state.json presence), the recent event tail + the latest dispatch correlation tuple, the artifact map, and task progress (roster + counts-by-status). Read-only; emits no events. Cold-probe safe: an unknown/never-init\'d featureId returns workflowExists:false and appends nothing (no phantom stream). Bound the event tail with limit (the full state/artifacts/tasks are always complete). Use for: a one-call status snapshot of a specific workflow. Do NOT use for: the cross-workflow pipeline roll-up (use pipeline); mutating or advancing a workflow (use exarchos_workflow).',
+    schema: z.object({
+      featureId: featureIdSchema,
+      // DR-8 shared shapes (imported from the SoT so the flattened exarchos_view
+      // registration cannot drift these field names' base types across verbs).
+      // `limit` bounds the recent-event tail; `follow` is reserved for task-009's
+      // `--follow` streaming (schema-declared now so its CLI flag auto-emits).
+      limit: lifecycleLimitField.optional(),
+      follow: followField.optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+    cli: {
+      flags: { featureId: { alias: 'f' } },
+      examples: ['exarchos vw inspect -f my-feature'],
+    },
+    // Typed-output totality (DR-1): union the generic capped-fallback shape so
+    // the schema admits BOTH the baseline projection AND a dispatch-core-capped
+    // {summary,counts,firstPage} envelope, keeping it total over emittable shapes.
+    outputSchema: withCappedShape(InspectOutputSchema),
     annotations: READ_ONLY_LOCAL,
   },
   makeDescribeAction(),

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -3725,6 +3725,10 @@ const viewActions: readonly ToolAction[] = [
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
+    // DR-7 (task-015): promote `ps` to a TOP-LEVEL CLI verb (`exarchos ps`)
+    // alongside its `vw ps` subcommand form. Both dispatch through the ONE
+    // `registerActionCommand` path (same Zod schema, no divergent parsing).
+    cli: { topLevel: 'ps' },
     outputSchema: withCappedShape(PsOutputSchema),
     // `ps scope:'worktree' probe:true` can append worktree.released /
     // worktree.orphan_detected, so the action is NOT readOnly. The heals are
@@ -3769,6 +3773,9 @@ const viewActions: readonly ToolAction[] = [
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
+    // DR-7 (task-015): promote `wait` to a TOP-LEVEL CLI verb (`exarchos wait`)
+    // alongside its `vw wait` subcommand form (one registerActionCommand path).
+    cli: { topLevel: 'wait' },
     outputSchema: withCappedShape(WaitOutputSchema),
     // Pure read: appends nothing on every path → readOnlyHint + idempotentHint
     // (the MCP-annotation hints derive from `readOnly`/`idempotent` here). DR-5
@@ -3803,8 +3810,19 @@ const viewActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
     cli: {
+      // DR-7 (task-015): promote `inspect` to the TOP-LEVEL `describe` verb — the
+      // workflow-PROJECTION describe (`exarchos describe -f my-feature`). The
+      // top-level NAME intentionally differs from the action name: the schema-
+      // introspection `describe` is a per-tool ACTION subcommand (`vw describe`,
+      // `wf describe`), NEVER a top-level command, so `exarchos describe` (→ the
+      // `inspect` action) does not collide with it. The task-014 hoist-loop guard
+      // re-checks the full top-level namespace at build time and confirms this.
+      topLevel: 'describe',
       flags: { featureId: { alias: 'f' } },
-      examples: ['exarchos vw inspect -f my-feature'],
+      examples: [
+        'exarchos vw inspect -f my-feature',
+        'exarchos describe -f my-feature',
+      ],
     },
     // Typed-output totality (DR-1): union the generic capped-fallback shape so
     // the schema admits BOTH the baseline projection AND a dispatch-core-capped
@@ -3844,8 +3862,14 @@ const viewActions: readonly ToolAction[] = [
     // bundle write, contained to the caller's worktree. The last worktree verb.
     posture: 'task-isolated',
     cli: {
+      // DR-7 (task-015): promote `export` to a TOP-LEVEL CLI verb
+      // (`exarchos export`) alongside its `vw export` subcommand form.
+      topLevel: 'export',
       flags: { featureId: { alias: 'f' }, output: { alias: 'o' } },
-      examples: ['exarchos vw export -f my-feature -o ./my-feature-export.zip'],
+      examples: [
+        'exarchos vw export -f my-feature -o ./my-feature-export.zip',
+        'exarchos export -f my-feature -o ./my-feature-export.zip',
+      ],
     },
     // Typed-output totality (DR-1): union the generic capped-fallback shape so
     // the schema admits BOTH the bundle-write result AND a dispatch-core-capped

--- a/servers/exarchos-mcp/src/storage/backend.ts
+++ b/servers/exarchos-mcp/src/storage/backend.ts
@@ -68,6 +68,41 @@ export interface StorageBackend {
   listStreams(): string[];
 
   /**
+   * Change token consumed by the Tier-2 cross-process poll floor
+   * (`event-store/subscriptions.ts`). The floor loop re-reads this on every
+   * tick and drains its cursor ONLY when the value changed since the last
+   * read — so a foreign writer's commit is delivered without re-scanning the
+   * event log every tick.
+   *
+   * The absolute value is meaningless; only equality between two successive
+   * reads on the SAME backend instance is load-bearing. Semantics differ
+   * per backend, but both satisfy the floor-loop contract — "the token
+   * differs from its previous value whenever an event this observer has not
+   * yet drained may have been committed by a party the Tier-1 in-process
+   * hook does NOT cover":
+   *
+   *  - {@link SqliteBackend}: `PRAGMA data_version`. SQLite guarantees the
+   *    value is UNCHANGED for commits on the observer's own connection and
+   *    differs only when some OTHER connection (a foreign process) committed
+   *    since the pragma last ran. That is exactly the Tier-2 signal: the
+   *    Tier-1 hook already wakes on this process's own commits, so the floor
+   *    must fire only on foreign ones. Near-free: a single-row pragma read
+   *    that retains no open statement across ticks.
+   *
+   *  - {@link InMemoryBackend}: a monotonic counter bumped on every
+   *    {@link StorageBackend.appendEvent}. In-memory has no cross-process
+   *    notion, so "foreign" collapses to "any append" — the observer's own
+   *    appends bump it. A single-process in-memory subscriber is already
+   *    served by the Tier-1 hook, so a floor tick that fires on an own
+   *    append merely triggers a redundant, cursor-guarded drain; it never
+   *    double-delivers.
+   *
+   * Required (not optional): both production backends implement it, and the
+   * subscription registry relies on its presence for the Tier-2 floor.
+   */
+  dataVersion(): number;
+
+  /**
    * Cross-stream query reducer (DR-3, optional).
    *
    * Returns every event of `eventType` whose `streamId` matches `streamPrefix`

--- a/servers/exarchos-mcp/src/storage/backend.ts
+++ b/servers/exarchos-mcp/src/storage/backend.ts
@@ -48,6 +48,120 @@ export interface DrainResult {
   readonly failed: number;
 }
 
+// ─── Workflow Summary (DR-3, `ps` fold) ──────────────────────────────────────
+
+/**
+ * Coarse lifecycle status derived from a workflow's phase. Distinct from the
+ * fine-grained `phase` (`plan`, `delegate`, `triage`, …): `status` collapses
+ * every non-terminal phase to `active` and surfaces only the three states a
+ * `ps`-style listing cares about — is this workflow still running, did it
+ * finish, was it cancelled, or is it wedged (`blocked`)?
+ *
+ * `completed` and `cancelled` are the terminal states (see
+ * {@link isTerminalWorkflowStatus}); `blocked` is NOT terminal (a blocked
+ * workflow can be resumed), so it stays visible in the default listing.
+ */
+export type WorkflowLifecycleStatus = 'active' | 'completed' | 'cancelled' | 'blocked';
+
+/** The terminal lifecycle statuses excluded from the default `ps` listing. */
+export const TERMINAL_WORKFLOW_STATUSES: ReadonlySet<WorkflowLifecycleStatus> = new Set<WorkflowLifecycleStatus>([
+  'completed',
+  'cancelled',
+]);
+
+/**
+ * Map a workflow `phase` string to its coarse {@link WorkflowLifecycleStatus}.
+ *
+ * Shared by both backends so the SQLite (join + json_extract) and in-memory
+ * (state-object) read paths derive `status` identically — the linchpin of the
+ * `ListWorkflowSummaries_BackendContract_SharedAcrossSqliteAndInMemory`
+ * parity contract. The terminal phases (`completed`, `cancelled`) and the
+ * resumable `blocked` phase are recognised by name across every workflow type
+ * (feature/debug/refactor/oneshot/discovery all share those three terminal
+ * phase labels); any other phase is `active`.
+ */
+export function deriveWorkflowStatus(phase: string): WorkflowLifecycleStatus {
+  switch (phase) {
+    case 'completed':
+      return 'completed';
+    case 'cancelled':
+      return 'cancelled';
+    case 'blocked':
+      return 'blocked';
+    default:
+      return 'active';
+  }
+}
+
+/** Whether a lifecycle status is terminal (hidden from the default listing). */
+export function isTerminalWorkflowStatus(status: WorkflowLifecycleStatus): boolean {
+  return TERMINAL_WORKFLOW_STATUSES.has(status);
+}
+
+/**
+ * Filter passed to {@link StorageBackend.listWorkflowSummaries}.
+ *
+ * All fields are optional; an omitted field means "no constraint on that
+ * axis". `workflowType` is the indexed pushdown axis (SQLite filters it in SQL
+ * against `streams.workflow_type`); `status`/`phase`/`includeTerminal` are the
+ * lifecycle axes applied by {@link matchesWorkflowSummaryFilter} identically on
+ * both backends.
+ */
+export interface WorkflowSummaryFilter {
+  /** Exact `workflow_type` match — pushed down to the indexed column in SQLite. */
+  workflowType?: string;
+  /** Exact derived-{@link WorkflowLifecycleStatus} match. Authoritative over the terminal default. */
+  status?: WorkflowLifecycleStatus;
+  /** Exact `phase` match. */
+  phase?: string;
+  /**
+   * Include terminal (`completed`/`cancelled`) workflows. Defaults to `false`
+   * — the default listing shows only live/blocked workflows. Ignored when an
+   * explicit `status` is supplied (that status is then authoritative).
+   */
+  includeTerminal?: boolean;
+}
+
+/**
+ * One row of the workflow-summary read model: the minimal projection a
+ * `ps`-style listing folds. `createdAt` is the earliest event-envelope
+ * timestamp for the stream (ISO-8601), or `null` when the stream carries no
+ * events — the consuming view computes `ageMs` from it.
+ */
+export interface WorkflowSummary {
+  readonly featureId: string;
+  readonly workflowType: string;
+  readonly phase: string;
+  readonly status: WorkflowLifecycleStatus;
+  readonly createdAt: string | null;
+}
+
+/**
+ * Shared lifecycle predicate applied by BOTH backends so SQLite and in-memory
+ * agree row-for-row (INV-2 facade equivalence). Deliberately does NOT re-check
+ * `workflowType`: SQLite owns that axis via the indexed SQL WHERE and the
+ * in-memory backend applies it in JS separately, so leaving it out here keeps
+ * the SQLite pushdown behaviourally load-bearing (a broken pushdown leaks
+ * foreign-type rows rather than being silently re-filtered here).
+ *
+ * Terminal handling: an explicit `status` is authoritative — filtering for
+ * `completed` returns completed workflows even without `includeTerminal`.
+ * With no explicit `status`, terminal workflows are hidden unless
+ * `includeTerminal` is set.
+ */
+export function matchesWorkflowSummaryFilter(
+  summary: WorkflowSummary,
+  filter: WorkflowSummaryFilter,
+): boolean {
+  if (filter.phase !== undefined && summary.phase !== filter.phase) return false;
+  if (filter.status !== undefined) {
+    // Explicit status is authoritative, terminal or not.
+    return summary.status === filter.status;
+  }
+  if (!filter.includeTerminal && isTerminalWorkflowStatus(summary.status)) return false;
+  return true;
+}
+
 // ─── Storage Backend Interface ──────────────────────────────────────────────
 
 /**
@@ -123,6 +237,29 @@ export interface StorageBackend {
   getState(featureId: string): WorkflowState | null;
   setState(featureId: string, state: WorkflowState, expectedVersion?: number): void;
   listStates(): Array<{ featureId: string; state: WorkflowState }>;
+
+  /**
+   * Cross-workflow summary read (DR-3) — the backend half of the `ps`
+   * workflows fold. Returns one {@link WorkflowSummary} per tracked workflow,
+   * filtered by {@link WorkflowSummaryFilter}.
+   *
+   * Required (not optional): both production backends implement it, and the
+   * `workflow-fold` view relies on its presence.
+   *
+   * Backend obligations:
+   *  - {@link SqliteBackend}: real pushdown — join `workflow_state × streams`
+   *    and constrain `streams.workflow_type = ?` in SQL against the
+   *    `idx_streams_workflow_type` index (never a post-fetch JS scan). Phase
+   *    comes from `json_extract(state, '$.phase')`; `createdAt` from
+   *    `MIN(events.timestamp)` per stream.
+   *  - {@link InMemoryBackend}: capability-equivalent — derives the same fields
+   *    from the in-memory state object and event arrays and applies the
+   *    filter in JS (no index to consult).
+   *
+   * Both apply {@link matchesWorkflowSummaryFilter} for the lifecycle axes so
+   * the two paths return the same rows for the same inputs.
+   */
+  listWorkflowSummaries(filter?: WorkflowSummaryFilter): WorkflowSummary[];
 
   // Outbox operations
   addOutboxEntry(streamId: string, event: WorkflowEvent): string;

--- a/servers/exarchos-mcp/src/storage/memory-backend.ts
+++ b/servers/exarchos-mcp/src/storage/memory-backend.ts
@@ -62,6 +62,17 @@ export class InMemoryBackend implements StorageBackend {
   /** Counter for generating unique outbox entry IDs */
   private outboxIdCounter = 0;
 
+  /**
+   * Monotonic Tier-2 poll-floor change token (see
+   * {@link StorageBackend.dataVersion}). Bumped on every {@link appendEvent}.
+   * In-memory has no cross-process notion, so — unlike SQLite's
+   * `PRAGMA data_version`, which ignores own-connection commits — this
+   * counter treats every append (including the observer's own) as a change.
+   * The floor loop's cursor guard makes the resulting redundant drains
+   * harmless (never a double delivery).
+   */
+  private appendVersion = 0;
+
   // ─── Event Operations ───────────────────────────────────────────────────
 
   appendEvent(streamId: string, event: WorkflowEvent): void {
@@ -71,6 +82,19 @@ export class InMemoryBackend implements StorageBackend {
       this.events.set(streamId, stream);
     }
     stream.push(event);
+    // Bump the change token AFTER the event is durably in the array so a
+    // concurrent dataVersion() read never observes a bumped token without
+    // the corresponding event being visible.
+    this.appendVersion++;
+  }
+
+  /**
+   * Tier-2 poll-floor change token: a monotonic count of appends. Own
+   * appends bump it (there is no foreign connection in memory). See
+   * {@link StorageBackend.dataVersion} for the cross-backend contract.
+   */
+  dataVersion(): number {
+    return this.appendVersion;
   }
 
   queryEvents(streamId: string, filters?: QueryFilters): WorkflowEvent[] {

--- a/servers/exarchos-mcp/src/storage/memory-backend.ts
+++ b/servers/exarchos-mcp/src/storage/memory-backend.ts
@@ -1,7 +1,15 @@
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import type { WorkflowState } from '../workflow/types.js';
 import type { QueryFilters } from '../event-store/store.js';
-import type { StorageBackend, EventSender, ViewCacheEntry, DrainResult } from './backend.js';
+import type {
+  StorageBackend,
+  EventSender,
+  ViewCacheEntry,
+  DrainResult,
+  WorkflowSummary,
+  WorkflowSummaryFilter,
+} from './backend.js';
+import { deriveWorkflowStatus, matchesWorkflowSummaryFilter } from './backend.js';
 import type { SnapshotRecord } from '../projections/snapshot-schema.js';
 import { resolveMaxRecords } from './snapshot-retention.js';
 
@@ -240,6 +248,62 @@ export class InMemoryBackend implements StorageBackend {
       result.push({ featureId, state: entry.state });
     }
     return result;
+  }
+
+  /**
+   * Cross-workflow summary read (DR-3). Capability-equivalent counterpart to
+   * {@link SqliteBackend.listWorkflowSummaries}: derives the same
+   * {@link WorkflowSummary} fields from the in-memory state objects and event
+   * arrays and applies the filter in JS (there is no index to push down to).
+   *
+   * `workflowType`/`phase` come off the stored state object; `status` from the
+   * shared {@link deriveWorkflowStatus}; `createdAt` is the earliest event
+   * timestamp for the stream (the event envelope). The shared
+   * {@link matchesWorkflowSummaryFilter} applies the lifecycle axes and the
+   * `workflowType` axis is applied here in JS — together they reproduce the
+   * SQLite path's rows exactly (INV-2 facade equivalence), the guarantee the
+   * `ListWorkflowSummaries_BackendContract_SharedAcrossSqliteAndInMemory` test
+   * pins.
+   */
+  listWorkflowSummaries(filter: WorkflowSummaryFilter = {}): WorkflowSummary[] {
+    const summaries: WorkflowSummary[] = [];
+
+    for (const [featureId, entry] of this.states) {
+      const state = entry.state as { phase?: unknown; workflowType?: unknown };
+      const phase = typeof state.phase === 'string' ? state.phase : '';
+      const workflowType = typeof state.workflowType === 'string' ? state.workflowType : '';
+
+      // Earliest event envelope = workflow creation instant. ISO-8601 sorts
+      // lexicographically, matching SQLite's MIN(timestamp).
+      let createdAt: string | null = null;
+      const events = this.events.get(featureId);
+      if (events && events.length > 0) {
+        createdAt = events[0].timestamp;
+        for (const event of events) {
+          if (event.timestamp < createdAt) createdAt = event.timestamp;
+        }
+      }
+
+      summaries.push({
+        featureId,
+        workflowType,
+        phase,
+        status: deriveWorkflowStatus(phase),
+        createdAt,
+      });
+    }
+
+    // Stable ORDER BY featureId ASC — parity with SqliteBackend.
+    summaries.sort((a, b) => a.featureId.localeCompare(b.featureId));
+
+    return summaries.filter((summary) => {
+      // workflow_type has no index in memory, so filter it in JS here; the
+      // shared predicate applies the lifecycle axes.
+      if (filter.workflowType !== undefined && summary.workflowType !== filter.workflowType) {
+        return false;
+      }
+      return matchesWorkflowSummaryFilter(summary, filter);
+    });
   }
 
   // ─── Outbox Operations ──────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/storage/sqlite-backend.ts
+++ b/servers/exarchos-mcp/src/storage/sqlite-backend.ts
@@ -208,6 +208,17 @@ interface Statements {
 const MAX_OUTBOX_RETRIES = 5;
 
 /**
+ * `workflowType` for a summary row: the registry's column when the `streams`
+ * row exists, else the workflow_state row's own copy, else `''`. Used by BOTH
+ * the SELECT projection and the WHERE pushdown in
+ * {@link SqliteBackend.listWorkflowSummaries} so the filtered and projected
+ * values can never disagree. The `''` tail mirrors the in-memory backend's
+ * `typeof state.workflowType === 'string' ? state.workflowType : ''`, keeping
+ * the two backends row-for-row equivalent (INV-2).
+ */
+const WORKFLOW_TYPE_EXPR = `COALESCE(s.workflow_type, json_extract(ws.state, '$.workflowType'), '')`;
+
+/**
  * Bounded retry policy for SQLITE_BUSY surfaced by the substrate
  * `atomicAppend` write path (#1259, T09, DR-12, refined by audit §F2.2).
  *
@@ -2150,20 +2161,29 @@ export class SqliteBackend implements StorageBackend {
     const params: unknown[] = [];
 
     if (filter.workflowType !== undefined) {
-      // Indexed pushdown on the registry's workflow_type column.
-      conditions.push('s.workflow_type = ?');
+      // Pushdown on the SAME coalesced expression the SELECT projects — NOT on
+      // the bare `s.workflow_type`, which would be NULL for a registry-less row
+      // and re-drop exactly the rows the LEFT JOIN below exists to keep.
+      conditions.push(`${WORKFLOW_TYPE_EXPR} = ?`);
       params.push(filter.workflowType);
       this.workflowTypePushdownQueries++;
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    // LEFT JOIN, not INNER: `registerStream()` is attempted on init but its
+    // write errors are swallowed, so a `workflow_state` row can outlive a
+    // missing `streams` row. An INNER JOIN silently OMITS those workflows,
+    // which diverges from the in-memory backend (it reads workflowType off the
+    // state object and never consults a registry) — an INV-2 facade-equivalence
+    // break that makes the same workflow visible via one backend and invisible
+    // via the other. Fall back to the state row's own workflowType.
     const sql = `
       SELECT ws.featureId AS featureId,
-             s.workflow_type AS workflowType,
+             ${WORKFLOW_TYPE_EXPR} AS workflowType,
              json_extract(ws.state, '$.phase') AS phase,
              (SELECT MIN(e.timestamp) FROM events e WHERE e.streamId = ws.featureId) AS createdAt
         FROM workflow_state ws
-        INNER JOIN streams s ON s.streamId = ws.featureId
+        LEFT JOIN streams s ON s.streamId = ws.featureId
         ${where}
         ORDER BY ws.featureId ASC`;
 

--- a/servers/exarchos-mcp/src/storage/sqlite-backend.ts
+++ b/servers/exarchos-mcp/src/storage/sqlite-backend.ts
@@ -1540,6 +1540,36 @@ export class SqliteBackend implements StorageBackend {
     return row ? row.sequence : 0;
   }
 
+  /**
+   * Tier-2 poll-floor change token (see {@link StorageBackend.dataVersion}).
+   *
+   * `PRAGMA data_version` is unchanged for commits made on THIS connection
+   * and differs only when another connection (a foreign process) committed
+   * since the pragma last ran. That is precisely the cross-process wake
+   * signal the subscription floor loop needs — the Tier-1 in-process hook
+   * already covers this connection's own commits, so the floor must fire
+   * only on foreign ones. The absolute value is connection-specific and
+   * meaningless; the caller compares successive reads for a change.
+   *
+   * Deliberately NOT a retained prepared statement: the floor loop must
+   * "hold no open SQLite statement across ticks" so it never pins a read
+   * snapshot that would hide the very foreign commit it is polling for. An
+   * inline `query(...).get()` fully reads and finalizes the pragma each call.
+   *
+   * bun:sqlite keys the single pragma column by `data_version`; the
+   * better-sqlite3 test shim does the same. A defensive fallback tolerates
+   * an unnamed column just in case.
+   */
+  dataVersion(): number {
+    const row = this.db.query('PRAGMA data_version').get() as
+      | Record<string, number | string>
+      | undefined;
+    if (!row) return 0;
+    const raw = row.data_version ?? row[''];
+    const value = typeof raw === 'number' ? raw : Number(raw ?? 0);
+    return Number.isFinite(value) ? value : 0;
+  }
+
   listStreams(): string[] {
     const rows = this.db
       .prepare('SELECT DISTINCT streamId FROM sequences ORDER BY streamId')

--- a/servers/exarchos-mcp/src/storage/sqlite-backend.ts
+++ b/servers/exarchos-mcp/src/storage/sqlite-backend.ts
@@ -4,7 +4,15 @@ import { dirname, join, basename, resolve, relative, isAbsolute } from 'node:pat
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import type { WorkflowState } from '../workflow/types.js';
 import type { QueryFilters } from '../event-store/store.js';
-import type { StorageBackend, EventSender, ViewCacheEntry, DrainResult } from './backend.js';
+import type {
+  StorageBackend,
+  EventSender,
+  ViewCacheEntry,
+  DrainResult,
+  WorkflowSummary,
+  WorkflowSummaryFilter,
+} from './backend.js';
+import { deriveWorkflowStatus, matchesWorkflowSummaryFilter } from './backend.js';
 import { VersionConflictError } from './memory-backend.js';
 import type { SnapshotRecord } from '../projections/snapshot-schema.js';
 import { resolveMaxRecords } from './snapshot-retention.js';
@@ -428,6 +436,19 @@ export class SqliteBackend implements StorageBackend {
    * invisible until users notice the latency.
    */
   private correlationFilteredQueries = 0;
+
+  /**
+   * Counter for {@link listWorkflowSummaries} calls that pushed a
+   * `workflow_type` predicate down to the indexed SQL WHERE (the
+   * `idx_streams_workflow_type` fast path). Incremented ONCE per filtered
+   * query. Exposed via {@link getStats} so the
+   * `WorkflowFold_TypeFilter_PushedDownToIndexedColumn` gate can assert the
+   * type filter took the index path rather than a post-fetch JS scan — a
+   * silent regression to a full workflow_state × streams scan would still
+   * return correct rows and otherwise stay invisible until users notice the
+   * latency.
+   */
+  private workflowTypePushdownQueries = 0;
 
   /**
    * Clock used for outbox retry-eligibility checks. Injectable so tests can
@@ -1589,8 +1610,11 @@ export class SqliteBackend implements StorageBackend {
    * object) so callers can compose per-subsystem stat snapshots without a
    * shared metrics interface.
    */
-  getStats(): { correlationFilteredQueries: number } {
-    return { correlationFilteredQueries: this.correlationFilteredQueries };
+  getStats(): { correlationFilteredQueries: number; workflowTypePushdownQueries: number } {
+    return {
+      correlationFilteredQueries: this.correlationFilteredQueries,
+      workflowTypePushdownQueries: this.workflowTypePushdownQueries,
+    };
   }
 
   /**
@@ -2097,6 +2121,73 @@ export class SqliteBackend implements StorageBackend {
       featureId: row.featureId,
       state: JSON.parse(row.state) as WorkflowState,
     }));
+  }
+
+  /**
+   * Cross-workflow summary read (DR-3). Real pushdown: the `workflow_type`
+   * predicate is compiled into the SQL WHERE against the
+   * `idx_streams_workflow_type` index — the INNER JOIN of `workflow_state ×
+   * streams` keys the type filter to the indexed registry column rather than
+   * scanning every row's state JSON.
+   *
+   * Per-row fields:
+   *  - `workflowType` from `streams.workflow_type` (the indexed, authoritative
+   *    registry value; equal to the state's own `workflowType` because
+   *    `registerStream` is written with the same value on the init path).
+   *  - `phase` from `json_extract(state, '$.phase')` on the persisted blob.
+   *  - `status` derived from `phase` via the shared {@link deriveWorkflowStatus}.
+   *  - `createdAt` from `MIN(events.timestamp)` per stream — the earliest
+   *    event envelope, i.e. the workflow's creation instant (indexed via
+   *    `idx_events_time (streamId, timestamp)`).
+   *
+   * The lifecycle axes (`status`/`phase`/`includeTerminal`) are applied by the
+   * shared {@link matchesWorkflowSummaryFilter} so this path and the in-memory
+   * path stay row-for-row equivalent. `workflowType` is intentionally NOT
+   * re-checked in JS — the SQL WHERE owns it, keeping the pushdown load-bearing.
+   */
+  listWorkflowSummaries(filter: WorkflowSummaryFilter = {}): WorkflowSummary[] {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filter.workflowType !== undefined) {
+      // Indexed pushdown on the registry's workflow_type column.
+      conditions.push('s.workflow_type = ?');
+      params.push(filter.workflowType);
+      this.workflowTypePushdownQueries++;
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `
+      SELECT ws.featureId AS featureId,
+             s.workflow_type AS workflowType,
+             json_extract(ws.state, '$.phase') AS phase,
+             (SELECT MIN(e.timestamp) FROM events e WHERE e.streamId = ws.featureId) AS createdAt
+        FROM workflow_state ws
+        INNER JOIN streams s ON s.streamId = ws.featureId
+        ${where}
+        ORDER BY ws.featureId ASC`;
+
+    const rows = this.db.prepare(sql).all(...params) as Array<{
+      featureId: string;
+      workflowType: string;
+      phase: string | null;
+      createdAt: string | null;
+    }>;
+
+    const summaries: WorkflowSummary[] = rows.map((row) => {
+      const phase = row.phase ?? '';
+      return {
+        featureId: row.featureId,
+        workflowType: row.workflowType,
+        phase,
+        status: deriveWorkflowStatus(phase),
+        createdAt: row.createdAt ?? null,
+      };
+    });
+
+    // Apply the lifecycle axes only — workflow_type is already SQL-filtered.
+    const lifecycleFilter: WorkflowSummaryFilter = { ...filter, workflowType: undefined };
+    return summaries.filter((summary) => matchesWorkflowSummaryFilter(summary, lifecycleFilter));
   }
 
   // ─── Outbox Operations ──────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/views/composite.test.ts
+++ b/servers/exarchos-mcp/src/views/composite.test.ts
@@ -1021,7 +1021,7 @@ describe('ps — launcher-session liveness (DR-7, Task 018)', () => {
     const listSpy = vi.fn((): readonly ProcessRecord[] => []);
     const table: ProcessTableSource = { list: listSpy };
 
-    const inFlight = await handleView({ action: 'ps' }, ctx, {
+    const inFlight = await handleView({ action: 'ps', scope: 'worktree' }, ctx, {
       processTableSource: table,
       realpath: (p) => p,
     });
@@ -1054,7 +1054,7 @@ describe('ps — launcher-session liveness (DR-7, Task 018)', () => {
     // The terminal folds → the launch column (and its affordance) clear
     // deterministically, again from events alone (no permanent phantom).
     await emitLaunchExecuted(ctx.eventStore, { worktreeId, exitCode: 0 });
-    const cleared = await handleView({ action: 'ps' }, ctx, { realpath: (p) => p });
+    const cleared = await handleView({ action: 'ps', scope: 'worktree' }, ctx, { realpath: (p) => p });
     const clearedData = cleared.data as {
       launches: WorktreeEntry[];
       launchCount: number;

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -30,10 +30,8 @@ import {
 import { handleViewInvariantsEffective } from './effective-catalog.js';
 import { handleViewInspect } from './lifecycle/inspect.js';
 import { handleViewWait, type WaitDeps } from './lifecycle/wait.js';
-import {
-  handleViewWorktrees,
-  handleViewPs,
-} from '../orchestrate/worktree/handlers.js';
+import { handleViewPs } from './lifecycle/ps.js';
+import { handleViewWorktrees } from '../orchestrate/worktree/handlers.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
 import type { QualityHintsConfig } from '../capabilities/resolver.js';
@@ -441,18 +439,19 @@ export async function handleView(
       return envelopeWrap(await handleViewWorktrees(rest, ctx), startedAt);
 
     case 'ps':
-      // WLM operational core (DR-4/DR-3) — list the live worktree-layer liveness
-      // pairs from the `worktrees@v1` fold (no process scan): in-flight merges,
-      // launches, AND prunes (`inFlightPrunes`, DR-3). `probe: true` additionally
-      // pulls the DR-5 process probe and emits worktree.released /
-      // worktree.orphan_detected (the deferred orphan emitter — the sole write
-      // path on this view surface). `rest`/`deps` thread every field/mode.
+      // DR-3 (Task 007) — scope-parameterized process-plane lister. `scope: 'all'`
+      // (default) composes task 005's workflows fold + task 006's operations fold;
+      // `scope: 'workflow'` returns the workflows section; `scope: 'worktree'`
+      // delegates to the CONSUMED WLM-6 kernel (inFlightMerges / launches /
+      // inFlightPrunes + the `probe: true` reclaim/reconcile write path — the sole
+      // write path, valid ONLY in worktree scope). `rest`/`deps` thread every
+      // field/mode.
       //
-      // DR-7 (Task 018) — for launcher-spawned sessions the launch column
-      // answers liveness from the `launch.*` event pair ALONE;
+      // DR-7 (Task 018) — for launcher-spawned worktree-scope sessions the launch
+      // column answers liveness from the `launch.*` event pair ALONE;
       // `withLaunchLivenessAffordance` surfaces that guarantee as an agent-first
       // `next_actions` hint when any launcher session is in flight (pure
-      // annotation — the WLM fold's `launches` data is untouched).
+      // annotation — keyed on the worktree-scope `launchCount`, a no-op otherwise).
       return envelopeWrap(
         withLaunchLivenessAffordance(await handleViewPs(rest, ctx, deps)),
         startedAt,

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -29,11 +29,10 @@ import {
 } from './tools.js';
 import { handleViewInvariantsEffective } from './effective-catalog.js';
 import { handleViewInspect } from './lifecycle/inspect.js';
+import { handleViewWait, type WaitDeps } from './lifecycle/wait.js';
 import {
   handleViewWorktrees,
   handleViewPs,
-  handleViewWait,
-  type WorktreeViewDeps,
 } from '../orchestrate/worktree/handlers.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
@@ -118,12 +117,14 @@ export async function handleView(
   args: Record<string, unknown>,
   ctx: DispatchContext,
   // WLM operational core (DR-4) — test-only DI seam for the `ps` / `wait`
-  // worktree-liveness arms (fake process-table source / realpath / sleep clock).
-  // Production dispatch (`core/dispatch.ts`) calls `handleView(args, ctx)` with
-  // no third argument, so the real OS-backed defaults are wired; only the named
-  // worktree tests thread it. Other action arms ignore it. An extra optional
-  // parameter keeps `handleView` assignable to `CompositeHandler` (2 params).
-  deps?: WorktreeViewDeps,
+  // liveness arms. `WaitDeps` is the superset (it extends `WorktreeViewDeps`
+  // with the generic-`wait` subscription/deadline seams) so one param threads
+  // both the worktree ps/wait scope AND the generic wait's phase/status/operation
+  // predicates. Production dispatch (`core/dispatch.ts`) calls `handleView(args,
+  // ctx)` with no third argument, so the real OS-backed defaults are wired; only
+  // the named lifecycle tests thread it. Other action arms ignore it. An extra
+  // optional parameter keeps `handleView` assignable to `CompositeHandler`.
+  deps?: WaitDeps,
 ): Promise<ToolResult> {
   const startedAt = Date.now();
   const { stateDir, eventStore } = ctx;
@@ -458,12 +459,12 @@ export async function handleView(
       );
 
     case 'wait':
-      // WLM operational core (DR-4/DR-3) — caller-bounded poll. Default
-      // until:'merge' blocks on the serialized merge on `integrationRef` reaching
-      // its terminal worktree.merge_executed; until:'idle' blocks until no
-      // in-flight prune_worktrees pass remains (prune terminal cleared). Both
-      // read-only, structured-timeout-on-expiry, no background timer. `rest`
-      // carries `until`/`integrationRef`/`timeoutMs` through unchanged.
+      // Generic event-driven gate (DR-5/DR-8) — a PURE CONSUMER that appends
+      // nothing. Feature-scoped phase/status/operation predicates resolve via a
+      // precheck then a DR-1 subscription (Tier-1 wake / Tier-2 floor), with
+      // structured WAIT_TIMEOUT/WAIT_FAILED on expiry/failure; the worktree
+      // `until: merge|idle` scope delegates to the absorbed WLM-6 kernel. `rest`
+      // carries featureId/phase/status/operation/until/integrationRef/timeoutMs.
       return envelopeWrap(await handleViewWait(rest, ctx, deps), startedAt);
 
     case 'inspect':

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -29,6 +29,7 @@ import {
 } from './tools.js';
 import { handleViewInvariantsEffective } from './effective-catalog.js';
 import { handleViewInspect } from './lifecycle/inspect.js';
+import { handleViewExport } from './lifecycle/export.js';
 import { handleViewWait, type WaitDeps } from './lifecycle/wait.js';
 import { handleViewPs } from './lifecycle/ps.js';
 import { handleViewWorktrees } from '../orchestrate/worktree/handlers.js';
@@ -475,6 +476,17 @@ export async function handleView(
       // events emitted (the CB-2 no-phantom-stream guarantee).
       return envelopeWrap(await handleViewInspect(rest, ctx), startedAt);
 
+    case 'export':
+      // Worktree-lifecycle diagnostic bundle (DR-6). Writes a zip
+      // (events.jsonl / state.json / metadata.json / artifacts/) to a path
+      // OUTSIDE `.exarchos/` and journals the INV-13 export.requested →
+      // export.executed pair around the write (storage idempotency key derived
+      // from a logical key per INV-8 — a crash-retry completes the SAME intent,
+      // a fresh invocation mints a new pair). Cold-probe safe: an unknown
+      // featureId returns workflowExists:false, writes NO zip and emits ZERO
+      // events. The CLI verb promotion is task-015.
+      return envelopeWrap(await handleViewExport(rest, ctx), startedAt);
+
     case 'describe':
       return envelopeWrap(
         await handleDescribe(rest as { actions: string[] }, viewActions),
@@ -512,6 +524,7 @@ export async function handleView(
             'ps',
             'wait',
             'inspect',
+            'export',
             'describe',
           ] as const,
         },

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -28,6 +28,7 @@ import {
   handleViewConvergence,
 } from './tools.js';
 import { handleViewInvariantsEffective } from './effective-catalog.js';
+import { handleViewInspect } from './lifecycle/inspect.js';
 import {
   handleViewWorktrees,
   handleViewPs,
@@ -465,6 +466,15 @@ export async function handleView(
       // carries `until`/`integrationRef`/`timeoutMs` through unchanged.
       return envelopeWrap(await handleViewWait(rest, ctx, deps), startedAt);
 
+    case 'inspect':
+      // Worktree-lifecycle single-workflow projection (DR-4). Pure read: folds
+      // the feature stream ONCE via the canonical event-store-first
+      // `resolveWorkflowState` and projects state / recent events + correlation
+      // tuple / artifacts / task progress. Appends nothing on any path — a cold
+      // probe of an unknown featureId returns `workflowExists:false` with ZERO
+      // events emitted (the CB-2 no-phantom-stream guarantee).
+      return envelopeWrap(await handleViewInspect(rest, ctx), startedAt);
+
     case 'describe':
       return envelopeWrap(
         await handleDescribe(rest as { actions: string[] }, viewActions),
@@ -501,6 +511,7 @@ export async function handleView(
             'worktrees',
             'ps',
             'wait',
+            'inspect',
             'describe',
           ] as const,
         },

--- a/servers/exarchos-mcp/src/views/lifecycle/errors.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/errors.test.ts
@@ -1,0 +1,250 @@
+// ─── Verb error-envelope edge cases across the surface (DR-8) ─────────────────
+//
+// A consolidated adversarial suite for the STRUCTURED-ERROR contract shared by
+// the worktree-lifecycle verbs (`wait` / `inspect` / `export` / `ps`). Boundary
+// discipline mirrors `wait.test.ts`: every test drives the REAL event store, the
+// REAL HSM topology (`getHSMDefinition`) and the REAL DR-2 liveness registry
+// (`featureScopedSurfaces`) — no hand-mocks of those seams. Determinism on the
+// one path that would otherwise subscribe comes from an INJECTED, immediately-
+// firing deadline (INV-16), so a regression that DROPS the fast-fail validation
+// surfaces as a `WAIT_TIMEOUT` rather than a hang.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../event-store/store.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { SubscriptionClock } from '../../event-store/subscriptions.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import { getHSMDefinition } from '../../workflow/state-machine.js';
+import { handleViewWait, featureScopedSurfaces, type WaitDeps } from './wait.js';
+import { handleViewInspect } from './inspect.js';
+import { handleViewExport } from './export.js';
+import { handleViewPs } from './ps.js';
+
+// ─── Manually-driven subscription clock (INV-16) ──────────────────────────────
+//
+// A deterministic SubscriptionClock whose Tier-2 floor loop never fires on its
+// own (the tests here never subscribe on the happy path). Injected only so a
+// KILL-PROBE run — one that reverts the phase-topology validation and falls
+// through to subscribe — spins NO real timer.
+class ManualSubscriptionClock implements SubscriptionClock {
+  time = 0;
+  now(): number {
+    return this.time;
+  }
+  scheduleInterval(): () => void {
+    return () => {};
+  }
+}
+
+/**
+ * Deps whose bounded deadline fires SYNCHRONOUSLY. With the phase validation in
+ * place, `wait` returns `INVALID_INPUT` BEFORE it would ever subscribe, so this
+ * deadline is never armed. With the validation reverted (kill-probe), `wait`
+ * subscribes and this deadline fires at once → a deterministic `WAIT_TIMEOUT`
+ * (not a hang), so the `INVALID_INPUT` assertion goes red fast.
+ */
+function immediateTimeoutDeps(): WaitDeps {
+  return {
+    now: () => 1000,
+    scheduleTimeout: (cb) => {
+      cb();
+      return () => {};
+    },
+    subscriptionOptions: { clock: new ManualSubscriptionClock() },
+  };
+}
+
+// ─── Arm / fixtures (mirrors wait.test.ts) ────────────────────────────────────
+
+interface Arm {
+  readonly stateDir: string;
+  readonly store: EventStore;
+  readonly ctx: DispatchContext;
+}
+
+let arms: Arm[] = [];
+
+afterEach(async () => {
+  for (const arm of arms) {
+    arm.store.close();
+    await rmrfAsync(arm.stateDir);
+  }
+  arms = [];
+});
+
+async function makeArm(): Promise<Arm> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), 'verb-errors-'));
+  const store = new EventStore(stateDir);
+  await store.initialize();
+  const ctx = { stateDir, eventStore: store, enableTelemetry: false } as unknown as DispatchContext;
+  const arm: Arm = { stateDir, store, ctx };
+  arms.push(arm);
+  return arm;
+}
+
+async function seedWorkflow(store: EventStore, featureId: string, workflowType = 'feature'): Promise<void> {
+  await store.append(featureId, { type: 'workflow.started', data: { featureId, workflowType } });
+}
+
+/** Sum committed events across every stream (event-count-invariance witness). */
+async function totalEvents(store: EventStore): Promise<number> {
+  let total = 0;
+  for (const streamId of store.listStreams()) {
+    total += (await store.query(streamId)).length;
+  }
+  return total;
+}
+
+/**
+ * The WAITABLE phases of a workflow type, derived INDEPENDENTLY from the REAL
+ * HSM registry (atomic + final states; compound containers excluded). The
+ * handler must produce exactly this set for a type — if it hardcoded a list,
+ * this registry-derived expectation would drift on any topology edit.
+ */
+function waitablePhases(workflowType: string): string[] {
+  return Object.values(getHSMDefinition(workflowType).states)
+    .filter((state) => state.type !== 'compound')
+    .map((state) => state.id)
+    .sort();
+}
+
+// ─── wait — invalid phase → topology-derived validTargets ─────────────────────
+
+describe('verb error envelopes (DR-8)', () => {
+  it('Wait_InvalidPhase_ValidTargetsFromTopologyForWorkflowType', async () => {
+    const { store, ctx } = await makeArm();
+
+    // ── feature workflow: `--phase explore` is a refactor-only phase ──────────
+    await seedWorkflow(store, 'feat-a', 'feature');
+    const beforeFeature = await totalEvents(store);
+    const featureResult = await handleViewWait(
+      { featureId: 'feat-a', phase: 'explore' },
+      ctx,
+      immediateTimeoutDeps(),
+    );
+
+    expect(featureResult.success).toBe(false);
+    expect(featureResult.error?.code).toBe('INVALID_INPUT');
+    const featureTargets = featureResult.error?.validTargets;
+    // Derived from the REAL feature HSM topology — not a hardcoded list.
+    expect(featureTargets).toEqual(waitablePhases('feature'));
+    expect(featureTargets).toEqual(expect.arrayContaining(['plan', 'delegate', 'review', 'synthesize']));
+    // Compound containers are NOT waitable phases (a workflow is never IN one).
+    expect(featureTargets).not.toContain('implementation');
+    // A refactor-only phase is not a feature target.
+    expect(featureTargets).not.toContain('explore');
+    expect(featureTargets).not.toContain('brief');
+    // Side-effect-free: the invalid-phase envelope appends nothing.
+    expect(await totalEvents(store)).toBe(beforeFeature);
+
+    // ── refactor workflow: `--phase delegate` is a feature-only phase ─────────
+    await seedWorkflow(store, 'feat-b', 'refactor');
+    const beforeRefactor = await totalEvents(store);
+    const refactorResult = await handleViewWait(
+      { featureId: 'feat-b', phase: 'delegate' },
+      ctx,
+      immediateTimeoutDeps(),
+    );
+
+    expect(refactorResult.success).toBe(false);
+    expect(refactorResult.error?.code).toBe('INVALID_INPUT');
+    const refactorTargets = refactorResult.error?.validTargets;
+    expect(refactorTargets).toEqual(waitablePhases('refactor'));
+    expect(refactorTargets).toEqual(expect.arrayContaining(['explore', 'brief']));
+    expect(refactorTargets).not.toContain('delegate');
+    // The two type topologies are DISTINCT — validTargets are per-workflow-type.
+    expect(refactorTargets).not.toEqual(featureTargets);
+    expect(await totalEvents(store)).toBe(beforeRefactor);
+  });
+
+  // ─── wait — unknown --operation surface → feature-scoped registry surfaces ───
+
+  it('Wait_UnknownOperationSurface_ValidTargetsListsFeatureScopedSurfaces', async () => {
+    const { store, ctx } = await makeArm();
+    await seedWorkflow(store, 'feat-op', 'feature');
+    const before = await totalEvents(store);
+
+    // `frobnicate` is not a registered DR-2 liveness surface at all.
+    const result = await handleViewWait({ featureId: 'feat-op', operation: 'frobnicate' }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    // validTargets = the feature-scoped surfaces straight off the REAL registry.
+    expect(result.error?.validTargets).toEqual(featureScopedSurfaces());
+    expect(result.error?.validTargets).toEqual(expect.arrayContaining(['merge', 'mutation']));
+    // The worktrees-scoped surfaces are NOT feature-observable → excluded.
+    expect(result.error?.validTargets).not.toContain('launch');
+    expect(result.error?.validTargets).not.toContain('prune');
+    // suggestedFix steers the caller to the worktree `until` scope.
+    expect(result.error?.suggestedFix?.tool).toBe('wait');
+    expect(result.error?.suggestedFix?.params).toHaveProperty('until');
+    // Side-effect-free.
+    expect(await totalEvents(store)).toBe(before);
+  });
+
+  // ─── inspect / wait / export on an unknown featureId → side-effect-free ──────
+
+  it('Verbs_UnknownFeatureId_SideEffectFreeExpectedShape', async () => {
+    const { store, ctx } = await makeArm();
+    // An UNRELATED workflow so the invariance witness is a non-zero baseline: a
+    // cold probe of a different id must not mutate it (no phantom stream).
+    await seedWorkflow(store, 'feat-real', 'feature');
+    const unknown = 'no-such-feature';
+
+    // ── inspect: expected shape is a `workflowExists: false` success ──────────
+    let before = await totalEvents(store);
+    const inspectResult = await handleViewInspect({ featureId: unknown }, ctx);
+    expect(inspectResult.success).toBe(true);
+    expect((inspectResult.data as { workflowExists?: boolean }).workflowExists).toBe(false);
+    expect((inspectResult.data as { eventCount?: number }).eventCount).toBe(0);
+    expect(inspectResult._meta?.workflowExists).toBe(false);
+    expect(await totalEvents(store)).toBe(before); // event-count invariance
+
+    // ── wait: expected shape is a structured INVALID_INPUT cold-probe ─────────
+    before = await totalEvents(store);
+    const waitResult = await handleViewWait({ featureId: unknown, phase: 'plan' }, ctx);
+    expect(waitResult.success).toBe(false);
+    expect(waitResult.error?.code).toBe('INVALID_INPUT');
+    expect(waitResult.error?.expectedShape).toBeDefined();
+    expect(await totalEvents(store)).toBe(before); // event-count invariance
+
+    // ── export: expected shape is a `workflowExists: false` / not-exported ─────
+    before = await totalEvents(store);
+    const exportResult = await handleViewExport({ featureId: unknown }, ctx);
+    expect(exportResult.success).toBe(true);
+    expect((exportResult.data as { workflowExists?: boolean }).workflowExists).toBe(false);
+    expect((exportResult.data as { exported?: boolean }).exported).toBe(false);
+    expect(exportResult._meta?.workflowExists).toBe(false);
+    expect(await totalEvents(store)).toBe(before); // event-count invariance
+  });
+
+  // ─── ps — probe outside the worktree scope → INVALID_INPUT + suggestedFix ────
+
+  it('Ps_ProbeOutsideWorktreeScope_InvalidInputWithSuggestedFix', async () => {
+    const { store, ctx } = await makeArm();
+    const before = await totalEvents(store);
+
+    // `probe` is a worktree-scope-only capability — the workflows/operations
+    // folds are pure reads with no process probe.
+    const workflowScoped = await handleViewPs({ scope: 'workflow', probe: true }, ctx);
+    expect(workflowScoped.success).toBe(false);
+    expect(workflowScoped.error?.code).toBe('INVALID_INPUT');
+    expect(workflowScoped.error?.validTargets).toContain('worktree');
+    expect(workflowScoped.error?.suggestedFix?.tool).toBe('exarchos_view');
+    expect(workflowScoped.error?.suggestedFix?.params).toMatchObject({ scope: 'worktree', probe: true });
+
+    // The DEFAULT scope ('all') is likewise not probe-able.
+    const defaultScoped = await handleViewPs({ probe: true }, ctx);
+    expect(defaultScoped.success).toBe(false);
+    expect(defaultScoped.error?.code).toBe('INVALID_INPUT');
+    expect(defaultScoped.error?.suggestedFix?.params).toMatchObject({ scope: 'worktree' });
+
+    // Pure read: rejecting probe appends nothing.
+    expect(await totalEvents(store)).toBe(before);
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/errors.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/errors.test.ts
@@ -180,8 +180,12 @@ describe('verb error envelopes (DR-8)', () => {
     // The worktrees-scoped surfaces are NOT feature-observable → excluded.
     expect(result.error?.validTargets).not.toContain('launch');
     expect(result.error?.validTargets).not.toContain('prune');
-    // suggestedFix steers the caller to the worktree `until` scope.
-    expect(result.error?.suggestedFix?.tool).toBe('wait');
+    // suggestedFix steers the caller to the worktree `until` scope — as a
+    // REAL action-call: `wait` is an exarchos_view action, not a tool of its
+    // own, so the shape must name the tool and carry `action` in params or a
+    // client cannot replay it verbatim (INV-5b).
+    expect(result.error?.suggestedFix?.tool).toBe('exarchos_view');
+    expect(result.error?.suggestedFix?.params).toMatchObject({ action: 'wait' });
     expect(result.error?.suggestedFix?.params).toHaveProperty('until');
     // Side-effect-free.
     expect(await totalEvents(store)).toBe(before);

--- a/servers/exarchos-mcp/src/views/lifecycle/export.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/export.test.ts
@@ -295,6 +295,67 @@ describe('export (DR-6 diagnostic bundle)', () => {
     expect((executed!.data as { missingArtifacts?: string[] }).missingArtifacts).toEqual([planRel]);
   });
 
+  it('Export_ArtifactRefEscapingBaseDir_RefusedByBothRoutesAndListedMissing', async () => {
+    const featureId = 'traversal-feature';
+    // A file that EXISTS and is readable, but lives OUTSIDE the workflow tree.
+    const outsideDir = await mkdtemp(path.join(tmpdir(), 'export-outside-'));
+    try {
+      const secretAbs = path.join(outsideDir, 'secret.txt');
+      await writeFile(secretAbs, 'TOP-SECRET-BYTES', 'utf8');
+
+      // BOTH escape routes: a `..` traversal relative to baseDir, and a bare
+      // absolute path (the old code fed `path.isAbsolute(value) ? value` to
+      // statSync/readFileSync with no containment check at all).
+      const viaTraversal = path.relative(tempDir, secretAbs);
+      expect(viaTraversal.startsWith('..')).toBe(true); // the ref really does escape
+      await seedWorkflow(featureId, { viaTraversal, viaAbsolute: secretAbs });
+
+      const outputPath = path.join(tempDir, 'traversal.zip');
+      const res = await handleViewExport({ featureId, output: outputPath }, ctx);
+      expect(res.success).toBe(true);
+
+      const entries = await readZipEntries(await fs.promises.readFile(outputPath));
+      const names = [...entries.keys()];
+      // No artifact entry from outside baseDir, by either route …
+      expect(names.some((n) => n.startsWith('artifacts/viaTraversal/'))).toBe(false);
+      expect(names.some((n) => n.startsWith('artifacts/viaAbsolute/'))).toBe(false);
+      // … and the bundle carries the file's bytes NOWHERE (the real assertion:
+      // an export zip must never absorb arbitrary readable files).
+      for (const buf of entries.values()) {
+        expect(buf.toString('utf8')).not.toContain('TOP-SECRET-BYTES');
+      }
+      // Refused refs degrade to `missing` — tolerated, never a throw.
+      const data = (res as { data: Record<string, unknown> }).data;
+      expect(data.missingArtifacts).toEqual(expect.arrayContaining([viaTraversal, secretAbs]));
+    } finally {
+      await rmrfAsync(outsideDir);
+    }
+  });
+
+  it('Export_AbsoluteInTreeArtifact_EntryNameIsPlatformBasenameNotWholePath', async () => {
+    // An absolute, IN-TREE artifact ref. The entry name must be the file's
+    // basename: `path.posix.basename()` does not treat `\` as a separator, so on
+    // Windows the old code emitted `artifacts/design/C:\…\design.md` as a single
+    // entry name. Passes either way on POSIX; this is the Windows lane's pin.
+    const featureId = 'abs-artifact-feature';
+    await mkdir(path.join(tempDir, 'docs', 'specs'), { recursive: true });
+    const absArtifact = path.join(tempDir, 'docs', 'specs', 'design.md');
+    await writeFile(absArtifact, '# Abs\ncontents', 'utf8');
+    await seedWorkflow(featureId, { design: absArtifact });
+
+    const outputPath = path.join(tempDir, 'abs-artifact.zip');
+    const res = await handleViewExport({ featureId, output: outputPath }, ctx);
+    expect(res.success).toBe(true);
+
+    const entries = await readZipEntries(await fs.promises.readFile(outputPath));
+    const names = [...entries.keys()];
+    expect(names).toContain('artifacts/design/design.md');
+    expect(entries.get('artifacts/design/design.md')!.toString('utf8')).toBe('# Abs\ncontents');
+    // No drive letter or backslash leaked into the posix entry name (INV-16).
+    const designEntry = names.find((n) => n.startsWith('artifacts/design/'))!;
+    expect(designEntry).not.toMatch(/[\\:]/);
+  });
+
   it('Export_InvalidOutputPath_SuggestedFixNoEvents', async () => {
     const featureId = 'invalid-path-feature';
     await seedWorkflow(featureId);

--- a/servers/exarchos-mcp/src/views/lifecycle/export.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/export.test.ts
@@ -1,0 +1,400 @@
+// ─── Tests for the `export` lifecycle verb (DR-6) ─────────────────────────────
+//
+// Boundary coverage: every assertion drives a REAL `EventStore` + the REAL
+// filesystem (a temp dir) across the composite seam — no hand-mocks of the state
+// source or the zip. The named cases pin:
+//   • the events.jsonl → state.json round-trip (replaying the bundle's event
+//     stream reconstructs its state.json — and the live projection);
+//   • the INV-13 two-event split + INV-8 idempotency: a fresh run appends
+//     EXACTLY one export.requested + one export.executed with a distinct key;
+//   • the crash precheck: a dangling requested is COMPLETED without duplicating
+//     the intent (the reused storage key makes the re-emit a cache-hit);
+//   • artifacts/ inclusion + missing-reference tolerance (listed in metadata);
+//   • the invalid-output-path guard (structured suggestedFix, ZERO events);
+//   • the cold-probe side-effect-free invariant (unknown featureId → no zip,
+//     ZERO events);
+//   • a data-transformation PROPERTY: replay(export(store)) === projection(store)
+//     over arbitrary event sequences.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fc } from '@fast-check/vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as yauzl from 'yauzl';
+import type { Readable } from 'node:stream';
+
+import { EventStore } from '../../event-store/store.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import { workflowStateProjection } from '../workflow-state-projection.js';
+import { resolveWorkflowState } from '../../orchestrate/resolve-state.js';
+import { handleViewExport, ExportOutputSchema } from './export.js';
+import { handleView } from '../composite.js';
+
+let tempDir: string;
+let eventStore: EventStore;
+let ctx: DispatchContext;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(tmpdir(), 'export-test-'));
+  eventStore = new EventStore(tempDir);
+  await eventStore.initialize();
+  // `cwd` is the base dir the handler resolves the default output path AND
+  // referenced-artifact paths against, so everything lands inside the temp dir.
+  ctx = { stateDir: tempDir, eventStore, enableTelemetry: false, cwd: tempDir };
+});
+
+afterEach(async () => {
+  await eventStore.close?.();
+  await rmrfAsync(tempDir);
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Seed a realistic feature workflow; artifact paths are OPTIONAL overrides. */
+async function seedWorkflow(
+  streamId: string,
+  artifacts?: Record<string, string>,
+): Promise<void> {
+  await eventStore.append(streamId, {
+    type: 'workflow.started',
+    data: { featureId: streamId, workflowType: 'feature' },
+  });
+  await eventStore.append(streamId, { type: 'workflow.transition', data: { to: 'delegate' } });
+  if (artifacts) {
+    const patch: Record<string, string> = {};
+    for (const [k, v] of Object.entries(artifacts)) patch[`artifacts.${k}`] = v;
+    await eventStore.append(streamId, {
+      type: 'state.patched',
+      data: { featureId: streamId, patch },
+    });
+  }
+  await eventStore.append(streamId, {
+    type: 'task.assigned',
+    data: { taskId: 't1', title: 'Build handler', branch: 'feat/t1' },
+  });
+  await eventStore.append(streamId, { type: 'task.completed', data: { taskId: 't1' } });
+}
+
+/** Read every entry of a zip buffer into a name → bytes map (yauzl, real reader). */
+function readZipEntries(zipBytes: Buffer): Promise<Map<string, Buffer>> {
+  return new Promise((resolve, reject) => {
+    yauzl.fromBuffer(zipBytes, { lazyEntries: true }, (err, zipfile) => {
+      if (err || !zipfile) return reject(err ?? new Error('no zipfile'));
+      const out = new Map<string, Buffer>();
+      zipfile.on('entry', (entry: yauzl.Entry) => {
+        zipfile.openReadStream(entry, (e: Error | null, stream?: Readable) => {
+          if (e || !stream) return reject(e ?? new Error('no read stream'));
+          const chunks: Buffer[] = [];
+          stream.on('data', (c: Buffer) => chunks.push(c));
+          stream.on('end', () => {
+            out.set(entry.fileName, Buffer.concat(chunks));
+            zipfile.readEntry();
+          });
+          stream.on('error', reject);
+        });
+      });
+      zipfile.on('end', () => resolve(out));
+      zipfile.on('error', reject);
+      zipfile.readEntry();
+    });
+  });
+}
+
+/** Fold an event list through the canonical projection (the "replay" leg). */
+function foldEvents(events: readonly WorkflowEvent[]): unknown {
+  let view = workflowStateProjection.init();
+  for (const e of events) view = workflowStateProjection.apply(view, e);
+  return view;
+}
+
+async function countByType(streamId: string, type: string): Promise<number> {
+  const events = await eventStore.query(streamId);
+  return events.filter((e) => e.type === type).length;
+}
+
+// ─── Named cases ──────────────────────────────────────────────────────────────
+
+describe('export (DR-6 diagnostic bundle)', () => {
+  it('Export_Bundle_ReplayEventsJsonlEqualsStateJson', async () => {
+    const featureId = 'round-trip-feature';
+    await seedWorkflow(featureId);
+
+    const outputPath = path.join(tempDir, 'bundle.zip');
+    const res = await handleViewExport({ featureId, output: outputPath }, ctx);
+    expect(res.success).toBe(true);
+
+    // The zip exists on disk and is a real ZIP (PK\x03\x04 magic).
+    expect(fs.existsSync(outputPath)).toBe(true);
+    const zipBytes = await fs.promises.readFile(outputPath);
+    expect(zipBytes.subarray(0, 4).toString('hex')).toBe('504b0304');
+
+    // Read the ACTUAL written bundle back and REPLAY events.jsonl.
+    const entries = await readZipEntries(zipBytes);
+    expect([...entries.keys()]).toEqual(
+      expect.arrayContaining(['events.jsonl', 'state.json', 'metadata.json']),
+    );
+
+    const jsonl = entries.get('events.jsonl')!.toString('utf8');
+    const replayedEvents = jsonl
+      .split('\n')
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as WorkflowEvent);
+    const replayedState = foldEvents(replayedEvents);
+    const stateJson = JSON.parse(entries.get('state.json')!.toString('utf8'));
+
+    // Round-trip: replaying the bundle's events reconstructs its state.json.
+    expect(replayedState).toEqual(stateJson);
+
+    // And that state is exactly the LIVE projection over the store (export.*
+    // events are identity in the projection, so they do not perturb it).
+    const live = await resolveWorkflowState({ featureId, eventStore });
+    expect('state' in live).toBe(true);
+    if ('state' in live) expect(live.state).toEqual(stateJson);
+  });
+
+  it('Export_Success_AppendsExactlyRequestedExecutedPair', async () => {
+    const featureId = 'pair-feature';
+    await seedWorkflow(featureId);
+
+    const first = await handleViewExport(
+      { featureId, output: path.join(tempDir, 'a.zip') },
+      ctx,
+    );
+    expect(first.success).toBe(true);
+    expect(await countByType(featureId, 'export.requested')).toBe(1);
+    expect(await countByType(featureId, 'export.executed')).toBe(1);
+
+    // A re-run mints a NEW logical key → a NEW pair (never a duplicate intent).
+    const second = await handleViewExport(
+      { featureId, output: path.join(tempDir, 'b.zip') },
+      ctx,
+    );
+    expect(second.success).toBe(true);
+    expect(await countByType(featureId, 'export.requested')).toBe(2);
+    expect(await countByType(featureId, 'export.executed')).toBe(2);
+
+    // The two pairs are keyed by DISTINCT idempotencyKeys (INV-8).
+    const events = await eventStore.query(featureId);
+    const requestedKeys = events
+      .filter((e) => e.type === 'export.requested')
+      .map((e) => (e.data as { idempotencyKey: string }).idempotencyKey);
+    expect(new Set(requestedKeys).size).toBe(2);
+
+    // Each requested has a paired executed carrying the SAME logical key.
+    const executedKeys = new Set(
+      events
+        .filter((e) => e.type === 'export.executed')
+        .map((e) => (e.data as { idempotencyKey: string }).idempotencyKey),
+    );
+    for (const k of requestedKeys) expect(executedKeys.has(k)).toBe(true);
+  });
+
+  it('Export_CrashBetweenPair_PrecheckCompletesWithoutDuplicateIntent', async () => {
+    const featureId = 'crash-feature';
+    await seedWorkflow(featureId);
+    const outputPath = path.join(tempDir, 'crash.zip');
+
+    // Simulate a crash between the pair: a durable INTENT with NO paired
+    // executed and no zip yet on disk. Emit it with the SAME derived storage key
+    // the handler uses, so the handler's re-emit collapses onto it.
+    const crashedKey = 'crashed-logical-key';
+    await eventStore.append(
+      featureId,
+      { type: 'export.requested', data: { featureId, outputPath, idempotencyKey: crashedKey } },
+      { idempotencyKey: `export.requested:${crashedKey}` },
+    );
+    expect(await countByType(featureId, 'export.requested')).toBe(1);
+    expect(await countByType(featureId, 'export.executed')).toBe(0);
+    expect(fs.existsSync(outputPath)).toBe(false);
+
+    // Recover.
+    const res = await handleViewExport({ featureId }, ctx);
+    expect(res.success).toBe(true);
+    const data = (res as { data: Record<string, unknown> }).data;
+    expect(data.recovered).toBe(true);
+    // The write completed and the bundle landed at the RECORDED intent path.
+    expect(data.outputPath).toBe(outputPath);
+    expect(fs.existsSync(outputPath)).toBe(true);
+
+    // No DUPLICATE intent: still exactly ONE requested (the re-emit was a
+    // cache-hit on the reused storage key) and now exactly ONE executed.
+    expect(await countByType(featureId, 'export.requested')).toBe(1);
+    expect(await countByType(featureId, 'export.executed')).toBe(1);
+
+    // The executed pairs to the crashed intent's key (INV-8), not a new one.
+    const events = await eventStore.query(featureId);
+    const executed = events.find((e) => e.type === 'export.executed');
+    expect((executed!.data as { idempotencyKey: string }).idempotencyKey).toBe(crashedKey);
+
+    // Idempotent re-recovery: running again over the completed pair mints a new
+    // pair (the intent is no longer dangling) but the on-disk zip already matches
+    // the deterministic bundle, so the write is SKIPPED.
+    const again = await handleViewExport({ featureId, output: outputPath }, ctx);
+    const againData = (again as { data: Record<string, unknown> }).data;
+    expect(againData.recovered).toBe(false);
+    expect(againData.bundleRewritten).toBe(false);
+  });
+
+  it('Export_ArtifactsDir_IncludedAndMissingRefsListedInMetadata', async () => {
+    const featureId = 'artifacts-feature';
+    // design → an artifact FILE that exists; plan → a reference that does NOT.
+    const designRel = 'docs/specs/design.md';
+    const planRel = 'docs/specs/missing-plan.md';
+    await mkdir(path.join(tempDir, 'docs', 'specs'), { recursive: true });
+    await writeFile(path.join(tempDir, designRel), '# Design\ncontents', 'utf8');
+    await seedWorkflow(featureId, { design: designRel, plan: planRel });
+
+    const outputPath = path.join(tempDir, 'artifacts.zip');
+    const res = await handleViewExport({ featureId, output: outputPath }, ctx);
+    expect(res.success).toBe(true);
+    const data = (res as { data: Record<string, unknown> }).data;
+
+    // The missing reference is tolerated + surfaced on the executed result.
+    expect(data.missingArtifacts).toEqual([planRel]);
+
+    const entries = await readZipEntries(await fs.promises.readFile(outputPath));
+    const names = [...entries.keys()];
+
+    // The existing artifact FILE is included under artifacts/… with its bytes.
+    const designEntry = names.find((n) => n.startsWith('artifacts/design/'));
+    expect(designEntry).toBeDefined();
+    expect(entries.get(designEntry!)!.toString('utf8')).toBe('# Design\ncontents');
+
+    // No artifact entry was created for the missing reference.
+    expect(names.some((n) => n.startsWith('artifacts/plan/'))).toBe(false);
+
+    // metadata.json lists the missing reference and the included entry.
+    const metadata = JSON.parse(entries.get('metadata.json')!.toString('utf8'));
+    expect(metadata.missingArtifacts).toEqual([planRel]);
+    expect(metadata.artifacts).toContain(designEntry);
+
+    // The executed EVENT also records the missing reference (INV-13 result).
+    const events = await eventStore.query(featureId);
+    const executed = events.find((e) => e.type === 'export.executed');
+    expect((executed!.data as { missingArtifacts?: string[] }).missingArtifacts).toEqual([planRel]);
+  });
+
+  it('Export_InvalidOutputPath_SuggestedFixNoEvents', async () => {
+    const featureId = 'invalid-path-feature';
+    await seedWorkflow(featureId);
+    const before = (await eventStore.query(featureId)).length;
+
+    // An EXISTING directory is not a valid destination file.
+    const res = await handleViewExport({ featureId, output: tempDir }, ctx);
+    expect(res.success).toBe(false);
+    const error = (res as { error: { code: string; suggestedFix?: unknown } }).error;
+    expect(error.code).toBe('INVALID_OUTPUT_PATH');
+    expect(error.suggestedFix).toBeDefined();
+
+    // Side-effect-free on rejection: NO events emitted (no requested, no
+    // executed), and the workflow stream is unchanged.
+    const after = (await eventStore.query(featureId)).length;
+    expect(after).toBe(before);
+    expect(await countByType(featureId, 'export.requested')).toBe(0);
+  });
+
+  it('Export_UnknownFeatureId_ExpectedShapeNoZip', async () => {
+    // Seed an UNRELATED workflow so the store is non-empty — a cold probe must
+    // perturb NEITHER stream.
+    await seedWorkflow('some-other-feature');
+    const unknown = 'never-initted-feature';
+    const defaultOutput = path.join(tempDir, `${unknown}-export.zip`);
+
+    const res = await handleViewExport({ featureId: unknown }, ctx);
+    expect(res.success).toBe(true);
+    const data = (res as { data: Record<string, unknown> }).data;
+    expect(data.workflowExists).toBe(false);
+    expect(data.exported).toBe(false);
+
+    // No zip written and ZERO events on the probed stream (no phantom stream).
+    expect(fs.existsSync(defaultOutput)).toBe(false);
+    expect((await eventStore.query(unknown)).length).toBe(0);
+  });
+
+  it('Export_CompositeSeam_ValidatesAgainstRegisteredOutputSchema', async () => {
+    // Drive the FULL composite seam so the result also validates against the
+    // registered ExportOutputSchema through the real envelope wrap.
+    const featureId = 'seam-feature';
+    await seedWorkflow(featureId);
+    const res = await handleView(
+      { action: 'export', featureId, output: path.join(tempDir, 'seam.zip') },
+      ctx,
+    );
+    expect(res.success).toBe(true);
+    expect(
+      ExportOutputSchema.safeParse(res).success,
+      'export envelope must validate against its registered outputSchema',
+    ).toBe(true);
+  });
+
+  it('Export_ReplayEqualsProjection_Property', async () => {
+    // Data-transformation property: for an arbitrary event sequence in the
+    // store, replaying the bundle's events.jsonl reconstructs EXACTLY the live
+    // projection over that same store — replay(export(store)) === projection(store).
+    const arbFeatureId = fc.constant('prop-feature');
+    const arbTail = fc.array(
+      fc.oneof(
+        fc.record({
+          type: fc.constant('workflow.transition'),
+          data: fc.record({ to: fc.constantFrom('plan', 'delegate', 'review', 'synthesize') }),
+        }),
+        fc.record({
+          type: fc.constant('state.patched'),
+          data: fc.record({
+            featureId: fc.constant('prop-feature'),
+            patch: fc.dictionary(
+              fc.constantFrom('artifacts.design', 'artifacts.plan'),
+              fc.string({ minLength: 1, maxLength: 12 }),
+            ),
+          }),
+        }),
+        fc.record({
+          type: fc.constant('task.assigned'),
+          data: fc.record({
+            taskId: fc.string({ minLength: 1, maxLength: 6 }),
+            title: fc.string({ maxLength: 12 }),
+            branch: fc.string({ minLength: 1, maxLength: 10 }),
+          }),
+        }),
+      ),
+      { minLength: 0, maxLength: 12 },
+    );
+
+    await fc.assert(
+      fc.asyncProperty(arbFeatureId, arbTail, async (featureId, tail) => {
+        const runDir = await mkdtemp(path.join(tempDir, 'run-'));
+        const store = new EventStore(runDir);
+        await store.initialize();
+        try {
+          await store.append(featureId, {
+            type: 'workflow.started',
+            data: { featureId, workflowType: 'feature' },
+          });
+          for (const ev of tail) await store.append(featureId, ev);
+
+          const domainEvents = await store.query(featureId);
+          // export(store): build the bundle from the store's domain events.
+          const { buildExportBundle } = await import('./export.js');
+          const bundle = buildExportBundle(featureId, domainEvents, runDir);
+          const jsonl = bundle.entries.get('events.jsonl')!.toString('utf8');
+          const replayed = foldEvents(
+            jsonl.split('\n').filter((l) => l.length > 0).map((l) => JSON.parse(l) as WorkflowEvent),
+          );
+
+          // projection(store): the canonical live fold.
+          const live = await resolveWorkflowState({ featureId, eventStore: store });
+          expect('state' in live).toBe(true);
+          if ('state' in live) expect(replayed).toEqual(live.state);
+        } finally {
+          store.close();
+        }
+      }),
+      { numRuns: 30 },
+    );
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/export.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/export.test.ts
@@ -192,6 +192,22 @@ describe('export (DR-6 diagnostic bundle)', () => {
         .map((e) => (e.data as { idempotencyKey: string }).idempotencyKey),
     );
     for (const k of requestedKeys) expect(executedKeys.has(k)).toBe(true);
+
+    // INV-13 ORDER (observed on the REAL handler, not a hand-seeded intent): the
+    // intent `export.requested` MUST be journaled BEFORE its result
+    // `export.executed`. `findDanglingIntent` keys crash-recovery on a
+    // requested-WITHOUT-a-paired-executed, so a swapped emission order silently
+    // breaks recovery even though the pair COUNTS stay 1:1. Assert strict
+    // sequence ordering per logical key — this fails if the two `append()` calls
+    // in export.ts are swapped.
+    for (const key of new Set(requestedKeys)) {
+      const keyOf = (e: WorkflowEvent): string => (e.data as { idempotencyKey: string }).idempotencyKey;
+      const requested = events.find((e) => e.type === 'export.requested' && keyOf(e) === key);
+      const executed = events.find((e) => e.type === 'export.executed' && keyOf(e) === key);
+      expect(requested).toBeDefined();
+      expect(executed).toBeDefined();
+      expect(requested!.sequence).toBeLessThan(executed!.sequence);
+    }
   });
 
   it('Export_CrashBetweenPair_PrecheckCompletesWithoutDuplicateIntent', async () => {

--- a/servers/exarchos-mcp/src/views/lifecycle/export.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/export.ts
@@ -1,0 +1,485 @@
+// ─── Lifecycle verb: `export` — diagnostic zip bundle (DR-6) ──────────────────
+//
+// The last worktree-lifecycle verb: writes a portable diagnostic bundle of ONE
+// workflow to a zip on disk (a path OUTSIDE `.exarchos/` — a non-idempotent
+// external side effect). The bundle carries
+//
+//   • events.jsonl   — the workflow's domain event stream, one JSON event/line
+//                       (the export's OWN `export.*` bookkeeping events are
+//                       excluded so the bundle is a stable function of the
+//                       domain log);
+//   • state.json      — `fold(events.jsonl)` via the canonical
+//                        `workflowStateProjection`, so REPLAYING events.jsonl
+//                        reconstructs state.json byte-for-byte (round-trip);
+//   • metadata.json   — deterministic bundle manifest (featureId / eventCount /
+//                        phase / workflowType / artifacts + missingArtifacts);
+//   • artifacts/       — every referenced artifact FILE that exists on disk;
+//                        references that do NOT exist are tolerated and listed
+//                        in `missingArtifacts` (metadata + the executed event).
+//
+// TWO-EVENT SPLIT (INV-13) + IDEMPOTENCY (INV-8). The write is journaled as a
+// `export.requested` INTENT (resolved destination path) BEFORE the zip is
+// written and a `export.executed` RESULT (contentHash / eventCount /
+// missingArtifacts) AFTER. Both carry a logical `idempotencyKey`; the STORAGE
+// idempotency key is DERIVED from it (`export.requested:<K>` / `export.executed
+// :<K>`) so a crash-retry of the SAME logical export collapses onto one intent
+// while a fresh invocation mints a distinct key and a NEW pair.
+//
+// CRASH PRECHECK. On invocation the handler scans for a `export.requested` with
+// no paired `export.executed` (a crash between the two events). When found it
+// REUSES that intent's key + destination and COMPLETES it rather than minting a
+// new intent — re-emitting `export.requested` with the same storage key is a
+// no-op cache-hit (never a duplicate intent), the on-disk zip is compared
+// against the freshly-built bundle's `contentHash` (deterministic bytes) and the
+// write is skipped when it already matches, then `export.executed` is emitted.
+//
+// COLD-PROBE SIDE-EFFECT-FREE (RCA 2026-05-30). `export` on an unknown /
+// never-`init`'d featureId returns `workflowExists:false`, writes NO zip and
+// emits ZERO events (existence is answered from the event log alone).
+//
+// WINDOWS / INV-16. Zip ENTRY names are built with `path.posix`; filesystem
+// paths with `path.join`; the zip is written to a temp sibling and atomically
+// renamed, and every stream/file handle is closed before the rename — so a
+// temp-dir removal on NTFS is never blocked by an open handle.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { z } from 'zod';
+import { createHash, randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { ZipFile } from 'yazl';
+
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { ToolResult } from '../../format.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import { workflowStateProjection, type WorkflowStateView } from '../workflow-state-projection.js';
+import { EnvelopeSchema } from '../../schemas/envelope.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Bundle manifest version — bumps if the entry layout changes. */
+const EXPORT_FORMAT_VERSION = 1;
+
+/** The two bookkeeping event types excluded from the exported domain stream. */
+const EXPORT_EVENT_TYPES = new Set<string>(['export.requested', 'export.executed']);
+
+/**
+ * Fixed entry mtime so the produced zip is byte-DETERMINISTIC for identical
+ * bundle content — the load-bearing precondition for the INV-13 crash precheck
+ * (compare a freshly-built bundle's contentHash against the on-disk zip). Epoch
+ * (UTC) keeps the extended-timestamp extra field timezone-independent.
+ */
+const FIXED_ZIP_MTIME = new Date(0);
+const FIXED_ZIP_MODE = 0o100644;
+
+// ─── Local input helpers (kept private — never user-facing flags) ─────────────
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function invalidInput(message: string, expectedShape?: Record<string, unknown>): ToolResult {
+  return {
+    success: false,
+    error: { code: 'INVALID_INPUT', message, ...(expectedShape ? { expectedShape } : {}) },
+  };
+}
+
+/** True for a value that is a URL (scheme://...) rather than a filesystem path. */
+function isUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+}
+
+function sha256(buf: Buffer): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+// ─── Pure bundle construction (the round-trip core) ───────────────────────────
+
+interface IncludedArtifact {
+  readonly entryName: string;
+  readonly bytes: Buffer;
+}
+
+/**
+ * Resolve the referenced-artifact set against `baseDir`: split into artifact
+ * FILES that exist on disk (included, as `artifacts/<key>/<basename>` entries)
+ * and referenced paths that do NOT exist (tolerated — listed in
+ * `missingArtifacts`). URL-valued artifacts (e.g. a `pr` link) are neither
+ * included nor treated as missing. Deterministic: both lists are sorted.
+ */
+function collectArtifacts(
+  artifacts: WorkflowStateView['artifacts'] | undefined,
+  baseDir: string,
+): { included: IncludedArtifact[]; missing: string[] } {
+  const included: IncludedArtifact[] = [];
+  const missing: string[] = [];
+
+  const candidates: Array<{ key: string; value: string }> = [];
+  for (const [key, value] of Object.entries(artifacts ?? {})) {
+    if (typeof value === 'string') {
+      candidates.push({ key, value });
+    } else if (Array.isArray(value)) {
+      value.forEach((v, i) => {
+        if (typeof v === 'string') candidates.push({ key: `${key}-${i}`, value: v });
+      });
+    }
+  }
+
+  for (const { key, value } of candidates) {
+    if (isUrl(value)) continue; // e.g. a `pr` URL is not a filesystem artifact
+    const abs = path.isAbsolute(value) ? value : path.join(baseDir, value);
+    let bytes: Buffer | undefined;
+    try {
+      const st = fs.statSync(abs);
+      if (st.isFile()) bytes = fs.readFileSync(abs);
+    } catch {
+      // ENOENT / unreadable → tolerated as missing
+    }
+    if (bytes) {
+      // Entry name uses path.posix (INV-16: zip entries are always posix).
+      const entryName = path.posix.join('artifacts', key, path.posix.basename(value));
+      included.push({ entryName, bytes });
+    } else {
+      missing.push(value);
+    }
+  }
+
+  included.sort((a, b) => (a.entryName < b.entryName ? -1 : a.entryName > b.entryName ? 1 : 0));
+  missing.sort();
+  return { included, missing };
+}
+
+export interface ExportBundle {
+  /** entry name (posix) → raw bytes. */
+  readonly entries: ReadonlyMap<string, Buffer>;
+  /** count of domain events in the exported extract (== `state.json` fold input). */
+  readonly eventCount: number;
+  /** referenced artifact paths that did not exist on disk (tolerated). */
+  readonly missingArtifacts: readonly string[];
+  /** `fold(domainEvents)` — exactly what `state.json` serializes. */
+  readonly state: WorkflowStateView;
+}
+
+/**
+ * Build the logical bundle from the workflow's DOMAIN events (the export's own
+ * `export.*` events are filtered out by the caller). `state.json` is
+ * `fold(domainEvents)` via the SAME projection a replay uses, so
+ * `replay(events.jsonl) === state.json` holds by construction.
+ */
+export function buildExportBundle(
+  featureId: string,
+  domainEvents: readonly WorkflowEvent[],
+  baseDir: string,
+): ExportBundle {
+  let view = workflowStateProjection.init();
+  for (const event of domainEvents) view = workflowStateProjection.apply(view, event);
+  const state = view;
+
+  const eventsJsonl =
+    domainEvents.length > 0 ? domainEvents.map((e) => JSON.stringify(e)).join('\n') + '\n' : '';
+  const stateJson = JSON.stringify(state, null, 2) + '\n';
+
+  const { included, missing } = collectArtifacts(state.artifacts, baseDir);
+
+  const metadata = {
+    featureId,
+    eventCount: domainEvents.length,
+    exportFormatVersion: EXPORT_FORMAT_VERSION,
+    phase: state.phase,
+    workflowType: state.workflowType,
+    lastEventAt: domainEvents.length > 0 ? domainEvents[domainEvents.length - 1].timestamp : null,
+    artifacts: included.map((a) => a.entryName),
+    missingArtifacts: missing,
+  };
+  const metadataJson = JSON.stringify(metadata, null, 2) + '\n';
+
+  const entries = new Map<string, Buffer>();
+  entries.set('events.jsonl', Buffer.from(eventsJsonl, 'utf8'));
+  entries.set('state.json', Buffer.from(stateJson, 'utf8'));
+  entries.set('metadata.json', Buffer.from(metadataJson, 'utf8'));
+  for (const a of included) entries.set(a.entryName, a.bytes);
+
+  return { entries, eventCount: domainEvents.length, missingArtifacts: missing, state };
+}
+
+/**
+ * Serialize the bundle to a DETERMINISTIC zip (fixed mtime + STORE mode + sorted
+ * entry order) so identical content yields byte-identical bytes. Closes the
+ * output stream before resolving (INV-16 — no lingering handle).
+ */
+export function zipBundle(entries: ReadonlyMap<string, Buffer>): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const zip = new ZipFile();
+    const chunks: Buffer[] = [];
+    zip.outputStream.on('data', (c: Buffer) => chunks.push(c));
+    zip.outputStream.on('error', reject);
+    zip.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
+
+    const names = [...entries.keys()].sort();
+    for (const name of names) {
+      zip.addBuffer(entries.get(name)!, name, {
+        mtime: FIXED_ZIP_MTIME,
+        mode: FIXED_ZIP_MODE,
+        compress: false,
+      });
+    }
+    zip.end();
+  });
+}
+
+// ─── Output-path resolution + validation ──────────────────────────────────────
+
+interface OutputPathValidation {
+  readonly ok: boolean;
+  readonly reason?: string;
+  readonly suggestion?: string;
+}
+
+/** Resolve `output` (default `./<featureId>-export.zip`) to an absolute path. */
+function resolveOutputPath(output: string | undefined, featureId: string, baseDir: string): string {
+  const raw = output ?? `${featureId}-export.zip`;
+  return path.isAbsolute(raw) ? raw : path.resolve(baseDir, raw);
+}
+
+/**
+ * Validate the destination BEFORE any event is emitted (the invalid-path path
+ * must be side-effect-free). Rejects an empty path, a directory-intent path
+ * (trailing separator or an existing directory), and a path whose parent cannot
+ * be created. Creating the parent directory for a valid path is expected setup,
+ * not a workflow mutation.
+ */
+function validateAndPrepareOutputPath(outputPath: string, featureId: string): OutputPathValidation {
+  if (!outputPath) {
+    return { ok: false, reason: 'output path is empty', suggestion: `${featureId}-export.zip` };
+  }
+  if (/[\\/]$/.test(outputPath)) {
+    return {
+      ok: false,
+      reason: 'output path is a directory (trailing separator); it must name a zip FILE',
+      suggestion: path.posix.join(outputPath.replace(/[\\/]+$/, ''), `${featureId}-export.zip`),
+    };
+  }
+  try {
+    const st = fs.statSync(outputPath);
+    if (st.isDirectory()) {
+      return {
+        ok: false,
+        reason: 'output path is an existing directory; it must name a zip FILE',
+        suggestion: path.join(outputPath, `${featureId}-export.zip`),
+      };
+    }
+  } catch {
+    // ENOENT is the happy path — the file does not exist yet.
+  }
+  try {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `cannot create the destination directory: ${err instanceof Error ? err.message : String(err)}`,
+      suggestion: `${featureId}-export.zip`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Atomic write: temp sibling → close handle → rename (INV-16 handle safety). */
+async function writeZipAtomic(outputPath: string, zipBytes: Buffer): Promise<void> {
+  const dir = path.dirname(outputPath);
+  const tmp = path.join(dir, `.${path.basename(outputPath)}.tmp-${randomUUID()}`);
+  try {
+    await fsp.writeFile(tmp, zipBytes); // opens + fully closes the handle on resolve
+    await fsp.rename(tmp, outputPath);
+  } catch (err) {
+    await fsp.rm(tmp, { force: true }).catch(() => undefined);
+    throw err;
+  }
+}
+
+// ─── Crash precheck ───────────────────────────────────────────────────────────
+
+interface DanglingIntent {
+  readonly idempotencyKey: string;
+  readonly outputPath: string;
+}
+
+/**
+ * The most-recent `export.requested` whose logical `idempotencyKey` has no
+ * paired `export.executed` — a crash between the INV-13 pair. `undefined` when
+ * every request is completed (the fresh-invocation path).
+ */
+function findDanglingIntent(events: readonly WorkflowEvent[]): DanglingIntent | undefined {
+  const executedKeys = new Set<string>();
+  for (const e of events) {
+    if (e.type === 'export.executed') {
+      const k = (e.data as { idempotencyKey?: unknown } | undefined)?.idempotencyKey;
+      if (typeof k === 'string') executedKeys.add(k);
+    }
+  }
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type !== 'export.requested') continue;
+    const data = e.data as { idempotencyKey?: unknown; outputPath?: unknown } | undefined;
+    const key = data?.idempotencyKey;
+    const outputPath = data?.outputPath;
+    if (typeof key === 'string' && typeof outputPath === 'string' && !executedKeys.has(key)) {
+      return { idempotencyKey: key, outputPath };
+    }
+  }
+  return undefined;
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+/**
+ * `export` — write a diagnostic zip bundle of one workflow (DR-6). Emits the
+ * INV-13 `export.requested` → `export.executed` pair around the write, derives
+ * the storage idempotency key from a logical key (INV-8), completes a crashed
+ * pair without duplicating the intent, and is cold-probe safe on an unknown
+ * featureId.
+ */
+export async function handleViewExport(
+  args: Record<string, unknown>,
+  ctx: DispatchContext,
+): Promise<ToolResult> {
+  const featureId = optionalString(args.featureId);
+  if (!featureId) {
+    return invalidInput('export requires featureId: string', { featureId: 'string' });
+  }
+
+  const { eventStore } = ctx;
+  const baseDir = ctx.cwd ?? process.cwd();
+
+  // Existence is answered from the event log ALONE (RCA 2026-05-30). A cold
+  // probe of an unknown / never-`init`'d featureId returns workflowExists:false
+  // and writes NOTHING (no zip) + emits ZERO events — the CB-2 no-phantom-stream
+  // guarantee.
+  const events = await eventStore.query(featureId);
+  if (events.length === 0) {
+    return {
+      success: true,
+      data: { featureId, workflowExists: false, exported: false },
+      _meta: { workflowExists: false },
+    };
+  }
+
+  // Crash precheck: a `export.requested` with no paired `export.executed` means
+  // a prior invocation crashed mid-flight. Complete THAT intent (reuse its key +
+  // destination) rather than minting a new one.
+  const dangling = findDanglingIntent(events);
+  const idempotencyKey = dangling?.idempotencyKey ?? randomUUID();
+  const outputPath = dangling
+    ? dangling.outputPath
+    : resolveOutputPath(optionalString(args.output), featureId, baseDir);
+  const recovered = dangling !== undefined;
+
+  // Validate the destination BEFORE any append (side-effect-free on rejection).
+  const validation = validateAndPrepareOutputPath(outputPath, featureId);
+  if (!validation.ok) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_OUTPUT_PATH',
+        message: `export: invalid output path "${outputPath}" — ${validation.reason}`,
+        suggestedFix: {
+          tool: 'exarchos_view',
+          params: { action: 'export', featureId, output: validation.suggestion },
+        },
+      },
+    };
+  }
+
+  // Build the bundle from DOMAIN events only (exclude the export's own
+  // bookkeeping) so the bundle — and its contentHash — is a stable function of
+  // the domain log across a crash-retry.
+  const domainEvents = events.filter((e) => !EXPORT_EVENT_TYPES.has(e.type));
+  const bundle = buildExportBundle(featureId, domainEvents, baseDir);
+  const zipBytes = await zipBundle(bundle.entries);
+  const contentHash = sha256(zipBytes);
+
+  // INV-13 INTENT — journaled BEFORE the write. On a crash-retry the reused
+  // storage key makes this a cache-hit (no duplicate intent). INV-8: the storage
+  // key is DERIVED from the logical key, and distinct from the executed key so
+  // both events persist.
+  await eventStore.append(
+    featureId,
+    { type: 'export.requested', data: { featureId, outputPath, idempotencyKey } },
+    { idempotencyKey: `export.requested:${idempotencyKey}` },
+  );
+
+  // Idempotent write: skip when the on-disk zip already matches (crash-recovery
+  // where the write completed but the executed event never landed).
+  let existingHash: string | undefined;
+  try {
+    existingHash = sha256(await fsp.readFile(outputPath));
+  } catch {
+    existingHash = undefined;
+  }
+  const bundleRewritten = existingHash !== contentHash;
+  if (bundleRewritten) {
+    await writeZipAtomic(outputPath, zipBytes);
+  }
+
+  // INV-13 RESULT — journaled AFTER the write, carrying the bundle's contentHash
+  // (the crash precheck's disk comparator), eventCount, and missingArtifacts.
+  await eventStore.append(
+    featureId,
+    {
+      type: 'export.executed',
+      data: {
+        featureId,
+        outputPath,
+        contentHash,
+        eventCount: bundle.eventCount,
+        ...(bundle.missingArtifacts.length > 0 ? { missingArtifacts: [...bundle.missingArtifacts] } : {}),
+        idempotencyKey,
+      },
+    },
+    { idempotencyKey: `export.executed:${idempotencyKey}` },
+  );
+
+  return {
+    success: true,
+    data: {
+      featureId,
+      workflowExists: true,
+      exported: true,
+      outputPath,
+      contentHash,
+      eventCount: bundle.eventCount,
+      missingArtifacts: [...bundle.missingArtifacts],
+      idempotencyKey,
+      recovered,
+      bundleRewritten,
+    },
+    _meta: { workflowExists: true },
+  };
+}
+
+// ─── Typed output schema (DR-1 — typed `data`, not a bare unknown envelope) ────
+//
+// Same derivation discipline as `inspect`: the MCP adapter `safeParse`s the REAL
+// handler output against this schema, so a STRICTER shape than the handler emits
+// breaks production. Declared in strip+passthrough mode; fields absent on the
+// cold-probe branch are `.optional()` so BOTH the exported and cold-probe shapes
+// validate against one schema.
+
+const ExportData = z
+  .object({
+    featureId: z.string(),
+    workflowExists: z.boolean(),
+    exported: z.boolean(),
+    outputPath: z.string().optional(),
+    contentHash: z.string().optional(),
+    eventCount: z.number().optional(),
+    missingArtifacts: z.array(z.string()).optional(),
+    idempotencyKey: z.string().optional(),
+    recovered: z.boolean().optional(),
+    bundleRewritten: z.boolean().optional(),
+  })
+  .passthrough();
+
+/** `export` success — the bundle-write result (or the cold-probe shape). */
+export const ExportOutputSchema = EnvelopeSchema(ExportData);

--- a/servers/exarchos-mcp/src/views/lifecycle/export.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/export.ts
@@ -91,6 +91,22 @@ function isUrl(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
 }
 
+/**
+ * CONTAINMENT. True when `abs` resolves to a path strictly inside `baseDir`.
+ *
+ * An artifact reference is workflow-authored data, not a trusted path: both a
+ * traversal (`../../etc/passwd`) and a bare absolute (`/etc/passwd`) would
+ * otherwise be `statSync`'d and read straight into the bundle, so an export zip
+ * could absorb arbitrary readable files. `path.relative` is the containment
+ * primitive — an escaping target yields a `..`-prefixed (or absolute) relative
+ * path, and an identical target yields `''` (baseDir itself is a directory, not
+ * an artifact file, so it is excluded too).
+ */
+function isContainedIn(abs: string, baseDir: string): boolean {
+  const rel = path.relative(baseDir, abs);
+  return rel !== '' && !rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel);
+}
+
 function sha256(buf: Buffer): string {
   return createHash('sha256').update(buf).digest('hex');
 }
@@ -129,17 +145,30 @@ function collectArtifacts(
 
   for (const { key, value } of candidates) {
     if (isUrl(value)) continue; // e.g. a `pr` URL is not a filesystem artifact
-    const abs = path.isAbsolute(value) ? value : path.join(baseDir, value);
+    // `path.resolve` collapses `..` segments AND absorbs an already-absolute
+    // `value` — so ONE containment check covers both escape routes. Anything
+    // outside `baseDir` is refused BEFORE statSync/readFileSync ever touch it
+    // and is reported as `missing` (the reference is real; the bundle just
+    // won't carry a file from outside the workflow's tree).
+    const abs = path.resolve(baseDir, value);
     let bytes: Buffer | undefined;
-    try {
-      const st = fs.statSync(abs);
-      if (st.isFile()) bytes = fs.readFileSync(abs);
-    } catch {
-      // ENOENT / unreadable → tolerated as missing
+    if (isContainedIn(abs, baseDir)) {
+      try {
+        const st = fs.statSync(abs);
+        if (st.isFile()) bytes = fs.readFileSync(abs);
+      } catch {
+        // ENOENT / unreadable → tolerated as missing
+      }
     }
     if (bytes) {
-      // Entry name uses path.posix (INV-16: zip entries are always posix).
-      const entryName = path.posix.join('artifacts', key, path.posix.basename(value));
+      // Entry name uses path.posix (INV-16: zip entries are always posix), but
+      // the basename MUST come off the RESOLVED platform path: path.posix
+      // does not treat `\` as a separator, so `path.posix.basename` on a
+      // Windows path (`C:\...\a.md`) returns the WHOLE string and yields a
+      // malformed `artifacts/<key>/C:\...\a.md` entry. `path.basename(abs)` is
+      // platform-native, and `abs` is by construction a path that stat'd on
+      // THIS platform.
+      const entryName = path.posix.join('artifacts', key, path.basename(abs));
       included.push({ entryName, bytes });
     } else {
       missing.push(value);

--- a/servers/exarchos-mcp/src/views/lifecycle/inspect.follow.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/inspect.follow.test.ts
@@ -1,0 +1,402 @@
+// ─── Tests for the `inspect --follow` streaming carriers (DR-4, task-009) ─────
+//
+// Two carriers stream a live workflow tail over the ONE DR-1 cursor-pump
+// subscription:
+//   • CLI (NDJSON)  — `runInspectFollow` frames each delivered event as an
+//     NDJSON `event` frame, deduped by sequence, with heartbeat frames on
+//     silence driven by an INJECTED timer (INV-16 — no wall-clock).
+//   • MCP (Tasks)   — `tasksFollow` drives the SAME core over the SAME
+//     subscription contract; `tasks/cancel` → subscription dispose.
+//
+// Boundary discipline: the named cases drive a REAL `EventStore` subscription
+// and observe disposal on the real handle. The dedup roundtrip property test
+// exercises the pure frame transform against an adversarial (owned) source
+// fixture — the killable heart of the by-sequence dedup guarantee.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fc } from '@fast-check/vitest';
+import { PassThrough } from 'node:stream';
+import * as path from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { EventStore } from '../../event-store/store.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import type {
+  SubscribeOptions,
+  SubscriptionClock,
+  SubscriptionFilter,
+  SubscriptionListener,
+} from '../../event-store/subscriptions.js';
+import { NdjsonEncoder } from '../../ndjson/encoder.js';
+import { FrameSchema, type Frame } from '../../ndjson/frames.js';
+import {
+  runInspectFollow,
+  type FollowSubscribe,
+} from '../../cli/follow-loop.js';
+import { tasksFollow } from '../../mcp/tasks-methods.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Collect a PassThrough's bytes once ended. */
+async function collect(stream: PassThrough): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/** Parse an NDJSON buffer into validated frames. */
+function parseFrames(raw: string): Frame[] {
+  return raw
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => FrameSchema.parse(JSON.parse(line) as unknown));
+}
+
+/** A synthetic WorkflowEvent fixture (owned — for the transform-only tests). */
+function evt(sequence: number): WorkflowEvent {
+  return {
+    streamId: 'feat-x',
+    sequence,
+    timestamp: new Date(1_700_000_000_000 + sequence * 1000).toISOString(),
+    type: 'task.completed',
+    schemaVersion: '1.0',
+  } as WorkflowEvent;
+}
+
+/**
+ * Manually-driven clock (INV-16). `now()` is fixed so heartbeat timestamps are
+ * deterministic; `scheduleInterval` records the tick so a test fires it with no
+ * wall-clock sleep. Cancelling drops the loop.
+ */
+class ManualClock implements SubscriptionClock {
+  readonly fixedNow: number;
+  private readonly loops: Array<{ tick: () => void }> = [];
+  constructor(fixedNow = 1_700_000_000_000) {
+    this.fixedNow = fixedNow;
+  }
+  now(): number {
+    return this.fixedNow;
+  }
+  scheduleInterval(tick: () => void): () => void {
+    const entry = { tick };
+    this.loops.push(entry);
+    return () => {
+      const i = this.loops.indexOf(entry);
+      if (i >= 0) this.loops.splice(i, 1);
+    };
+  }
+  /** Fire one tick on every live loop. */
+  fireAll(): void {
+    for (const { tick } of [...this.loops]) tick();
+  }
+  get loopCount(): number {
+    return this.loops.length;
+  }
+}
+
+/**
+ * A hermetic subscribe fixture that captures the listener so a test can drive
+ * exact deliveries. Returns a disposable handle; tracks disposal.
+ */
+function capturingSubscribe(): {
+  subscribe: FollowSubscribe;
+  deliver(event: WorkflowEvent): void;
+  disposed(): boolean;
+} {
+  let listener: SubscriptionListener | undefined;
+  let disposed = false;
+  const subscribe: FollowSubscribe = (_filter, onEvent) => {
+    listener = onEvent;
+    return {
+      id: 'capturing',
+      get disposed(): boolean {
+        return disposed;
+      },
+      dispose(): void {
+        disposed = true;
+      },
+      perf: () => ({ floorMs: 0, floorTicks: 0, floorDrains: 0 }),
+    };
+  };
+  return {
+    subscribe,
+    deliver: (event) => listener?.(event),
+    disposed: () => disposed,
+  };
+}
+
+interface SpyCall {
+  readonly filter: SubscriptionFilter;
+  readonly options?: SubscribeOptions;
+  disposeCount: number;
+}
+
+/** Wrap a real subscribe fn, recording each call's contract + dispose count. */
+function spySubscribe(inner: FollowSubscribe): {
+  subscribe: FollowSubscribe;
+  calls: SpyCall[];
+} {
+  const calls: SpyCall[] = [];
+  const subscribe: FollowSubscribe = (filter, onEvent, options) => {
+    const rec: SpyCall = { filter, options, disposeCount: 0 };
+    calls.push(rec);
+    const h = inner(filter, onEvent, options);
+    return {
+      id: h.id,
+      get disposed(): boolean {
+        return h.disposed;
+      },
+      dispose(): void {
+        rec.disposeCount++;
+        h.dispose();
+      },
+      perf: () => h.perf(),
+    };
+  };
+  return { subscribe, calls };
+}
+
+// ─── Real-EventStore fixture ────────────────────────────────────────────────
+
+let tempDir: string;
+let store: EventStore;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(tmpdir(), 'inspect-follow-'));
+  store = new EventStore(tempDir);
+  await store.initialize();
+});
+
+afterEach(async () => {
+  store.disposeSubscriptions();
+  await store.close?.();
+  await rmrfAsync(tempDir);
+});
+
+/** The real DR-1 subscription contract, bound to the fixture store. */
+function realSubscribe(): FollowSubscribe {
+  return (filter, onEvent, options) => store.subscribe(filter, onEvent, options);
+}
+
+async function seed(streamId: string, n: number): Promise<void> {
+  await store.append(streamId, {
+    type: 'workflow.started',
+    data: { featureId: streamId, workflowType: 'feature' },
+  });
+  for (let i = 2; i <= n; i++) {
+    await store.append(streamId, { type: 'workflow.transition', data: { to: `p${i}` } });
+  }
+}
+
+// ─── CLI (NDJSON) carrier ────────────────────────────────────────────────────
+
+describe('inspect --follow — CLI NDJSON carrier (DR-4)', () => {
+  it('InspectFollow_AppendedEvents_NdjsonFramesDedupedBySequence', async () => {
+    const FEATURE = 'feat-ndjson';
+    const sink = new PassThrough();
+    const encoder = new NdjsonEncoder(sink);
+    const controller = new AbortController();
+
+    const handle = runInspectFollow({
+      subscribe: realSubscribe(),
+      featureId: FEATURE,
+      fromSequence: 0,
+      onFrame: (frame) => encoder.write(frame),
+      signal: controller.signal,
+      // No clock → no heartbeat, so the frame stream is purely event + end.
+    });
+
+    // Live appends over the REAL subscription — delivered synchronously
+    // post-commit by the Tier-1 hook.
+    await seed(FEATURE, 3);
+
+    controller.abort();
+    await handle.done;
+    sink.end();
+
+    const frames = parseFrames(await collect(sink));
+    const eventFrames = frames.filter((f) => f.type === 'event');
+    const seqs = eventFrames.map((f) => (f as { sequence: number }).sequence);
+
+    // Each committed sequence appears EXACTLY once, in ascending order.
+    expect(seqs).toEqual([1, 2, 3]);
+    expect(new Set(seqs).size).toBe(seqs.length); // no duplicate frame
+    // Terminal `end` frame closes the stream in-band.
+    expect(frames.at(-1)).toMatchObject({ type: 'end' });
+  });
+
+  it('InspectFollow_SilentGap_HeartbeatFramesOnInjectedTimer', async () => {
+    const clock = new ManualClock();
+    const src = capturingSubscribe();
+    const frames: Frame[] = [];
+    const controller = new AbortController();
+
+    const handle = runInspectFollow({
+      subscribe: src.subscribe,
+      featureId: 'feat-hb',
+      onFrame: (frame) => frames.push(frame),
+      signal: controller.signal,
+      clock,
+      heartbeatIntervalMs: 1000,
+    });
+
+    // Silence: an injected tick emits a heartbeat with the INJECTED timestamp.
+    clock.fireAll();
+    // Activity: a delivered event resets the idle marker...
+    src.deliver(evt(1));
+    // ...so the very next tick is SUPPRESSED (heartbeat only marks silence).
+    clock.fireAll();
+    // Silence again → heartbeat resumes.
+    clock.fireAll();
+
+    const heartbeats = frames.filter((f) => f.type === 'heartbeat');
+    expect(heartbeats).toHaveLength(2); // one before, one after — NOT during activity
+    // INV-16: timestamp is derived from the injected clock, not wall-clock.
+    const expectedTs = new Date(clock.fixedNow).toISOString();
+    for (const hb of heartbeats) {
+      expect((hb as { timestamp: string }).timestamp).toBe(expectedTs);
+    }
+    // The event frame landed between the two heartbeats.
+    expect(frames.map((f) => f.type)).toEqual(['heartbeat', 'event', 'heartbeat']);
+
+    controller.abort();
+    await handle.done;
+    // Heartbeat loop cancelled on teardown — no live timer leaks.
+    expect(clock.loopCount).toBe(0);
+  });
+
+  it('InspectFollow_Abort_SubscriptionDisposed', async () => {
+    const spy = spySubscribe(realSubscribe());
+    const controller = new AbortController();
+    const handle = runInspectFollow({
+      subscribe: spy.subscribe,
+      featureId: 'feat-abort',
+      fromSequence: 0,
+      onFrame: () => {},
+      signal: controller.signal,
+    });
+
+    // Live before abort — no process signal involved.
+    expect(handle.disposed()).toBe(false);
+    expect(spy.calls[0].disposeCount).toBe(0);
+
+    controller.abort();
+    await handle.done;
+
+    // The abort disposed the REAL DR-1 subscription (INV-15).
+    expect(handle.disposed()).toBe(true);
+    expect(spy.calls[0].disposeCount).toBe(1);
+  });
+});
+
+// ─── MCP (Tasks) carrier ─────────────────────────────────────────────────────
+
+describe('inspect --follow — MCP Tasks carrier (DR-4)', () => {
+  it('InspectFollow_McpTasks_SharesSubscriptionContract', async () => {
+    const FEATURE = 'feat-shared';
+    // ONE subscribe spy handed to BOTH facades proves they drive the SAME
+    // DR-1 subscription contract (same filter + options), not two divergent
+    // paths.
+    const spy = spySubscribe(realSubscribe());
+
+    const cliFrames: Frame[] = [];
+    const mcpFrames: Frame[] = [];
+    const cliCtl = new AbortController();
+
+    // CLI arm.
+    const cli = runInspectFollow({
+      subscribe: spy.subscribe,
+      featureId: FEATURE,
+      fromSequence: 0,
+      onFrame: (f) => cliFrames.push(f),
+      signal: cliCtl.signal,
+    });
+    // MCP Tasks arm — SAME core, SAME contract; owns its cancel seam.
+    const mcp = tasksFollow({
+      subscribe: spy.subscribe,
+      featureId: FEATURE,
+      fromSequence: 0,
+      onFrame: (f) => mcpFrames.push(f),
+    });
+
+    // Both registered against the same contract.
+    expect(spy.calls).toHaveLength(2);
+    expect(spy.calls[0].filter).toEqual({ streamId: FEATURE });
+    expect(spy.calls[1].filter).toEqual({ streamId: FEATURE });
+    expect(spy.calls[0].options).toEqual({ fromSequence: 0 });
+    expect(spy.calls[1].options).toEqual({ fromSequence: 0 });
+
+    // Same live events → byte-identical event-frame streams (INV-2).
+    await seed(FEATURE, 3);
+
+    const cliSeqs = cliFrames.filter((f) => f.type === 'event').map((f) => (f as { sequence: number }).sequence);
+    const mcpSeqs = mcpFrames.filter((f) => f.type === 'event').map((f) => (f as { sequence: number }).sequence);
+    expect(cliSeqs).toEqual([1, 2, 3]);
+    expect(mcpSeqs).toEqual(cliSeqs);
+
+    // task-cancel → subscription dispose (the MCP-facade wire).
+    expect(mcp.disposed()).toBe(false);
+    mcp.cancel();
+    await mcp.done;
+    expect(mcp.disposed()).toBe(true);
+    expect(spy.calls[1].disposeCount).toBe(1);
+
+    cliCtl.abort();
+    await cli.done;
+    expect(spy.calls[0].disposeCount).toBe(1);
+  });
+});
+
+// ─── Dedup roundtrip property (data-transformation) ──────────────────────────
+
+describe('inspect --follow — dedup roundtrip property (DR-4)', () => {
+  it('InspectFollow_FrameStream_ContainsEachSequenceExactlyOnceMonotonic', () => {
+    fc.assert(
+      fc.property(
+        // A source of (possibly duplicated, possibly out-of-order) sequences —
+        // the adversary the by-sequence dedup guard must collapse.
+        fc.array(fc.integer({ min: 1, max: 40 }), { minLength: 0, maxLength: 30 }),
+        (seqs) => {
+          const src = capturingSubscribe();
+          const frames: Frame[] = [];
+          const controller = new AbortController();
+          runInspectFollow({
+            subscribe: src.subscribe,
+            featureId: 'feat-prop',
+            onFrame: (f) => frames.push(f),
+            signal: controller.signal,
+          });
+          for (const s of seqs) src.deliver(evt(s));
+
+          const out = frames
+            .filter((f) => f.type === 'event')
+            .map((f) => (f as { sequence: number }).sequence);
+
+          // Expected = the "record highs" of the input (monotonic, exactly once).
+          const expected: number[] = [];
+          let running = 0;
+          for (const s of seqs) {
+            if (s > running) {
+              expected.push(s);
+              running = s;
+            }
+          }
+          expect(out).toEqual(expected);
+          // Strictly increasing → no duplicate, always monotonic.
+          for (let i = 1; i < out.length; i++) {
+            expect(out[i]).toBeGreaterThan(out[i - 1]);
+          }
+          // Every emitted sequence came from the source.
+          const inputSet = new Set(seqs);
+          for (const s of out) expect(inputSet.has(s)).toBe(true);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/inspect.follow.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/inspect.follow.test.ts
@@ -230,6 +230,47 @@ describe('inspect --follow — CLI NDJSON carrier (DR-4)', () => {
     expect(frames.at(-1)).toMatchObject({ type: 'end' });
   });
 
+  it('InspectFollow_HeartbeatSinkThrows_ContainedAndLaterFramesStillFlow', async () => {
+    // `onFrame` is a CALLER-supplied sink (NDJSON encoder write / MCP
+    // task-update push). The heartbeat fires inside `scheduleInterval`, so a
+    // throwing sink must be contained — otherwise it escapes the tick as an
+    // unhandled process-level exception, the same gap `floorTick()` had.
+    const clock = new ManualClock();
+    const src = capturingSubscribe();
+    const frames: Frame[] = [];
+    const controller = new AbortController();
+    let failNextHeartbeat = true;
+
+    const handle = runInspectFollow({
+      subscribe: src.subscribe,
+      featureId: 'feat-hb-throw',
+      onFrame: (frame) => {
+        if (frame.type === 'heartbeat' && failNextHeartbeat) throw new Error('sink boom');
+        frames.push(frame);
+      },
+      signal: controller.signal,
+      clock,
+      heartbeatIntervalMs: 1000,
+    });
+
+    // The heartbeat tick's sink throws → contained, not process-level.
+    expect(() => clock.fireAll()).not.toThrow();
+    expect(frames).toHaveLength(0); // the throwing heartbeat delivered nothing
+
+    // The follow loop survives: real event frames still flow afterwards …
+    src.deliver(evt(1));
+    expect(frames.map((f) => f.type)).toEqual(['event']);
+
+    // … and a later heartbeat still emits once the sink recovers.
+    failNextHeartbeat = false;
+    clock.fireAll(); // suppressed — the delivered event reset the idle marker
+    clock.fireAll(); // silence → heartbeat resumes
+    expect(frames.map((f) => f.type)).toEqual(['event', 'heartbeat']);
+
+    controller.abort();
+    await handle.done;
+  });
+
   it('InspectFollow_SilentGap_HeartbeatFramesOnInjectedTimer', async () => {
     const clock = new ManualClock();
     const src = capturingSubscribe();

--- a/servers/exarchos-mcp/src/views/lifecycle/inspect.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/inspect.test.ts
@@ -3,8 +3,10 @@
 // Boundary coverage: every assertion drives a REAL `EventStore` +
 // `resolveWorkflowState` across the composite seam — no mocks of the state
 // source. The three named cases pin:
-//   • the cold-probe side-effect-free invariant (unknown featureId →
-//     workflowExists:false, ZERO events emitted — event-count invariance);
+//   • the RATIFIED cold-probe contract (spec DR-4/DR-8): an unknown featureId →
+//     success:true + workflowExists:false, ZERO events emitted (event-count
+//     invariance) — the side-effect-free shape shared with rehydrate/get, NOT an
+//     error envelope;
 //   • the exists path (state / recent events / correlation / artifacts / tasks),
 //     validated against the registered `InspectOutputSchema` through the real
 //     envelope wrap;
@@ -97,7 +99,11 @@ describe('inspect (DR-4 single-workflow projection)', () => {
 
     const res = await handleViewInspect({ featureId: unknown }, ctx);
 
-    // Cold-probe contract: exists:false, empty projection, success.
+    // RATIFIED cold-probe contract (spec DR-4/DR-8, revised 2026-07): an unknown
+    // featureId returns `success: true` with `_meta.workflowExists: false` and an
+    // empty projection — the canonical, side-effect-free cold-probe shared with
+    // `rehydrate`/`get`. It is NOT an error envelope (the earlier spec draft
+    // wrongly said so); the assertions below pin the ratified success shape.
     expect(res.success).toBe(true);
     const data = (res as { data: Record<string, unknown> }).data;
     expect(data.workflowExists).toBe(false);

--- a/servers/exarchos-mcp/src/views/lifecycle/inspect.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/inspect.test.ts
@@ -1,0 +1,220 @@
+// ─── Tests for the `inspect` lifecycle verb (DR-4) ────────────────────────────
+//
+// Boundary coverage: every assertion drives a REAL `EventStore` +
+// `resolveWorkflowState` across the composite seam — no mocks of the state
+// source. The three named cases pin:
+//   • the cold-probe side-effect-free invariant (unknown featureId →
+//     workflowExists:false, ZERO events emitted — event-count invariance);
+//   • the exists path (state / recent events / correlation / artifacts / tasks),
+//     validated against the registered `InspectOutputSchema` through the real
+//     envelope wrap;
+//   • the INV-5d visible-surface fence (inspect is an ACTION on exarchos_view,
+//     not a 5th visible tool, and does not perturb the slim registration).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { EventStore } from '../../event-store/store.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import { handleViewInspect, InspectOutputSchema } from './inspect.js';
+import { handleView } from '../composite.js';
+import { TOOL_REGISTRY, buildToolDescription } from '../../registry.js';
+
+let tempDir: string;
+let eventStore: EventStore;
+let ctx: DispatchContext;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(tmpdir(), 'inspect-test-'));
+  eventStore = new EventStore(tempDir);
+  await eventStore.initialize();
+  ctx = { stateDir: tempDir, eventStore, enableTelemetry: false };
+});
+
+afterEach(async () => {
+  await eventStore.close?.();
+  await rmrfAsync(tempDir);
+});
+
+/** Seed a realistic feature workflow and return its streamId. */
+async function seedWorkflow(streamId: string): Promise<void> {
+  await eventStore.append(streamId, {
+    type: 'workflow.started',
+    data: { featureId: streamId, workflowType: 'feature' },
+  });
+  await eventStore.append(streamId, { type: 'workflow.transition', data: { to: 'delegate' } });
+  await eventStore.append(streamId, {
+    type: 'state.patched',
+    data: {
+      featureId: streamId,
+      patch: {
+        'artifacts.design': 'docs/specs/2026-07-13-feature.md',
+        'artifacts.plan': 'docs/specs/2026-07-13-feature.md',
+      },
+    },
+  });
+  await eventStore.append(streamId, {
+    type: 'task.assigned',
+    data: { taskId: 't1', title: 'Build handler', branch: 'feat/t1' },
+  });
+  await eventStore.append(streamId, { type: 'task.completed', data: { taskId: 't1' } });
+  await eventStore.append(streamId, {
+    type: 'task.assigned',
+    data: { taskId: 't2', title: 'Wire route', branch: 'feat/t2' },
+    // Correlation tuple on the most recent activity — inspect surfaces THIS one.
+    operationId: 'op-inspect-1',
+    correlationId: streamId,
+    causationId: 'cause-42',
+  });
+}
+
+// ─── Parse the "Actions: a, b, c" advertisement out of a slimDescription. ──────
+function advertisedActions(slim: string | undefined): string[] {
+  if (!slim) return [];
+  const m = slim.match(/Actions:\s*([^\n]+)/);
+  if (!m) return [];
+  return m[1].split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+describe('inspect (DR-4 single-workflow projection)', () => {
+  it('Inspect_UnknownFeatureId_WorkflowExistsFalseNoSideEffect', async () => {
+    // Seed an UNRELATED workflow so the store is non-empty — a side-effecting
+    // inspect must perturb NEITHER the probed stream nor any other.
+    const other = 'other-feature';
+    await seedWorkflow(other);
+    const unknown = 'never-initted-feature';
+
+    // Event-count baseline: the probed stream is empty, the unrelated stream has
+    // its seeded events.
+    const unknownBefore = (await eventStore.query(unknown)).length;
+    const otherBefore = (await eventStore.query(other)).length;
+    expect(unknownBefore).toBe(0);
+    expect(otherBefore).toBeGreaterThan(0);
+
+    const res = await handleViewInspect({ featureId: unknown }, ctx);
+
+    // Cold-probe contract: exists:false, empty projection, success.
+    expect(res.success).toBe(true);
+    const data = (res as { data: Record<string, unknown> }).data;
+    expect(data.workflowExists).toBe(false);
+    expect(data.recentEvents).toEqual([]);
+    expect(data.eventCount).toBe(0);
+    expect((res._meta as Record<string, unknown>).workflowExists).toBe(false);
+
+    // Event-count INVARIANCE — the probe emitted ZERO events, on the probed
+    // stream AND everywhere else (the CB-2 no-phantom-stream guarantee).
+    const unknownAfter = (await eventStore.query(unknown)).length;
+    const otherAfter = (await eventStore.query(other)).length;
+    expect(unknownAfter).toBe(unknownBefore);
+    expect(otherAfter).toBe(otherBefore);
+  });
+
+  it('Inspect_KnownWorkflow_ReturnsStateEventsArtifacts', async () => {
+    const streamId = 'shipped-feature';
+    await seedWorkflow(streamId);
+
+    // Drive the FULL composite seam so the result also validates against the
+    // registered outputSchema through the real envelope wrap.
+    const res = await handleView({ action: 'inspect', featureId: streamId }, ctx);
+    expect(res.success).toBe(true);
+    expect(
+      InspectOutputSchema.safeParse(res).success,
+      'inspect envelope must validate against its registered outputSchema',
+    ).toBe(true);
+
+    const data = (res as { data: Record<string, unknown> }).data;
+    expect(data.workflowExists).toBe(true);
+
+    // State via the canonical resolveWorkflowState fold.
+    const state = data.state as Record<string, unknown>;
+    expect(state.phase).toBe('delegate');
+    expect(state.workflowType).toBe('feature');
+
+    // Artifacts from the projected map.
+    const artifacts = data.artifacts as Record<string, unknown>;
+    expect(artifacts.design).toBe('docs/specs/2026-07-13-feature.md');
+    expect(artifacts.plan).toBe('docs/specs/2026-07-13-feature.md');
+
+    // Task progress: roster + counts-by-status (t1 complete, t2 pending).
+    const taskProgress = data.taskProgress as {
+      total: number;
+      byStatus: Record<string, number>;
+      tasks: Array<Record<string, unknown>>;
+    };
+    expect(taskProgress.total).toBe(2);
+    expect(taskProgress.byStatus.complete).toBe(1);
+    expect(taskProgress.byStatus.pending).toBe(1);
+    expect(taskProgress.tasks.map((t) => t.id)).toEqual(['t1', 't2']);
+
+    // Recent events: non-empty, ordered, and the tail carries the max sequence.
+    const recentEvents = data.recentEvents as Array<{ type: string; sequence: number }>;
+    expect(recentEvents.length).toBe(6);
+    expect(recentEvents[0].type).toBe('workflow.started');
+    expect(recentEvents[recentEvents.length - 1].type).toBe('task.assigned');
+    expect(recentEvents[recentEvents.length - 1].sequence).toBe(6);
+    expect(data.eventCount).toBe(6);
+
+    // Correlation tuple = the most recent stamped dispatch boundary.
+    const correlation = data.correlation as Record<string, unknown>;
+    expect(correlation.operationId).toBe('op-inspect-1');
+    expect(correlation.correlationId).toBe(streamId);
+    expect(correlation.causationId).toBe('cause-42');
+  });
+
+  it('Inspect_KnownWorkflow_LimitBoundsRecentEventTail', async () => {
+    // The `limit` field (shared DR-8 shape) bounds ONLY the event tail — the
+    // full state/artifacts/tasks stay complete regardless.
+    const streamId = 'bounded-feature';
+    await seedWorkflow(streamId);
+
+    const res = await handleViewInspect({ featureId: streamId, limit: 2 }, ctx);
+    expect(res.success).toBe(true);
+    const data = (res as { data: Record<string, unknown> }).data;
+    const recentEvents = data.recentEvents as Array<{ sequence: number }>;
+    expect(recentEvents.length).toBe(2);
+    // The tail is the NEWEST 2 events (sequences 5 and 6).
+    expect(recentEvents.map((e) => e.sequence)).toEqual([5, 6]);
+    // Full projection is unbounded: both tasks and the full count survive.
+    expect((data.taskProgress as { total: number }).total).toBe(2);
+    expect(data.eventCount).toBe(6);
+  });
+
+  it('Inspect_UnknownFeatureId_MissingFeatureId_ReturnsInvalidInput', async () => {
+    const res = await handleViewInspect({}, ctx);
+    expect(res.success).toBe(false);
+    expect((res as { error: { code: string } }).error.code).toBe('INVALID_INPUT');
+  });
+
+  it('Inspect_SchemaDescribe_AllFourCompositeTools_ByteUnchanged', () => {
+    // INV-5d fence: `inspect` is an ACTION on exarchos_view, NOT a 5th visible
+    // tool. The visible composite-tool surface stays exactly 4.
+    const visible = TOOL_REGISTRY.filter((t) => !t.hidden);
+    expect(visible.map((t) => t.name).sort()).toEqual([
+      'exarchos_event',
+      'exarchos_orchestrate',
+      'exarchos_view',
+      'exarchos_workflow',
+    ]);
+    expect(TOOL_REGISTRY).toHaveLength(5);
+
+    // `inspect` landed as an exarchos_view ACTION (not a tool).
+    const view = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view')!;
+    expect(view.actions.map((a) => a.name)).toContain('inspect');
+    expect(TOOL_REGISTRY.map((t) => t.name)).not.toContain('inspect');
+
+    // The slim registration every agent pays for on tools/list is a curated,
+    // token-economy subset — adding `inspect` must NOT perturb the per-tool slim
+    // describe byte-output of ANY of the four visible composite tools. The slim
+    // path stays byte-identical to each tool's frozen slimDescription and no
+    // tool's "Actions:" advertisement gains `inspect`.
+    for (const t of visible) {
+      const slim = buildToolDescription(t, true);
+      expect(slim).toBe(t.slimDescription);
+      expect(advertisedActions(slim)).not.toContain('inspect');
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/inspect.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/inspect.ts
@@ -1,0 +1,286 @@
+// ─── Lifecycle verb: `inspect` — single-workflow projection (DR-4) ────────────
+//
+// The read leg of the worktree-lifecycle verb set that answers "what is the
+// state of ONE workflow?" in a single composite call: it folds the feature's
+// event stream ONCE and projects
+//
+//   • state          — phase / workflowType / timestamps, via the CANONICAL
+//                       `resolveWorkflowState` path (SQLite event store is the
+//                       only source of truth — NEVER `.state.json` presence);
+//   • recentEvents   — the last N event summaries (type / timestamp / sequence);
+//   • correlation    — the most recent dispatch's correlation tuple
+//                       (operationId / correlationId / causationId);
+//   • artifacts      — the projected artifact map (design / plan / pr);
+//   • taskProgress   — task roster + counts-by-status.
+//
+// It rides `exarchos_view` as an ACTION (INV-5d — NO new visible tool; the
+// visible composite-tool count stays 4). Pure read: it appends NOTHING, on any
+// path.
+//
+// COLD-PROBE SIDE-EFFECT-FREE INVARIANT (RCA 2026-05-30-state-source-integrity,
+// the CB-2 phantom-workflow class). `inspect` on an unknown / never-`init`'d
+// featureId returns `workflowExists: false` and emits ZERO events. Existence is
+// answered from the event log alone — a stream with no events does not exist —
+// so a cold probe never materializes a phantom stream. The handler short-circuits
+// on the empty stream BEFORE any further read, guaranteeing event-count invariance
+// (events-before == events-after) for the unknown-featureId path.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { z } from 'zod';
+
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { ToolResult } from '../../format.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import { resolveWorkflowState } from '../../orchestrate/resolve-state.js';
+import type { WorkflowStateView } from '../workflow-state-projection.js';
+import { EnvelopeSchema } from '../../schemas/envelope.js';
+
+// ─── Bounded-output default ───────────────────────────────────────────────────
+
+/**
+ * Default `recentEvents` window when the caller omits `limit`. The full stream
+ * is folded regardless (state/artifacts/tasks are complete); only the
+ * event-summary tail is bounded so a long-lived workflow's `inspect` stays
+ * economical. A caller passing `limit` widens or narrows just this tail.
+ */
+const DEFAULT_RECENT_EVENTS = 20;
+
+// ─── Local input helpers (kept private — never user-facing flags) ─────────────
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** Parse a positive integer (>= 1) from a number or numeric string (coerced flags). */
+function optionalPosInt(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 1) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const n = Number(value);
+    return n >= 1 ? n : undefined;
+  }
+  return undefined;
+}
+
+function invalidInput(message: string, expectedShape?: Record<string, unknown>): ToolResult {
+  return {
+    success: false,
+    error: { code: 'INVALID_INPUT', message, ...(expectedShape ? { expectedShape } : {}) },
+  };
+}
+
+// ─── Pure projections over the folded stream ──────────────────────────────────
+
+/** Compact event-summary line for the `recentEvents` tail. */
+interface EventSummary {
+  readonly type: string;
+  readonly timestamp: string;
+  readonly sequence: number;
+  readonly source?: string;
+}
+
+function summarizeEvent(event: WorkflowEvent): EventSummary {
+  return {
+    type: event.type,
+    timestamp: event.timestamp,
+    sequence: event.sequence,
+    ...(typeof event.source === 'string' ? { source: event.source } : {}),
+  };
+}
+
+/** The dispatch-boundary correlation tuple (#1291). */
+interface CorrelationTuple {
+  readonly operationId?: string;
+  readonly correlationId?: string;
+  readonly causationId?: string;
+}
+
+/**
+ * The correlation tuple of the MOST RECENT event that carries any tuple field —
+ * the correlation context of the workflow's latest dispatch activity. Scans from
+ * the tail so the newest boundary wins; returns `undefined` when no event in the
+ * stream was stamped (pre-#1291 logs / un-stamped direct appends).
+ */
+function latestCorrelationTuple(events: readonly WorkflowEvent[]): CorrelationTuple | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i];
+    if (ev.operationId !== undefined || ev.correlationId !== undefined || ev.causationId !== undefined) {
+      return {
+        ...(ev.operationId !== undefined ? { operationId: ev.operationId } : {}),
+        ...(ev.correlationId !== undefined ? { correlationId: ev.correlationId } : {}),
+        ...(ev.causationId !== undefined ? { causationId: ev.causationId } : {}),
+      };
+    }
+  }
+  return undefined;
+}
+
+/** Task-progress roll-up: full roster + counts-by-status. */
+interface TaskProgress {
+  readonly total: number;
+  readonly byStatus: Record<string, number>;
+  readonly tasks: ReadonlyArray<Record<string, unknown>>;
+}
+
+function projectTaskProgress(state: WorkflowStateView): TaskProgress {
+  const tasks = Array.isArray(state.tasks) ? state.tasks : [];
+  const byStatus: Record<string, number> = {};
+  for (const t of tasks) {
+    const status = typeof t.status === 'string' ? t.status : 'unknown';
+    byStatus[status] = (byStatus[status] ?? 0) + 1;
+  }
+  return {
+    total: tasks.length,
+    byStatus,
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      title: t.title,
+      status: t.status,
+      ...(t.branch !== undefined ? { branch: t.branch } : {}),
+      ...(t.worktreePath !== undefined ? { worktreePath: t.worktreePath } : {}),
+      ...(t.completedAt !== undefined ? { completedAt: t.completedAt } : {}),
+    })),
+  };
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+/**
+ * `inspect` — project a single workflow's state, recent events + correlation
+ * tuple, artifacts, and task progress in one read.
+ *
+ * Pure read (INV-2 — the same DispatchContext + args project an identical
+ * ToolResult on the CLI and MCP facades): folds the feature stream once and
+ * appends nothing. The `follow` flag is schema-declared (imported from
+ * `schema-fields.ts`) so its CLI flag auto-emits; the streaming behavior lands
+ * in task-009 — this handler is the single-shot projection task-009 tails.
+ */
+export async function handleViewInspect(
+  args: Record<string, unknown>,
+  ctx: DispatchContext,
+): Promise<ToolResult> {
+  const featureId = optionalString(args.featureId);
+  if (!featureId) {
+    return invalidInput('inspect requires featureId: string', { featureId: 'string' });
+  }
+
+  const { eventStore } = ctx;
+
+  // Existence is answered from the event log ALONE (RCA 2026-05-30): the SQLite
+  // event store is the only source of truth, NEVER `.state.json` presence. One
+  // pure read of the stream drives both the existence check and the projections
+  // below.
+  const events = await eventStore.query(featureId);
+  const workflowExists = events.length > 0;
+
+  // Cold-probe short-circuit: an unknown / never-`init`'d featureId returns
+  // `workflowExists: false` and emits ZERO events. We return BEFORE any further
+  // read (no `resolveWorkflowState` fold, no append) so the unknown-featureId
+  // path is provably event-count-invariant (events-before == events-after) —
+  // the CB-2 no-phantom-stream guarantee.
+  if (!workflowExists) {
+    return {
+      success: true,
+      data: {
+        featureId,
+        workflowExists: false,
+        recentEvents: [],
+        eventCount: 0,
+      },
+      _meta: { workflowExists: false },
+    };
+  }
+
+  // State via the CANONICAL event-store-first resolver (#1504). Pure fold — no
+  // append. On a materialization failure the resolver's structured error is
+  // returned verbatim (INV-2 facade parity).
+  const resolved = await resolveWorkflowState({ featureId, eventStore });
+  if ('error' in resolved) {
+    return resolved.error;
+  }
+  const state = resolved.state as unknown as WorkflowStateView;
+
+  const limit = optionalPosInt(args.limit) ?? DEFAULT_RECENT_EVENTS;
+  const recentEvents = events.slice(-limit).map(summarizeEvent);
+  const correlation = latestCorrelationTuple(events);
+
+  return {
+    success: true,
+    data: {
+      featureId,
+      workflowExists: true,
+      state: {
+        phase: state.phase,
+        workflowType: state.workflowType,
+        createdAt: state.createdAt,
+        updatedAt: state.updatedAt,
+      },
+      artifacts: state.artifacts,
+      taskProgress: projectTaskProgress(state),
+      recentEvents,
+      ...(correlation !== undefined ? { correlation } : {}),
+      eventCount: events.length,
+    },
+    _meta: { workflowExists: true },
+  };
+}
+
+// ─── Typed output schema (DR-1 — typed `data`, NOT `EnvelopeSchema(z.unknown())`) ──
+//
+// Derivation discipline (mirrors `orchestrate/worktree/schemas.ts`): the MCP
+// adapter `safeParse`s the REAL handler output against this schema and, on a
+// miss, REPLACES the result with an INTERNAL_ERROR — so a schema STRICTER than
+// the real output breaks production. Every object is declared in strip mode with
+// `.passthrough()` (future field additions tolerated) and fields that are absent
+// on the cold-probe branch (`state` / `artifacts` / `taskProgress` /
+// `correlation`) are `.optional()` so BOTH the exists and cold-probe shapes
+// validate against one schema.
+
+const EventSummarySchema = z
+  .object({
+    type: z.string(),
+    timestamp: z.string(),
+    sequence: z.number(),
+    source: z.string().optional(),
+  })
+  .passthrough();
+
+const CorrelationTupleSchema = z
+  .object({
+    operationId: z.string().optional(),
+    correlationId: z.string().optional(),
+    causationId: z.string().optional(),
+  })
+  .passthrough();
+
+const InspectStateSchema = z
+  .object({
+    phase: z.string(),
+    workflowType: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .passthrough();
+
+const TaskProgressSchema = z
+  .object({
+    total: z.number(),
+    byStatus: z.record(z.string(), z.number()),
+    tasks: z.array(z.record(z.string(), z.unknown())),
+  })
+  .passthrough();
+
+/** `inspect` success — the single-workflow projection. */
+const InspectData = z
+  .object({
+    featureId: z.string(),
+    workflowExists: z.boolean(),
+    recentEvents: z.array(EventSummarySchema),
+    eventCount: z.number(),
+    state: InspectStateSchema.optional(),
+    artifacts: z.record(z.string(), z.unknown()).optional(),
+    taskProgress: TaskProgressSchema.optional(),
+    correlation: CorrelationTupleSchema.optional(),
+  })
+  .passthrough();
+
+export const InspectOutputSchema = EnvelopeSchema(InspectData);

--- a/servers/exarchos-mcp/src/views/lifecycle/operations-fold.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/operations-fold.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fc } from '@fast-check/vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import {
+  foldInFlightOperations,
+  type OperationEventLike,
+} from './operations-fold.js';
+import {
+  LIVENESS_DESCRIPTORS,
+  getLivenessDescriptor,
+  type LivenessDescriptor,
+} from '../../event-store/liveness-registry.js';
+import type { EventType } from '../../event-store/schemas.js';
+import { EventStore } from '../../event-store/store.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import { percentile } from '../../telemetry/percentile.js';
+import { WORKTREES_STREAM } from '../../orchestrate/worktree/manager.js';
+
+const RUN_BENCHMARKS = process.env.RUN_BENCHMARKS === 'true';
+
+// ─── DR-3 (task 006): generic `ps` operations fold ──────────────────────────
+//
+// `foldInFlightOperations` is driven ENTIRELY by the REAL liveness-registry
+// (`LIVENESS_DESCRIPTORS`, imported — never hand-rolled) — every test below
+// exercises the real registry's real descriptors, real `startType`/
+// `terminalTypes`, and real `instanceKeyOf` derivations. The only exception is
+// the conformance test at the bottom, which passes a caller-supplied registry
+// override to prove the fold itself carries zero surface-specific code — the
+// DR-3 acceptance criterion ("adding a surface to the registry must add it to
+// `ps` with no fold change").
+
+describe('OperationsFold — generic in-flight operations (DR-3)', () => {
+  it('OperationsFold_StartedWithoutTerminal_ListedInFlight', () => {
+    const events: OperationEventLike[] = [
+      {
+        type: 'launch.executing_started',
+        data: { instanceId: 'wt-A' },
+        timestamp: '2026-07-13T00:00:00.000Z',
+      },
+    ];
+
+    const rows = foldInFlightOperations(events, { now: () => Date.parse('2026-07-13T00:00:05.000Z') });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      surface: 'launch',
+      instanceKey: 'wt-A',
+      streamScope: 'worktrees',
+      startType: 'launch.executing_started',
+      startedAt: '2026-07-13T00:00:00.000Z',
+      ageMs: 5000,
+    });
+  });
+
+  it('OperationsFold_TerminalPresent_Excluded', () => {
+    const events: OperationEventLike[] = [
+      {
+        type: 'launch.executing_started',
+        data: { instanceId: 'wt-A' },
+        timestamp: '2026-07-13T00:00:00.000Z',
+      },
+      {
+        type: 'launch.executed',
+        data: { instanceId: 'wt-A' },
+        timestamp: '2026-07-13T00:00:01.000Z',
+      },
+    ];
+
+    const rows = foldInFlightOperations(events);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('OperationsFold_ConcurrentSameStreamOps_PairsByInstanceKey', () => {
+    // start A, start B, terminal B → exactly A listed. Both events ride the
+    // SAME stream scope (`worktrees`) and the SAME surface (`launch`) — the
+    // pairing must discriminate purely by instance key, not by ordinal
+    // position or event count.
+    const events: OperationEventLike[] = [
+      { type: 'launch.executing_started', data: { instanceId: 'A' }, timestamp: '2026-07-13T00:00:00.000Z' },
+      { type: 'launch.executing_started', data: { instanceId: 'B' }, timestamp: '2026-07-13T00:00:01.000Z' },
+      { type: 'launch.executed', data: { instanceId: 'B' }, timestamp: '2026-07-13T00:00:02.000Z' },
+    ];
+
+    const rows = foldInFlightOperations(events);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.instanceKey).toBe('A');
+    expect(rows[0]?.surface).toBe('launch');
+  });
+
+  it('OperationsFold_MutationSurface_ListedGenerically', () => {
+    // Proves the fold carries no mutation-specific code: the mutation surface
+    // (a `'feature'`-scope surface, unlike the two `'worktrees'`-scope
+    // surfaces exercised above) flows through the exact same generic
+    // registry-driven loop with no special-casing anywhere in
+    // `operations-fold.ts` — grep the module: there is no `'mutation'`
+    // string literal branch to have hit.
+    const events: OperationEventLike[] = [
+      {
+        type: 'mutation.executing_started',
+        data: { instanceId: 'op-mut-1', command: 'npx stryker run', repoRoot: '/repo' },
+        timestamp: '2026-07-13T00:00:00.000Z',
+      },
+    ];
+
+    const rows = foldInFlightOperations(events);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      surface: 'mutation',
+      instanceKey: 'op-mut-1',
+      streamScope: 'feature',
+      startType: 'mutation.executing_started',
+    });
+  });
+
+  it('OperationsFold_RestartAfterTerminal_ReopensTheInstance', () => {
+    const events: OperationEventLike[] = [
+      { type: 'prune.executing_started', data: { instanceId: 'op-1' }, timestamp: '2026-07-13T00:00:00.000Z' },
+      { type: 'prune.executed', data: { instanceId: 'op-1' }, timestamp: '2026-07-13T00:00:01.000Z' },
+      { type: 'prune.executing_started', data: { instanceId: 'op-1' }, timestamp: '2026-07-13T00:00:02.000Z' },
+    ];
+
+    const rows = foldInFlightOperations(events);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.startedAt).toBe('2026-07-13T00:00:02.000Z');
+  });
+
+  it('OperationsFold_UnresolvableKey_SkippedNeverThrows', () => {
+    // A pre-retrofit mutation row carrying neither instanceId nor operationId
+    // — `instanceKeyOf` returns undefined and the fold must not throw or list
+    // a phantom entry for it.
+    const events: OperationEventLike[] = [
+      {
+        type: 'mutation.executing_started',
+        data: { command: 'npx stryker run', repoRoot: '/repo' },
+        timestamp: '2026-07-13T00:00:00.000Z',
+      },
+    ];
+
+    expect(() => foldInFlightOperations(events)).not.toThrow();
+    expect(foldInFlightOperations(events)).toHaveLength(0);
+  });
+
+  it('OperationsFold_EveryRegisteredSurface_ObservableInOneFold', () => {
+    // All four INV-10 surfaces, interleaved in one event list, each with one
+    // in-flight start — the fold's per-descriptor loop must surface every
+    // one of them in a single pass, independently of stream/surface identity.
+    const events: OperationEventLike[] = [
+      { type: 'merge.executing_started', data: { instanceId: 'M1' }, timestamp: '2026-07-13T00:00:00.000Z' },
+      { type: 'launch.executing_started', data: { instanceId: 'L1' }, timestamp: '2026-07-13T00:00:01.000Z' },
+      { type: 'mutation.executing_started', data: { instanceId: 'MU1' }, timestamp: '2026-07-13T00:00:02.000Z' },
+      { type: 'prune.executing_started', data: { instanceId: 'P1' }, timestamp: '2026-07-13T00:00:03.000Z' },
+    ];
+
+    const rows = foldInFlightOperations(events);
+    const bySurface = new Map(rows.map((r) => [r.surface, r.instanceKey]));
+
+    expect(bySurface.get('merge')).toBe('M1');
+    expect(bySurface.get('launch')).toBe('L1');
+    expect(bySurface.get('mutation')).toBe('MU1');
+    expect(bySurface.get('prune')).toBe('P1');
+    expect(rows).toHaveLength(4);
+  });
+
+  // ── Property test (state-machine): pairing correctness over arbitrary
+  //    start/terminal/surface interleavings ──────────────────────────────
+  //
+  // An independent reference model — a plain `Set<string>` of `surface:key`
+  // compound keys, mutated by the same start-adds/terminal-removes rule the
+  // registry documents — is compared against `foldInFlightOperations` over
+  // hundreds of randomly generated event sequences spanning ALL FOUR
+  // registered surfaces and a small key alphabet. This both restates the
+  // property from `liveness-registry.test.ts` (single-surface) at the fold
+  // level AND additionally proves cross-surface isolation: a `launch` START
+  // for key `'A'` must never be cleared by a `merge` TERMINAL for the same
+  // literal key `'A'`.
+  it('OperationsFold_InFlightListing_MatchesReferenceModelOverArbitraryInterleavings', () => {
+    const keyAlphabet = ['A', 'B', 'C'] as const;
+    const opArb = fc.record({
+      surfaceIndex: fc.constantFrom(0, 1, 2, 3),
+      op: fc.constantFrom<'start' | 'terminal'>('start', 'terminal'),
+      key: fc.constantFrom(...keyAlphabet),
+    });
+
+    fc.assert(
+      fc.property(fc.array(opArb, { minLength: 0, maxLength: 80 }), (ops) => {
+        const events: OperationEventLike[] = ops.map(({ surfaceIndex, op, key }, i) => {
+          const descriptor = LIVENESS_DESCRIPTORS[surfaceIndex];
+          return {
+            type: op === 'start' ? descriptor.startType : descriptor.terminalTypes[0],
+            data: { instanceId: key },
+            timestamp: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+          };
+        });
+
+        const rows = foldInFlightOperations(events);
+        const actual = new Set(rows.map((r) => `${r.surface}:${r.instanceKey}`));
+
+        // Reference model: independent from the implementation under test.
+        const expected = new Set<string>();
+        for (const { surfaceIndex, op, key } of ops) {
+          const surface = LIVENESS_DESCRIPTORS[surfaceIndex].surface;
+          const compound = `${surface}:${key}`;
+          if (op === 'start') expected.add(compound);
+          else expected.delete(compound);
+        }
+
+        expect(actual).toEqual(expected);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // ── DR-3 acceptance criterion: a hypothetical fifth surface requires ZERO
+  //    fold change ──────────────────────────────────────────────────────
+  //
+  // `foldInFlightOperations` accepts an optional `registry` override
+  // precisely so this conformance test can prove genericity: a descriptor
+  // for a surface that does NOT exist in the real registry (a synthetic
+  // `'deploy'` surface, standing in for "whatever task 004+N adds next") is
+  // paired and surfaced correctly with no code change to
+  // `operations-fold.ts` — only the caller-supplied descriptor list grew.
+  // Production callers never pass this option; it defaults to the real
+  // `LIVENESS_DESCRIPTORS`.
+  it('OperationsFold_HypotheticalFifthSurface_RequiresNoFoldChange', () => {
+    const syntheticDescriptor: LivenessDescriptor = {
+      surface: 'deploy' as unknown as LivenessDescriptor['surface'],
+      startType: 'deploy.executing_started' as unknown as EventType,
+      terminalTypes: ['deploy.executed' as unknown as EventType],
+      streamScope: 'feature',
+      instanceKeyOf: (data) =>
+        typeof data?.instanceId === 'string' ? data.instanceId : undefined,
+    };
+
+    const registry = [...LIVENESS_DESCRIPTORS, syntheticDescriptor];
+
+    const events: OperationEventLike[] = [
+      {
+        type: 'deploy.executing_started' as unknown as string,
+        data: { instanceId: 'D1' },
+        timestamp: '2026-07-13T00:00:00.000Z',
+      },
+      // A real, registered surface stays correctly paired alongside the
+      // synthetic one — proves the fold treats every descriptor uniformly.
+      { type: 'merge.executing_started', data: { instanceId: 'M1' }, timestamp: '2026-07-13T00:00:00.000Z' },
+      { type: 'merge.executed', data: { instanceId: 'M1' }, timestamp: '2026-07-13T00:00:01.000Z' },
+    ];
+
+    const rows = foldInFlightOperations(events, { registry });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ surface: 'deploy', instanceKey: 'D1' });
+  });
+
+  // ── Boundary: real registry + a REAL event store (not hand-mocked) ──────
+  //
+  // Every test above hand-builds `OperationEventLike` literals (matching the
+  // sibling `liveness-registry.test.ts` convention) but always against the
+  // REAL imported registry. This test additionally routes events through a
+  // REAL `EventStore` (append → query → fold) so the fold is proven against
+  // genuine store-backed `WorkflowEvent` rows, not just literals shaped by
+  // hand.
+  describe('real EventStore boundary', () => {
+    let tmpDir: string;
+    let store: EventStore;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'operations-fold-bench-'));
+      store = new EventStore(tmpDir);
+      await store.initialize();
+    });
+
+    afterEach(async () => {
+      store.close();
+      await rmrfAsync(tmpDir);
+    });
+
+    it('OperationsFold_RealEventStoreEvents_MatchesGenericFold', async () => {
+      const featureStream = 'feat-ops-fold-boundary';
+
+      // `merge` and `mutation` ride the feature stream.
+      await store.append(featureStream, {
+        type: 'merge.executing_started',
+        data: {
+          taskId: 'T1',
+          sourceBranch: 'feat/x',
+          targetBranch: 'main',
+          recoveryPointSha: 'deadbeef',
+          startedAt: '2026-07-13T00:00:00.000Z',
+          instanceId: 'T1',
+        },
+      });
+      await store.append(featureStream, {
+        type: 'mutation.executing_started',
+        data: { command: 'npx stryker run', repoRoot: '/repo', instanceId: 'op-mut-1' },
+      });
+      await store.append(featureStream, {
+        type: 'mutation.executed',
+        data: {
+          command: 'npx stryker run',
+          repoRoot: '/repo',
+          passed: true,
+          exitCode: 0,
+          instanceId: 'op-mut-1',
+        },
+      });
+
+      // `launch` and `prune` ride the singleton worktrees stream.
+      await store.append(WORKTREES_STREAM, {
+        type: 'launch.executing_started',
+        data: { worktreeId: '/wt/a', holderPid: 4242, holderStartedAt: null, instanceId: '/wt/a' },
+      });
+      await store.append(WORKTREES_STREAM, {
+        type: 'prune.executing_started',
+        data: { operationId: 'op-prune-1', repoRoot: '/repo', instanceId: 'op-prune-1' },
+      });
+      await store.append(WORKTREES_STREAM, {
+        type: 'prune.executed',
+        data: { operationId: 'op-prune-1', repoRoot: '/repo', instanceId: 'op-prune-1' },
+      });
+
+      const featureEvents = await store.query(featureStream);
+      const worktreesEvents = await store.query(WORKTREES_STREAM);
+      const merged = [...featureEvents, ...worktreesEvents];
+
+      const rows = foldInFlightOperations(merged);
+      const bySurface = new Map(rows.map((r) => [r.surface, r.instanceKey]));
+
+      // merge (in flight — no terminal) and launch (in flight — no terminal)
+      // are listed; mutation and prune both reached a terminal and are
+      // excluded.
+      expect(bySurface.get('merge')).toBe('T1');
+      expect(bySurface.get('launch')).toBe('/wt/a');
+      expect(bySurface.has('mutation')).toBe(false);
+      expect(bySurface.has('prune')).toBe(false);
+      expect(rows).toHaveLength(2);
+    });
+
+    // ── Benchmark: cold fold over 10k real store-backed events ────────────
+    //
+    // Boundary/offline cadence (RUN_BENCHMARKS=true), never the default inner
+    // loop — matches the sibling `telemetry/benchmarks/*.test.ts` convention.
+    // 10k events across all four surfaces (a realistic mix of in-flight and
+    // terminated instances) are appended to a real `EventStore`, queried back
+    // once (cold — no prior fold on this data), then folded repeatedly to
+    // compute a p95 over real wall-clock runs.
+    it.skipIf(!RUN_BENCHMARKS)('operations-fold-cold-10k-events', async () => {
+      const streamId = 'bench-ops-fold-cold-10k';
+      const surfaces = LIVENESS_DESCRIPTORS;
+      const eventCount = 10_000;
+
+      const batch: Array<{ type: string; data: Record<string, unknown>; timestamp: string }> = [];
+      for (let i = 0; i < eventCount; i++) {
+        const descriptor = surfaces[i % surfaces.length];
+        // Every 3rd instance is left in flight (start with no terminal);
+        // the other two thirds get their terminal appended immediately
+        // after — a realistic mostly-quiescent-with-some-stragglers mix.
+        const key = `k-${i}`;
+        const isInFlight = i % 3 === 0;
+        batch.push({
+          type: descriptor.startType,
+          data: { instanceId: key },
+          timestamp: new Date(2026, 0, 1, 0, 0, 0, i).toISOString(),
+        });
+        if (!isInFlight) {
+          batch.push({
+            type: descriptor.terminalTypes[0],
+            data: { instanceId: key },
+            timestamp: new Date(2026, 0, 1, 0, 0, 1, i).toISOString(),
+          });
+        }
+      }
+
+      await store.batchAppend(streamId, batch);
+      const events = await store.query(streamId);
+      expect(events.length).toBeGreaterThanOrEqual(eventCount);
+
+      // Act — repeated cold folds over the same (already-queried) event
+      // list, timing each run independently to compute a p95.
+      const elapsedRuns: number[] = [];
+      for (let run = 0; run < 15; run++) {
+        const start = performance.now();
+        foldInFlightOperations(events);
+        elapsedRuns.push(performance.now() - start);
+      }
+
+      const p95 = percentile(elapsedRuns, 0.95);
+      console.log(
+        `[operations-fold] cold ${events.length} events, p95 over 15 runs: ${p95.toFixed(3)}ms`,
+      );
+      expect(p95).toBeLessThan(250);
+    });
+  });
+});
+
+// ── Type-level guard: LIVENESS_DESCRIPTORS export shape stays stable ───────
+void ((): void => {
+  const _ = getLivenessDescriptor('merge');
+  void _;
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/operations-fold.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/operations-fold.test.ts
@@ -132,13 +132,14 @@ describe('OperationsFold — generic in-flight operations (DR-3)', () => {
   });
 
   it('OperationsFold_UnresolvableKey_SkippedNeverThrows', () => {
-    // A pre-retrofit mutation row carrying neither instanceId nor operationId
-    // — `instanceKeyOf` returns undefined and the fold must not throw or list
-    // a phantom entry for it.
+    // A `launch` row carrying neither instanceId nor worktreeId — `instanceKeyOf`
+    // returns undefined (launch has no singleton fallback) and the fold must not
+    // throw or list a phantom entry for it. (Mutation now resolves keyless rows
+    // to the DR-2 singleton, so `launch` is the surface that stays unresolvable.)
     const events: OperationEventLike[] = [
       {
-        type: 'mutation.executing_started',
-        data: { command: 'npx stryker run', repoRoot: '/repo' },
+        type: 'launch.executing_started',
+        data: { holderPid: 4242 },
         timestamp: '2026-07-13T00:00:00.000Z',
       },
     ];
@@ -168,53 +169,138 @@ describe('OperationsFold — generic in-flight operations (DR-3)', () => {
     expect(rows).toHaveLength(4);
   });
 
-  // ── Property test (state-machine): pairing correctness over arbitrary
-  //    start/terminal/surface interleavings ──────────────────────────────
+  // ── S-6 regression: cross-stream mis-pairing (finding 1) ───────────────────
   //
-  // An independent reference model — a plain `Set<string>` of `surface:key`
-  // compound keys, mutated by the same start-adds/terminal-removes rule the
-  // registry documents — is compared against `foldInFlightOperations` over
-  // hundreds of randomly generated event sequences spanning ALL FOUR
-  // registered surfaces and a small key alphabet. This both restates the
-  // property from `liveness-registry.test.ts` (single-surface) at the fold
-  // level AND additionally proves cross-surface isolation: a `launch` START
-  // for key `'A'` must never be cleared by a `merge` TERMINAL for the same
-  // literal key `'A'`.
-  it('OperationsFold_InFlightListing_MatchesReferenceModelOverArbitraryInterleavings', () => {
+  // Two feature workflows whose merge `instanceKey` COLLIDES (a recurring taskId
+  // `T11`, or a shared branch pair) must pair PER STREAM. A terminal on
+  // workflow-B's stream may only clear B's in-flight merge — it must NOT clear
+  // workflow-A's genuinely-stuck merge, which would make A vanish from `ps
+  // operations`. This is the exact S-6 failure the feature exists to prevent; a
+  // mutation that drops stream-scoping (pairing by `(surface, instanceKey)`
+  // alone) fails this test.
+  it('OperationsFold_SameMergeKeyDifferentFeatureStreams_TerminalDoesNotCrossClear', () => {
+    const events: OperationEventLike[] = [
+      // feat-a starts a merge with key T11.
+      { type: 'merge.executing_started', data: { instanceId: 'T11' }, streamId: 'feat-a', timestamp: '2026-07-13T00:00:00.000Z' },
+      // feat-b starts a merge with the SAME key T11.
+      { type: 'merge.executing_started', data: { instanceId: 'T11' }, streamId: 'feat-b', timestamp: '2026-07-13T00:00:01.000Z' },
+      // Only feat-b's merge terminates.
+      { type: 'merge.executed', data: { instanceId: 'T11' }, streamId: 'feat-b', timestamp: '2026-07-13T00:00:02.000Z' },
+    ];
+
+    const rows = foldInFlightOperations(events);
+    const merges = rows.filter((r) => r.surface === 'merge');
+
+    // feat-a's T11 merge is STILL in flight; feat-b's was cleared.
+    expect(merges).toHaveLength(1);
+    expect(merges[0]?.instanceKey).toBe('T11');
+    expect(merges[0]?.streamId).toBe('feat-a');
+    // The row names the stuck workflow so a consumer can answer "which is stuck?".
+    expect(merges[0]?.featureId).toBe('feat-a');
+  });
+
+  it('OperationsFold_WorktreesScope_SameKeyOneStream_PairsByKeyAcrossInstances', () => {
+    // The dual of the S-6 case: launch is `worktrees`-scoped (one shared
+    // singleton stream), so cross-instance concurrency on that one stream is
+    // NORMAL and pairs by key alone. A `featureId` is never attributed to a
+    // worktrees-scoped op (it names no workflow).
+    const events: OperationEventLike[] = [
+      { type: 'launch.executing_started', data: { instanceId: 'wt-A' }, streamId: 'worktrees', timestamp: '2026-07-13T00:00:00.000Z' },
+      { type: 'launch.executing_started', data: { instanceId: 'wt-B' }, streamId: 'worktrees', timestamp: '2026-07-13T00:00:01.000Z' },
+      { type: 'launch.executed', data: { instanceId: 'wt-B' }, streamId: 'worktrees', timestamp: '2026-07-13T00:00:02.000Z' },
+    ];
+
+    const rows = foldInFlightOperations(events);
+    const launches = rows.filter((r) => r.surface === 'launch');
+    expect(launches).toHaveLength(1);
+    expect(launches[0]?.instanceKey).toBe('wt-A');
+    expect(launches[0]?.streamId).toBe('worktrees');
+    expect(launches[0]?.featureId).toBeUndefined();
+  });
+
+  // ── Property test (state-machine): pairing correctness over arbitrary
+  //    start/terminal/surface/STREAM interleavings (finding 2) ─────────────
+  //
+  // An independent reference model — a plain `Set<string>` of compound keys,
+  // mutated by the same start-adds/terminal-removes rule the registry documents
+  // — is compared against `foldInFlightOperations` over hundreds of randomly
+  // generated event sequences spanning ALL FOUR surfaces, a small key alphabet,
+  // AND a stream dimension. It proves three isolations at once:
+  //   • cross-surface: a `launch` START for `'A'` is never cleared by a `merge`
+  //     TERMINAL for the same literal `'A'`;
+  //   • cross-stream (the S-6 property): a `feature`-scoped START for `'A'` on
+  //     stream `s1` is never cleared by a TERMINAL for `'A'` on stream `s2`;
+  //   • singleton-stream collapse: a `worktrees`-scoped surface pairs by key
+  //     alone, so the stream dimension is IGNORED for it (concurrent ops on the
+  //     one shared stream is the normal case).
+  // The reference model's compound key mirrors that scope-dependent rule exactly.
+  it('OperationsFold_InFlightListing_MatchesReferenceModelOverArbitraryStreamInterleavings', () => {
     const keyAlphabet = ['A', 'B', 'C'] as const;
+    const streamAlphabet = ['s1', 's2'] as const;
     const opArb = fc.record({
       surfaceIndex: fc.constantFrom(0, 1, 2, 3),
       op: fc.constantFrom<'start' | 'terminal'>('start', 'terminal'),
       key: fc.constantFrom(...keyAlphabet),
+      stream: fc.constantFrom(...streamAlphabet),
     });
+
+    // The reference model's identity for an instance: feature-scoped surfaces
+    // are per-(stream,key); worktrees-scoped surfaces are per-key (stream elided).
+    const refId = (surfaceIndex: number, stream: string, key: string): string => {
+      const descriptor = LIVENESS_DESCRIPTORS[surfaceIndex];
+      return descriptor.streamScope === 'feature'
+        ? `${descriptor.surface}:${stream}:${key}`
+        : `${descriptor.surface}:${key}`;
+    };
 
     fc.assert(
       fc.property(fc.array(opArb, { minLength: 0, maxLength: 80 }), (ops) => {
-        const events: OperationEventLike[] = ops.map(({ surfaceIndex, op, key }, i) => {
+        const events: OperationEventLike[] = ops.map(({ surfaceIndex, op, key, stream }, i) => {
           const descriptor = LIVENESS_DESCRIPTORS[surfaceIndex];
           return {
             type: op === 'start' ? descriptor.startType : descriptor.terminalTypes[0],
             data: { instanceId: key },
+            streamId: stream,
             timestamp: new Date(2026, 0, 1, 0, 0, i).toISOString(),
           };
         });
 
         const rows = foldInFlightOperations(events);
-        const actual = new Set(rows.map((r) => `${r.surface}:${r.instanceKey}`));
+        const actual = new Set(
+          rows.map((r) => {
+            const idx = LIVENESS_DESCRIPTORS.findIndex((d) => d.surface === r.surface);
+            return refId(idx, r.streamId ?? '', r.instanceKey);
+          }),
+        );
 
         // Reference model: independent from the implementation under test.
         const expected = new Set<string>();
-        for (const { surfaceIndex, op, key } of ops) {
-          const surface = LIVENESS_DESCRIPTORS[surfaceIndex].surface;
-          const compound = `${surface}:${key}`;
-          if (op === 'start') expected.add(compound);
-          else expected.delete(compound);
+        for (const { surfaceIndex, op, key, stream } of ops) {
+          const id = refId(surfaceIndex, stream, key);
+          if (op === 'start') expected.add(id);
+          else expected.delete(id);
         }
 
         expect(actual).toEqual(expected);
       }),
-      { numRuns: 200 },
+      { numRuns: 300 },
     );
+  });
+
+  it('OperationsFold_FeatureSurface_SameKeyDistinctStreams_PairIndependently', () => {
+    // A focused witness of the cross-stream property the generator explores:
+    // two mutation starts for key `'K'` on different feature streams, one
+    // terminated, leaves exactly the other in flight (same-key/different-stream
+    // feature ops pair independently — finding 2).
+    const events: OperationEventLike[] = [
+      { type: 'mutation.executing_started', data: { instanceId: 'K' }, streamId: 'feat-a', timestamp: '2026-07-13T00:00:00.000Z' },
+      { type: 'mutation.executing_started', data: { instanceId: 'K' }, streamId: 'feat-b', timestamp: '2026-07-13T00:00:01.000Z' },
+      { type: 'mutation.executed', data: { instanceId: 'K' }, streamId: 'feat-a', timestamp: '2026-07-13T00:00:02.000Z' },
+    ];
+    const rows = foldInFlightOperations(events).filter((r) => r.surface === 'mutation');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.streamId).toBe('feat-b');
+    expect(rows[0]?.instanceKey).toBe('K');
   });
 
   // ── DR-3 acceptance criterion: a hypothetical fifth surface requires ZERO

--- a/servers/exarchos-mcp/src/views/lifecycle/operations-fold.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/operations-fold.ts
@@ -58,12 +58,30 @@ export interface InFlightOperation {
   readonly instanceKey: string;
   /** Which stream family this surface's pair rides on (`'feature'` | `'worktrees'`). */
   readonly streamScope: LivenessStreamScope;
+  /**
+   * The stream this instance's START rode. For `feature`-scoped surfaces this
+   * distinguishes two workflows whose `instanceKey` collides (DR-2 per-stream
+   * pairing); for the singleton `worktrees` scope it is the shared stream id.
+   * `undefined` only for a keyless test fixture.
+   */
+  readonly streamId: string | undefined;
+  /**
+   * The workflow this operation belongs to — the featureId — for `feature`-scoped
+   * surfaces (where `streamId` IS the featureId), so a consumer can answer "which
+   * workflow is stuck?". `undefined` for `worktrees`-scoped surfaces (launch /
+   * prune ride the shared singleton stream, not a workflow's feature stream).
+   */
+  readonly featureId: string | undefined;
   /** The `<surface>.executing_started` CLAIM event type that opened this instance. */
   readonly startType: string;
   /** ISO 8601 instant the instance started, from the START event's envelope `timestamp`. */
   readonly startedAt: string | undefined;
-  /** Age in milliseconds at fold time (`now - startedAt`), or `undefined` when `startedAt` is unresolvable. */
-  readonly ageMs: number | undefined;
+  /**
+   * Age in milliseconds at fold time (`now - startedAt`), or `null` when
+   * `startedAt` is unresolvable. Standardized on `number | null` to match the
+   * sibling workflow-fold's `ageMs` (one age contract across both `ps` folds).
+   */
+  readonly ageMs: number | null;
 }
 
 /** Options for {@link foldInFlightOperations}. */
@@ -108,15 +126,19 @@ export function foldInFlightOperations(
   const rows: InFlightOperation[] = [];
   for (const descriptor of registry) {
     const inFlight = computeInFlightInstances(descriptor, events);
-    for (const [instanceKey, startEvent] of inFlight) {
+    for (const { instanceKey, streamId, startEvent } of inFlight.values()) {
       const startedAt = livenessStartedAt(startEvent as OperationEventLike);
       rows.push({
         surface: descriptor.surface,
         instanceKey,
         streamScope: descriptor.streamScope,
+        streamId,
+        // `feature`-scoped streams ARE the featureId; `worktrees`-scoped launch/
+        // prune ride the shared singleton stream, so they name no workflow.
+        featureId: descriptor.streamScope === 'feature' ? streamId : undefined,
         startType: descriptor.startType,
         startedAt,
-        ageMs: startedAt !== undefined ? Math.max(0, nowMs - Date.parse(startedAt)) : undefined,
+        ageMs: startedAt !== undefined ? Math.max(0, nowMs - Date.parse(startedAt)) : null,
       });
     }
   }

--- a/servers/exarchos-mcp/src/views/lifecycle/operations-fold.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/operations-fold.ts
@@ -1,0 +1,124 @@
+// ─── Lifecycle verb substrate: `ps` operations fold (DR-3, task 006) ─────────
+//
+// A GENERIC fold over an ordered event list that answers "which INV-10
+// liveness instances are still IN FLIGHT?" across EVERY registered surface —
+// merge / launch / mutation / prune today, and whatever a future task 004+N
+// adds to the registry tomorrow — with ZERO surface-specific code in this
+// file. The whole per-surface contract (which event starts an instance, which
+// event(s) terminate it, how to derive its instance key) lives in
+// `event-store/liveness-registry.ts` (task 004); this module contributes
+// exactly one thing on top of that registry: iterate every descriptor,
+// delegate the pairing to the registry's own `computeInFlightInstances`
+// helper, and shape the survivors into a uniform row a `ps` consumer (task
+// 007) can render without knowing which surface produced it.
+//
+// DR-3 acceptance criterion this file exists to satisfy: "adding a surface to
+// the registry must add it to `ps` with no fold change." Because the loop
+// below iterates `LIVENESS_DESCRIPTORS` (or a caller-supplied override, used
+// only by this file's own conformance test) rather than naming `'merge'` /
+// `'launch'` / `'mutation'` / `'prune'` anywhere, a fifth registry entry is
+// picked up automatically — nothing here needs to change.
+//
+// Age: derived from the event ENVELOPE (`timestamp`, via the registry's own
+// `livenessStartedAt`) rather than any surface-specific data field — the same
+// uniformity discipline the registry itself documents.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import {
+  LIVENESS_DESCRIPTORS,
+  computeInFlightInstances,
+  livenessStartedAt,
+  type LivenessDescriptor,
+  type LivenessEventLike,
+  type LivenessSurface,
+  type LivenessStreamScope,
+} from '../../event-store/liveness-registry.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * The minimal event shape this fold operates on: a {@link LivenessEventLike}
+ * (`type` + optional `data`) plus the envelope `timestamp` age is derived
+ * from. Real `WorkflowEvent` rows (and `EventStore.query()` results) satisfy
+ * this structurally — no adapter needed.
+ */
+export interface OperationEventLike extends LivenessEventLike {
+  readonly timestamp?: string;
+}
+
+/**
+ * One in-flight liveness instance, shaped uniformly across every surface —
+ * the row shape a `ps` consumer (task 007) renders alongside task 005's
+ * workflow-fold.
+ */
+export interface InFlightOperation {
+  /** Which liveness surface this instance belongs to (registry-derived, not hardcoded). */
+  readonly surface: LivenessSurface;
+  /** The instance's canonical key, per the descriptor's own `instanceKeyOf`. */
+  readonly instanceKey: string;
+  /** Which stream family this surface's pair rides on (`'feature'` | `'worktrees'`). */
+  readonly streamScope: LivenessStreamScope;
+  /** The `<surface>.executing_started` CLAIM event type that opened this instance. */
+  readonly startType: string;
+  /** ISO 8601 instant the instance started, from the START event's envelope `timestamp`. */
+  readonly startedAt: string | undefined;
+  /** Age in milliseconds at fold time (`now - startedAt`), or `undefined` when `startedAt` is unresolvable. */
+  readonly ageMs: number | undefined;
+}
+
+/** Options for {@link foldInFlightOperations}. */
+export interface FoldInFlightOperationsOptions {
+  /**
+   * The descriptor set to fold over. Defaults to the REAL
+   * {@link LIVENESS_DESCRIPTORS} — the whole point of the generic design. Only
+   * ever overridden by this module's own conformance test, to prove that a
+   * hypothetical fifth surface flows through with no code change here.
+   */
+  readonly registry?: readonly LivenessDescriptor[];
+  /** Clock hook for `ageMs` (defaults to `Date.now`) — deterministic in tests. */
+  readonly now?: () => number;
+}
+
+// ─── The fold ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fold an ordered event list into every liveness instance still IN FLIGHT,
+ * across every descriptor in `options.registry` (default: the real
+ * registry). For each descriptor this simply delegates the START/TERMINAL
+ * pairing to {@link computeInFlightInstances} — the registry's own pairing
+ * helper — and maps the surviving `instanceKey -> START event` entries into
+ * {@link InFlightOperation} rows. No `if (surface === '...')` branch exists
+ * anywhere in this function; that is the DR-3 genericity guarantee.
+ *
+ * Ordering / semantics are exactly `computeInFlightInstances`'s: a START with
+ * no later matching TERMINAL (by instance key, scanning `events` left to
+ * right) is in flight; a re-START after a TERMINAL reopens the instance; an
+ * orphan TERMINAL (no prior START) is a no-op; an unresolvable key is
+ * skipped. This fold adds no additional semantics on top of that contract —
+ * it is purely a shape-and-merge step across descriptors.
+ */
+export function foldInFlightOperations(
+  events: readonly OperationEventLike[],
+  options?: FoldInFlightOperationsOptions,
+): readonly InFlightOperation[] {
+  const registry = options?.registry ?? LIVENESS_DESCRIPTORS;
+  const now = options?.now ?? Date.now;
+  const nowMs = now();
+
+  const rows: InFlightOperation[] = [];
+  for (const descriptor of registry) {
+    const inFlight = computeInFlightInstances(descriptor, events);
+    for (const [instanceKey, startEvent] of inFlight) {
+      const startedAt = livenessStartedAt(startEvent as OperationEventLike);
+      rows.push({
+        surface: descriptor.surface,
+        instanceKey,
+        streamScope: descriptor.streamScope,
+        startType: descriptor.startType,
+        startedAt,
+        ageMs: startedAt !== undefined ? Math.max(0, nowMs - Date.parse(startedAt)) : undefined,
+      });
+    }
+  }
+  return rows;
+}

--- a/servers/exarchos-mcp/src/views/lifecycle/ps.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/ps.test.ts
@@ -1,0 +1,315 @@
+// ─── `ps` scope-parameterized lister contract tests (DR-3, task 007) ──────────
+//
+// The redesigned `ps` composes THREE folds behind one `scope` axis:
+//   • scope:'all' (default) → task 005 workflows fold + task 006 operations fold
+//   • scope:'workflow'      → workflows fold only
+//   • scope:'worktree'      → the CONSUMED WLM-6 worktree fold (inFlightMerges /
+//                             launches / prunes + the probe write path)
+//
+// BOUNDARY DISCIPLINE (high tier): every test drives the REAL folds — task 005's
+// `foldWorkflowSummaries` over a real `InMemoryBackend`, task 006's
+// `foldInFlightOperations` over real store-backed events, and the real WLM-6
+// `handleViewPs` kernel over a real `EventStore` — with NO hand-mocked fold. The
+// InMemoryBackend is injected as BOTH `ctx.storage` (the workflows read) AND the
+// EventStore's read backend (the operations read) so one seeded corpus feeds both
+// sections coherently.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../event-store/store.js';
+import { InMemoryBackend } from '../../storage/memory-backend.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import type { WorkflowState } from '../../workflow/types.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import { WORKTREES_STREAM } from '../../orchestrate/worktree/manager.js';
+import type { WorktreeViewDeps } from '../../orchestrate/worktree/handlers.js';
+import type { InFlightMerge } from '../../orchestrate/worktree/projections/worktrees.js';
+import { handleView } from '../../views/composite.js';
+import { handleViewPs } from './ps.js';
+import type { WorkflowFoldRow } from './workflow-fold.js';
+import type { InFlightOperation } from './operations-fold.js';
+
+// ─── Deterministic clock ───────────────────────────────────────────────────────
+
+const NOW_MS = Date.parse('2026-07-13T00:00:10.000Z');
+/** Injected fixed clock → deterministic `ageMs` on both sections. */
+const FIXED_DEPS: WorktreeViewDeps = { now: () => NOW_MS };
+
+// ─── Arms ──────────────────────────────────────────────────────────────────────
+
+interface Arm {
+  readonly stateDir: string;
+  readonly ctx: DispatchContext;
+  readonly backend: InMemoryBackend;
+}
+
+const arms: Arm[] = [];
+
+/**
+ * An arm whose ONE `InMemoryBackend` backs both `ctx.storage` (workflows) and the
+ * `EventStore` reads (operations). Seed via the backend's own methods so both
+ * sections observe the same corpus.
+ */
+async function createArm(): Promise<Arm> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), 'ps-lifecycle-'));
+  const backend = new InMemoryBackend();
+  backend.initialize();
+  const eventStore = new EventStore(stateDir, { backend });
+  await eventStore.initialize();
+  const ctx: DispatchContext = { stateDir, eventStore, enableTelemetry: false, storage: backend };
+  const arm = { stateDir, ctx, backend };
+  arms.push(arm);
+  return arm;
+}
+
+/** A plain real-EventStore arm (no injected backend) for the WLM-6 worktree fold. */
+async function createRealArm(): Promise<{ stateDir: string; ctx: DispatchContext }> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), 'ps-worktree-'));
+  const eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+  const ctx: DispatchContext = { stateDir, eventStore, enableTelemetry: false };
+  arms.push({ stateDir, ctx, backend: null as unknown as InMemoryBackend });
+  return { stateDir, ctx };
+}
+
+afterEach(async () => {
+  while (arms.length > 0) {
+    const arm = arms.pop();
+    if (arm) await rmrfAsync(arm.stateDir);
+  }
+});
+
+// ─── Seed helpers (via the shared backend) ─────────────────────────────────────
+
+let seq = 0;
+
+function seedWorkflow(
+  backend: InMemoryBackend,
+  spec: { featureId: string; workflowType: string; phase: string; createdAt: string },
+): void {
+  backend.setState(
+    spec.featureId,
+    { featureId: spec.featureId, workflowType: spec.workflowType, phase: spec.phase } as unknown as WorkflowState,
+  );
+  backend.appendEvent(spec.featureId, {
+    streamId: spec.featureId,
+    sequence: ++seq,
+    timestamp: spec.createdAt,
+    type: 'workflow.started',
+    schemaVersion: '1.0',
+  } as WorkflowEvent);
+}
+
+function seedEvent(
+  backend: InMemoryBackend,
+  streamId: string,
+  type: string,
+  data: Record<string, unknown>,
+  timestamp: string,
+): void {
+  backend.appendEvent(streamId, {
+    streamId,
+    sequence: ++seq,
+    timestamp,
+    type,
+    schemaVersion: '1.0',
+    data,
+  } as WorkflowEvent);
+}
+
+// ─── DR-3: default scope:'all' → workflows + operations sections ───────────────
+
+describe('ps scope:"all" — composed workflows + operations sections (DR-3)', () => {
+  it('Ps_DefaultScope_All_ReturnsWorkflowsAndOperationsSections', async () => {
+    const arm = await createArm();
+
+    // Two live workflows + one terminal (excluded from the default listing).
+    seedWorkflow(arm.backend, { featureId: 'feat-a', workflowType: 'feature', phase: 'delegate', createdAt: '2026-07-13T00:00:00.000Z' });
+    seedWorkflow(arm.backend, { featureId: 'dbg-b', workflowType: 'debug', phase: 'triage', createdAt: '2026-07-13T00:00:05.000Z' });
+    seedWorkflow(arm.backend, { featureId: 'feat-done', workflowType: 'feature', phase: 'completed', createdAt: '2026-07-13T00:00:01.000Z' });
+
+    // Operations: one in-flight merge (feature stream), one in-flight launch
+    // (worktrees stream), one COMPLETED prune (excluded — has its terminal).
+    seedEvent(arm.backend, 'feat-a', 'merge.executing_started', { instanceId: 'M1', sourceBranch: 'feat/a', targetBranch: 'main' }, '2026-07-13T00:00:02.000Z');
+    seedEvent(arm.backend, WORKTREES_STREAM, 'launch.executing_started', { instanceId: '/wt/a', worktreeId: '/wt/a' }, '2026-07-13T00:00:03.000Z');
+    seedEvent(arm.backend, WORKTREES_STREAM, 'prune.executing_started', { instanceId: 'P1', operationId: 'P1' }, '2026-07-13T00:00:04.000Z');
+    seedEvent(arm.backend, WORKTREES_STREAM, 'prune.executed', { instanceId: 'P1', operationId: 'P1' }, '2026-07-13T00:00:06.000Z');
+
+    // Default scope (omitted) MUST resolve to 'all' and return BOTH sections.
+    const result = await handleViewPs({}, arm.ctx, FIXED_DEPS);
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      scope: string;
+      workflows: WorkflowFoldRow[];
+      workflowCount: number;
+      operations: InFlightOperation[];
+      operationCount: number;
+    };
+
+    expect(data.scope).toBe('all');
+
+    // ── Workflows section (task 005 fold) — the two live workflows, terminal hidden.
+    expect(data.workflowCount).toBe(2);
+    const wfIds = data.workflows.map((w) => w.featureId).sort();
+    expect(wfIds).toEqual(['dbg-b', 'feat-a']);
+    expect(data.workflows.some((w) => w.featureId === 'feat-done')).toBe(false);
+    // Deterministic age: feat-a created at T+0, now T+10 → 10_000ms.
+    const featA = data.workflows.find((w) => w.featureId === 'feat-a');
+    expect(featA?.ageMs).toBe(10_000);
+    expect(featA?.workflowType).toBe('feature');
+
+    // ── Operations section (task 006 fold) — the in-flight merge + launch only.
+    expect(data.operationCount).toBe(2);
+    const bySurface = new Map(data.operations.map((o) => [o.surface, o.instanceKey]));
+    expect(bySurface.get('merge')).toBe('M1');
+    expect(bySurface.get('launch')).toBe('/wt/a');
+    // The prune reached its terminal → NOT in flight.
+    expect(bySurface.has('prune')).toBe(false);
+  });
+
+  it('Ps_AllScope_RoutesThroughComposite', async () => {
+    // End-to-end proof the composite router forwards a bare `ps` (no scope) to the
+    // new scoped handler with the default `all` semantics.
+    const arm = await createArm();
+    seedWorkflow(arm.backend, { featureId: 'feat-x', workflowType: 'feature', phase: 'plan', createdAt: '2026-07-13T00:00:00.000Z' });
+
+    const result = await handleView({ action: 'ps' }, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(true);
+    const data = result.data as { scope: string; workflows: unknown[]; operations: unknown[] };
+    expect(data.scope).toBe('all');
+    expect(Array.isArray(data.workflows)).toBe(true);
+    expect(Array.isArray(data.operations)).toBe(true);
+  });
+});
+
+// ─── DR-3: scope:'workflow' — workflows section only, filterable ───────────────
+
+describe('ps scope:"workflow" — workflows section only', () => {
+  it('Ps_WorkflowScope_ReturnsWorkflowsSection_NoOperations', async () => {
+    const arm = await createArm();
+    seedWorkflow(arm.backend, { featureId: 'feat-a', workflowType: 'feature', phase: 'delegate', createdAt: '2026-07-13T00:00:00.000Z' });
+    // An in-flight operation exists, but scope:'workflow' must NOT surface it.
+    seedEvent(arm.backend, WORKTREES_STREAM, 'launch.executing_started', { instanceId: '/wt/z' }, '2026-07-13T00:00:01.000Z');
+
+    const result = await handleViewPs({ scope: 'workflow' }, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(true);
+    const data = result.data as { scope: string; workflowCount: number; operations?: unknown };
+    expect(data.scope).toBe('workflow');
+    expect(data.workflowCount).toBe(1);
+    expect(data.operations).toBeUndefined();
+  });
+
+  it('Ps_WorkflowScope_AllFlagIncludesTerminal_And_TypeFilter', async () => {
+    const arm = await createArm();
+    seedWorkflow(arm.backend, { featureId: 'feat-live', workflowType: 'feature', phase: 'delegate', createdAt: '2026-07-13T00:00:00.000Z' });
+    seedWorkflow(arm.backend, { featureId: 'feat-done', workflowType: 'feature', phase: 'completed', createdAt: '2026-07-13T00:00:01.000Z' });
+    seedWorkflow(arm.backend, { featureId: 'dbg-live', workflowType: 'debug', phase: 'triage', createdAt: '2026-07-13T00:00:02.000Z' });
+
+    // all:true → include terminal; workflowType filter → feature only. Combined:
+    // feat-live + feat-done (both feature; terminal admitted), dbg-live excluded.
+    const result = await handleViewPs({ scope: 'workflow', all: true, workflowType: 'feature' }, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(true);
+    const data = result.data as { workflows: WorkflowFoldRow[] };
+    expect(data.workflows.map((w) => w.featureId).sort()).toEqual(['feat-done', 'feat-live']);
+  });
+
+  it('Ps_WorkflowScope_UnknownStatus_RejectedInvalidInput', async () => {
+    const arm = await createArm();
+    const result = await handleViewPs({ scope: 'workflow', status: 'not-a-status' }, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toMatch(/status/i);
+  });
+});
+
+// ─── DR-3: probe gating — worktree-scope-only ──────────────────────────────────
+
+describe('ps probe gating — worktree-scope-only (DR-3)', () => {
+  it('Ps_WorkflowScopeWithProbe_RejectedInvalidInput', async () => {
+    const arm = await createArm();
+    // probe only makes sense over the worktree fold (it runs the DR-5 process
+    // probe + reclaim writes). With scope:'workflow' it must be rejected.
+    const result = await handleViewPs({ scope: 'workflow', probe: true }, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toMatch(/probe/i);
+  });
+
+  it('Ps_DefaultAllScopeWithProbe_RejectedInvalidInput', async () => {
+    const arm = await createArm();
+    // Same gate on the DEFAULT (all) scope — probe is not a pure-read capability.
+    const result = await handleViewPs({ probe: true }, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toMatch(/probe/i);
+  });
+
+  it('Ps_ScopeRepo_RejectedAsPipelineOnlyAxis', async () => {
+    const arm = await createArm();
+    const result = await handleViewPs({ scope: 'repo' }, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toMatch(/pipeline/i);
+  });
+});
+
+// ─── DR-3: scope:'worktree' — the CONSUMED WLM-6 fold, capabilities preserved ──
+
+describe('ps scope:"worktree" — WLM-6 capabilities preserved (consumed, not duplicated)', () => {
+  it('Ps_WorktreeScope_PreservesWlm6Capabilities', async () => {
+    const { ctx } = await createRealArm();
+    // Seed an in-flight serialized merge on the singleton worktrees stream.
+    await ctx.eventStore.append(
+      WORKTREES_STREAM,
+      {
+        type: 'worktree.merge_requested',
+        data: { integrationRef: 'main', operationId: 'op-wt', sourceBranch: 'feat/x', holderPid: 4242, holderStartedAt: 'boot-4242' },
+      },
+      { idempotencyKey: 'worktree.merge_requested:op-wt' },
+    );
+
+    const result = await handleViewPs({ scope: 'worktree' }, ctx, FIXED_DEPS);
+    expect(result.success).toBe(true);
+
+    // The WLM-6 worktree shape (inFlightMerges/launches/prunes) — proving the
+    // delegate is the WLM-6 kernel, NOT the composed workflows/operations shape.
+    const data = result.data as {
+      inFlight: InFlightMerge[];
+      count: number;
+      launches: unknown[];
+      launchCount: number;
+      prunes: unknown[];
+      pruneCount: number;
+      workflows?: unknown;
+      operations?: unknown;
+    };
+    expect(data.count).toBe(1);
+    expect(data.inFlight[0].integrationRef).toBe('main');
+    expect(data.inFlight[0].sourceBranch).toBe('feat/x');
+    expect(data.launchCount).toBe(0);
+    expect(data.pruneCount).toBe(0);
+    // It is the worktree fold, not the composed one.
+    expect(data.workflows).toBeUndefined();
+    expect(data.operations).toBeUndefined();
+  });
+
+  it('Ps_WorktreeScope_ProbeAccepted_RunsReclaim', async () => {
+    const { ctx } = await createRealArm();
+    // probe:true is VALID in worktree scope — it must run the DR-5 process probe
+    // and surface a `probe` block (empty store → nothing to reclaim, but the block
+    // is present, proving the capability is preserved).
+    const result = await handleViewPs(
+      { scope: 'worktree', probe: true },
+      ctx,
+      { processTableSource: { list: () => [] }, realpath: (p) => p, now: () => NOW_MS },
+    );
+    expect(result.success).toBe(true);
+    const data = result.data as { probe?: { probed: number } };
+    expect(data.probe).toBeDefined();
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/ps.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/ps.test.ts
@@ -298,6 +298,61 @@ describe('ps scope:"worktree" — WLM-6 capabilities preserved (consumed, not du
     expect(data.operations).toBeUndefined();
   });
 
+  it('Ps_NoStorageBackend_SurfacesStructuredMetaWarning', async () => {
+    // Finding 6a: with no storage backend wired, the workflows section can't be
+    // read. Instead of a SILENT empty section (which reads as "no workflows
+    // exist"), the handler surfaces a structured `_meta.warning`. The operations
+    // section (event-store-backed) is unaffected.
+    const { ctx } = await createRealArm(); // ctx has no `storage`
+    await ctx.eventStore.append(
+      WORKTREES_STREAM,
+      { type: 'launch.executing_started', data: { worktreeId: '/wt/x', instanceId: '/wt/x', holderPid: 1, holderStartedAt: null } },
+    );
+
+    const result = await handleViewPs({}, ctx, FIXED_DEPS);
+    expect(result.success).toBe(true);
+    const data = result.data as { workflows: unknown[]; workflowCount: number; operations: InFlightOperation[] };
+    expect(data.workflowCount).toBe(0);
+    // The degraded read is announced, not silent.
+    const meta = result._meta as { warning?: string } | undefined;
+    expect(meta?.warning).toBeDefined();
+    expect(meta?.warning).toMatch(/workflows section unavailable/i);
+    // Operations section still works — the launch is in flight.
+    expect(data.operations.some((o) => o.surface === 'launch')).toBe(true);
+  });
+
+  it('Ps_StorageBackendPresent_NoMetaWarning', async () => {
+    // The warning is present ONLY on degrade — a normally-wired ctx omits it.
+    const arm = await createArm();
+    seedWorkflow(arm.backend, { featureId: 'feat-a', workflowType: 'feature', phase: 'plan', createdAt: '2026-07-13T00:00:00.000Z' });
+    const result = await handleViewPs({}, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(true);
+    expect(result._meta).toBeUndefined();
+  });
+
+  it('Ps_SameMergeKeyTwoFeatureStreams_TerminalDoesNotCrossClear_S6', async () => {
+    // Finding 1 end-to-end through the real handler + perf-pushdown gather: two
+    // feature workflows share the merge key 'T11'; only feat-b's merge
+    // terminates. `ps --scope all` must still show feat-a's stuck merge (the S-6
+    // guarantee), attributed to feat-a.
+    const arm = await createArm();
+    seedWorkflow(arm.backend, { featureId: 'feat-a', workflowType: 'feature', phase: 'delegate', createdAt: '2026-07-13T00:00:00.000Z' });
+    seedWorkflow(arm.backend, { featureId: 'feat-b', workflowType: 'feature', phase: 'delegate', createdAt: '2026-07-13T00:00:00.000Z' });
+
+    seedEvent(arm.backend, 'feat-a', 'merge.executing_started', { instanceId: 'T11' }, '2026-07-13T00:00:01.000Z');
+    seedEvent(arm.backend, 'feat-b', 'merge.executing_started', { instanceId: 'T11' }, '2026-07-13T00:00:02.000Z');
+    seedEvent(arm.backend, 'feat-b', 'merge.executed', { instanceId: 'T11' }, '2026-07-13T00:00:03.000Z');
+
+    const result = await handleViewPs({}, arm.ctx, FIXED_DEPS);
+    expect(result.success).toBe(true);
+    const data = result.data as { operations: InFlightOperation[] };
+    const merges = data.operations.filter((o) => o.surface === 'merge');
+    expect(merges).toHaveLength(1);
+    expect(merges[0]?.instanceKey).toBe('T11');
+    expect(merges[0]?.streamId).toBe('feat-a');
+    expect(merges[0]?.featureId).toBe('feat-a');
+  });
+
   it('Ps_WorktreeScope_ProbeAccepted_RunsReclaim', async () => {
     const { ctx } = await createRealArm();
     // probe:true is VALID in worktree scope — it must run the DR-5 process probe

--- a/servers/exarchos-mcp/src/views/lifecycle/ps.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/ps.ts
@@ -60,6 +60,10 @@ import {
   type InFlightOperation,
   type OperationEventLike,
 } from './operations-fold.js';
+import {
+  LIVENESS_DESCRIPTORS,
+  everyExecutingStartedType,
+} from '../../event-store/liveness-registry.js';
 import { scopeField } from './schema-fields.js';
 
 // ─── Scope vocabulary ─────────────────────────────────────────────────────────
@@ -155,21 +159,27 @@ interface WorkflowsSection {
   readonly workflowCount: number;
 }
 
+/** `_meta.warning` surfaced when the workflows section can't be read (no backend). */
+const NO_STORAGE_WARNING =
+  'workflows section unavailable: no storage backend wired to this context — ' +
+  'the operations section (event-store-backed) is unaffected';
+
 /**
  * Fold the WORKFLOWS section for the `workflow` / `all` scopes: task 005's
  * `foldWorkflowSummaries` over `ctx.storage`, honoring the status / phase /
  * workflowType / all (includeTerminal) filters. When no storage backend is wired
  * (a test-context shape only — production always supplies a SqliteBackend), the
- * section degrades to empty rather than throwing; the operations section (which
- * rides `eventStore`, always present) is unaffected.
+ * section degrades to empty AND surfaces a structured `_meta.warning` (rather
+ * than a silent empty section that reads as "no workflows exist"); the
+ * operations section (which rides `eventStore`, always present) is unaffected.
  */
 function foldWorkflowsSection(
   backend: StorageBackend | undefined,
   args: Record<string, unknown>,
   nowMs: number | undefined,
-): { section: WorkflowsSection } | { error: ToolResult } {
+): { section: WorkflowsSection; warning?: string } | { error: ToolResult } {
   if (backend === undefined) {
-    return { section: { workflows: [], workflowCount: 0 } };
+    return { section: { workflows: [], workflowCount: 0 }, warning: NO_STORAGE_WARNING };
   }
 
   const filter: WorkflowSummaryFilter = {};
@@ -204,21 +214,46 @@ function foldWorkflowsSection(
 // ─── Operations section (task 006) ────────────────────────────────────────────
 
 /**
- * Gather every liveness event across every stream, globally ordered by
+ * The registry's liveness event types — every `<surface>.executing_started`
+ * START plus every declared TERMINAL, deduplicated. Derived from the DR-2
+ * registry (never hardcoded), so a fifth surface's types are picked up
+ * automatically. This is the type-scoped pushdown set `gatherOperationEvents`
+ * restricts its reads to.
+ */
+function livenessEventTypes(): readonly string[] {
+  const types = new Set<string>(everyExecutingStartedType());
+  for (const descriptor of LIVENESS_DESCRIPTORS) {
+    for (const terminal of descriptor.terminalTypes) types.add(terminal);
+  }
+  return [...types];
+}
+
+/**
+ * Gather the liveness events across every stream, globally ordered by
  * `(timestamp, sequence)`, so `foldInFlightOperations` can pair START/TERMINAL
  * across the feature streams (merge / mutation) AND the singleton `worktrees`
  * stream (launch / prune) in one pass. `WorkflowEvent` rows satisfy
- * {@link OperationEventLike} structurally — no adapter needed. Non-liveness
- * events are folded harmlessly (the registry-driven fold ignores them).
+ * {@link OperationEventLike} structurally (including `streamId`, load-bearing for
+ * the DR-2 per-stream pairing) — no adapter needed.
+ *
+ * Perf (DR-3): rather than loading the FULL event log of every stream and
+ * global-sorting it on each `ps --scope all`, this pushes the type filter down
+ * to the backend — only the registry's liveness start/terminal types are
+ * materialized (`query(streamId, { type })`, which the SqliteBackend and
+ * InMemoryBackend both honor at the storage layer). The remaining sort is over
+ * the small liveness slice, not the whole log.
  */
 async function gatherOperationEvents(
   eventStore: DispatchContext['eventStore'],
 ): Promise<OperationEventLike[]> {
   const streams = eventStore.listStreams();
+  const types = livenessEventTypes();
   const all: WorkflowEvent[] = [];
   for (const streamId of streams) {
-    const events = await eventStore.query(streamId);
-    for (const event of events) all.push(event);
+    for (const type of types) {
+      const events = await eventStore.query(streamId, { type });
+      for (const event of events) all.push(event);
+    }
   }
   all.sort((a, b) => {
     const byTs = a.timestamp.localeCompare(b.timestamp);
@@ -294,12 +329,16 @@ export async function handleViewPs(
   // Workflows section (both remaining scopes need it).
   const workflowsResult = foldWorkflowsSection(ctx.storage, args, nowMs);
   if ('error' in workflowsResult) return workflowsResult.error;
-  const { section: workflows } = workflowsResult;
+  const { section: workflows, warning } = workflowsResult;
+  // Surface a degraded-read warning structurally instead of a silent empty
+  // section (finding 6a). Only present when a section actually degraded.
+  const metaField = warning !== undefined ? { _meta: { warning } } : {};
 
   if (scope === 'workflow') {
     return {
       success: true,
       data: { scope, ...workflows },
+      ...metaField,
     };
   }
 
@@ -308,5 +347,6 @@ export async function handleViewPs(
   return {
     success: true,
     data: { scope, ...workflows, ...operations },
+    ...metaField,
   };
 }

--- a/servers/exarchos-mcp/src/views/lifecycle/ps.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/ps.ts
@@ -1,0 +1,312 @@
+// ─── Lifecycle verb: `ps` — scope-parameterized process-plane lister (DR-3) ───
+//
+// The one lifecycle verb that answers "what is RUNNING / TRACKED right now?".
+// It is a scope-parameterized COMPOSITION of three folds — it carries no fold
+// logic of its own (INV-2), only the scope routing + section shaping:
+//
+//   • scope: 'workflow'  → the WORKFLOWS section: task 005's `foldWorkflowSummaries`
+//                          over the storage backend (every tracked workflow, one
+//                          row: featureId / workflowType / phase / status / ageMs),
+//                          filterable by status / phase / workflowType / all.
+//   • scope: 'worktree'  → the WLM-6 worktree liveness fold, CONSUMED not
+//                          duplicated: delegates to `handleWorktreeScopePs`
+//                          (`orchestrate/worktree/handlers.ts`) so the
+//                          inFlightMerges / launches / inFlightPrunes columns AND
+//                          the `probe: true` reclaim/reconcile write path are
+//                          preserved byte-for-byte.
+//   • scope: 'all'       → DEFAULT. BOTH the workflows section (005) AND an
+//                          OPERATIONS section: task 006's `foldInFlightOperations`
+//                          over every liveness surface (merge / launch / mutation /
+//                          prune — surface-generic, registry-driven), gathered
+//                          across every stream.
+//
+// ## Scope collision resolution (task 007, honoring task 019's discovery)
+//
+// The `scope` field is the SHARED `schema-fields.ts` shape — widened by task 007
+// to the union `['repo','all','workflow','worktree']` so `pipeline` (`repo`/`all`)
+// and `ps` (`workflow`/`worktree`/`all`) declare ONE `scope` definition on the
+// `exarchos_view` tool (a divergent enum value set would make
+// `buildRegistrationSchema` THROW). `ps` validates its OWN subset here — it
+// REJECTS `repo` (a pipeline-only member) — and `pipeline` ignores the ps-only
+// members at its handler. The flattener only requires the value SET to match
+// across the two actions, which the single shared shape guarantees.
+//
+// ## Probe gating (DR-3)
+//
+// `probe: true` is a WORKTREE-scope-only capability (it runs the DR-5 process
+// probe and emits reclaim/reconcile writes). Passing it with any non-worktree
+// scope is a structured `INVALID_INPUT` — probe has no meaning over a workflows
+// or operations fold, both of which are pure reads.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { ToolResult } from '../../format.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import type {
+  StorageBackend,
+  WorkflowLifecycleStatus,
+  WorkflowSummaryFilter,
+} from '../../storage/backend.js';
+import {
+  handleWorktreeScopePs,
+  type WorktreeViewDeps,
+} from '../../orchestrate/worktree/handlers.js';
+import {
+  foldWorkflowSummaries,
+  type WorkflowFoldRow,
+} from './workflow-fold.js';
+import {
+  foldInFlightOperations,
+  type InFlightOperation,
+  type OperationEventLike,
+} from './operations-fold.js';
+import { scopeField } from './schema-fields.js';
+
+// ─── Scope vocabulary ─────────────────────────────────────────────────────────
+
+/** The `ps`-plane scopes. A SUBSET of the shared `scopeField` union — `repo` is
+ *  a `pipeline`-only member `ps` rejects. */
+export type PsScope = 'workflow' | 'worktree' | 'all';
+
+const PS_SCOPES: readonly PsScope[] = ['workflow', 'worktree', 'all'];
+
+/** The workflow lifecycle statuses a `ps --status` filter may request. */
+const WORKFLOW_STATUSES: readonly WorkflowLifecycleStatus[] = [
+  'active',
+  'completed',
+  'cancelled',
+  'blocked',
+];
+
+// ─── Local input helpers (kept private — never user-facing flags) ─────────────
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+/** Parse a positive-int `limit` from a number or numeric string (coerced flags). */
+function optionalPosInt(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 1) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const n = Number(value);
+    return n >= 1 ? n : undefined;
+  }
+  return undefined;
+}
+
+function invalidInput(
+  message: string,
+  extra?: {
+    expectedShape?: Record<string, unknown>;
+    validTargets?: readonly string[];
+    suggestedFix?: { tool: string; params: Record<string, unknown> };
+  },
+): ToolResult {
+  return {
+    success: false,
+    error: {
+      code: 'INVALID_INPUT',
+      message,
+      ...(extra?.expectedShape ? { expectedShape: extra.expectedShape } : {}),
+      ...(extra?.validTargets ? { validTargets: extra.validTargets } : {}),
+      ...(extra?.suggestedFix ? { suggestedFix: extra.suggestedFix } : {}),
+    },
+  };
+}
+
+/** Resolve the requested `ps` scope, defaulting to `all`, or an error result. */
+function resolveScope(raw: unknown): { scope: PsScope } | { error: ToolResult } {
+  const s = optionalString(raw);
+  if (s === undefined) return { scope: 'all' };
+  // `repo` is a valid shared-`scopeField` member but a `pipeline`-only axis — a
+  // `ps --scope repo` request has no meaning here, so reject it explicitly
+  // (INV-5b self-correcting error) rather than silently defaulting.
+  if (s === 'repo') {
+    return {
+      error: invalidInput(
+        "ps: scope 'repo' is a pipeline-only axis — use pipeline for repo scoping. ps scopes are 'workflow' | 'worktree' | 'all'.",
+        {
+          validTargets: PS_SCOPES,
+          suggestedFix: { tool: 'exarchos_view', params: { action: 'pipeline', scope: 'repo' } },
+        },
+      ),
+    };
+  }
+  if ((PS_SCOPES as readonly string[]).includes(s)) {
+    return { scope: s as PsScope };
+  }
+  return {
+    error: invalidInput(
+      `ps: unknown scope '${s}' — expected 'workflow' | 'worktree' | 'all'.`,
+      { validTargets: PS_SCOPES },
+    ),
+  };
+}
+
+// ─── Workflows section (task 005) ─────────────────────────────────────────────
+
+/** The workflows-section payload: the folded rows + their count. */
+interface WorkflowsSection {
+  readonly workflows: readonly WorkflowFoldRow[];
+  readonly workflowCount: number;
+}
+
+/**
+ * Fold the WORKFLOWS section for the `workflow` / `all` scopes: task 005's
+ * `foldWorkflowSummaries` over `ctx.storage`, honoring the status / phase /
+ * workflowType / all (includeTerminal) filters. When no storage backend is wired
+ * (a test-context shape only — production always supplies a SqliteBackend), the
+ * section degrades to empty rather than throwing; the operations section (which
+ * rides `eventStore`, always present) is unaffected.
+ */
+function foldWorkflowsSection(
+  backend: StorageBackend | undefined,
+  args: Record<string, unknown>,
+  nowMs: number | undefined,
+): { section: WorkflowsSection } | { error: ToolResult } {
+  if (backend === undefined) {
+    return { section: { workflows: [], workflowCount: 0 } };
+  }
+
+  const filter: WorkflowSummaryFilter = {};
+  const status = optionalString(args.status);
+  if (status !== undefined) {
+    if (!(WORKFLOW_STATUSES as readonly string[]).includes(status)) {
+      return {
+        error: invalidInput(
+          `ps: unknown status '${status}' — expected one of ${WORKFLOW_STATUSES.join(', ')}.`,
+          { validTargets: WORKFLOW_STATUSES },
+        ),
+      };
+    }
+    filter.status = status as WorkflowLifecycleStatus;
+  }
+  const phase = optionalString(args.phase);
+  if (phase !== undefined) filter.phase = phase;
+  const workflowType = optionalString(args.workflowType);
+  if (workflowType !== undefined) filter.workflowType = workflowType;
+  if (optionalBoolean(args.all) === true) filter.includeTerminal = true;
+
+  let workflows = foldWorkflowSummaries(backend, {
+    ...filter,
+    ...(nowMs !== undefined ? { nowMs } : {}),
+  });
+  const limit = optionalPosInt(args.limit);
+  if (limit !== undefined) workflows = workflows.slice(0, limit);
+
+  return { section: { workflows, workflowCount: workflows.length } };
+}
+
+// ─── Operations section (task 006) ────────────────────────────────────────────
+
+/**
+ * Gather every liveness event across every stream, globally ordered by
+ * `(timestamp, sequence)`, so `foldInFlightOperations` can pair START/TERMINAL
+ * across the feature streams (merge / mutation) AND the singleton `worktrees`
+ * stream (launch / prune) in one pass. `WorkflowEvent` rows satisfy
+ * {@link OperationEventLike} structurally — no adapter needed. Non-liveness
+ * events are folded harmlessly (the registry-driven fold ignores them).
+ */
+async function gatherOperationEvents(
+  eventStore: DispatchContext['eventStore'],
+): Promise<OperationEventLike[]> {
+  const streams = eventStore.listStreams();
+  const all: WorkflowEvent[] = [];
+  for (const streamId of streams) {
+    const events = await eventStore.query(streamId);
+    for (const event of events) all.push(event);
+  }
+  all.sort((a, b) => {
+    const byTs = a.timestamp.localeCompare(b.timestamp);
+    return byTs !== 0 ? byTs : a.sequence - b.sequence;
+  });
+  return all;
+}
+
+/** The operations-section payload: the folded in-flight rows + their count. */
+interface OperationsSection {
+  readonly operations: readonly InFlightOperation[];
+  readonly operationCount: number;
+}
+
+/** Fold the OPERATIONS section for the `all` scope (task 006, surface-generic). */
+async function foldOperationsSection(
+  eventStore: DispatchContext['eventStore'],
+  nowMs: number | undefined,
+): Promise<OperationsSection> {
+  const events = await gatherOperationEvents(eventStore);
+  const operations = foldInFlightOperations(
+    events,
+    nowMs !== undefined ? { now: () => nowMs } : undefined,
+  );
+  return { operations, operationCount: operations.length };
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────────
+
+/**
+ * `ps` — the scope-parameterized process-plane lister (DR-3). Routes:
+ *
+ *   - `scope: 'worktree'` → the CONSUMED WLM-6 fold (`handleWorktreeScopePs`),
+ *     the only scope where `probe: true` is valid;
+ *   - `scope: 'workflow'` → the workflows section only;
+ *   - `scope: 'all'` (default) → workflows section + operations section.
+ *
+ * `probe` on a non-worktree scope is a structured `INVALID_INPUT`. Every path is
+ * a pure read except `scope: 'worktree'` + `probe: true` (the reclaim/reconcile
+ * write path, unchanged from WLM-6).
+ */
+export async function handleViewPs(
+  args: Record<string, unknown>,
+  ctx: DispatchContext,
+  deps?: WorktreeViewDeps,
+): Promise<ToolResult> {
+  const resolved = resolveScope(args.scope);
+  if ('error' in resolved) return resolved.error;
+  const { scope } = resolved;
+
+  // Probe is a worktree-scope-only capability (it runs the DR-5 process probe +
+  // emits reclaim/reconcile writes). It has no meaning over the pure-read
+  // workflows / operations folds → reject rather than silently ignore.
+  if (args.probe !== undefined && scope !== 'worktree') {
+    return invalidInput(
+      `ps: probe is only valid for scope: 'worktree' (received scope: '${scope}') — the workflows/operations folds are pure reads with no process probe.`,
+      {
+        expectedShape: { scope: "'worktree'", probe: 'boolean' },
+        validTargets: ['worktree'],
+        suggestedFix: { tool: 'exarchos_view', params: { action: 'ps', scope: 'worktree', probe: true } },
+      },
+    );
+  }
+
+  // Worktree scope: delegate to the CONSUMED WLM-6 kernel unchanged — it owns the
+  // inFlightMerges / launches / inFlightPrunes fold and the probe write path.
+  if (scope === 'worktree') {
+    return handleWorktreeScopePs(args, ctx, deps);
+  }
+
+  const nowMs = deps?.now?.();
+
+  // Workflows section (both remaining scopes need it).
+  const workflowsResult = foldWorkflowsSection(ctx.storage, args, nowMs);
+  if ('error' in workflowsResult) return workflowsResult.error;
+  const { section: workflows } = workflowsResult;
+
+  if (scope === 'workflow') {
+    return {
+      success: true,
+      data: { scope, ...workflows },
+    };
+  }
+
+  // scope: 'all' → workflows + operations.
+  const operations = await foldOperationsSection(ctx.eventStore, nowMs);
+  return {
+    success: true,
+    data: { scope, ...workflows, ...operations },
+  };
+}

--- a/servers/exarchos-mcp/src/views/lifecycle/s6-recovery.acceptance.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/s6-recovery.acceptance.test.ts
@@ -1,0 +1,283 @@
+// ─── S-6 north-star: stuck-executing merge recovery acceptance (DR-3/DR-5/DR-8) ─
+//
+// The feature's ACCEPTANCE walkthrough. ONE test drives the REAL SQLite event
+// store + the REAL lifecycle handlers (`ps`, `inspect`, `wait`) + the REAL DR-2
+// liveness registry — NO mocks of the store, the folds, or the registry — end
+// to end through the corrected S-6 story:
+//
+//   1. A merge crashes mid-flight: a `merge.executing_started` with NO terminal
+//      is committed to a real store (the simulated crash).
+//   2. `ps --scope all` lists the stuck merge in its OPERATIONS section
+//      (`{surface:'merge', instanceKey:…}`) — the DR-3 north-star assertion.
+//   3. `inspect` projects the workflow with the unpaired start still in flight
+//      (the `merge.executing_started` is in `recentEvents`; no merge terminal).
+//   4. `wait --operation merge` with a short timeout returns a STRUCTURED
+//      `WAIT_TIMEOUT` (DR-5/DR-8 — the CLI would map this to exit 17) while no
+//      terminal exists to clear the in-flight instance.
+//   5. Appending `merge.recovered` (a registry terminal for merge, matched by
+//      INSTANCE KEY) clears the in-flight set; a fresh `wait --operation merge`
+//      now RESOLVES immediately, and `ps` no longer lists the merge.
+//
+// Determinism comes from INJECTED clocks/timers only (INV-16): a `ManualClock`
+// on the subscription registry and a captured `scheduleTimeout` that fires the
+// bounded deadline directly — never a wall-clock sleep. The behavioral steps
+// ARE the adequacy: a broken `ps` / `inspect` / `wait` would fail this test.
+//
+// The final `it` is a FENCE, not the proof: a grep guard that neither generic
+// verb (`wait.ts` / `operations-fold.ts`) branches on the `merge` surface
+// literal — the DR-3 genericity that lets the behavioral steps above hold for
+// every liveness surface, not just merge.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../event-store/store.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import type { SubscriptionClock } from '../../event-store/subscriptions.js';
+import { handleViewPs } from './ps.js';
+import { handleViewInspect } from './inspect.js';
+import { handleViewWait, type WaitDeps } from './wait.js';
+import type { InFlightOperation } from './operations-fold.js';
+
+// ─── Deterministic clock (INV-16) ─────────────────────────────────────────────
+
+/** Fixed fold-time clock → deterministic `ageMs` on the `ps` operations section. */
+const NOW_MS = Date.parse('2026-07-13T00:00:10.000Z');
+
+/**
+ * A real, deterministic {@link SubscriptionClock} whose Tier-2 floor loop fires
+ * only when the test calls `fireAll()` — mirrors `wait.test.ts`. Injected via
+ * `WaitDeps.subscriptionOptions` so the wait's own DR-1 subscription runs on it
+ * (the FIRST subscribe on the fresh store adopts this clock). This walkthrough
+ * never fires the floor: step 4 resolves via the fired deadline, so no foreign
+ * event ever needs draining.
+ */
+class ManualSubscriptionClock implements SubscriptionClock {
+  time = 0;
+  private readonly loops: Array<{ tick: () => void }> = [];
+  now(): number {
+    return this.time;
+  }
+  scheduleInterval(tick: () => void): () => void {
+    const entry = { tick };
+    this.loops.push(entry);
+    return () => {
+      const i = this.loops.indexOf(entry);
+      if (i >= 0) this.loops.splice(i, 1);
+    };
+  }
+  fireAll(): void {
+    for (const { tick } of [...this.loops]) tick();
+  }
+}
+
+// ─── Real-store arm ────────────────────────────────────────────────────────────
+
+interface Arm {
+  readonly stateDir: string;
+  readonly store: EventStore;
+  readonly ctx: DispatchContext;
+}
+
+let arms: Arm[] = [];
+
+afterEach(async () => {
+  for (const arm of arms) {
+    arm.store.close();
+    await rmrfAsync(arm.stateDir);
+  }
+  arms = [];
+});
+
+/**
+ * A plain, REAL SQLite `EventStore` (no injected backend) — the same wiring
+ * `wait.test.ts` uses, so the DR-1 subscription primitive, the Tier-1 commit
+ * hook, and the cross-stream `ps` reads all run against real substrate. The
+ * operations section of `ps --scope all` reads purely from the event store, so
+ * `ctx.storage` is deliberately unset (the workflows section degrades to empty;
+ * the S-6 north-star is the OPERATIONS section).
+ */
+async function makeArm(): Promise<Arm> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), 's6-acceptance-'));
+  const store = new EventStore(stateDir);
+  await store.initialize();
+  const ctx: DispatchContext = { stateDir, eventStore: store, enableTelemetry: false };
+  const arm: Arm = { stateDir, store, ctx };
+  arms.push(arm);
+  return arm;
+}
+
+/** Flush the micro/macrotask queue so a not-awaited `wait` reaches its subscribe. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+/** Deterministic wait deps: a fixed clock + a captured deadline the test fires. */
+function deterministicDeps(clock: SubscriptionClock): {
+  deps: WaitDeps;
+  fireDeadline: () => void;
+} {
+  let deadlineCb: (() => void) | undefined;
+  const deps: WaitDeps = {
+    now: () => 1000,
+    scheduleTimeout: (cb) => {
+      deadlineCb = cb;
+      return () => {
+        deadlineCb = undefined;
+      };
+    },
+    subscriptionOptions: { clock },
+  };
+  return { deps, fireDeadline: () => deadlineCb?.() };
+}
+
+// ─── Seed helpers (via the REAL store's append path) ───────────────────────────
+
+async function seedWorkflow(store: EventStore, featureId: string): Promise<void> {
+  await store.append(featureId, {
+    type: 'workflow.started',
+    data: { featureId, workflowType: 'feature' },
+  });
+}
+
+/** Commit a `merge.executing_started` CLAIM with NO terminal — the crash. */
+async function seedCrashedMerge(store: EventStore, featureId: string, instanceId: string): Promise<void> {
+  await store.append(featureId, {
+    type: 'merge.executing_started',
+    data: {
+      instanceId,
+      sourceBranch: 'feat/s6',
+      targetBranch: 'main',
+      recoveryPointSha: 'deadbeef',
+      startedAt: new Date().toISOString(),
+    },
+  });
+}
+
+/** Append the DR-2 registry terminal `merge.recovered`, matched by instance key. */
+async function appendMergeRecovered(store: EventStore, featureId: string, instanceId: string): Promise<void> {
+  await store.append(featureId, {
+    type: 'merge.recovered',
+    data: {
+      instanceId,
+      sourceBranch: 'feat/s6',
+      targetBranch: 'main',
+      recoveryPointSha: 'deadbeef',
+    },
+  });
+}
+
+// ─── The acceptance walkthrough ───────────────────────────────────────────────
+
+describe('S-6 stuck-executing merge recovery (acceptance — real store, real handlers)', () => {
+  it('S6_StuckMerge_PsInspectWaitTimeout_ThenRecoveredWaitResolves', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 's6-feat';
+    const instanceId = 'merge-crash-1';
+
+    // ── Step 1: seed the crash — a merge start with no terminal on a real store.
+    await seedWorkflow(store, featureId);
+    await seedCrashedMerge(store, featureId, instanceId);
+
+    // ── Step 2 (DR-3 north-star): `ps --scope all` lists the stuck merge in its
+    //    OPERATIONS section, shaped {surface:'merge', instanceKey:…}. ───────────
+    const psResult = await handleViewPs({ scope: 'all' }, ctx, { now: () => NOW_MS });
+    expect(psResult.success).toBe(true);
+    const psData = psResult.data as {
+      scope: string;
+      operations: InFlightOperation[];
+      operationCount: number;
+    };
+    expect(psData.scope).toBe('all');
+    const stuckMerge = psData.operations.find((o) => o.surface === 'merge');
+    expect(stuckMerge).toBeDefined();
+    expect(stuckMerge?.instanceKey).toBe(instanceId);
+    expect(stuckMerge?.streamScope).toBe('feature');
+    expect(stuckMerge?.startType).toBe('merge.executing_started');
+    // Deterministic age off the injected clock (started at T+…, now T+10) → > 0.
+    expect(stuckMerge?.ageMs).toBeGreaterThanOrEqual(0);
+
+    // ── Step 3: `inspect` shows the unpaired start still in flight — the
+    //    `merge.executing_started` is in `recentEvents`, with NO merge terminal. ─
+    const inspectResult = await handleViewInspect({ featureId }, ctx);
+    expect(inspectResult.success).toBe(true);
+    const inspectData = inspectResult.data as {
+      workflowExists: boolean;
+      recentEvents: Array<{ type: string }>;
+    };
+    expect(inspectData.workflowExists).toBe(true);
+    const inspectedTypes = inspectData.recentEvents.map((e) => e.type);
+    expect(inspectedTypes).toContain('merge.executing_started');
+    expect(inspectedTypes).not.toContain('merge.executed');
+    expect(inspectedTypes).not.toContain('merge.recovered');
+
+    // ── Step 4 (DR-5/DR-8): `wait --operation merge` with a short timeout returns
+    //    a STRUCTURED WAIT_TIMEOUT (CLI → exit 17) while no terminal exists. ─────
+    const { deps, fireDeadline } = deterministicDeps(new ManualSubscriptionClock());
+    const timeoutMs = 250;
+    const waitP = handleViewWait({ featureId, operation: 'merge', timeoutMs }, ctx, deps);
+    await flush(); // let the precheck fold + subscription register + deadline capture
+    fireDeadline(); // fire the bounded deadline directly (no wall-clock sleep)
+    const timeoutResult = await waitP;
+
+    expect(timeoutResult.success).toBe(false);
+    expect(timeoutResult.error?.code).toBe('WAIT_TIMEOUT');
+    expect((timeoutResult.data as { reason: string }).reason).toBe('wait-timeout');
+    expect((timeoutResult.data as { operation?: string }).operation).toBe('merge');
+    expect((timeoutResult.data as { timeoutMs: number }).timeoutMs).toBe(timeoutMs);
+
+    // ── Step 5: append `merge.recovered` (registry terminal, matched by instance
+    //    key) → a FRESH `wait --operation merge` now resolves immediately. ───────
+    await appendMergeRecovered(store, featureId, instanceId);
+
+    const resolveResult = await handleViewWait({ featureId, operation: 'merge' }, ctx);
+    expect(resolveResult.success).toBe(true);
+    expect((resolveResult.data as { resolved: boolean }).resolved).toBe(true);
+    expect((resolveResult.data as { waitedMs: number }).waitedMs).toBe(0); // precheck — never subscribed
+    expect((resolveResult.data as { operation?: string }).operation).toBe('merge');
+
+    // And `ps` corroborates: the merge is no longer in flight (recovery cleared it).
+    const psAfter = await handleViewPs({ scope: 'all' }, ctx, { now: () => NOW_MS });
+    const opsAfter = (psAfter.data as { operations: InFlightOperation[] }).operations;
+    expect(opsAfter.some((o) => o.surface === 'merge')).toBe(false);
+  });
+
+  // ── Step 6 — FENCE (a guard, not the proof): the DR-3 genericity that makes the
+  //    behavioral walkthrough above hold for every liveness surface is that the
+  //    generic verbs never BRANCH on the `merge` surface literal. The registry is
+  //    the only place a surface is named; the operation predicate + operations
+  //    fold iterate it. This grep fails loudly if a future edit re-introduces
+  //    merge-specific control flow (`surface === 'merge'` / `case 'merge'`). ─────
+  it('S6_Fence_GenericVerbsDoNotBranchOnMergeLiteral', () => {
+    const waitSrc = readFileSync(fileURLToPath(new URL('./wait.ts', import.meta.url)), 'utf-8');
+    const foldSrc = readFileSync(fileURLToPath(new URL('./operations-fold.ts', import.meta.url)), 'utf-8');
+
+    // Merge-specific BRANCHING patterns (comments and the worktree-scope
+    // `until: 'merge'` suggestedFix payload are NOT branching and do not match).
+    const MERGE_BRANCH_PATTERNS: readonly RegExp[] = [
+      /===\s*['"]merge['"]/,
+      /['"]merge['"]\s*===/,
+      /!==\s*['"]merge['"]/,
+      /['"]merge['"]\s*!==/,
+      /case\s+['"]merge['"]/,
+    ];
+
+    for (const file of [
+      { name: 'wait.ts', text: waitSrc },
+      { name: 'operations-fold.ts', text: foldSrc },
+    ]) {
+      for (const pattern of MERGE_BRANCH_PATTERNS) {
+        expect(
+          pattern.test(file.text),
+          `${file.name} must not branch on the 'merge' surface literal (matched ${pattern})`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/schema-fields.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/schema-fields.ts
@@ -12,30 +12,36 @@
 // *contract*: a different base kind (enum/string/number/boolean/...), a
 // different enum value set, or a different default. (Optionality and
 // refinements like `.min()`/`.positive()` are contract-neutral — the per-action
-// handler schema re-validates those via dispatch.) So a lifecycle verb that
-// hand-rolled `scope: z.string()` while `pipeline` already declares
-// `scope: z.enum(['repo','all'])` would crash MCP registration at module load.
+// handler schema re-validates those via dispatch.) So two view actions that
+// declare `scope` with DIFFERENT enum value sets would crash MCP registration
+// at module load — which is exactly why `scope` is defined ONCE here and every
+// action that carries a scope axis imports THIS shape.
 //
 // BASE-TYPE ALIGNMENT (where a name ALSO exists on an existing view action)
 // The four names below already appear on shipped `exarchos_view` actions; the
 // canonical shape here is aligned to the EXISTING contract EXACTLY so the
 // composed registration never throws. `registry.construction.test.ts` pins this
 // (both the "does not throw" guard and the base-type-match assertions):
-//   • scope        → z.enum(['repo','all'])   (matches `pipeline.scope`)
+//   • scope        → z.enum(['repo','all','workflow','worktree'])  (the UNION —
+//                     `pipeline` uses the ['repo','all'] members, `ps` uses the
+//                     ['workflow','worktree','all'] members; both import THIS shape)
 //   • phase        → z.string()               (matches `invariants_effective.phase`)
 //   • workflowType → z.string()               (matches `invariants_effective.workflowType`)
 //   • limit        → coercedPositiveInt()      (matches the shared `limit` on
 //                                               pipeline/tasks/stack_status/etc.)
 //
-// SCOPE CAVEAT (for tasks 007/008/010/013 and the feature owner)
-// The shared `scope` value set is `['repo','all']` — forced by the still-inline
-// `pipeline.scope` on the same tool. It is NOT `['workflow','worktree','all']`
-// as DR-3's `ps` prose reads: an enum with that value set would diverge from
-// `pipeline.scope` and make `buildRegistrationSchema` THROW (DR-8's own
-// registration-integrity criterion). Until `pipeline.scope` is migrated onto
-// this shared shape (a `registry.ts` edit no task in the plan makes), the `ps`
-// process-plane selector must NOT reuse this `scope` for a workflow/worktree/all
-// axis — pick a distinct field name for that axis, or migrate `pipeline` first.
+// SCOPE — the UNION resolution (DR-3, task 007)
+// `ps` needs a `workflow|worktree|all` axis; `pipeline` (GA) uses `repo|all`.
+// Two actions declaring `scope` with divergent enum value sets on the SAME tool
+// make `buildRegistrationSchema` THROW. Task 007 resolved this by WIDENING this
+// shared shape to the additive UNION of both value sets and migrating
+// `pipeline.scope` onto it — so the tool carries ONE `scope` definition (no
+// collision). Every existing `pipeline` value (`repo`/`all`) is still valid, and
+// each action validates its OWN subset at the handler: `pipeline` acts on
+// `repo`/`all` (and ignores `workflow`/`worktree`); `ps` accepts
+// `workflow`/`worktree`/`all` and REJECTS `repo`. The registration-flattener
+// only cares that the enum value SET matches across actions — it does; per-action
+// subset enforcement is a handler concern, re-validated via dispatch.
 //
 // The remaining names are new to `exarchos_view`, so their base type is a free
 // (but deliberate) choice; each is documented at its declaration.
@@ -45,11 +51,15 @@ import { z } from 'zod';
 import { coercedPositiveInt } from '../../coerce.js';
 
 /**
- * `scope` — repo-scoping selector. COLLIDES with `pipeline.scope`, so the base
- * type is pinned to that action's exact `z.enum(['repo','all'])` contract. See
- * the SCOPE CAVEAT above before reusing this for a process-plane axis.
+ * `scope` — the shared scoping selector across `exarchos_view` (DR-3, task 007).
+ * The UNION of every action's scope members so ONE definition serves both
+ * `pipeline` (`repo`/`all`) and `ps` (`workflow`/`worktree`/`all`) without a
+ * flattener collision. Each action validates its own subset at the handler
+ * (`pipeline` acts on `repo`/`all`; `ps` accepts `workflow`/`worktree`/`all` and
+ * rejects `repo`) — the registration guard only requires the enum value SET to
+ * match across the actions that declare it, which this single shape guarantees.
  */
-export const scopeField = z.enum(['repo', 'all']);
+export const scopeField = z.enum(['repo', 'all', 'workflow', 'worktree']);
 
 /**
  * `status` — workflow status filter (`ps`) / terminal-status predicate

--- a/servers/exarchos-mcp/src/views/lifecycle/schema-fields.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/schema-fields.ts
@@ -1,0 +1,132 @@
+// ─── Shared lifecycle-verb field shapes (DR-8) ──────────────────────────────
+//
+// One canonical Zod definition per lifecycle field name. Every lifecycle verb
+// (`ps` / `wait` / `inspect` / `export`) imports the SAME shape from here
+// instead of redefining it inline, so the four verb schemas cannot drift a
+// shared field's base type apart from one another.
+//
+// WHY THIS MODULE EXISTS — the registry-THROW footgun
+// `buildRegistrationSchema` (registry.ts) flattens every action of a composite
+// tool (`exarchos_view`) into ONE strict object. Its field-contract guard
+// THROWS if two actions declare the same field name with a divergent
+// *contract*: a different base kind (enum/string/number/boolean/...), a
+// different enum value set, or a different default. (Optionality and
+// refinements like `.min()`/`.positive()` are contract-neutral — the per-action
+// handler schema re-validates those via dispatch.) So a lifecycle verb that
+// hand-rolled `scope: z.string()` while `pipeline` already declares
+// `scope: z.enum(['repo','all'])` would crash MCP registration at module load.
+//
+// BASE-TYPE ALIGNMENT (where a name ALSO exists on an existing view action)
+// The four names below already appear on shipped `exarchos_view` actions; the
+// canonical shape here is aligned to the EXISTING contract EXACTLY so the
+// composed registration never throws. `registry.construction.test.ts` pins this
+// (both the "does not throw" guard and the base-type-match assertions):
+//   • scope        → z.enum(['repo','all'])   (matches `pipeline.scope`)
+//   • phase        → z.string()               (matches `invariants_effective.phase`)
+//   • workflowType → z.string()               (matches `invariants_effective.workflowType`)
+//   • limit        → coercedPositiveInt()      (matches the shared `limit` on
+//                                               pipeline/tasks/stack_status/etc.)
+//
+// SCOPE CAVEAT (for tasks 007/008/010/013 and the feature owner)
+// The shared `scope` value set is `['repo','all']` — forced by the still-inline
+// `pipeline.scope` on the same tool. It is NOT `['workflow','worktree','all']`
+// as DR-3's `ps` prose reads: an enum with that value set would diverge from
+// `pipeline.scope` and make `buildRegistrationSchema` THROW (DR-8's own
+// registration-integrity criterion). Until `pipeline.scope` is migrated onto
+// this shared shape (a `registry.ts` edit no task in the plan makes), the `ps`
+// process-plane selector must NOT reuse this `scope` for a workflow/worktree/all
+// axis — pick a distinct field name for that axis, or migrate `pipeline` first.
+//
+// The remaining names are new to `exarchos_view`, so their base type is a free
+// (but deliberate) choice; each is documented at its declaration.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { z } from 'zod';
+import { coercedPositiveInt } from '../../coerce.js';
+
+/**
+ * `scope` — repo-scoping selector. COLLIDES with `pipeline.scope`, so the base
+ * type is pinned to that action's exact `z.enum(['repo','all'])` contract. See
+ * the SCOPE CAVEAT above before reusing this for a process-plane axis.
+ */
+export const scopeField = z.enum(['repo', 'all']);
+
+/**
+ * `status` — workflow status filter (`ps`) / terminal-status predicate
+ * (`wait`). Base type `z.string()`, not an enum: the two consumers accept
+ * different valid sets — `ps` filters any workflow status (active + terminal),
+ * `wait` resolves only on a terminal status (`completed`/`failed`/`cancelled`)
+ * — so a single shared enum would be wrong for one of them. Each verb validates
+ * its own valid set at the handler. No existing `exarchos_view` field collision.
+ */
+export const statusField = z.string();
+
+/**
+ * `phase` — SDLC phase name. COLLIDES with `invariants_effective.phase`, so the
+ * base type is pinned to that action's `z.string()` contract.
+ */
+export const phaseField = z.string();
+
+/**
+ * `workflowType` — workflow-kind filter. COLLIDES with
+ * `invariants_effective.workflowType`, so the base type is pinned to that
+ * action's `z.string()` contract.
+ */
+export const workflowTypeField = z.string();
+
+/**
+ * `all` — boolean "include completed/cancelled" (unfiltered) flag. Base type
+ * `z.boolean()`. No existing `exarchos_view` field collision.
+ */
+export const allField = z.boolean();
+
+/**
+ * `follow` — boolean `--follow` streaming flag (`inspect`). Base type
+ * `z.boolean()`. No existing `exarchos_view` field collision.
+ */
+export const followField = z.boolean();
+
+/**
+ * `limit` — bounded-output item cap. COLLIDES with the shared `limit` declared
+ * across `pipeline`/`tasks`/`stack_status`/… so the base type is pinned to the
+ * exact `coercedPositiveInt()` (number, coerces numeric strings) those actions
+ * use. Reusing the same factory keeps the flattened contract identical.
+ */
+export const limitField = coercedPositiveInt();
+
+/**
+ * `output` — `export` destination FILE PATH (DR-6: default
+ * `./<featureId>-export.zip`). Base type `z.string()` — it is a path, NOT a
+ * `table|json` format enum. No existing `exarchos_view` field collision.
+ */
+export const outputField = z.string();
+
+/**
+ * `operation` — `wait --operation <surface>` liveness surface selector (the S-6
+ * predicate). Base type `z.string()`, not an enum: the valid surface set is the
+ * live liveness-descriptor registry (extensible — new surfaces land as one
+ * registry entry), so `wait` validates the surface (and its feature-scope
+ * eligibility) against that registry at the handler rather than freezing a
+ * hardcoded enum here. No existing `exarchos_view` field collision.
+ */
+export const operationField = z.string();
+
+/**
+ * Name → canonical shape map, for programmatic composition (e.g. the
+ * registration-construction guard test) and to keep the field roster in one
+ * place. Verb handlers normally import the individual `*Field` consts.
+ */
+export const LIFECYCLE_FIELD_SHAPES = {
+  scope: scopeField,
+  status: statusField,
+  phase: phaseField,
+  workflowType: workflowTypeField,
+  all: allField,
+  follow: followField,
+  limit: limitField,
+  output: outputField,
+  operation: operationField,
+} as const;
+
+/** The canonical lifecycle field names this module defines (DR-8). */
+export type LifecycleFieldName = keyof typeof LIFECYCLE_FIELD_SHAPES;

--- a/servers/exarchos-mcp/src/views/lifecycle/wait.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/wait.test.ts
@@ -141,12 +141,15 @@ function deterministicDeps(clock?: SubscriptionClock): {
   deps: WaitDeps;
   fireDeadline: () => void;
   deadlineScheduled: () => boolean;
+  scheduledMs: () => number | undefined;
 } {
   let deadlineCb: (() => void) | undefined;
+  let scheduledMs: number | undefined;
   const deps: WaitDeps = {
     now: () => 1000,
-    scheduleTimeout: (cb) => {
+    scheduleTimeout: (cb, ms) => {
       deadlineCb = cb;
+      scheduledMs = ms;
       return () => {
         deadlineCb = undefined;
       };
@@ -157,6 +160,7 @@ function deterministicDeps(clock?: SubscriptionClock): {
     deps,
     fireDeadline: () => deadlineCb?.(),
     deadlineScheduled: () => deadlineCb !== undefined,
+    scheduledMs: () => scheduledMs,
   };
 }
 
@@ -181,6 +185,31 @@ describe('wait — phase predicate', () => {
     expect((result.data as { waitedMs: number }).waitedMs).toBe(0);
     expect((result.data as { phase?: string }).phase).toBe('plan-review');
     expect(await totalEvents(store)).toBe(before);
+  });
+
+  it('Wait_TimeoutMsAboveNodeTimerCeiling_ClampedNotWrappedToNearImmediate', async () => {
+    // Node's setTimeout does NOT clamp: a delay above 2^31-1 ms silently
+    // becomes 1ms and fires almost immediately, flipping a deliberately-huge
+    // timeoutMs into a near-instant WAIT_TIMEOUT — the exact opposite of the
+    // caller's "wait longer" intent. The resolved budget must be clamped.
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-clamp';
+    await seedWorkflow(store, featureId);
+
+    const { deps, fireDeadline, scheduledMs } = deterministicDeps();
+    // Well past the ceiling (~24.85 days).
+    const waitP = handleViewWait(
+      { featureId, phase: 'plan-review', timeoutMs: 9_999_999_999 },
+      ctx,
+      deps,
+    );
+    await flush(); // let the precheck complete and the deadline get scheduled
+
+    expect(scheduledMs()).toBe(2_147_483_647);
+
+    fireDeadline(); // resolve the pending wait so the test doesn't hang
+    const result = await waitP;
+    expect(result.success).toBe(false);
   });
 
   it('Wait_InProcessTransition_ResolvesOnTier1Wake', async () => {
@@ -414,7 +443,10 @@ describe('wait — operation predicate (S-6)', () => {
     // validTargets = the feature-scoped surfaces; suggestedFix points at `until`.
     expect(result.error?.validTargets).toEqual(expect.arrayContaining(['merge', 'mutation']));
     expect(result.error?.validTargets).not.toContain('launch');
-    expect(result.error?.suggestedFix?.tool).toBe('wait');
+    // `wait` is an exarchos_view ACTION, not a tool of its own — the fix must
+    // name the tool and carry `action`, or a client cannot replay it (INV-5b).
+    expect(result.error?.suggestedFix?.tool).toBe('exarchos_view');
+    expect(result.error?.suggestedFix?.params).toMatchObject({ action: 'wait' });
     expect(result.error?.suggestedFix?.params).toHaveProperty('until');
     expect(await totalEvents(store)).toBe(before); // side-effect free
   });

--- a/servers/exarchos-mcp/src/views/lifecycle/wait.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/wait.test.ts
@@ -332,6 +332,33 @@ describe('wait — status predicate', () => {
     expect(result.error?.code).toBe('WAIT_FAILED');
     expect((result.data as { terminalStatus: string }).terminalStatus).toBe('cancelled');
   });
+
+  it('Wait_StatusPredicate_NonTerminalStatus_InvalidInputWithTerminalTargets', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-status-nonterminal';
+    await seedWorkflow(store, featureId);
+    // Drive the workflow INTO the `delegate` phase. Pre-fix, `--status delegate`
+    // built a statusPredicate whose seedPhase already equals `delegate`, so the
+    // precheck resolved IMMEDIATELY on phase-equality — conflating status with
+    // phase. The guard must reject `delegate` (a non-terminal phase, not a
+    // terminal status) with INVALID_INPUT BEFORE that conflation can occur,
+    // symmetric with the `--phase` topology guard and the `--operation` surface
+    // guard.
+    await appendTransition(store, featureId, 'plan', 'delegate');
+
+    const before = await totalEvents(store);
+    const result = await handleViewWait({ featureId, status: 'delegate' }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    // validTargets = exactly the terminal statuses; `delegate` is not among them.
+    expect(result.error?.validTargets).toEqual(['completed', 'failed', 'cancelled']);
+    expect(result.error?.validTargets).not.toContain('delegate');
+    expect(result.error?.expectedShape).toHaveProperty('status');
+    // It must NOT have resolved immediately (the pre-fix phase-equality bug).
+    expect((result.data as { resolved?: boolean } | undefined)?.resolved).not.toBe(true);
+    expect(await totalEvents(store)).toBe(before); // side-effect free
+  });
 });
 
 // ─── Operation predicate (S-6) ────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/views/lifecycle/wait.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/wait.test.ts
@@ -1,0 +1,576 @@
+// ─── `wait` — generic event-driven gate (DR-5 / DR-8) ────────────────────────
+//
+// Boundary discipline: every test drives the REAL event store + REAL DR-1
+// subscription primitive + REAL DR-2 liveness registry — no hand-mocks of those
+// seams. Determinism comes from INJECTED clocks/timers only (INV-16): a
+// `ManualClock` on the subscription registry drives the Tier-2 floor tick-by-
+// tick, and a captured `scheduleTimeout` fires the bounded deadline directly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fc from 'fast-check';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../event-store/store.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+import type { SubscriptionClock } from '../../event-store/subscriptions.js';
+import {
+  handleViewWait,
+  phasePredicate,
+  statusPredicate,
+  operationPredicate,
+  type WaitDeps,
+} from './wait.js';
+import { LIVENESS_REGISTRY } from '../../event-store/liveness-registry.js';
+
+// ─── Manually-driven subscription clock (INV-16) ──────────────────────────────
+//
+// Mirrors the `ManualClock` in `subscriptions.test.ts`: a real, deterministic
+// SubscriptionClock whose Tier-2 floor loop fires only when the test calls
+// `fireAll()` — no wall-clock sleep. Injected via `WaitDeps.subscriptionOptions`
+// so the wait's own DR-1 subscription runs on it (the FIRST subscribe on a fresh
+// store, so the lazily-created registry adopts this clock).
+class ManualSubscriptionClock implements SubscriptionClock {
+  time = 0;
+  private readonly loops: Array<{ tick: () => void }> = [];
+  now(): number {
+    return this.time;
+  }
+  scheduleInterval(tick: () => void): () => void {
+    const entry = { tick };
+    this.loops.push(entry);
+    return () => {
+      const i = this.loops.indexOf(entry);
+      if (i >= 0) this.loops.splice(i, 1);
+    };
+  }
+  fireAll(): void {
+    for (const { tick } of [...this.loops]) tick();
+  }
+}
+
+// ─── Arm / fixtures ──────────────────────────────────────────────────────────
+
+interface Arm {
+  readonly stateDir: string;
+  readonly store: EventStore;
+  readonly ctx: DispatchContext;
+}
+
+let arms: Arm[] = [];
+
+afterEach(async () => {
+  for (const arm of arms) {
+    arm.store.close();
+    await rmrfAsync(arm.stateDir);
+  }
+  arms = [];
+});
+
+async function makeArm(): Promise<Arm> {
+  const stateDir = await mkdtemp(path.join(tmpdir(), 'wait-verb-'));
+  const store = new EventStore(stateDir);
+  await store.initialize();
+  const ctx = { stateDir, eventStore: store, enableTelemetry: false } as unknown as DispatchContext;
+  const arm: Arm = { stateDir, store, ctx };
+  arms.push(arm);
+  return arm;
+}
+
+/** Flush the microtask + macrotask queue so a not-awaited `wait` reaches its subscribe. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function seedWorkflow(store: EventStore, featureId: string, workflowType = 'feature'): Promise<void> {
+  await store.append(featureId, { type: 'workflow.started', data: { featureId, workflowType } });
+}
+
+async function appendTransition(
+  store: EventStore,
+  featureId: string,
+  from: string,
+  to: string,
+): Promise<void> {
+  await store.append(featureId, {
+    type: 'workflow.transition',
+    data: { from, to, trigger: 'test', featureId },
+  });
+}
+
+async function appendMergeStart(store: EventStore, featureId: string, instanceId: string): Promise<void> {
+  await store.append(featureId, {
+    type: 'merge.executing_started',
+    data: {
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      recoveryPointSha: 'deadbeef',
+      startedAt: new Date().toISOString(),
+      instanceId,
+    },
+  });
+}
+
+async function appendMergeTerminal(store: EventStore, featureId: string, instanceId: string): Promise<void> {
+  await store.append(featureId, {
+    type: 'merge.executed',
+    data: {
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      mergeSha: 'cafef00d',
+      rollbackSha: 'deadbeef',
+      instanceId,
+    },
+  });
+}
+
+/** Sum committed events across every stream (event-count-invariance witness). */
+async function totalEvents(store: EventStore): Promise<number> {
+  let total = 0;
+  for (const streamId of store.listStreams()) {
+    total += (await store.query(streamId)).length;
+  }
+  return total;
+}
+
+/** Deterministic deps: a fixed clock + a captured deadline the test fires. */
+function deterministicDeps(clock?: SubscriptionClock): {
+  deps: WaitDeps;
+  fireDeadline: () => void;
+  deadlineScheduled: () => boolean;
+} {
+  let deadlineCb: (() => void) | undefined;
+  const deps: WaitDeps = {
+    now: () => 1000,
+    scheduleTimeout: (cb) => {
+      deadlineCb = cb;
+      return () => {
+        deadlineCb = undefined;
+      };
+    },
+    ...(clock ? { subscriptionOptions: { clock } } : {}),
+  };
+  return {
+    deps,
+    fireDeadline: () => deadlineCb?.(),
+    deadlineScheduled: () => deadlineCb !== undefined,
+  };
+}
+
+// ─── Precheck (immediate resolution, no subscription) ────────────────────────
+
+describe('wait — phase predicate', () => {
+  it('Wait_PhaseAlreadyPassed_ReturnsImmediatelyWithoutSubscribing', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-passed';
+    await seedWorkflow(store, featureId);
+    await appendTransition(store, featureId, 'plan', 'plan-review');
+    await appendTransition(store, featureId, 'plan-review', 'delegate');
+
+    const before = await totalEvents(store);
+    // No injected deadline is fired: if this SUBSCRIBED, it would hang → the
+    // test would time out. Immediate precheck resolution is the only way it
+    // returns without us firing a deadline.
+    const result = await handleViewWait({ featureId, phase: 'plan-review' }, ctx);
+
+    expect(result.success).toBe(true);
+    expect((result.data as { resolved: boolean }).resolved).toBe(true);
+    expect((result.data as { waitedMs: number }).waitedMs).toBe(0);
+    expect((result.data as { phase?: string }).phase).toBe('plan-review');
+    expect(await totalEvents(store)).toBe(before);
+  });
+
+  it('Wait_InProcessTransition_ResolvesOnTier1Wake', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-tier1';
+    await seedWorkflow(store, featureId);
+
+    const clock = new ManualSubscriptionClock();
+    const { deps } = deterministicDeps(clock);
+    const before = await totalEvents(store);
+
+    const waitP = handleViewWait({ featureId, phase: 'plan-review', timeoutMs: 60_000 }, ctx, deps);
+    await flush(); // let the precheck complete and the subscription register
+
+    // In-process append → Tier-1 post-commit hook delivers synchronously; NO
+    // floor tick is fired (clock.fireAll never called).
+    await appendTransition(store, featureId, 'plan', 'plan-review');
+    const result = await waitP;
+
+    expect(result.success).toBe(true);
+    expect((result.data as { phase?: string }).phase).toBe('plan-review');
+    const perf = (result.data as { perf?: { floorTicks: number; floorDrains: number } }).perf;
+    expect(perf?.floorTicks).toBe(0); // resolved on Tier-1 wake — no floor tick consumed
+    expect(perf?.floorDrains).toBe(0);
+    // The transition is the ONLY new event; wait appended nothing.
+    expect(await totalEvents(store)).toBe(before + 1);
+  });
+
+  it('Wait_ForeignConnectionEvent_ResolvesWithinOneFloorTick_PerfSurfaced', async () => {
+    const { store, ctx, stateDir } = await makeArm();
+    const featureId = 'feat-foreign';
+    await seedWorkflow(store, featureId);
+
+    // A second connection on the same DB: its commit does NOT wake `store`'s
+    // Tier-1 hook, so only the Tier-2 poll floor can pull it.
+    const foreign = new EventStore(stateDir);
+    await foreign.initialize();
+    try {
+      const clock = new ManualSubscriptionClock();
+      const { deps } = deterministicDeps(clock);
+
+      const waitP = handleViewWait({ featureId, phase: 'plan-review', timeoutMs: 60_000 }, ctx, deps);
+      await flush(); // wait subscribes on `store` with the ManualClock floor
+
+      await appendTransition(foreign, featureId, 'plan', 'plan-review'); // foreign — no Tier-1 wake
+      await flush();
+      // Exactly one floor tick drains the foreign commit and resolves the wait.
+      clock.fireAll();
+      const result = await waitP;
+
+      expect(result.success).toBe(true);
+      expect((result.data as { phase?: string }).phase).toBe('plan-review');
+      const perf = (result.data as { perf?: { floorMs: number; floorDrains: number } }).perf;
+      expect(perf).toBeDefined();
+      expect(perf?.floorMs).toBeGreaterThan(0); // the floor interval is surfaced
+      expect(perf?.floorDrains).toBe(1); // resolved within ONE floor drain
+    } finally {
+      foreign.close();
+    }
+  });
+
+  it('Wait_Timeout_StructuredWaitTimeout', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-timeout';
+    await seedWorkflow(store, featureId); // stays in 'plan'
+
+    const { deps, fireDeadline } = deterministicDeps(new ManualSubscriptionClock());
+    const before = await totalEvents(store);
+
+    const waitP = handleViewWait({ featureId, phase: 'delegate', timeoutMs: 5000 }, ctx, deps);
+    await flush();
+    fireDeadline(); // fire the bounded deadline
+    const result = await waitP;
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('WAIT_TIMEOUT');
+    expect((result.data as { reason: string }).reason).toBe('wait-timeout');
+    expect((result.data as { timeoutMs: number }).timeoutMs).toBe(5000);
+    expect(await totalEvents(store)).toBe(before);
+  });
+
+  it('Wait_WorkflowCancelledMidWait_WaitFailed', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-cancel';
+    await seedWorkflow(store, featureId);
+
+    const { deps } = deterministicDeps(new ManualSubscriptionClock());
+    const before = await totalEvents(store);
+
+    const waitP = handleViewWait({ featureId, phase: 'review', timeoutMs: 60_000 }, ctx, deps);
+    await flush();
+    // The workflow is cancelled while we wait on `review` → review unreachable.
+    await appendTransition(store, featureId, 'plan', 'cancelled');
+    const result = await waitP;
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('WAIT_FAILED');
+    expect((result.data as { terminalStatus: string }).terminalStatus).toBe('cancelled');
+    expect(await totalEvents(store)).toBe(before + 1); // only the transition
+  });
+});
+
+// ─── Status predicate ─────────────────────────────────────────────────────────
+
+describe('wait — status predicate', () => {
+  it('Wait_StatusPredicate_ResolvesOnRequestedTerminal', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-status-ok';
+    await seedWorkflow(store, featureId);
+    await appendTransition(store, featureId, 'plan', 'plan-review');
+
+    const { deps } = deterministicDeps(new ManualSubscriptionClock());
+    const waitP = handleViewWait({ featureId, status: 'completed', timeoutMs: 60_000 }, ctx, deps);
+    await flush();
+    await appendTransition(store, featureId, 'plan-review', 'completed');
+    const result = await waitP;
+
+    expect(result.success).toBe(true);
+    expect((result.data as { status?: string }).status).toBe('completed');
+  });
+
+  it('Wait_StatusPredicate_AlreadyTerminal_ReturnsImmediately', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-status-done';
+    await seedWorkflow(store, featureId);
+    await appendTransition(store, featureId, 'plan', 'completed');
+
+    const before = await totalEvents(store);
+    const result = await handleViewWait({ featureId, status: 'completed' }, ctx);
+
+    expect(result.success).toBe(true);
+    expect((result.data as { waitedMs: number }).waitedMs).toBe(0);
+    expect(await totalEvents(store)).toBe(before);
+  });
+
+  it('Wait_StatusPredicate_DifferentTerminalArrives_WaitFailed', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-status-diff';
+    await seedWorkflow(store, featureId);
+
+    const { deps } = deterministicDeps(new ManualSubscriptionClock());
+    const waitP = handleViewWait({ featureId, status: 'completed', timeoutMs: 60_000 }, ctx, deps);
+    await flush();
+    // Requested `completed`, but `cancelled` arrives first → WAIT_FAILED.
+    await appendTransition(store, featureId, 'plan', 'cancelled');
+    const result = await waitP;
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('WAIT_FAILED');
+    expect((result.data as { terminalStatus: string }).terminalStatus).toBe('cancelled');
+  });
+});
+
+// ─── Operation predicate (S-6) ────────────────────────────────────────────────
+
+describe('wait — operation predicate (S-6)', () => {
+  it('Wait_OperationPredicate_ResolvesOnRegistryTerminalByInstanceKey', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-op';
+    await seedWorkflow(store, featureId);
+    await appendMergeStart(store, featureId, 'merge-1'); // in flight
+
+    const { deps } = deterministicDeps(new ManualSubscriptionClock());
+    const before = await totalEvents(store);
+
+    const waitP = handleViewWait({ featureId, operation: 'merge', timeoutMs: 60_000 }, ctx, deps);
+    await flush();
+    // The registry terminal for the SAME instance key clears the in-flight set.
+    await appendMergeTerminal(store, featureId, 'merge-1');
+    const result = await waitP;
+
+    expect(result.success).toBe(true);
+    expect((result.data as { operation?: string }).operation).toBe('merge');
+    expect(await totalEvents(store)).toBe(before + 1); // only the terminal event
+  });
+
+  it('Wait_OperationPredicate_NoInFlight_ReturnsImmediately', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-op-idle';
+    await seedWorkflow(store, featureId);
+    // A merge that already completed → nothing in flight.
+    await appendMergeStart(store, featureId, 'merge-done');
+    await appendMergeTerminal(store, featureId, 'merge-done');
+
+    const before = await totalEvents(store);
+    const result = await handleViewWait({ featureId, operation: 'merge' }, ctx);
+
+    expect(result.success).toBe(true);
+    expect((result.data as { waitedMs: number }).waitedMs).toBe(0);
+    expect(await totalEvents(store)).toBe(before);
+  });
+
+  it('Wait_OperationPredicate_NonFeatureScopedSurface_InvalidInputWithSuggestedFix', async () => {
+    const { store, ctx } = await makeArm();
+    const featureId = 'feat-op-launch';
+    await seedWorkflow(store, featureId);
+
+    const before = await totalEvents(store);
+    // `launch` is worktrees-scoped (not feature-observable).
+    const result = await handleViewWait({ featureId, operation: 'launch' }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    // validTargets = the feature-scoped surfaces; suggestedFix points at `until`.
+    expect(result.error?.validTargets).toEqual(expect.arrayContaining(['merge', 'mutation']));
+    expect(result.error?.validTargets).not.toContain('launch');
+    expect(result.error?.suggestedFix?.tool).toBe('wait');
+    expect(result.error?.suggestedFix?.params).toHaveProperty('until');
+    expect(await totalEvents(store)).toBe(before); // side-effect free
+  });
+});
+
+// ─── Worktree scope preservation (WLM-6 kernel absorbed) ─────────────────────
+
+describe('wait — worktree scope (WLM-6 absorbed)', () => {
+  it('Wait_WorktreeScope_PreservesWlm6Capabilities', async () => {
+    const { store, ctx } = await makeArm();
+    const before = await totalEvents(store);
+
+    // `until: 'idle'` on a store with no in-flight prune resolves immediately —
+    // the exact WLM-6 kernel behavior, now reached through the generic verb.
+    const result = await handleViewWait({ until: 'idle', timeoutMs: 1000 }, ctx);
+
+    expect(result.success).toBe(true);
+    expect((result.data as { until?: string; resolved: boolean }).until).toBe('idle');
+    expect((result.data as { resolved: boolean }).resolved).toBe(true);
+    expect(await totalEvents(store)).toBe(before); // pure read
+  });
+});
+
+// ─── Event-count invariance across EVERY path (load-bearing) ──────────────────
+
+describe('wait — appends zero events on every path', () => {
+  it('Wait_AllPaths_AppendZeroEvents', async () => {
+    const { store, ctx } = await makeArm();
+
+    // Seed several workflows in distinct states so each path is reachable.
+    await seedWorkflow(store, 'wf-plan'); // stays in plan
+    await seedWorkflow(store, 'wf-passed');
+    await appendTransition(store, 'wf-passed', 'plan', 'plan-review');
+    await seedWorkflow(store, 'wf-done');
+    await appendTransition(store, 'wf-done', 'plan', 'completed');
+    await seedWorkflow(store, 'wf-op');
+    await appendMergeStart(store, 'wf-op', 'm-1');
+    await appendMergeTerminal(store, 'wf-op', 'm-1');
+
+    // Every terminal-outcome invocation (some via a fired deadline).
+    const invocations: Array<() => Promise<unknown>> = [
+      // precheck-resolved (phase already visited)
+      () => handleViewWait({ featureId: 'wf-passed', phase: 'plan-review' }, ctx),
+      // precheck-resolved (status already terminal)
+      () => handleViewWait({ featureId: 'wf-done', status: 'completed' }, ctx),
+      // precheck-failed (status different terminal already)
+      () => handleViewWait({ featureId: 'wf-done', status: 'cancelled' }, ctx),
+      // precheck-resolved (operation none in flight)
+      () => handleViewWait({ featureId: 'wf-op', operation: 'merge' }, ctx),
+      // no feature predicate → worktree kernel (INVALID_INPUT: missing integrationRef)
+      () => handleViewWait({ featureId: 'wf-plan' }, ctx),
+      // invalid input (non-feature-scoped operation)
+      () => handleViewWait({ featureId: 'wf-plan', operation: 'prune' }, ctx),
+      // cold probe (unknown featureId)
+      () => handleViewWait({ featureId: 'no-such-feature', phase: 'plan' }, ctx),
+      // worktree scope (idle, no prunes)
+      () => handleViewWait({ until: 'idle', timeoutMs: 1000 }, ctx),
+      // subscription → timeout (deadline fired)
+      async () => {
+        const { deps, fireDeadline } = deterministicDeps(new ManualSubscriptionClock());
+        const p = handleViewWait({ featureId: 'wf-plan', phase: 'delegate', timeoutMs: 5000 }, ctx, deps);
+        await flush();
+        fireDeadline();
+        return p;
+      },
+    ];
+
+    for (const run of invocations) {
+      const before = await totalEvents(store);
+      await run();
+      expect(await totalEvents(store)).toBe(before);
+    }
+  });
+});
+
+// ─── Property test (state-machine): resolves iff the predicate is satisfied ───
+
+describe('wait — predicate state-machine property', () => {
+  const PHASES = ['plan', 'plan-review', 'delegate', 'review', 'synthesize', 'completed', 'cancelled'] as const;
+  const TERMINALS = new Set(['completed', 'failed', 'cancelled']);
+
+  // Build a random ordered transition-event list from an arbitrary phase walk.
+  const transitionsArb = fc.array(
+    fc.record({ from: fc.constantFrom(...PHASES), to: fc.constantFrom(...PHASES) }),
+    { maxLength: 12 },
+  );
+
+  it('PhasePredicate_ResolvesIffTargetVisited_ElseFailedIffTerminal', () => {
+    fc.assert(
+      fc.property(
+        transitionsArb,
+        fc.constantFrom(...PHASES),
+        fc.constantFrom(...PHASES),
+        (walk, seed, target) => {
+          const events = walk.map((t) => ({
+            streamId: 'f',
+            sequence: 0,
+            type: 'workflow.transition',
+            timestamp: '',
+            data: t,
+          })) as unknown as Parameters<ReturnType<typeof phasePredicate>['evaluate']>[0];
+
+          const verdict = phasePredicate('f', target, seed).evaluate(events);
+
+          // Model: resolved iff target ∈ {seed} ∪ {from,to across the walk}.
+          const visited = new Set<string>([seed]);
+          let latest = seed;
+          for (const t of walk) {
+            visited.add(t.from);
+            visited.add(t.to);
+            latest = t.to;
+          }
+          const modelResolved = visited.has(target);
+          const modelFailed = !modelResolved && TERMINALS.has(latest) && latest !== target;
+
+          expect(verdict.kind === 'resolved').toBe(modelResolved);
+          expect(verdict.kind === 'failed').toBe(modelFailed);
+          expect(verdict.kind === 'pending').toBe(!modelResolved && !modelFailed);
+        },
+      ),
+    );
+  });
+
+  it('StatusPredicate_ResolvesIffLatestIsRequested_FailsIffDifferentTerminal', () => {
+    fc.assert(
+      fc.property(
+        transitionsArb,
+        fc.constantFrom('completed', 'failed', 'cancelled'),
+        (walk, requested) => {
+          const events = walk.map((t) => ({
+            streamId: 'f',
+            sequence: 0,
+            type: 'workflow.transition',
+            timestamp: '',
+            data: t,
+          })) as unknown as Parameters<ReturnType<typeof statusPredicate>['evaluate']>[0];
+
+          const verdict = statusPredicate('f', requested, 'plan').evaluate(events);
+
+          let latest = 'plan';
+          for (const t of walk) latest = t.to;
+          const modelResolved = latest === requested;
+          const modelFailed = !modelResolved && TERMINALS.has(latest);
+
+          expect(verdict.kind === 'resolved').toBe(modelResolved);
+          expect(verdict.kind === 'failed').toBe(modelFailed);
+        },
+      ),
+    );
+  });
+
+  it('OperationPredicate_ResolvesIffNoUnpairedStart', () => {
+    const descriptor = LIVENESS_REGISTRY.merge;
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            kind: fc.constantFrom('start', 'terminal'),
+            key: fc.constantFrom('a', 'b', 'c'),
+          }),
+          { maxLength: 12 },
+        ),
+        (ops) => {
+          const events = ops.map((o) => ({
+            streamId: 'f',
+            sequence: 0,
+            type: o.kind === 'start' ? descriptor.startType : descriptor.terminalTypes[0],
+            timestamp: '',
+            data: { instanceId: o.key },
+          })) as unknown as Parameters<ReturnType<typeof operationPredicate>['evaluate']>[0];
+
+          const verdict = operationPredicate('f', descriptor).evaluate(events);
+
+          // Model the in-flight fold: last write per key wins.
+          const inFlight = new Set<string>();
+          for (const o of ops) {
+            if (o.kind === 'start') inFlight.add(o.key);
+            else inFlight.delete(o.key);
+          }
+          expect(verdict.kind === 'resolved').toBe(inFlight.size === 0);
+          expect(verdict.kind).not.toBe('failed'); // operation never fails
+        },
+      ),
+    );
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/wait.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/wait.ts
@@ -589,6 +589,23 @@ export async function handleViewWait(
       }
       predicate = phasePredicate(featureId, axis.value, seedPhase);
     } else {
+      // ── Status-target terminality validation (DR-8, symmetric with --phase/--operation) ──
+      // A `status` predicate resolves only on a WORKFLOW-TERMINAL status
+      // (completed/failed/cancelled — `WAIT_TERMINAL_STATUSES`). A non-terminal
+      // value (e.g. a mid-pipeline phase like `delegate`) is not a status at
+      // all: the pre-fix code built a statusPredicate that resolved immediately
+      // on phase-equality, silently conflating status with phase. Reject it up
+      // front — mirroring the topology guard on `--phase` and the surface guard
+      // on `--operation` so all three axes fail fast on an unreachable target.
+      if (!isWaitTerminal(axis.value)) {
+        return invalidInput(
+          `wait --status '${axis.value}' is not a terminal workflow status — a status predicate resolves only on completed/failed/cancelled`,
+          {
+            validTargets: [...WAIT_TERMINAL_STATUSES],
+            expectedShape: { status: 'a terminal workflow status (completed/failed/cancelled)' },
+          },
+        );
+      }
       predicate = statusPredicate(featureId, axis.value, seedPhase);
     }
   }

--- a/servers/exarchos-mcp/src/views/lifecycle/wait.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/wait.ts
@@ -1,0 +1,592 @@
+// ─── Lifecycle verb: `wait` — event-driven gate (DR-5 / DR-8) ─────────────────
+//
+// The one lifecycle verb that BLOCKS: it resolves when a predicate over the
+// event log becomes true, or returns a STRUCTURED timeout/failure. It is a
+// PURE CONSUMER (INV-1 / #1316 Q7) — it appends NOTHING on every path: no
+// `wait.started`/`wait.completed` self-journaling, no phantom stream. The log
+// records domain facts, not observations of them.
+//
+// ## Two-part shape: precheck, then subscription
+//
+//   1. PRECHECK — fold the feature stream ONCE and evaluate the predicate. If it
+//      is ALREADY satisfied (or already failed), return immediately WITHOUT ever
+//      registering a subscription (the "already past `--phase plan-review`"
+//      case: exit 0, no floor tick consumed).
+//   2. SUBSCRIPTION — otherwise register a DR-1 cursor-pump subscription
+//      (`event-store/subscriptions.ts`) filtered to the predicate's event types,
+//      seeded at the precheck head so no event is missed in the gap. The
+//      subscription's two wake tiers do the work: Tier-1 (in-process post-commit
+//      hook) resolves an own-process transition with no floor tick; Tier-2 (the
+//      cross-process poll floor) resolves a FOREIGN connection's event within one
+//      floor interval. A bounded deadline timer guarantees the wait NEVER hangs —
+//      expiry returns a structured `WAIT_TIMEOUT`.
+//
+// ## Predicates (exactly one axis per call)
+//
+//   • `phase`     — resolves when the workflow has entered the target phase
+//                   (already-visited ⇒ immediate). A terminal (`failed` /
+//                   `cancelled`) arriving first makes the phase unreachable ⇒
+//                   `WAIT_FAILED`.
+//   • `status`    — resolves on the REQUESTED terminal status
+//                   (`completed`/`failed`/`cancelled`); a DIFFERENT terminal ⇒
+//                   `WAIT_FAILED`; already-terminal ⇒ immediate.
+//   • `operation` — the S-6 predicate: resolves when the feature's unpaired
+//                   `<surface>.executing_started` (by instance key, via the DR-2
+//                   liveness registry) gains its terminal; none in flight ⇒
+//                   immediate. FEATURE-SCOPED surfaces only (`merge`, `mutation`);
+//                   a `worktrees`-scoped surface (`launch`, `prune`) is not
+//                   feature-observable and returns `INVALID_INPUT` with the
+//                   feature-scoped `validTargets` and a `suggestedFix` → `until`.
+//   • `until`     — the WLM-6 worktree predicates (`merge` / `idle` +
+//                   `integrationRef`), retained as the WORKTREE SCOPE of this
+//                   same verb: absorbed by delegating to the kernel in
+//                   `orchestrate/worktree/handlers.ts`.
+//
+// The SCOPE axis is expressed by WHICH predicate field is set — never a `scope`
+// field (task-019 pins the shared `scope` shape to `z.enum(['repo','all'])` to
+// match `pipeline.scope`, so a `workflow|worktree` `scope` would THROW at MCP
+// registration). `phase`/`status`/`operation` are imported from the DR-8
+// `schema-fields.ts` SoT so their base types cannot drift across lifecycle verbs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { DispatchContext } from '../../core/dispatch.js';
+import type { ToolResult } from '../../format.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import type {
+  SubscriptionFilter,
+  SubscriptionHandle,
+  SubscriptionPerf,
+  SubscriptionRegistryOptions,
+} from '../../event-store/subscriptions.js';
+import {
+  LIVENESS_REGISTRY,
+  LIVENESS_DESCRIPTORS,
+  computeInFlightInstances,
+  type LivenessDescriptor,
+  type LivenessSurface,
+} from '../../event-store/liveness-registry.js';
+import { resolveWorkflowState } from '../../orchestrate/resolve-state.js';
+import { DEFAULT_WAIT_TIMEOUT_MS } from '../../orchestrate/worktree/manager.js';
+import {
+  handleWorktreeUntilWait,
+  type WorktreeViewDeps,
+} from '../../orchestrate/worktree/handlers.js';
+import { phaseField, statusField, operationField } from './schema-fields.js';
+
+// ─── Terminal-status vocabulary (DR-5) ────────────────────────────────────────
+
+/**
+ * The workflow terminal statuses a `status` predicate may request AND the set a
+ * `phase` predicate treats as "the workflow ended elsewhere" (⇒ target
+ * unreachable ⇒ `WAIT_FAILED`). Mirrors the SDK `isTerminal` vocabulary and the
+ * `schema-fields.ts` `status` doc — `completed`/`cancelled` are the built-in HSM
+ * terminal phases (`workflow/terminal-phases.ts`) and `failed` is admitted for
+ * workflow types that fail out. Each is reached via a `workflow.transition`
+ * whose `to` equals the status (cancel folds through `workflow.transition` too —
+ * `workflow/events.ts` maps the internal `transition` event).
+ */
+const WAIT_TERMINAL_STATUSES = ['completed', 'failed', 'cancelled'] as const;
+
+/** Event types that carry a phase `{ from, to }` (both fold to a phase change). */
+const TRANSITION_EVENT_TYPES = ['workflow.transition', 'workflow.cancel'] as const;
+
+function isWaitTerminal(phase: string): boolean {
+  return (WAIT_TERMINAL_STATUSES as readonly string[]).includes(phase);
+}
+
+// ─── Local input helpers (kept private — never user-facing flags) ─────────────
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function invalidInput(
+  message: string,
+  extra?: {
+    expectedShape?: Record<string, unknown>;
+    validTargets?: readonly string[];
+    suggestedFix?: { tool: string; params: Record<string, unknown> };
+  },
+): ToolResult {
+  return {
+    success: false,
+    error: {
+      code: 'INVALID_INPUT',
+      message,
+      ...(extra?.expectedShape ? { expectedShape: extra.expectedShape } : {}),
+      ...(extra?.validTargets ? { validTargets: extra.validTargets } : {}),
+      ...(extra?.suggestedFix ? { suggestedFix: extra.suggestedFix } : {}),
+    },
+  };
+}
+
+/** Read `{ from, to }` off a transition-carrying event, tolerating loose data. */
+function transitionEnds(event: WorkflowEvent): { from?: string; to?: string } {
+  const data = event.data as Record<string, unknown> | undefined;
+  const from = typeof data?.from === 'string' ? data.from : undefined;
+  const to = typeof data?.to === 'string' ? data.to : undefined;
+  return { from, to };
+}
+
+function isTransitionEvent(event: WorkflowEvent): boolean {
+  return (TRANSITION_EVENT_TYPES as readonly string[]).includes(event.type);
+}
+
+// ─── Deps ──────────────────────────────────────────────────────────────────────
+
+/**
+ * `wait` DI seam. Extends {@link WorktreeViewDeps} (so the `until` worktree
+ * scope's timing/process seams pass straight through to the absorbed WLM-6
+ * kernel) with the two feature-scope timing seams:
+ *   - `subscriptionOptions` — threaded to `eventStore.subscribe`'s registry
+ *     options so a test can inject a `ManualClock` and drive the Tier-2 floor
+ *     tick-by-tick (the foreign-connection determinism seam, INV-16);
+ *   - `scheduleTimeout` — the bounded-deadline scheduler, so the `WAIT_TIMEOUT`
+ *     path is deterministic (a test fires the deadline directly).
+ * Production dispatch omits every field → real `setTimeout` deadline + the
+ * registry's real unref'd floor.
+ */
+export interface WaitDeps extends WorktreeViewDeps {
+  readonly subscriptionOptions?: SubscriptionRegistryOptions;
+  /** Monotone clock for the wait deadline / waitedMs. Defaults to `Date.now`. (Also in WorktreeViewDeps.) */
+  readonly now?: () => number;
+  /** One-shot deadline scheduler; returns an idempotent canceller. Defaults to `setTimeout`. */
+  readonly scheduleTimeout?: (cb: () => void, ms: number) => () => void;
+}
+
+function defaultScheduleTimeout(cb: () => void, ms: number): () => void {
+  const timer = setTimeout(cb, ms);
+  // Never keep the process alive on the deadline alone (the dispatch owns liveness).
+  (timer as unknown as { unref?: () => void }).unref?.();
+  return () => clearTimeout(timer);
+}
+
+// ─── Predicate model (pure) ────────────────────────────────────────────────────
+
+/**
+ * A predicate verdict over an ordered slice of relevant events. Pure and total:
+ * both the precheck (full history) and the live path (accumulated deliveries)
+ * fold through the SAME {@link Predicate.evaluate}, so "resolves iff satisfied"
+ * holds by construction — the property test pins exactly this.
+ */
+export type WaitVerdict =
+  | { readonly kind: 'pending' }
+  | { readonly kind: 'resolved'; readonly detail: Record<string, unknown> }
+  | { readonly kind: 'failed'; readonly detail: Record<string, unknown> };
+
+/** A feature-scoped wait predicate: a subscription filter + a pure evaluator. */
+export interface Predicate {
+  /** The DR-1 subscription filter this predicate observes. */
+  readonly filter: SubscriptionFilter;
+  /** Narrow a full event history to the subset this predicate reasons over. */
+  relevant(events: readonly WorkflowEvent[]): readonly WorkflowEvent[];
+  /** Fold a relevant-event slice → verdict. Pure; deterministic; total. */
+  evaluate(events: readonly WorkflowEvent[]): WaitVerdict;
+  /** The predicate-identifying fields stamped onto a `WAIT_TIMEOUT`. */
+  readonly timeoutDetail: Record<string, unknown>;
+}
+
+/**
+ * `phase` predicate. Resolves once the target phase has been ENTERED (present in
+ * the visited set: the seed/current phase plus every transition `from`/`to`),
+ * which makes "already past `--phase X`" resolve at precheck. A terminal status
+ * reached without the target ⇒ the target is unreachable ⇒ `failed`.
+ */
+export function phasePredicate(featureId: string, target: string, seedPhase: string): Predicate {
+  return {
+    filter: { streamId: featureId, eventTypes: [...TRANSITION_EVENT_TYPES] },
+    relevant: (events) => events.filter(isTransitionEvent),
+    evaluate: (events) => {
+      const visited = new Set<string>();
+      if (seedPhase.length > 0) visited.add(seedPhase);
+      let latest = seedPhase;
+      for (const event of events) {
+        const { from, to } = transitionEnds(event);
+        if (from !== undefined) visited.add(from);
+        if (to !== undefined) {
+          visited.add(to);
+          latest = to;
+        }
+      }
+      if (visited.has(target)) {
+        return { kind: 'resolved', detail: { predicate: 'phase', phase: target } };
+      }
+      if (isWaitTerminal(latest) && latest !== target) {
+        return {
+          kind: 'failed',
+          detail: { predicate: 'phase', phase: target, terminalStatus: latest },
+        };
+      }
+      return { kind: 'pending' };
+    },
+    timeoutDetail: { predicate: 'phase', phase: target },
+  };
+}
+
+/**
+ * `status` predicate. Resolves when the workflow's latest phase equals the
+ * REQUESTED terminal status; a DIFFERENT terminal status ⇒ `failed`.
+ */
+export function statusPredicate(featureId: string, requested: string, seedPhase: string): Predicate {
+  return {
+    filter: { streamId: featureId, eventTypes: [...TRANSITION_EVENT_TYPES] },
+    relevant: (events) => events.filter(isTransitionEvent),
+    evaluate: (events) => {
+      let latest = seedPhase;
+      for (const event of events) {
+        const { to } = transitionEnds(event);
+        if (to !== undefined) latest = to;
+      }
+      if (latest === requested) {
+        return { kind: 'resolved', detail: { predicate: 'status', status: requested } };
+      }
+      if (isWaitTerminal(latest)) {
+        return {
+          kind: 'failed',
+          detail: { predicate: 'status', status: requested, terminalStatus: latest },
+        };
+      }
+      return { kind: 'pending' };
+    },
+    timeoutDetail: { predicate: 'status', status: requested },
+  };
+}
+
+/**
+ * `operation` predicate (S-6). Resolves when the feature has NO in-flight
+ * instance of `descriptor.surface` — i.e. every `<surface>.executing_started`
+ * has gained its terminal, paired by the DR-2 registry's instance key. None in
+ * flight ⇒ immediate. Never `failed` (a surface simply goes idle or times out).
+ */
+export function operationPredicate(featureId: string, descriptor: LivenessDescriptor): Predicate {
+  const terminalTypes: readonly string[] = descriptor.terminalTypes;
+  const isRelevant = (event: WorkflowEvent): boolean =>
+    event.type === descriptor.startType || terminalTypes.includes(event.type);
+  return {
+    filter: { streamId: featureId, eventTypes: [descriptor.startType, ...descriptor.terminalTypes] },
+    relevant: (events) => events.filter(isRelevant),
+    evaluate: (events) => {
+      const inFlight = computeInFlightInstances(descriptor, events);
+      if (inFlight.size === 0) {
+        return { kind: 'resolved', detail: { predicate: 'operation', operation: descriptor.surface } };
+      }
+      return { kind: 'pending' };
+    },
+    timeoutDetail: { predicate: 'operation', operation: descriptor.surface },
+  };
+}
+
+/** The DR-2 feature-scoped liveness surfaces `wait --operation` accepts. */
+export function featureScopedSurfaces(): LivenessSurface[] {
+  return LIVENESS_DESCRIPTORS.filter((d) => d.streamScope === 'feature').map((d) => d.surface);
+}
+
+// ─── Result envelopes (structured, never-hang) ────────────────────────────────
+
+function waitSuccess(
+  detail: Record<string, unknown>,
+  waitedMs: number,
+  perf?: SubscriptionPerf,
+): ToolResult {
+  return {
+    success: true,
+    data: { resolved: true, waitedMs, ...detail, ...(perf ? { perf } : {}) },
+  };
+}
+
+function waitFailed(
+  detail: Record<string, unknown>,
+  waitedMs: number,
+  perf?: SubscriptionPerf,
+): ToolResult {
+  const terminal = typeof detail.terminalStatus === 'string' ? detail.terminalStatus : 'a terminal';
+  const target =
+    typeof detail.phase === 'string'
+      ? `phase '${detail.phase}'`
+      : typeof detail.status === 'string'
+        ? `status '${detail.status}'`
+        : 'the predicate';
+  return {
+    success: false,
+    error: {
+      code: 'WAIT_FAILED',
+      message: `workflow reached terminal status '${terminal}' before ${target} — the predicate can no longer be satisfied`,
+    },
+    data: { reason: 'wait-failed', waitedMs, ...detail, ...(perf ? { perf } : {}) },
+  };
+}
+
+function waitTimeoutResult(
+  timeoutDetail: Record<string, unknown>,
+  timeoutMs: number,
+  waitedMs: number,
+  perf?: SubscriptionPerf,
+): ToolResult {
+  return {
+    success: false,
+    error: {
+      code: 'WAIT_TIMEOUT',
+      message: `wait predicate was not satisfied within ${timeoutMs}ms`,
+    },
+    data: { reason: 'wait-timeout', timeoutMs, waitedMs, ...timeoutDetail, ...(perf ? { perf } : {}) },
+  };
+}
+
+// ─── Subscription-driven wait (never hangs) ───────────────────────────────────
+
+/**
+ * Register the DR-1 subscription and race predicate resolution against the
+ * bounded deadline. Seeds the accumulator with the precheck-relevant events and
+ * the precheck head sequence so an event landing in the precheck→subscribe gap
+ * is delivered by the subscription's unconditional initial drain (no gap, no
+ * double). Disposes the subscription on every exit (INV-15 — no daemon).
+ */
+function subscribeUntil(
+  eventStore: DispatchContext['eventStore'],
+  predicate: Predicate,
+  seedRelevant: readonly WorkflowEvent[],
+  headSequence: number,
+  timeoutMs: number,
+  startedAt: number,
+  deps: WaitDeps | undefined,
+): Promise<ToolResult> {
+  const nowFn = deps?.now ?? Date.now;
+  return new Promise<ToolResult>((resolve) => {
+    const accumulated: WorkflowEvent[] = [...seedRelevant];
+    let settled = false;
+    let handle: SubscriptionHandle | undefined;
+    let cancelTimer: (() => void) | undefined;
+
+    const finish = (result: ToolResult): void => {
+      if (settled) return;
+      settled = true;
+      cancelTimer?.();
+      handle?.dispose();
+      resolve(result);
+    };
+
+    const onEvent = (event: WorkflowEvent): void => {
+      if (settled) return;
+      accumulated.push(event);
+      const verdict = predicate.evaluate(accumulated);
+      if (verdict.kind === 'pending') return;
+      const waitedMs = nowFn() - startedAt;
+      const perf = handle?.perf();
+      finish(
+        verdict.kind === 'resolved'
+          ? waitSuccess(verdict.detail, waitedMs, perf)
+          : waitFailed(verdict.detail, waitedMs, perf),
+      );
+    };
+
+    handle = eventStore.subscribe(
+      predicate.filter,
+      onEvent,
+      { fromSequence: headSequence },
+      deps?.subscriptionOptions,
+    );
+
+    // The subscription constructor runs its initial drain SYNCHRONOUSLY: if a
+    // gap event already satisfied the predicate, `onEvent` ran with `handle`
+    // still undefined, so `finish` could not dispose. Dispose now and skip the
+    // deadline entirely.
+    if (settled) {
+      handle.dispose();
+      return;
+    }
+
+    const schedule = deps?.scheduleTimeout ?? defaultScheduleTimeout;
+    cancelTimer = schedule(() => {
+      const waitedMs = nowFn() - startedAt;
+      finish(waitTimeoutResult(predicate.timeoutDetail, timeoutMs, waitedMs, handle?.perf()));
+    }, timeoutMs);
+  });
+}
+
+// ─── Predicate selection + feature-scope gating ───────────────────────────────
+
+type PredicateAxis =
+  | { readonly axis: 'phase'; readonly value: string }
+  | { readonly axis: 'status'; readonly value: string }
+  | { readonly axis: 'operation'; readonly value: string };
+
+/** Extract exactly one feature-scoped predicate axis from args, or an error. */
+function selectAxis(args: Record<string, unknown>): { axis: PredicateAxis } | { error: ToolResult } {
+  const phase = parseField(phaseField, args.phase);
+  const status = parseField(statusField, args.status);
+  const operation = parseField(operationField, args.operation);
+  const present = [
+    phase !== undefined ? ({ axis: 'phase', value: phase } as const) : undefined,
+    status !== undefined ? ({ axis: 'status', value: status } as const) : undefined,
+    operation !== undefined ? ({ axis: 'operation', value: operation } as const) : undefined,
+  ].filter((a): a is PredicateAxis => a !== undefined);
+
+  if (present.length === 0) {
+    return {
+      error: invalidInput(
+        'wait requires exactly one predicate: phase, status, operation, or until (worktree scope)',
+        { expectedShape: { phase: 'string', status: 'string', operation: 'string', until: "'merge' | 'idle'" } },
+      ),
+    };
+  }
+  if (present.length > 1) {
+    return {
+      error: invalidInput(
+        `wait accepts exactly one predicate axis; received ${present.map((p) => p.axis).join(', ')}`,
+        { validTargets: ['phase', 'status', 'operation', 'until'] },
+      ),
+    };
+  }
+  return { axis: present[0] };
+}
+
+/** Zod-field parse that treats empty/absent as "not provided". */
+function parseField(field: { safeParse(v: unknown): { success: boolean; data?: unknown } }, value: unknown): string | undefined {
+  const s = optionalString(value);
+  if (s === undefined) return undefined;
+  const parsed = field.safeParse(s);
+  return parsed.success && typeof parsed.data === 'string' ? parsed.data : s;
+}
+
+/** Resolve the timeout budget (positive int) or the default. */
+function resolveTimeoutMs(args: Record<string, unknown>): number {
+  const raw = args.timeoutMs;
+  if (typeof raw === 'number' && Number.isInteger(raw) && raw > 0) return raw;
+  if (typeof raw === 'string' && /^\d+$/.test(raw)) {
+    const n = Number(raw);
+    if (n > 0) return n;
+  }
+  return DEFAULT_WAIT_TIMEOUT_MS;
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────────
+
+/**
+ * `wait` — the generic event-driven gate. Routes the `until` worktree scope to
+ * the absorbed WLM-6 kernel; otherwise runs a feature-scoped phase / status /
+ * operation predicate as precheck-then-subscription. Appends ZERO events on
+ * every path.
+ */
+export async function handleViewWait(
+  args: Record<string, unknown>,
+  ctx: DispatchContext,
+  deps?: WaitDeps,
+): Promise<ToolResult> {
+  // ── Scope routing ────────────────────────────────────────────────────────────
+  // A FEATURE predicate (phase/status/operation) selects the feature scope; its
+  // ABSENCE routes to the WORKTREE SCOPE — the absorbed WLM-6 kernel, which
+  // handles `until: merge|idle` (defaulting to 'merge', preserving the shipped
+  // contract) over the singleton `worktrees` stream. So an explicit `until`, a
+  // bare `integrationRef` merge-wait, and a bare no-arg call all reach the kernel
+  // unchanged; only a phase/status/operation call takes the feature path below.
+  const hasFeaturePredicate =
+    optionalString(args.phase) !== undefined ||
+    optionalString(args.status) !== undefined ||
+    optionalString(args.operation) !== undefined;
+
+  // `until` is the worktree scope's own selector — combining it with a feature
+  // predicate mixes two scopes in one call, which has no coherent meaning.
+  if (hasFeaturePredicate && args.until !== undefined) {
+    return invalidInput(
+      'wait: `until` (worktree scope) cannot be combined with a feature predicate (phase/status/operation)',
+      { validTargets: ['phase', 'status', 'operation', 'until'] },
+    );
+  }
+  if (!hasFeaturePredicate) {
+    // Worktree scope: appends nothing; operates on `worktrees`, not a featureId,
+    // so there is NO feature cold-probe here — WLM-6 behavior preserved exactly.
+    return handleWorktreeUntilWait(args, ctx, deps);
+  }
+
+  const startedAt = deps?.now?.() ?? Date.now();
+  const { eventStore } = ctx;
+
+  const featureId = optionalString(args.featureId);
+  if (!featureId) {
+    return invalidInput('wait requires featureId: string for a phase/status/operation predicate', {
+      expectedShape: { featureId: 'string' },
+    });
+  }
+
+  const selected = selectAxis(args);
+  if ('error' in selected) return selected.error;
+  const { axis } = selected;
+
+  // ── Cold-probe: an unknown / never-init'd featureId is a side-effect-free
+  //    error (DR-8) — one pure read, no stream registration, no events. ──────────
+  const events = await eventStore.query(featureId);
+  if (events.length === 0) {
+    return invalidInput(
+      `wait: unknown featureId '${featureId}' — no such workflow (nothing to wait on)`,
+      { expectedShape: { featureId: 'an existing workflow id' } },
+    );
+  }
+  // The precheck head: the subscription seeds its cursor here so the gap between
+  // this fold and registration is closed by the initial drain (no missed event).
+  const headSequence = events[events.length - 1].sequence;
+
+  // ── Build the predicate (operation gates its surface here) ───────────────────
+  let predicate: Predicate;
+  if (axis.axis === 'operation') {
+    const built = buildOperationPredicate(featureId, axis.value);
+    if ('error' in built) return built.error;
+    predicate = built.predicate;
+  } else {
+    // phase / status need the current phase as a seed (canonical resolver).
+    const resolved = await resolveWorkflowState({ featureId, eventStore });
+    if ('error' in resolved) return resolved.error;
+    const seedPhase = typeof resolved.state.phase === 'string' ? resolved.state.phase : '';
+    predicate =
+      axis.axis === 'phase'
+        ? phasePredicate(featureId, axis.value, seedPhase)
+        : statusPredicate(featureId, axis.value, seedPhase);
+  }
+
+  // ── Precheck: resolve/fail without ever subscribing when already decided ─────
+  const seedRelevant = predicate.relevant(events);
+  const verdict = predicate.evaluate(seedRelevant);
+  if (verdict.kind === 'resolved') return waitSuccess(verdict.detail, 0);
+  if (verdict.kind === 'failed') return waitFailed(verdict.detail, 0);
+
+  // ── Subscribe-until (Tier-1 wake / Tier-2 floor) with a bounded deadline ─────
+  const timeoutMs = resolveTimeoutMs(args);
+  return subscribeUntil(eventStore, predicate, seedRelevant, headSequence, timeoutMs, startedAt, deps);
+}
+
+/**
+ * Build the `operation` predicate, gating the surface: it must be a registered
+ * DR-2 liveness surface AND feature-scoped (`merge`/`mutation`). A worktrees-
+ * scoped surface (`launch`/`prune`) is not feature-observable ⇒ `INVALID_INPUT`
+ * with the feature-scoped `validTargets` and a `suggestedFix` pointing at the
+ * `until` worktree predicates.
+ */
+function buildOperationPredicate(
+  featureId: string,
+  surface: string,
+): { predicate: Predicate } | { error: ToolResult } {
+  const valid = featureScopedSurfaces();
+  const descriptor = (LIVENESS_REGISTRY as Record<string, LivenessDescriptor | undefined>)[surface];
+  if (descriptor === undefined) {
+    return {
+      error: invalidInput(
+        `wait --operation '${surface}' is not a known liveness surface`,
+        {
+          validTargets: valid,
+          suggestedFix: { tool: 'wait', params: { until: 'merge' } },
+        },
+      ),
+    };
+  }
+  if (descriptor.streamScope !== 'feature') {
+    return {
+      error: invalidInput(
+        `wait --operation '${surface}' is a worktrees-scoped surface — not feature-observable. Use the worktree scope (\`wait --until merge|idle\`) for launch/prune.`,
+        {
+          validTargets: valid,
+          suggestedFix: { tool: 'wait', params: { until: 'merge' } },
+        },
+      ),
+    };
+  }
+  return { predicate: operationPredicate(featureId, descriptor) };
+}

--- a/servers/exarchos-mcp/src/views/lifecycle/wait.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/wait.ts
@@ -66,6 +66,7 @@ import {
   type LivenessSurface,
 } from '../../event-store/liveness-registry.js';
 import { resolveWorkflowState } from '../../orchestrate/resolve-state.js';
+import { getHSMDefinition } from '../../workflow/state-machine.js';
 import { DEFAULT_WAIT_TIMEOUT_MS } from '../../orchestrate/worktree/manager.js';
 import {
   handleWorktreeUntilWait,
@@ -279,6 +280,33 @@ export function operationPredicate(featureId: string, descriptor: LivenessDescri
 /** The DR-2 feature-scoped liveness surfaces `wait --operation` accepts. */
 export function featureScopedSurfaces(): LivenessSurface[] {
   return LIVENESS_DESCRIPTORS.filter((d) => d.streamScope === 'feature').map((d) => d.surface);
+}
+
+/**
+ * The valid `wait --phase` targets for a workflow type (DR-8): every WAITABLE
+ * phase in that type's HSM topology — the atomic + final states a workflow can
+ * actually be IN. Compound states are excluded because a workflow's phase is
+ * always an atomic leaf (or a final terminal), never a compound container, so a
+ * `--phase implementation` wait could never resolve.
+ *
+ * Derived from the REAL HSM registry (`getHSMDefinition`) — never a hardcoded
+ * list — so a topology edit or a custom-registered workflow type is reflected
+ * with no change here, and the targets are per-TYPE (feature ≠ refactor).
+ * Returns `undefined` for a type with NO registered topology (`getHSMDefinition`
+ * throws): the caller then SKIPS phase validation, so an un-topologized/custom
+ * type keeps the pre-DR-8 permissive behavior rather than rejecting a
+ * legitimate wait it cannot adjudicate.
+ */
+export function topologyPhaseTargets(workflowType: string): readonly string[] | undefined {
+  try {
+    const hsm = getHSMDefinition(workflowType);
+    return Object.values(hsm.states)
+      .filter((state) => state.type !== 'compound')
+      .map((state) => state.id)
+      .sort();
+  } catch {
+    return undefined;
+  }
 }
 
 // ─── Result envelopes (structured, never-hang) ────────────────────────────────
@@ -536,10 +564,33 @@ export async function handleViewWait(
     const resolved = await resolveWorkflowState({ featureId, eventStore });
     if ('error' in resolved) return resolved.error;
     const seedPhase = typeof resolved.state.phase === 'string' ? resolved.state.phase : '';
-    predicate =
-      axis.axis === 'phase'
-        ? phasePredicate(featureId, axis.value, seedPhase)
-        : statusPredicate(featureId, axis.value, seedPhase);
+    if (axis.axis === 'phase') {
+      // ── Phase-target topology validation (DR-8) ─────────────────────────────
+      // The `--phase` target must be a real phase in THIS workflow type's HSM
+      // topology — not a hardcoded list. An off-topology phase can NEVER be
+      // entered, so the pre-DR-8 permissive behavior (subscribe, then block until
+      // the deadline) was a guaranteed WAIT_TIMEOUT masquerading as a live wait.
+      // Fail fast with a self-correcting `INVALID_INPUT` whose `validTargets` are
+      // the topology's waitable phases FOR THE WORKFLOW'S TYPE (feature ≠
+      // refactor), so the caller sees exactly which phases exist. Skipped only
+      // for a type with no registered topology (`topologyPhaseTargets` →
+      // undefined), preserving the permissive path there.
+      const workflowType =
+        typeof resolved.state.workflowType === 'string' ? resolved.state.workflowType : '';
+      const validPhases = topologyPhaseTargets(workflowType);
+      if (validPhases !== undefined && !validPhases.includes(axis.value)) {
+        return invalidInput(
+          `wait --phase '${axis.value}' is not a phase in the '${workflowType}' workflow topology — the workflow can never enter it`,
+          {
+            validTargets: validPhases,
+            expectedShape: { phase: 'a phase in the workflow topology' },
+          },
+        );
+      }
+      predicate = phasePredicate(featureId, axis.value, seedPhase);
+    } else {
+      predicate = statusPredicate(featureId, axis.value, seedPhase);
+    }
   }
 
   // ── Precheck: resolve/fail without ever subscribing when already decided ─────

--- a/servers/exarchos-mcp/src/views/lifecycle/wait.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/wait.ts
@@ -476,13 +476,21 @@ function parseField(field: { safeParse(v: unknown): { success: boolean; data?: u
   return parsed.success && typeof parsed.data === 'string' ? parsed.data : s;
 }
 
-/** Resolve the timeout budget (positive int) or the default. */
+/**
+ * Node's `setTimeout` delay ceiling (2^31-1 ms ≈ 24.85 days). A delay ABOVE
+ * this does not clamp — it silently wraps to 1ms and fires almost immediately,
+ * which would turn an over-large `timeoutMs` into a near-instant WAIT_TIMEOUT:
+ * the exact opposite of the caller's "wait longer" intent.
+ */
+const MAX_TIMER_MS = 2_147_483_647;
+
+/** Resolve the timeout budget (positive int, clamped to the timer ceiling) or the default. */
 function resolveTimeoutMs(args: Record<string, unknown>): number {
   const raw = args.timeoutMs;
-  if (typeof raw === 'number' && Number.isInteger(raw) && raw > 0) return raw;
+  if (typeof raw === 'number' && Number.isInteger(raw) && raw > 0) return Math.min(raw, MAX_TIMER_MS);
   if (typeof raw === 'string' && /^\d+$/.test(raw)) {
     const n = Number(raw);
-    if (n > 0) return n;
+    if (n > 0) return Math.min(n, MAX_TIMER_MS);
   }
   return DEFAULT_WAIT_TIMEOUT_MS;
 }
@@ -640,7 +648,7 @@ function buildOperationPredicate(
         `wait --operation '${surface}' is not a known liveness surface`,
         {
           validTargets: valid,
-          suggestedFix: { tool: 'wait', params: { until: 'merge' } },
+          suggestedFix: { tool: 'exarchos_view', params: { action: 'wait', until: 'merge' } },
         },
       ),
     };
@@ -651,7 +659,7 @@ function buildOperationPredicate(
         `wait --operation '${surface}' is a worktrees-scoped surface — not feature-observable. Use the worktree scope (\`wait --until merge|idle\`) for launch/prune.`,
         {
           validTargets: valid,
-          suggestedFix: { tool: 'wait', params: { until: 'merge' } },
+          suggestedFix: { tool: 'exarchos_view', params: { action: 'wait', until: 'merge' } },
         },
       ),
     };

--- a/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.bench.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.bench.ts
@@ -1,0 +1,75 @@
+import { bench, describe } from 'vitest';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import type { WorkflowState } from '../../storage/backend.js';
+import { SqliteBackend } from '../../storage/sqlite-backend.js';
+import { foldWorkflowSummaries } from './workflow-fold.js';
+
+/**
+ * Cold-read benchmark for the workflow-fold view (DR-3 SLA: p95 < 250 ms over
+ * a 10k-event store). Lives OUTSIDE the `src/bench` directory so it is excluded
+ * from the vitest hot loop (test.include only globs the `src/bench` tree), and
+ * runs only under `vitest bench` (benchmark.include globs all bench files under
+ * src) at the boundary/offline cadence.
+ *
+ * Corpus: 200 workflows × 50 events = 10,000 events, spread across workflow
+ * types and lifecycle phases, in a single in-memory SQLite database. Exercises
+ * the indexed `workflow_type` join, `json_extract` phase read, and the
+ * `MIN(events.timestamp)` per-stream envelope subquery under realistic density.
+ */
+
+const WORKFLOW_COUNT = 200;
+const EVENTS_PER_WORKFLOW = 50;
+const TYPES = ['feature', 'debug', 'refactor'] as const;
+const PHASES = ['plan', 'delegate', 'review', 'blocked', 'completed', 'cancelled'] as const;
+const EPOCH = Date.parse('2026-01-01T00:00:00.000Z');
+
+function buildTenThousandEventStore(): SqliteBackend {
+  const backend = new SqliteBackend(':memory:');
+  backend.initialize();
+
+  for (let w = 0; w < WORKFLOW_COUNT; w++) {
+    const featureId = `wf-${String(w).padStart(4, '0')}`;
+    const workflowType = TYPES[w % TYPES.length];
+    const phase = PHASES[w % PHASES.length];
+
+    backend.setState(featureId, {
+      featureId,
+      workflowType,
+      phase,
+    } as unknown as WorkflowState);
+    backend.registerStream(featureId, workflowType);
+
+    for (let e = 0; e < EVENTS_PER_WORKFLOW; e++) {
+      backend.appendEvent(featureId, {
+        streamId: featureId,
+        sequence: e + 1,
+        timestamp: new Date(EPOCH + w * 1000 + e).toISOString(),
+        type: 'workflow.transition',
+        schemaVersion: '1.0',
+      } as WorkflowEvent);
+    }
+  }
+
+  return backend;
+}
+
+describe('workflow-fold cold read (DR-3)', () => {
+  const backend = buildTenThousandEventStore();
+  const nowMs = Date.parse('2026-02-01T00:00:00.000Z');
+
+  bench(
+    'workflow-fold-cold-10k-events',
+    () => {
+      foldWorkflowSummaries(backend, { includeTerminal: true, nowMs });
+    },
+    { warmupIterations: 5, iterations: 100 },
+  );
+
+  bench(
+    'workflow-fold-cold-10k-events-type-filtered',
+    () => {
+      foldWorkflowSummaries(backend, { workflowType: 'feature', nowMs });
+    },
+    { warmupIterations: 5, iterations: 100 },
+  );
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fc } from '@fast-check/vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import type { WorkflowState } from '../../workflow/types.js';
+import type {
+  StorageBackend,
+  WorkflowSummary,
+  WorkflowSummaryFilter,
+} from '../../storage/backend.js';
+import {
+  deriveWorkflowStatus,
+  matchesWorkflowSummaryFilter,
+} from '../../storage/backend.js';
+import { InMemoryBackend } from '../../storage/memory-backend.js';
+import { SqliteBackend } from '../../storage/sqlite-backend.js';
+import { foldWorkflowSummaries } from './workflow-fold.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+interface WorkflowSpec {
+  featureId: string;
+  workflowType: string;
+  phase: string;
+  /** Event-envelope timestamp (ISO-8601). Defaults to a fixed instant. */
+  createdAtIso?: string;
+}
+
+const T0 = '2026-07-01T00:00:00.000Z';
+
+/**
+ * Seed one workflow into `backend`: its state (carrying workflowType + phase),
+ * its stream-registry row (for the SQLite indexed join — a no-op on backends
+ * without `registerStream`), and a `workflow.started` event so the envelope
+ * timestamp exists. Uses the REAL backends — no hand-mocks.
+ */
+function seed(backend: StorageBackend, spec: WorkflowSpec): void {
+  const state = {
+    featureId: spec.featureId,
+    workflowType: spec.workflowType,
+    phase: spec.phase,
+  } as unknown as WorkflowState;
+  backend.setState(spec.featureId, state);
+  backend.registerStream?.(spec.featureId, spec.workflowType);
+  backend.appendEvent(spec.featureId, {
+    streamId: spec.featureId,
+    sequence: 1,
+    timestamp: spec.createdAtIso ?? T0,
+    type: 'workflow.started',
+    schemaVersion: '1.0',
+  } as WorkflowEvent);
+}
+
+function makeSqlite(): { backend: SqliteBackend; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'workflow-fold-'));
+  const backend = new SqliteBackend(join(dir, 'test.db'));
+  backend.initialize();
+  return {
+    backend,
+    cleanup: () => {
+      backend.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeMemory(): { backend: InMemoryBackend; cleanup: () => void } {
+  const backend = new InMemoryBackend();
+  backend.initialize();
+  return { backend, cleanup: () => backend.close() };
+}
+
+// A representative multi-type, multi-status corpus reused across tests.
+const CORPUS: WorkflowSpec[] = [
+  { featureId: 'feat-active', workflowType: 'feature', phase: 'delegate' },
+  { featureId: 'feat-blocked', workflowType: 'feature', phase: 'blocked' },
+  { featureId: 'feat-done', workflowType: 'feature', phase: 'completed' },
+  { featureId: 'feat-cancelled', workflowType: 'feature', phase: 'cancelled' },
+  { featureId: 'dbg-active', workflowType: 'debug', phase: 'triage' },
+  { featureId: 'dbg-done', workflowType: 'debug', phase: 'completed' },
+];
+
+// ─── Cleanup registry ────────────────────────────────────────────────────────
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()!();
+  vi.restoreAllMocks();
+});
+
+/** Set up a real SqliteBackend seeded with CORPUS, auto-cleaned. */
+function sqliteWithCorpus(): SqliteBackend {
+  const { backend, cleanup } = makeSqlite();
+  cleanups.push(cleanup);
+  for (const spec of CORPUS) seed(backend, spec);
+  return backend;
+}
+
+// ─── WorkflowFold_TypeFilter_PushedDownToIndexedColumn ────────────────────────
+
+describe('workflow-fold view (DR-3)', () => {
+  it('WorkflowFold_TypeFilter_PushedDownToIndexedColumn', () => {
+    const backend = sqliteWithCorpus();
+
+    // Capture every SQL string the backend compiles during the filtered read.
+    const db = (backend as unknown as { db: { prepare: (sql: string) => unknown } }).db;
+    const preparedSql: string[] = [];
+    const original = db.prepare.bind(db);
+    vi.spyOn(db, 'prepare').mockImplementation((sql: string) => {
+      preparedSql.push(sql);
+      return original(sql);
+    });
+
+    const rows = foldWorkflowSummaries(backend, { workflowType: 'debug', includeTerminal: true });
+
+    // Behavioural proof: only debug workflows returned. If the type predicate
+    // were NOT pushed down to SQL, the INNER JOIN would return every type and
+    // — because the JS lifecycle filter deliberately does not re-check
+    // workflowType — feature rows would leak through here.
+    expect(rows.map((r) => r.featureId).sort()).toEqual(['dbg-active', 'dbg-done']);
+
+    // Structural proof: the summary query compiled the type predicate into a
+    // SQL WHERE against the indexed streams.workflow_type column.
+    const summarySql = preparedSql.find(
+      (sql) => sql.includes('json_extract') && sql.includes('workflow_type'),
+    );
+    expect(summarySql).toBeDefined();
+    expect(summarySql!).toMatch(/where[\s\S]*s\.workflow_type\s*=\s*\?/i);
+
+    // Counter proof: the indexed pushdown path fired exactly once.
+    expect(backend.getStats().workflowTypePushdownQueries).toBe(1);
+  });
+
+  // An unfiltered read must NOT emit the type predicate nor bump the counter.
+  it('WorkflowFold_NoTypeFilter_DoesNotPushDown', () => {
+    const backend = sqliteWithCorpus();
+    foldWorkflowSummaries(backend, { includeTerminal: true });
+    expect(backend.getStats().workflowTypePushdownQueries).toBe(0);
+  });
+
+  // ─── WorkflowFold_StatusFilter_ReturnsMatchingRows ─────────────────────────
+
+  it('WorkflowFold_StatusFilter_ReturnsMatchingRows', () => {
+    const backend = sqliteWithCorpus();
+
+    // 'active' is non-terminal, so this is independent of the terminal default.
+    const active = foldWorkflowSummaries(backend, { status: 'active' });
+    expect(active.map((r) => r.featureId).sort()).toEqual(['dbg-active', 'feat-active']);
+    expect(active.every((r) => r.status === 'active')).toBe(true);
+
+    // 'blocked' is non-terminal too.
+    const blocked = foldWorkflowSummaries(backend, { status: 'blocked' });
+    expect(blocked.map((r) => r.featureId)).toEqual(['feat-blocked']);
+
+    // An explicit terminal status is authoritative even without includeTerminal.
+    const completed = foldWorkflowSummaries(backend, { status: 'completed' });
+    expect(completed.map((r) => r.featureId).sort()).toEqual(['dbg-done', 'feat-done']);
+  });
+
+  // ─── WorkflowFold_PhaseFilter_ReturnsMatchingRows ──────────────────────────
+
+  it('WorkflowFold_PhaseFilter_ReturnsMatchingRows', () => {
+    const backend = sqliteWithCorpus();
+
+    const delegate = foldWorkflowSummaries(backend, { phase: 'delegate' });
+    expect(delegate.map((r) => r.featureId)).toEqual(['feat-active']);
+    expect(delegate[0].phase).toBe('delegate');
+
+    const triage = foldWorkflowSummaries(backend, { phase: 'triage' });
+    expect(triage.map((r) => r.featureId)).toEqual(['dbg-active']);
+  });
+
+  // ─── WorkflowFold_Default_ExcludesTerminalStates ───────────────────────────
+
+  it('WorkflowFold_Default_ExcludesTerminalStates', () => {
+    const backend = sqliteWithCorpus();
+
+    const rows = foldWorkflowSummaries(backend);
+    const ids = rows.map((r) => r.featureId).sort();
+
+    // completed + cancelled workflows are hidden by default.
+    expect(ids).toEqual(['dbg-active', 'feat-active', 'feat-blocked']);
+    expect(ids).not.toContain('feat-done');
+    expect(ids).not.toContain('feat-cancelled');
+    expect(ids).not.toContain('dbg-done');
+    // No returned row is terminal.
+    expect(rows.every((r) => r.status !== 'completed' && r.status !== 'cancelled')).toBe(true);
+  });
+
+  // ─── WorkflowFold_AllFlag_IncludesCompleted ────────────────────────────────
+
+  it('WorkflowFold_AllFlag_IncludesCompleted', () => {
+    const backend = sqliteWithCorpus();
+
+    const all = foldWorkflowSummaries(backend, { includeTerminal: true });
+    const ids = all.map((r) => r.featureId).sort();
+
+    // Every workflow, terminal included.
+    expect(ids).toEqual([
+      'dbg-active',
+      'dbg-done',
+      'feat-active',
+      'feat-blocked',
+      'feat-cancelled',
+      'feat-done',
+    ]);
+    expect(ids).toContain('feat-done');
+    expect(ids).toContain('dbg-done');
+  });
+
+  // ─── Age is computed from the event envelope ───────────────────────────────
+
+  it('WorkflowFold_Age_ComputedFromEventEnvelope', () => {
+    const backend = sqliteWithCorpus();
+    const nowMs = Date.parse('2026-07-01T00:00:10.000Z'); // 10s after T0
+    const rows = foldWorkflowSummaries(backend, { includeTerminal: true, nowMs });
+    for (const row of rows) {
+      expect(row.ageMs).toBe(10_000);
+    }
+    // Oldest-first ordering with equal ages falls back to featureId.
+    expect(rows[0].featureId).toBe('dbg-active');
+  });
+});
+
+// ─── ListWorkflowSummaries_BackendContract_SharedAcrossSqliteAndInMemory ──────
+
+describe('listWorkflowSummaries backend contract', () => {
+  /** Strip createdAt (backend-derived, identical here) → stable comparison key. */
+  function normalize(rows: WorkflowSummary[]): Array<Omit<WorkflowSummary, 'createdAt'>> {
+    return rows
+      .map(({ featureId, workflowType, phase, status }) => ({ featureId, workflowType, phase, status }))
+      .sort((a, b) => a.featureId.localeCompare(b.featureId));
+  }
+
+  const FILTERS: WorkflowSummaryFilter[] = [
+    {},
+    { includeTerminal: true },
+    { workflowType: 'feature' },
+    { workflowType: 'feature', includeTerminal: true },
+    { workflowType: 'debug' },
+    { status: 'active' },
+    { status: 'blocked' },
+    { status: 'completed' },
+    { phase: 'delegate' },
+    { phase: 'completed' },
+    { phase: 'completed', includeTerminal: true },
+  ];
+
+  it('ListWorkflowSummaries_BackendContract_SharedAcrossSqliteAndInMemory', () => {
+    const sqlite = makeSqlite();
+    const memory = makeMemory();
+    try {
+      for (const spec of CORPUS) {
+        seed(sqlite.backend, spec);
+        seed(memory.backend, spec);
+      }
+
+      for (const filter of FILTERS) {
+        const fromSqlite = normalize(sqlite.backend.listWorkflowSummaries(filter));
+        const fromMemory = normalize(memory.backend.listWorkflowSummaries(filter));
+        expect(fromMemory, `filter=${JSON.stringify(filter)}`).toEqual(fromSqlite);
+      }
+
+      // And the event-envelope createdAt agrees too (both read MIN timestamp).
+      const sqliteAll = sqlite.backend.listWorkflowSummaries({ includeTerminal: true });
+      const memoryAll = memory.backend.listWorkflowSummaries({ includeTerminal: true });
+      const byId = (rows: WorkflowSummary[]) =>
+        Object.fromEntries(rows.map((r) => [r.featureId, r.createdAt]));
+      expect(byId(memoryAll)).toEqual(byId(sqliteAll));
+    } finally {
+      sqlite.cleanup();
+      memory.cleanup();
+    }
+  });
+});
+
+// ─── Property tests (collections) ─────────────────────────────────────────────
+
+describe('workflow-fold filter properties', () => {
+  const statusArb = fc.constantFrom('active', 'completed', 'cancelled', 'blocked');
+  const phaseArb = fc.constantFrom('plan', 'delegate', 'triage', 'completed', 'cancelled', 'blocked', 'review');
+
+  const summaryArb: fc.Arbitrary<WorkflowSummary> = fc
+    .record({
+      featureId: fc.string({ minLength: 1, maxLength: 8 }),
+      workflowType: fc.constantFrom('feature', 'debug', 'refactor'),
+      phase: phaseArb,
+    })
+    .map(({ featureId, workflowType, phase }) => ({
+      featureId,
+      workflowType,
+      phase,
+      status: deriveWorkflowStatus(phase),
+      createdAt: T0,
+    }));
+
+  const filterArb: fc.Arbitrary<WorkflowSummaryFilter> = fc.record(
+    {
+      workflowType: fc.constantFrom('feature', 'debug', 'refactor'),
+      status: statusArb,
+      phase: phaseArb,
+      includeTerminal: fc.boolean(),
+    },
+    { requiredKeys: [] },
+  );
+
+  // filter(filter(rows)) === filter(rows): the lifecycle predicate is pure and
+  // idempotent, so re-filtering an already-filtered collection is a no-op.
+  it('WorkflowFold_Filter_Idempotent', () => {
+    fc.assert(
+      fc.property(fc.array(summaryArb, { maxLength: 30 }), filterArb, (rows, filter) => {
+        const once = rows.filter((r) => matchesWorkflowSummaryFilter(r, filter));
+        const twice = once.filter((r) => matchesWorkflowSummaryFilter(r, filter));
+        expect(twice).toEqual(once);
+      }),
+    );
+  });
+
+  // filtered ⊆ unfiltered: every row that survives a filter is present in the
+  // full (includeTerminal, no-axis) set.
+  it('WorkflowFold_Filtered_SubsetOfUnfiltered', () => {
+    fc.assert(
+      fc.property(fc.array(summaryArb, { maxLength: 30 }), filterArb, (rows, filter) => {
+        const filtered = rows.filter((r) => matchesWorkflowSummaryFilter(r, filter));
+        const unfiltered = rows.filter((r) =>
+          matchesWorkflowSummaryFilter(r, { includeTerminal: true }),
+        );
+        for (const row of filtered) {
+          expect(unfiltered).toContain(row);
+        }
+      }),
+    );
+  });
+
+  // Idempotence + subset through the real in-memory backend + view.
+  it('WorkflowFold_ViewFiltered_SubsetOfAll', () => {
+    const { backend, cleanup } = makeMemory();
+    try {
+      for (const spec of CORPUS) seed(backend, spec);
+      fc.assert(
+        fc.property(filterArb, (filter) => {
+          const filtered = foldWorkflowSummaries(backend, filter).map((r) => r.featureId);
+          const all = foldWorkflowSummaries(backend, { includeTerminal: true }).map((r) => r.featureId);
+          for (const id of filtered) expect(all).toContain(id);
+        }),
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts
@@ -35,15 +35,18 @@ const T0 = '2026-07-01T00:00:00.000Z';
  * its stream-registry row (for the SQLite indexed join — a no-op on backends
  * without `registerStream`), and a `workflow.started` event so the envelope
  * timestamp exists. Uses the REAL backends — no hand-mocks.
+ *
+ * `skipRegistry` models the REACHABLE state where `registerStream()` failed and
+ * its error was swallowed: a `workflow_state` row with no `streams` row.
  */
-function seed(backend: StorageBackend, spec: WorkflowSpec): void {
+function seed(backend: StorageBackend, spec: WorkflowSpec, skipRegistry = false): void {
   const state = {
     featureId: spec.featureId,
     workflowType: spec.workflowType,
     phase: spec.phase,
   } as unknown as WorkflowState;
   backend.setState(spec.featureId, state);
-  backend.registerStream?.(spec.featureId, spec.workflowType);
+  if (!skipRegistry) backend.registerStream?.(spec.featureId, spec.workflowType);
   backend.appendEvent(spec.featureId, {
     streamId: spec.featureId,
     sequence: 1,
@@ -116,18 +119,26 @@ describe('workflow-fold view (DR-3)', () => {
     const rows = foldWorkflowSummaries(backend, { workflowType: 'debug', includeTerminal: true });
 
     // Behavioural proof: only debug workflows returned. If the type predicate
-    // were NOT pushed down to SQL, the INNER JOIN would return every type and
+    // were NOT pushed down to SQL, the join would return every type and
     // — because the JS lifecycle filter deliberately does not re-check
     // workflowType — feature rows would leak through here.
     expect(rows.map((r) => r.featureId).sort()).toEqual(['dbg-active', 'dbg-done']);
 
     // Structural proof: the summary query compiled the type predicate into a
-    // SQL WHERE against the indexed streams.workflow_type column.
+    // SQL WHERE built on the registry's workflow_type column. The predicate is
+    // the COALESCE expression rather than a bare `s.workflow_type = ?` because
+    // the join is a LEFT JOIN: a workflow whose `streams` row is missing (a
+    // swallowed registerStream failure) must still be filtered on its state
+    // row's own workflowType instead of being silently dropped. The load-
+    // bearing property this pins is unchanged — the type predicate lives in
+    // SQL, never in JS. Only index utilisation on streams.workflow_type is
+    // traded away, which the per-row MIN(timestamp) correlated subquery below
+    // already dominates.
     const summarySql = preparedSql.find(
       (sql) => sql.includes('json_extract') && sql.includes('workflow_type'),
     );
     expect(summarySql).toBeDefined();
-    expect(summarySql!).toMatch(/where[\s\S]*s\.workflow_type\s*=\s*\?/i);
+    expect(summarySql!).toMatch(/where[\s\S]*coalesce\(s\.workflow_type[\s\S]*=\s*\?/i);
 
     // Counter proof: the indexed pushdown path fired exactly once.
     expect(backend.getStats().workflowTypePushdownQueries).toBe(1);
@@ -269,6 +280,55 @@ describe('listWorkflowSummaries backend contract', () => {
       const byId = (rows: WorkflowSummary[]) =>
         Object.fromEntries(rows.map((r) => [r.featureId, r.createdAt]));
       expect(byId(memoryAll)).toEqual(byId(sqliteAll));
+    } finally {
+      sqlite.cleanup();
+      memory.cleanup();
+    }
+  });
+
+  it('ListWorkflowSummaries_StateRowWithoutRegistryRow_StillListedAndBackendsAgree', () => {
+    // `registerStream()` is attempted on init but its write errors are
+    // SWALLOWED, so a `workflow_state` row can outlive a missing `streams` row.
+    // An INNER JOIN drops those workflows entirely — they vanish from `ps` and
+    // the SQLite backend disagrees with the in-memory one, which reads
+    // workflowType off the state object and never consults a registry (INV-2).
+    const sqlite = makeSqlite();
+    const memory = makeMemory();
+    try {
+      const orphan: WorkflowSpec = {
+        featureId: 'orphan-feat',
+        workflowType: 'feature',
+        phase: 'delegate',
+      };
+      // A registered sibling, so the JOIN has a matching row to find as well.
+      seed(sqlite.backend, CORPUS[0]);
+      seed(memory.backend, CORPUS[0]);
+      seed(sqlite.backend, orphan, true);
+      seed(memory.backend, orphan, true);
+
+      // Listed at all, with workflowType recovered from the state row …
+      const rows = sqlite.backend.listWorkflowSummaries();
+      expect(rows.map((r) => r.featureId)).toContain('orphan-feat');
+      expect(rows.find((r) => r.featureId === 'orphan-feat')!.workflowType).toBe('feature');
+
+      // … and the two backends agree — unfiltered AND under the workflowType
+      // pushdown, which must filter on the same coalesced expression it selects
+      // (a bare `s.workflow_type = ?` is NULL for the orphan and re-drops it).
+      const filters: WorkflowSummaryFilter[] = [
+        {},
+        { workflowType: 'feature' },
+        { workflowType: 'debug' },
+        { includeTerminal: true },
+      ];
+      for (const filter of filters) {
+        expect(
+          normalize(memory.backend.listWorkflowSummaries(filter)),
+          `filter=${JSON.stringify(filter)}`,
+        ).toEqual(normalize(sqlite.backend.listWorkflowSummaries(filter)));
+      }
+      expect(
+        sqlite.backend.listWorkflowSummaries({ workflowType: 'feature' }).map((r) => r.featureId),
+      ).toContain('orphan-feat');
     } finally {
       sqlite.cleanup();
       memory.cleanup();

--- a/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.test.ts
@@ -101,46 +101,22 @@ function sqliteWithCorpus(): SqliteBackend {
   return backend;
 }
 
-// ─── WorkflowFold_TypeFilter_PushedDownToIndexedColumn ────────────────────────
+// ─── WorkflowFold_TypeFilter_PushedDownToSql ─────────────────────────────────
 
 describe('workflow-fold view (DR-3)', () => {
-  it('WorkflowFold_TypeFilter_PushedDownToIndexedColumn', () => {
+  it('WorkflowFold_TypeFilter_PushedDownToSql', () => {
     const backend = sqliteWithCorpus();
-
-    // Capture every SQL string the backend compiles during the filtered read.
-    const db = (backend as unknown as { db: { prepare: (sql: string) => unknown } }).db;
-    const preparedSql: string[] = [];
-    const original = db.prepare.bind(db);
-    vi.spyOn(db, 'prepare').mockImplementation((sql: string) => {
-      preparedSql.push(sql);
-      return original(sql);
-    });
 
     const rows = foldWorkflowSummaries(backend, { workflowType: 'debug', includeTerminal: true });
 
     // Behavioural proof: only debug workflows returned. If the type predicate
     // were NOT pushed down to SQL, the join would return every type and
     // — because the JS lifecycle filter deliberately does not re-check
-    // workflowType — feature rows would leak through here.
+    // workflowType — feature rows would leak through here. This is the real
+    // guarantee: the type filter lives in SQL, never in JS.
     expect(rows.map((r) => r.featureId).sort()).toEqual(['dbg-active', 'dbg-done']);
 
-    // Structural proof: the summary query compiled the type predicate into a
-    // SQL WHERE built on the registry's workflow_type column. The predicate is
-    // the COALESCE expression rather than a bare `s.workflow_type = ?` because
-    // the join is a LEFT JOIN: a workflow whose `streams` row is missing (a
-    // swallowed registerStream failure) must still be filtered on its state
-    // row's own workflowType instead of being silently dropped. The load-
-    // bearing property this pins is unchanged — the type predicate lives in
-    // SQL, never in JS. Only index utilisation on streams.workflow_type is
-    // traded away, which the per-row MIN(timestamp) correlated subquery below
-    // already dominates.
-    const summarySql = preparedSql.find(
-      (sql) => sql.includes('json_extract') && sql.includes('workflow_type'),
-    );
-    expect(summarySql).toBeDefined();
-    expect(summarySql!).toMatch(/where[\s\S]*coalesce\(s\.workflow_type[\s\S]*=\s*\?/i);
-
-    // Counter proof: the indexed pushdown path fired exactly once.
+    // Counter proof: the pushdown path fired exactly once.
     expect(backend.getStats().workflowTypePushdownQueries).toBe(1);
   });
 

--- a/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.ts
+++ b/servers/exarchos-mcp/src/views/lifecycle/workflow-fold.ts
@@ -1,0 +1,95 @@
+import type {
+  StorageBackend,
+  WorkflowLifecycleStatus,
+  WorkflowSummaryFilter,
+} from '../../storage/backend.js';
+
+/**
+ * Workflow-fold view (DR-3) — the read half of the `ps` workflows fold.
+ *
+ * Folds the backend's {@link StorageBackend.listWorkflowSummaries} rows into
+ * the display shape a `ps`-style listing renders: one row per workflow with a
+ * computed `ageMs`. The heavy lifting (the indexed `workflow_type` pushdown,
+ * the lifecycle-axis filtering, the terminal-state default) lives in the
+ * backend so both storage implementations stay row-for-row equivalent; this
+ * view is the thin, backend-agnostic layer that adds age.
+ *
+ * It is NOT an event fold — it reads the projected summary rows, never a
+ * `switch (event.type)` over `WorkflowEvent` — so it sits entirely outside the
+ * single-workflow-fold CI gate (`scripts/check-single-workflow-fold.mjs`).
+ */
+
+/**
+ * One rendered workflow row. `ageMs` is the elapsed time since the workflow's
+ * earliest event envelope, or `null` when the stream carries no events (no
+ * envelope to measure from).
+ */
+export interface WorkflowFoldRow {
+  readonly featureId: string;
+  readonly workflowType: string;
+  readonly phase: string;
+  readonly status: WorkflowLifecycleStatus;
+  readonly ageMs: number | null;
+}
+
+/**
+ * Options for {@link foldWorkflowSummaries}: the backend
+ * {@link WorkflowSummaryFilter} plus an injectable clock for deterministic age
+ * assertions.
+ */
+export interface WorkflowFoldOptions extends WorkflowSummaryFilter {
+  /** Wall-clock reference for age computation, in epoch ms. Defaults to `Date.now()`. */
+  nowMs?: number;
+}
+
+/**
+ * Read the filtered workflow summaries from `backend` and fold them into
+ * {@link WorkflowFoldRow}s, computing `ageMs` from each row's event-envelope
+ * `createdAt` against `nowMs`.
+ *
+ * Rows are ordered oldest-first (largest `ageMs`), with envelope-less rows
+ * (`ageMs === null`) sorted last and `featureId` as a stable tie-break — the
+ * order a `ps` listing wants (the stalest workflows, the ones most likely to
+ * need attention, surface at the top).
+ */
+export function foldWorkflowSummaries(
+  backend: StorageBackend,
+  options: WorkflowFoldOptions = {},
+): WorkflowFoldRow[] {
+  const { nowMs, ...filter } = options;
+  const now = nowMs ?? Date.now();
+
+  const rows: WorkflowFoldRow[] = backend
+    .listWorkflowSummaries(filter)
+    .map((summary) => ({
+      featureId: summary.featureId,
+      workflowType: summary.workflowType,
+      phase: summary.phase,
+      status: summary.status,
+      ageMs: computeAgeMs(summary.createdAt, now),
+    }));
+
+  rows.sort((a, b) => {
+    // Nulls last; otherwise oldest (largest age) first.
+    if (a.ageMs === null && b.ageMs === null) return a.featureId.localeCompare(b.featureId);
+    if (a.ageMs === null) return 1;
+    if (b.ageMs === null) return -1;
+    if (a.ageMs !== b.ageMs) return b.ageMs - a.ageMs;
+    return a.featureId.localeCompare(b.featureId);
+  });
+
+  return rows;
+}
+
+/**
+ * Elapsed ms from an ISO-8601 event-envelope timestamp to `nowMs`. Returns
+ * `null` when there is no envelope (`createdAt === null`) or the timestamp is
+ * unparseable, and clamps negative ages (a clock-skewed future envelope) to 0
+ * so `ageMs` is never negative.
+ */
+function computeAgeMs(createdAt: string | null, nowMs: number): number | null {
+  if (createdAt === null) return null;
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) return null;
+  return Math.max(0, nowMs - created);
+}

--- a/servers/exarchos-mcp/src/views/tools.pipeline.test.ts
+++ b/servers/exarchos-mcp/src/views/tools.pipeline.test.ts
@@ -515,6 +515,40 @@ describe('handleViewPipeline — DR-6/DR-7 repo scoping + perceivability (task 0
     });
   });
 
+  it('Pipeline_ScopeOutOfSubset_RejectedAsInvalidInput', async () => {
+    // Task fix-C: the shared `scopeField` widening (task 007 → the 4-member
+    // union so `pipeline` and `ps` share ONE `scope` definition) lets a `ps`-only
+    // scope (`workflow`/`worktree`) reach the pipeline handler. GA rejected
+    // out-of-subset scopes; the widening must NOT silently coerce them to
+    // unscoped. A `ps`-only member returns a structured INVALID_INPUT with
+    // validTargets ['repo','all'] (mirroring how `ps` rejects the pipeline-only
+    // `repo` member) and a self-correcting `suggestedFix` routing to `ps`.
+    await seedStarted('scope-reject', { repoRoot: '/repo/z' });
+
+    const workflowResult = await handleViewPipeline(
+      { scope: 'workflow', includeCompleted: true },
+      stateDir,
+      store,
+    );
+    expect(workflowResult.success).toBe(false);
+    expect(workflowResult.error?.code).toBe('INVALID_INPUT');
+    expect(workflowResult.error?.validTargets).toEqual(['repo', 'all']);
+    expect(workflowResult.error?.suggestedFix?.params).toMatchObject({
+      action: 'ps',
+      scope: 'workflow',
+    });
+
+    // The sibling ps-only member is rejected identically.
+    const worktreeResult = await handleViewPipeline(
+      { scope: 'worktree', includeCompleted: true },
+      stateDir,
+      store,
+    );
+    expect(worktreeResult.success).toBe(false);
+    expect(worktreeResult.error?.code).toBe('INVALID_INPUT');
+    expect(worktreeResult.error?.validTargets).toEqual(['repo', 'all']);
+  });
+
   it('Pipeline_ScopeAll_IncludesLegacyUnscopedRows', async () => {
     // scope:'all' reproduces the full cross-repo inventory INCLUDING legacy rows
     // that carry no `repoRoot` (undefined) — those match only unscoped/'all'.

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -704,7 +704,13 @@ export async function handleViewPipeline(
     // flags auto-emit). `repoRoot` scopes to an arbitrary repo (normalized before
     // compare); `scope` forces `"all"` (unfiltered) or `"repo"` (requires a key).
     repoRoot?: string;
-    scope?: 'repo' | 'all';
+    // The shared `scopeField` (lifecycle `schema-fields.ts`) was widened to the
+    // 4-member union so `pipeline` and `ps` declare ONE `scope` definition on
+    // `exarchos_view` (a divergent enum value set would make
+    // `buildRegistrationSchema` THROW). `pipeline` acts ONLY on the `{repo, all}`
+    // subset; the `ps`-only members (`workflow`/`worktree`) can reach this
+    // handler through the widened registration and are REJECTED below.
+    scope?: 'repo' | 'all' | 'workflow' | 'worktree';
   },
   stateDir: string,
   eventStore: EventStore,
@@ -721,6 +727,39 @@ export async function handleViewPipeline(
   callerRepoKey?: string,
 ): Promise<ToolResult> {
   try {
+    // Subset guard — `pipeline` acts only on the `{repo, all}` axis. The shared
+    // `scopeField` union (widened by task 007 so `pipeline` and `ps` share one
+    // `scope` definition without a flattener collision) can surface a `ps`-only
+    // member (`workflow`/`worktree`) here. GA rejected out-of-subset scopes; the
+    // widening must not silently coerce them to unscoped. Reject with a
+    // structured, self-correcting `INVALID_INPUT` (mirroring how `ps` rejects the
+    // pipeline-only `repo` member — see `views/lifecycle/ps.ts`) rather than a
+    // silent fall-through to the default caller-key / unscoped branch.
+    if (args.scope !== undefined && args.scope !== 'repo' && args.scope !== 'all') {
+      const outOfSubset = args.scope;
+      const isPsScope = outOfSubset === 'workflow' || outOfSubset === 'worktree';
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_INPUT',
+          message:
+            `pipeline: scope '${outOfSubset}' is not a pipeline axis — pipeline scopes are 'repo' | 'all'.` +
+            (isPsScope
+              ? ` ('workflow' | 'worktree' are ps-only scopes — use ps for those.)`
+              : ''),
+          validTargets: ['repo', 'all'],
+          ...(isPsScope
+            ? {
+                suggestedFix: {
+                  tool: 'exarchos_view',
+                  params: { action: 'ps', scope: outOfSubset },
+                },
+              }
+            : {}),
+        },
+      };
+    }
+
     const store = eventStore;
     const materializer = getOrCreateMaterializer(stateDir);
 

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -844,6 +844,11 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
       // effect on any workflow's projected state (folded by `worktrees@v1`).
       case 'prune.executing_started':
       case 'prune.executed':
+      // DR-6 (lifecycle-verbs task 012) — the two-event `export` contract is an
+      // audit trail (INV-13) of a zip-bundle write; it carries no
+      // workflow_state-affecting fields, so it leaves the projection unchanged.
+      case 'export.requested':
+      case 'export.executed':
       // #1319 — lands on the shared `meta/feedback` stream, never a feature
       // stream, so it has no effect on any workflow's projected state.
       case 'feedback.recorded':


### PR DESCRIPTION
## Summary

Adds generic workflow-lifecycle verbs — `ps` / `inspect` / `wait` / `export` — as layer L7 of the runtime: supervisor primitives over the event log that replace ad-hoc `view pipeline` / `workflow get` polling. Built on two new substrate pieces: a **two-tier cursor-pump subscription** (Tier-1 in-process wake + Tier-2 cross-process `dataVersion()` poll floor) and a **liveness descriptor registry** that turns INV-10 from convention into a checkable pairing contract. Closes the S-6 "wait out / inspect a stuck long-running operation" audit gap via a feature-scoped `wait --operation` predicate (correcting the original `wait --phase` sketch, which was semantically unsound against shipped reducer behavior).

## Changes

- **DR-1 subscription primitive** (`event-store/subscriptions.ts`) — cursor-pump subscription: Tier-1 signal-driven in-process delivery + Tier-2 injectable-clock poll floor keyed on `dataVersion()`; AbortSignal disposal, per-sequence dedup, leak-tested to zero handles.
- **DR-2 liveness registry** (`event-store/liveness-registry.ts`) — one descriptor per surface (`startType`, `terminalTypes`, `streamScope`, `instanceKeyOf`); canonical additive `instanceId`; pairing scoped per `(streamId, instanceKey)` for feature surfaces, by key for the singleton `worktrees` stream. Conformance test enforces the new-surface `instanceId` rule.
- **DR-3 `ps`** (`views/lifecycle/ps.ts`, `operations-fold.ts`, `workflow-fold.ts`) — two honestly-shaped sections (`workflows` + `operations`), scope `workflow|worktree|all`, `workflowType` pushdown via a new `listWorkflowSummaries` backend read.
- **DR-4 `inspect`** (`views/lifecycle/inspect.ts`, `cli/follow-loop.ts`) — workflow projection (existence via `_meta.workflowExists`, cold-probe side-effect-free) + `--follow` over DR-1 (NDJSON on CLI, MCP Tasks on the MCP path).
- **DR-5 `wait`** (`views/lifecycle/wait.ts`) — `--phase` (reached-or-passed), `--status` (terminal, guarded), `--operation` (feature-scoped S-6 predicate); absorbs the WLM-6 `until` kernel.
- **DR-6 `export`** (`views/lifecycle/export.ts`) — diagnostic zip (`yazl`, pinned) with the INV-13 two-event split + crash-precheck idempotency.
- **DR-7 CLI promotion / DR-8 schema union** (`registry.ts`, `views/composite.ts`, `schema-fields.ts`, `adapters/cli.ts`) — one canonical Zod shape per field name so `buildRegistrationSchema` cannot throw on a same-name/different-base collision; `pipeline.scope` migrated onto the widened union; visible composite tool count stays 4.
- **Docs** — `docs/architecture/runtime.md` L7 + liveness convention; unified spec `docs/specs/2026-07-07-lifecycle-verbs.md`.

## Test Plan

- Delegated across 6 waves (19 tasks) + a 3-task adversarial-review fix cycle; each task subagent-implemented and kill-probe / independent-mutation verified.
- **Adversarial review** (4 fresh-context reviewers) found and closed 2 HIGH (cross-stream liveness mis-pairing that masked a stuck merge; unpinned `yazl` breaking INV-13 crash-precheck determinism), 9 MEDIUM, 6 LOW. HIGH fixes are kill-probe-anchored (revert → 5 cross-stream tests go red, incl. an explicit S-6 regression).
- MCP server suite: **9047 passed / 26 failed** — all 26 are the pre-existing `merge-orchestrate.*` / `store.race` baseline (untouched files); **zero new failures**. Root suite 898 passed. `tsc --noEmit` clean on both. `npm run build` passes (bun single-file bundle; `export` smoke-tested from `dist/`).

---
**Results:** MCP tests 9047 pass (26 pre-existing baseline, 0 new) · Root tests 898 pass · Typecheck 0 errors · Build OK
**Design:** [docs/specs/2026-07-07-lifecycle-verbs.md](docs/specs/2026-07-07-lifecycle-verbs.md) (DR-1..DR-8)
**Related:** Closes #1316 · epic #1090 (children #1103–#1106 absorbed) · #1315 · #1599 (Z2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Intent

<!-- intent-grounded -->

**Surfaces:** docs, servers

56 files changed across 2 surfaces: docs, servers