### PR TITLE
fix(projections): retract dropped tasks from the rehydration fold

### DIFF
--- a/servers/exarchos-mcp/src/projections/rehydration/reducer.test.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/reducer.test.ts
@@ -663,6 +663,160 @@ describe('rehydration reducer — state.patched.tasks fold (Fix 2 / #1179)', () 
     expect(RehydrationDocumentSchema.safeParse(next).success).toBe(true);
   });
 
+  it('Rehydration_PlanNarrowedByRevision_RetractsDroppedPendingTasks', () => {
+    // GIVEN: a plan-review revision narrows the plan — the planner stamps
+    // 4 tasks, then re-stamps only 2. This is the counted plan-review
+    // revision edge the HSM explicitly supports, so a narrowed plan is a
+    // normal outcome, not a corruption.
+    const initial = rehydrationReducer.initial;
+    const widePlan = rehydrationReducer.apply(
+      initial,
+      makeEvent(
+        'state.patched',
+        {
+          featureId: 'feat-narrow',
+          fields: ['tasks'],
+          patch: {
+            tasks: [
+              { id: 'T1', title: 'kept', status: 'pending' },
+              { id: 'T2', title: 'kept', status: 'pending' },
+              { id: 'T3', title: 'dropped by revision', status: 'pending' },
+              { id: 'T4', title: 'dropped by revision', status: 'pending' },
+            ],
+          },
+        },
+        1,
+      ),
+    );
+    expect(widePlan.taskProgress).toHaveLength(4);
+
+    const narrowPlan = rehydrationReducer.apply(
+      widePlan,
+      makeEvent(
+        'state.patched',
+        {
+          featureId: 'feat-narrow',
+          fields: ['tasks'],
+          patch: {
+            tasks: [
+              { id: 'T1', title: 'kept', status: 'pending' },
+              { id: 'T2', title: 'kept', status: 'pending' },
+            ],
+          },
+        },
+        2,
+      ),
+    );
+
+    // THEN: the dropped ids are retracted rather than wedged in as
+    // permanent pending ghosts. Pre-fix this returned 4 — the fold could
+    // only append, so every id ever declared accumulated forever and the
+    // document reported the high-water union of all plan revisions.
+    expect(narrowPlan.taskProgress).toHaveLength(2);
+    expect(narrowPlan.taskProgress.map((t) => t.id).sort()).toEqual(['T1', 'T2']);
+
+    // AND: the resulting document still conforms to the schema.
+    expect(RehydrationDocumentSchema.safeParse(narrowPlan).success).toBe(true);
+  });
+
+  it('Rehydration_PlanDropsTaskCarryingLifecycleEvidence_RetainsIt', () => {
+    // GIVEN: a plan of 3 tasks where one is in flight and one has completed
+    const initial = rehydrationReducer.initial;
+    const plan = rehydrationReducer.apply(
+      initial,
+      makeEvent(
+        'state.patched',
+        {
+          featureId: 'feat-evidence',
+          fields: ['tasks'],
+          patch: {
+            tasks: [
+              { id: 'KEEP', title: 'stays in plan', status: 'pending' },
+              { id: 'WORKED', title: 'dropped while in flight', status: 'pending' },
+              { id: 'DONE', title: 'dropped after completing', status: 'pending' },
+              { id: 'GHOST', title: 'dropped untouched', status: 'pending' },
+            ],
+          },
+        },
+        1,
+      ),
+    );
+    let next = rehydrationReducer.apply(
+      plan,
+      makeEvent('task.assigned', { taskId: 'WORKED', title: 'w' }, 2),
+    );
+    next = rehydrationReducer.apply(next, makeEvent('task.completed', { taskId: 'DONE' }, 3));
+
+    // WHEN: a revision drops all three of WORKED / DONE / GHOST
+    const narrowed = rehydrationReducer.apply(
+      next,
+      makeEvent(
+        'state.patched',
+        {
+          featureId: 'feat-evidence',
+          fields: ['tasks'],
+          patch: { tasks: [{ id: 'KEEP', title: 'stays in plan', status: 'pending' }] },
+        },
+        4,
+      ),
+    );
+
+    // THEN: only the untouched pending ghost is retracted. Entries carrying
+    // lifecycle evidence are retained even though the plan dropped them —
+    // real work exists against them, and a plan that drops in-flight or
+    // completed work is an anomaly a human should see rather than one the
+    // projection silently erases.
+    const byId = new Map(narrowed.taskProgress.map((t) => [t.id, t.status]));
+    expect(byId.get('KEEP')).toBe('pending');
+    expect(byId.get('WORKED')).toBe('in_progress');
+    expect(byId.get('DONE')).toBe('complete');
+    expect(byId.has('GHOST')).toBe(false);
+    expect(narrowed.taskProgress).toHaveLength(3);
+  });
+
+  it('Rehydration_StatePatchedWithoutTasksSubtree_LeavesTaskProgressIntact', () => {
+    // GIVEN: a stamped plan
+    const initial = rehydrationReducer.initial;
+    const plan = rehydrationReducer.apply(
+      initial,
+      makeEvent(
+        'state.patched',
+        {
+          featureId: 'feat-artifacts-only',
+          fields: ['tasks'],
+          patch: {
+            tasks: [
+              { id: 'T1', title: 'a', status: 'pending' },
+              { id: 'T2', title: 'b', status: 'pending' },
+            ],
+          },
+        },
+        1,
+      ),
+    );
+
+    // WHEN: a later state.patched carries only `artifacts` and no `tasks`
+    // subtree — the two subtrees are independent contributions.
+    const artifactsOnly = rehydrationReducer.apply(
+      plan,
+      makeEvent(
+        'state.patched',
+        {
+          featureId: 'feat-artifacts-only',
+          fields: ['artifacts'],
+          patch: { artifacts: { pr: 'https://example.test/pr/1' } },
+        },
+        2,
+      ),
+    );
+
+    // THEN: retraction does NOT fire — an absent `tasks` subtree asserts
+    // nothing about membership, so it must not be read as "the plan is now
+    // empty". Without this, any artifacts-only patch would wipe the plan.
+    expect(artifactsOnly.taskProgress).toHaveLength(2);
+    expect(artifactsOnly.artifacts['pr']).toBe('https://example.test/pr/1');
+  });
+
   it('Rehydration_StatePatchedTasksFollowedByPlanReexpansion_DoesNotResurrectCompleted', () => {
     // GIVEN: a plan was patched and one task completed
     const initial = rehydrationReducer.initial;

--- a/servers/exarchos-mcp/src/projections/rehydration/reducer.test.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/reducer.test.ts
@@ -772,6 +772,9 @@ describe('rehydration reducer — state.patched.tasks fold (Fix 2 / #1179)', () 
     expect(byId.get('DONE')).toBe('complete');
     expect(byId.has('GHOST')).toBe(false);
     expect(narrowed.taskProgress).toHaveLength(3);
+
+    // AND: the resulting document still conforms to the schema.
+    expect(RehydrationDocumentSchema.safeParse(narrowed).success).toBe(true);
   });
 
   it('Rehydration_StatePatchedWithoutTasksSubtree_LeavesTaskProgressIntact', () => {
@@ -815,6 +818,9 @@ describe('rehydration reducer — state.patched.tasks fold (Fix 2 / #1179)', () 
     // empty". Without this, any artifacts-only patch would wipe the plan.
     expect(artifactsOnly.taskProgress).toHaveLength(2);
     expect(artifactsOnly.artifacts['pr']).toBe('https://example.test/pr/1');
+
+    // AND: the resulting document still conforms to the schema.
+    expect(RehydrationDocumentSchema.safeParse(artifactsOnly).success).toBe(true);
   });
 
   it('Rehydration_StatePatchedTasksFollowedByPlanReexpansion_DoesNotResurrectCompleted', () => {

--- a/servers/exarchos-mcp/src/projections/rehydration/reducer.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/reducer.ts
@@ -246,12 +246,30 @@ const extractPlanTasks = extractPlanTasksFromPatch;
  * while still preventing the regression case (a re-assertion of `pending`
  * over a `completed` entry is ignored). New ids in the plan are appended
  * with their plan-declared status. Per CR review 4178067854.
+ *
+ * Membership retraction: `patch.tasks` carries the planner's FULL task list
+ * — `workflow set` stamps it wholesale, never as a partial delta — so the
+ * newest assertion is authoritative on membership. An id the plan no longer
+ * declares is dropped, but ONLY while it is still `pending`. Once an entry
+ * carries lifecycle evidence (`in_progress` / `complete` / `failed`) real
+ * work exists against it, and a plan that drops it is an anomaly a human
+ * should see rather than one the projection silently erases. Statuses
+ * outside the canonical ladder are likewise retained — `rankOf` cannot
+ * distinguish them from `pending`, and erasing real work is the worse
+ * failure, so retraction tests the literal status instead.
+ *
+ * Without this, a plan narrowed during a plan-review revision — an edge the
+ * HSM explicitly supports — left every dropped id wedged in the document as
+ * a permanent pending ghost, because the fold could only ever append.
  */
 function foldPlanTasks(
   progress: readonly TaskProgressEntry[],
   planTasks: readonly ExtractedPlanTask[],
 ): TaskProgressEntry[] {
-  const next = progress.slice();
+  const planIds = new Set(planTasks.map((planTask) => planTask.id));
+  const next = progress.filter(
+    (entry) => planIds.has(entry.id) || entry.status !== 'pending',
+  );
   const indexById = new Map(next.map((entry, idx) => [entry.id, idx]));
   for (const planTask of planTasks) {
     const existingIdx = indexById.get(planTask.id);


### PR DESCRIPTION
## Summary

`foldPlanTasks` (`projections/rehydration/reducer.ts`) could only ever **append**. It folds `state.patched` `patch.tasks` — the planner's full task list, stamped wholesale — into `taskProgress`, appending unseen ids and promoting statuses up the rank ladder. There was no path to drop an id the plan no longer declares.

The HSM **explicitly supports plan-review revisions**, so a plan that narrows is a normal outcome, not corruption. Every id ever declared therefore accumulated forever: `taskProgress` reported the *high-water union* of all revisions rather than the current plan.

Found on `debloat-wave1-structural-enforcement`, whose plan went `15 -> 33 -> 34 -> 32 -> 26 -> 25` across eight review rounds. It reported **34** tasks against a 25-task plan, wedging 9 phantom `pending` entries. No replay could clear them — replay is deterministic, so it regenerated the same 34. These surface as the phantom in-progress blockers that `prepare_synthesis` trips over.

Notably, the *same handler* already retracts the sibling `artifacts` subtree via its `unset` branch. Only the tasks subtree lacked the path.

## Changes

- **`foldPlanTasks` retracts** ids absent from the newest plan assertion. Sound because `patch.tasks` is stamped wholesale (never a partial delta), so the newest assertion is authoritative on membership.
- Retraction is **bounded to entries still `pending`**. Once an entry carries lifecycle evidence (`in_progress` / `complete` / `failed`) real work exists against it, and a plan dropping it is an anomaly a human should see rather than one the projection silently erases. Statuses outside the canonical ladder are retained too — `rankOf` cannot distinguish them from `pending`, and erasing real work is the worse failure — so the check tests the literal status.
- Three regression tests.

**No projection-version bump.** `rehydrate` hydrates from snapshot *then tails events since*, so a checkpointed stream self-heals the moment its next plan assertion folds through the fixed code. A stream that never stamps another plan is finished and its ghosts are inert. Bumping would have orphaned 62 streams' caches and touched 8 test files to buy a lazy heal we get for free.

## Test Plan

- **Kill-probe** — reverted the fold and confirmed both bug-targeting tests fail; restored and confirmed they pass. (The third, `StatePatchedWithoutTasksSubtree`, passes pre-fix by design: it guards against over-retraction wiping the plan on an artifacts-only patch.)
- **Real-data replay** — folded the live 105-event stream through the fixed reducer: **34 -> 25**, ids matching the plan exactly, zero ghosts.
- `npx tsc --noEmit` clean.
- `src/projections` + `src/workflow` + `src/views`: **1593 passed, 0 failed** (115 files).
- Full server suite: 9074 passed / 26 failed. Those 26 are the **pre-existing local-only baseline** (all `merge-orchestrate.*` + `event-store/store.race`) — proven by reverting this change and reproducing the identical 9 files / 26 tests.

New tests:
- `Rehydration_PlanNarrowedByRevision_RetractsDroppedPendingTasks`
- `Rehydration_PlanDropsTaskCarryingLifecycleEvidence_RetainsIt`
- `Rehydration_StatePatchedWithoutTasksSubtree_LeavesTaskProgressIntact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
