### PR TITLE
wave-3b: test-suite de-divergence — 17 relocations + DR-2 gate + ratchet (#1705)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,7 +654,11 @@ jobs:
         run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
 
       - name: Manifest gate — no pre-image case dropped (DR-2, Task 004)
-        run: node scripts/audit/manifest-gate-ci.mjs
+        # Reconstruct against the PR's actual base branch (not a hardcoded
+        # origin/main) so a stacked PR onto a non-main base verifies against the
+        # right merge-base; on push events base_ref is empty and the tool
+        # defaults to origin/main.
+        run: node scripts/audit/manifest-gate-ci.mjs ${{ github.base_ref && format('--base origin/{0}', github.base_ref) || '' }}
 
   # ─────────────────────────────────────────────────────────────────────
   # grep-gates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,50 @@ jobs:
         run: bash scripts/validate-no-legacy.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # manifest-gate (DR-2 / Task 004)
+  # ─────────────────────────────────────────────────────────────────────
+  # The primary de-divergence guarantee: on each consolidation PR, prove NO
+  # pre-image test case was lost. Reconstructs BOTH pre-images (the legacy
+  # __tests__ copy AND the co-located canonical copy) from the PR's merge-base
+  # via `git show <merge-base>:<path>` (hence `fetch-depth: 0`) and asserts
+  # every case survives into the PR-HEAD result (merged file or relocated
+  # <base>.legacy.test.ts sibling) verbatim modulo import-path rewrites, or as
+  # a textual duplicate — BIDIRECTIONAL (both sides). Equivalence is TEXTUAL
+  # only; a divergent vi.mock/vi.hoisted/env preamble forces relocate, never a
+  # silent drop. The gate is inert on PRs that touch no consolidation pair.
+  # WIRED into `ci-gate.needs` below so it is REQUIRED — a job merely present
+  # in ci.yml but absent from the aggregator fails OPEN (the Wave-S lesson).
+  # Host class: deps-tail, unfiltered — see docs/guides/ci-gate-hosting.md.
+  # ─────────────────────────────────────────────────────────────────────
+  manifest-gate:
+    name: Manifest Gate (textual case-preservation)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # DR-2: reconstruct pre-images from the merge-base via `git show`, so
+          # the full history (not a shallow clone) must be present.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            servers/exarchos-mcp/package-lock.json
+
+      # The gate imports consolidate-suite.mjs, which pulls in `typescript` (a
+      # ROOT devDependency) for TS-compiler-API case extraction. Only the root
+      # install is needed — no MCP-server deps, no native build.
+      - name: Install dependencies (root)
+        run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
+
+      - name: Manifest gate — no pre-image case dropped (DR-2, Task 004)
+        run: node scripts/audit/manifest-gate-ci.mjs
+
+  # ─────────────────────────────────────────────────────────────────────
   # grep-gates
   # ─────────────────────────────────────────────────────────────────────
   # Fast pre-test structural checks that enforce architectural invariants
@@ -1006,7 +1050,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [changes, test-root, test-mcp, test-windows, test-windows-root, validate-no-legacy, grep-gates, outcome-tests]
+    needs: [changes, test-root, test-mcp, test-windows, test-windows-root, validate-no-legacy, manifest-gate, grep-gates, outcome-tests]
     if: (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') && always()
     steps:
       - name: Evaluate results
@@ -1017,6 +1061,7 @@ jobs:
           echo "test-windows=${{ needs.test-windows.result }}"
           echo "test-windows-root=${{ needs.test-windows-root.result }}"
           echo "validate-no-legacy=${{ needs.validate-no-legacy.result }}"
+          echo "manifest-gate=${{ needs.manifest-gate.result }}"
           echo "grep-gates=${{ needs.grep-gates.result }}"
           echo "outcome-tests=${{ needs.outcome-tests.result }}"
 
@@ -1094,6 +1139,13 @@ jobs:
           fi
           if [[ "${{ needs.validate-no-legacy.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "::error::Validate no legacy: ${{ needs.validate-no-legacy.result }}"
+            exit 1
+          fi
+          # manifest-gate (DR-2, Task 004) is BLOCKING. It runs on every PR and
+          # is inert unless the PR touches a consolidation pair, so it needs no
+          # path-filter skip-guard (its `if:` references no changes.outputs.*).
+          if [[ "${{ needs.manifest-gate.result }}" =~ ^(failure|cancelled)$ ]]; then
+            echo "::error::Manifest gate (textual case-preservation): ${{ needs.manifest-gate.result }}"
             exit 1
           fi
           if [[ "${{ needs.grep-gates.result }}" =~ ^(failure|cancelled)$ ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,17 @@ jobs:
         working-directory: servers/exarchos-mcp
         run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
 
+      # Duplicate-location ratchet (DR-1, Task 022). An (area, basename)
+      # intersection guard that FAILS on any legacy __tests__/<area>/<base>.test.ts
+      # twin of a co-located subject not in the (empty) allowlist. Shares Task
+      # 001's `enumeratePairs` — so it imports consolidate-suite.mjs, which pulls
+      # in `typescript` (a root devDependency); it therefore rides the root
+      # install above rather than the zero-dep prefix. No extra install step.
+      # The allowlist shrinks to 0 once all 17 pairs relocate, so this gate is
+      # green only in the consolidated end-state (it lands with/after the pairs).
+      - name: Duplicate-location ratchet (DR-1, Task 022)
+        run: node scripts/audit/check-no-duplicate-suites.mjs
+
       # ── Wave-S tsx-tail + bun gates (DR-8, DR-2, DR-10) ────────────────────
       # These ride the UNFILTERED grep-gates host so they fire on every PR,
       # using the BOTH dep trees installed by the two steps above. See

--- a/docs/specs/2026-07-18-test-mass-consolidation.md
+++ b/docs/specs/2026-07-18-test-mass-consolidation.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-18 · **Feature:** `test-mass-consolidation` · **Depth:** deep
 **Inputs:** epic #1701 · issue #1705 · parent spec `docs/specs/2026-07-15-debloat-wave1-structural-enforcement.md` · coverage/mutation substrate PR #1719 (`c78450c7`, on `origin/main`) · CI-substrate lessons from Wave S (#1711 — `ci-gate.needs` semantics)
-**Revisions:** rev.0 → rev.1 → rev.2 → rev.3 → **rev.4**. Three 3-voter adversarial rounds (9 voters) — see Exploration for the full trail.
+**Revisions:** rev.0 → rev.1 → rev.2 → rev.3 → rev.4 → **rev.5**. rev.0–4: three 3-voter adversarial rounds (9 voters) — see Exploration. rev.5 (delegate-phase, 2026-07-20): DR-7 consolidated from per-pair PRs to a single campaign PR (realized split = all 17 relocate); no guarantee weakened, ~17× flaky-CI exposure removed.
 
 > One unified artifact: `## Requirements` holds the DR-N source; `## Decomposition` maps tasks → DR-N within this same document.
 
@@ -48,7 +48,7 @@ The durable defect is **structural**: one unit tested from two drifting director
 - **Merge** the legacy cases into the co-located canonical file **iff** the two files' module-scope preambles (imports, `vi.mock`/`vi.hoisted`/`vi.stubEnv`/`vi.stubGlobal`, module-scope helpers/consts, hooks) are **textually identical modulo import-path rewrites** — then drop only cases that are textually identical (modulo imports) to one already present, and move the rest. Identical preambles ⇒ no divergent mock or colliding helper to mishandle, so the merge is sound by construction.
 - **Relocate** otherwise: move the legacy file into the co-located directory as a distinct sibling (e.g. `<x>.legacy.test.ts`), unchanged except import-path rewrites. This kills the two-directory divergence without forcing incompatible mocks into one file. `state-store` and `compensation` are known relocate cases.
 
-Either way, the legacy `__tests__/` copy is gone. Each pair lands as its own PR; a **CI job wired into `ci-gate.needs`** (so it actually blocks) reconstructs both pre-images from the merge-base (`git show`, `fetch-depth: 0`) and fails the PR unless every pre-image case is present in the PR-HEAD result (merged file or relocated sibling) or is a textually-proven duplicate. Coverage non-regression (#1719) is a union-limited backstop; mutation is deferred (#1720). A ratchet guard forbids any `__tests__/` twin for any co-located subject, allowlist shrinking to **0**. Chosen via the `deep`-rung decisions (scope = all 17 pairs; operation = preamble-conditional merge/relocate; oracle = textual-identity CI gate primary + coverage backstop).
+Either way, the legacy `__tests__/` copy is gone. The campaign lands as one consolidation PR (DR-7, rev.5); a **CI job wired into `ci-gate.needs`** (so it actually blocks) reconstructs both pre-images from the merge-base (`git show`, `fetch-depth: 0`) and fails the PR unless every pre-image case is present in the PR-HEAD result (merged file or relocated sibling) or is a textually-proven duplicate. Coverage non-regression (#1719) is a union-limited backstop; mutation is deferred (#1720). A ratchet guard forbids any `__tests__/` twin for any co-located subject, allowlist shrinking to **0**. Chosen via the `deep`-rung decisions (scope = all 17 pairs; operation = preamble-conditional merge/relocate; oracle = textual-identity CI gate primary + coverage backstop).
 
 ## Requirements
 
@@ -104,14 +104,14 @@ Because the DR-2 textual gate is **uniform across all 17 pairs** and bidirection
 - INV-8 idempotent-retry cases and INV-1 reducer/projection/schema-validation cases are present (merged or relocated) in the result and named in the PR; none is dropped except as a textual duplicate.
 - Oracle strength is not keyed to invariant membership.
 
-### DR-7: Per-pair PRs (the enforcement seam), ci-gate-wired, serialized
+### DR-7: Consolidated campaign PR (the enforcement seam), ci-gate-wired
 
-Each pair lands as its own PR so the DR-2 gate + DR-3 ratchet run in CI per pair — a local `git merge --no-ff` triggers no CI and cannot enforce. PRs land serially so the ratchet sees a coherent cumulative state.
+The load-bearing constraint is that the DR-2 gate + DR-3 ratchet run **in CI on a PR** — a local `git merge --no-ff` triggers no CI and cannot enforce. The enforcement seam is therefore a *PR*, but not necessarily one PR *per pair*: the DR-2 gate is **diff-scoped** (it reconstructs pre-images from the merge-base and validates every pair touched in the diff, so N pairs verify in one CI run), and the ratchet is a whole-tree check, so a single PR carrying all 17 relocations transitions the allowlist **17 → 0 atomically**. **Revised (rev.5):** the campaign lands as **two PRs total** — PR-1 = foundation tooling + spec (#1728, merged `bfd6ef96`); PR-2 = the whole remaining campaign (Task 004 gate + all 17 relocations + Task 022 ratchet + Task 023 closeout). This supersedes the earlier per-pair-PR model. No guarantee is weakened (DR-1/DR-2/DR-3 all hold on a bundled diff), and it *removes* the per-pair model's accepted ~17× flaky-CI exposure by running the instrumented suite once instead of seventeen times.
 
 **Acceptance criteria:**
-- Each consolidation lands via its own PR that triggers the DR-2 gate (ci-gate-required) + DR-3 ratchet; no pair merges via a CI-invisible local merge.
-- PRs land single-writer (stacked; manual sequential merge where `serialize_merge` is `CAPABILITY_DENIED`).
-- **Operational risk (accepted):** 17 serialized coverage-instrumented PRs each re-run the MCP suite, exposing the campaign ~17× to the documented flaky-E2E / perf / `SQLITE_BUSY` class; mitigation is `gh run rerun --failed` per the known-flake runbook, not baseline relaxation.
+- The consolidation lands via a PR (not a CI-invisible local merge) that triggers the DR-2 gate (ci-gate-required) + DR-3 ratchet; the gate validates all touched pairs in one run.
+- On PR-2's HEAD the ratchet's allowlist is empty and passes (0 `__tests__` twins remain for the 17 subjects).
+- Pilot discipline is preserved *inside* the campaign build (relocate + verify a couple of pairs before the rest), not as a PR boundary.
 
 ### DR-8: Base-substrate preflight (a delegate-phase dispatch check)
 
@@ -155,7 +155,8 @@ Divergent loop (no `/exarchos:discover`) + three adversarial rounds:
 - **Delete legacy wholesale:** rejected — legacy asserts *more* for several pairs.
 - **Force every pair into one file (rev.2/3):** rejected — unsound where module-scope mocks diverge (vitest file-scoping); hence preamble-conditional relocate.
 - **Semantic identity hash:** rejected — silently ignores mock/env context; textual identity only.
-- **Local `git merge --no-ff` per pair:** rejected — no CI event; per-pair PRs instead.
+- **Local `git merge --no-ff` (CI-invisible):** rejected — no CI event; the consolidation lands via a PR (DR-7) so the gate runs.
+- **Per-pair PRs (rev.0–4):** superseded by rev.5 — the DR-2 gate is diff-scoped, so one consolidation PR verifies all 17 pairs in a single CI run and drops the ~17× flaky-CI exposure.
 - **Defer 8/10 pairs (rev.2):** superseded — checkpoint chose all 17.
 - **Top-20 large-suite minimization:** deferred.
 
@@ -180,14 +181,14 @@ Divergent loop (no `/exarchos:discover`) + three adversarial rounds:
 | DR-4 | Mutation deferred (#1720) | 023 |
 | DR-5 | Keep-classes protected | 002, 005–021 |
 | DR-6 | Substrate-backstop preservation | 001, 005, 008, 009, 014, 015, 019 |
-| DR-7 | Per-pair PRs (enforcement seam), serialized | 004, 005–021, 023 |
+| DR-7 | Consolidated campaign PR (enforcement seam), ci-gate-wired | 004, 005–021, 023 |
 | DR-8 | Base-substrate preflight | 003 |
 
 (“005–021” denotes each of tasks 005 through 021 individually — the 17 pairs.)
 
 ### Tasks
 
-All 17 pair tasks are high-tier, boundary-touching; each lands as its own PR (DR-7) gated by the DR-2 CI check; each is merge-or-relocate per the tool's `--plan`. Verification per pair = DR-2 textual gate (blocking) + DR-3 coverage ratchet (blocking) + green suite.
+All 17 pair tasks are high-tier, boundary-touching; all land together in the single consolidation PR (DR-7, rev.5) gated by the DR-2 CI check; each is merge-or-relocate per the tool's `--plan` (**realized: all 17 relocate, 0 merge**). Verification per pair = DR-2 textual gate (blocking) + DR-3 coverage ratchet (blocking) + green suite.
 
 ### Task 001: Consolidation tool — enumerate / plan(merge|relocate) / emit / verify (textual, TS compiler API)
 
@@ -221,119 +222,119 @@ All 17 pair tasks are high-tier, boundary-touching; each lands as its own PR (DR
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-6, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/guards.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/guards.test.ts`
-**Verification:** high — own PR; `--plan` decides merge/relocate; DR-2 textual gate (bidirectional) blocking; coverage backstop ≥ baseline; green suite; substrate-backstop preservation of the invariant INV-8 (idempotent-retry cases present). Pilot: validates tool + ci-gate wiring end-to-end and reports the realized merge/relocate split.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); `--plan` decides merge/relocate; DR-2 textual gate (bidirectional) blocking; coverage backstop ≥ baseline; green suite; substrate-backstop preservation of the invariant INV-8 (idempotent-retry cases present). Pilot: validates tool + ci-gate wiring end-to-end and reports the realized merge/relocate split.
 **Dependencies:** 001, 002, 003, 004 · **Parallelizable:** Yes (pilot group)
 
 ### Task 006: Consolidate workflow/state-machine (asymmetry + high-volume pilot)
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/state-machine.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite. Pilot: highest merge-volume (3338 legacy). Must not touch adjacent `state-machine.property.test.ts` (keep-class).
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite. Pilot: highest merge-volume (3338 legacy). Must not touch adjacent `state-machine.property.test.ts` (keep-class).
 **Dependencies:** 001, 002, 003, 004 · **Parallelizable:** Yes (pilot group)
 
 ### Task 007: Consolidate workflow/tools
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/tools.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts`
-**Verification:** high — own PR; DR-2 gate run with the eight co-located `tools.*.test.ts` split files as canonical context (a case already split out is a textual duplicate, not re-added); coverage backstop; green suite. Must not touch `tools.update.race.test.ts`.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate run with the eight co-located `tools.*.test.ts` split files as canonical context (a case already split out is a textual duplicate, not re-added); coverage backstop; green suite. Must not touch `tools.update.race.test.ts`.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 008: Consolidate workflow/compensation (INV-8, known relocate)
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-6, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/compensation.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts`
-**Verification:** high — own PR; the twins' `child_process` mocks diverge (sync vs async factory) so `--plan` yields **relocate** (legacy file moved co-located as a sibling, not force-merged); DR-2 gate confirms every legacy case present verbatim; coverage backstop; green suite; INV-8 idempotent-retry cases preserved.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); the twins' `child_process` mocks diverge (sync vs async factory) so `--plan` yields **relocate** (legacy file moved co-located as a sibling, not force-merged); DR-2 gate confirms every legacy case present verbatim; coverage backstop; green suite; INV-8 idempotent-retry cases preserved.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 009: Consolidate workflow/state-store (INV-1, known relocate)
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-6, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/state-store.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/state-store-resolve.test.ts` (fold-in)
-**Verification:** high — own PR; legacy has 22 module-scope mock/env constructs vs 0 co-located → `--plan` yields **relocate**; DR-2 gate (all three source files as pre-image) confirms presence; coverage backstop; green suite; INV-1 reducer/projection cases preserved.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); legacy has 22 module-scope mock/env constructs vs 0 co-located → `--plan` yields **relocate**; DR-2 gate (all three source files as pre-image) confirms presence; coverage backstop; green suite; INV-1 reducer/projection cases preserved.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 010: Consolidate views/handlers
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/views/handlers.test.ts`, `servers/exarchos-mcp/src/__tests__/views/handlers.test.ts`, `servers/exarchos-mcp/src/__tests__/views/tools-error-paths.test.ts` (fold-in)
-**Verification:** high — own PR; DR-2 gate (both legacy files as pre-image); coverage backstop; green suite.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate (both legacy files as pre-image); coverage backstop; green suite.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 011: Consolidate event-store/schemas (INV-1, largest target)
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-6, DR-7
 **Files:** `servers/exarchos-mcp/src/event-store/schemas.test.ts`, `servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts`
-**Verification:** high — own PR; DR-2 gate (bidirectional load-bearing given the 4702-line canonical); coverage backstop; green suite; INV-1 schema-validation cases preserved. Must not touch `schemas.onboard.test.ts`. Sequence late.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate (bidirectional load-bearing given the 4702-line canonical); coverage backstop; green suite; INV-1 schema-validation cases preserved. Must not touch `schemas.onboard.test.ts`. Sequence late.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 012: Consolidate workflow/checkpoint
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/checkpoint.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/checkpoint.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 013: Consolidate workflow/migration
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/migration.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/migration.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 014: Consolidate workflow/schemas (INV-1)
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-6, DR-7
 **Files:** `servers/exarchos-mcp/src/workflow/schemas.test.ts`, `servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite; INV-1 cases preserved. Distinct from event-store/schemas (Task 011) — the (area, basename) allowlist must not conflate them.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite; INV-1 cases preserved. Distinct from event-store/schemas (Task 011) — the (area, basename) allowlist must not conflate them.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 015: Consolidate views/materializer (INV-1 projection)
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-6, DR-7
 **Files:** `servers/exarchos-mcp/src/views/materializer.test.ts`, `servers/exarchos-mcp/src/__tests__/views/materializer.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite; INV-1 (projection) cases preserved. **Must not touch adjacent `views/materializer.property.test.ts` (keep-class).**
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite; INV-1 (projection) cases preserved. **Must not touch adjacent `views/materializer.property.test.ts` (keep-class).**
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 016: Consolidate views/pipeline-view
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/views/pipeline-view.test.ts`, `servers/exarchos-mcp/src/__tests__/views/pipeline-view.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 017: Consolidate views/snapshot-store
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/views/snapshot-store.test.ts`, `servers/exarchos-mcp/src/__tests__/views/snapshot-store.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 018: Consolidate views/task-detail-view
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/views/task-detail-view.test.ts`, `servers/exarchos-mcp/src/__tests__/views/task-detail-view.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite. Smallest pair.
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite. Smallest pair.
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 019: Consolidate event-store/tools (INV-1)
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-6, DR-7
 **Files:** `servers/exarchos-mcp/src/event-store/tools.test.ts`, `servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite; INV-1 cases preserved. This canonical file imports `fast-check` (a mixed file, not a dedicated property suite — its fc cases relocate/merge verbatim). Distinct from workflow/tools (Task 007). 
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite; INV-1 cases preserved. This canonical file imports `fast-check` (a mixed file, not a dedicated property suite — its fc cases relocate/merge verbatim). Distinct from workflow/tools (Task 007). 
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 020: Consolidate sync/outbox
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/sync/outbox.test.ts`, `servers/exarchos-mcp/src/__tests__/sync/outbox.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite. (Missed by the audit and by rev.0–3; surfaced by the round-3 exhaustive enumeration.)
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite. (Missed by the audit and by rev.0–3; surfaced by the round-3 exhaustive enumeration.)
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 021: Consolidate utils/process
 
 **Risk Tier:** high · **Boundary Touching:** true · **Implements:** DR-1, DR-2, DR-3, DR-5, DR-7
 **Files:** `servers/exarchos-mcp/src/utils/process.test.ts`, `servers/exarchos-mcp/src/__tests__/utils/process.test.ts`
-**Verification:** high — own PR; DR-2 gate; coverage backstop; green suite. Disjoint assertions (legacy tests `isPidAlive`; co-located tests `needsWindowsShell`/`runCommandSync`/`spawnCommandSync`) — `--plan` likely **relocate** or additive merge; the gate proves `isPidAlive` coverage is not dropped. (Also missed until round-3 enumeration.)
+**Verification:** high — lands in the consolidation PR (DR-7, rev.5); DR-2 gate; coverage backstop; green suite. Disjoint assertions (legacy tests `isPidAlive`; co-located tests `needsWindowsShell`/`runCommandSync`/`spawnCommandSync`) — `--plan` likely **relocate** or additive merge; the gate proves `isPidAlive` coverage is not dropped. (Also missed until round-3 enumeration.)
 **Dependencies:** 001, 002, 003, 004, 005, 006 · **Parallelizable:** Yes (main wave)
 
 ### Task 022: Duplicate-location ratchet guard (area-qualified, allowlist → empty)
@@ -347,7 +348,15 @@ All 17 pair tasks are high-tier, boundary-touching; each lands as its own PR (DR
 
 **Risk Tier:** medium · **Boundary Touching:** false · **Implements:** DR-1, DR-3, DR-4, DR-7
 **Files:** `docs/specs/2026-07-18-test-mass-consolidation.md`
-**Verification:** medium — confirm none of the 17 subjects remains a duplicate-location pair (Task 022 guard green, empty allowlist), every per-pair PR passed the DR-2 gate + coverage ratchet in CI, record the realized merge/relocate split and the #1720 mutation-re-enablement follow-up, update epic #1705 with the de-divergence (not LoC-lever) reframe.
+**Verification:** medium — confirm none of the 17 subjects remains a duplicate-location pair (Task 022 guard green, empty allowlist), the DR-2 gate + coverage ratchet pass in CI on the consolidation PR, record the realized merge/relocate split and the #1720 mutation-re-enablement follow-up, update epic #1705 with the de-divergence (not LoC-lever) reframe.
+
+**Closeout record (2026-07-20):**
+- **Realized split: all 17 pairs RELOCATE, 0 merge** — `--plan` found no pair with textually-identical module-scope preambles, so every legacy file moved to a co-located `<x>.legacy.test.ts` sibling (import-path rewrite only, no in-file merge). **1,580 pre-image cases verified preserved** across the 17 pairs (`consolidate-suite --verify --base origin/main`, 0 dropped).
+- **Landing: 2 PRs (rev.5 consolidation), not per-pair.** PR-1 = #1728 (foundation tooling + spec, merged `bfd6ef96`). PR-2 = Task 004 gate + all 17 relocations + Task 022 ratchet + this closeout.
+- **Ratchet:** empty allowlist; 0 `__tests__` twins remain for the 17 subjects (`check-no-duplicate-suites` green on PR-2 HEAD).
+- **#1720 mutation re-enablement:** still blocked (StrykerJS full-suite dry-run, upstream of `--mutate` scope). Follow-up: add a source-targeted spot-check over the consolidated modules once #1720 lands.
+- **Epic #1705:** to update with the de-divergence (roughly LoC-neutral) reframe — the "largest LoC lever" premise was wrong; the value is eliminating the two-directory maintenance hazard.
+
 **Dependencies:** 022 · **Parallelizable:** No
 
 ### Parallelization
@@ -358,8 +367,8 @@ Critical path: **001 → 004 → {005, 006} (pilots) → {007–021} (main wave,
 - Delegate runs Task 003 before each wave; pairs base on `origin/main` (≥ #1719).
 - Pilots 005 (guards, INV-8) and 006 (state-machine, high-volume) validate the tool + ci-gate wiring and report the realized merge/relocate split before the fan-out.
 - Main-wave 007–021 run concurrently in isolated worktrees, each a distinct co-located file + distinct legacy file (no conflicts); only 004/022 touch `ci.yml` and are sequenced.
-- **Per-pair PRs are the enforcement seam (DR-7):** each triggers the ci-gate-required DR-2 gate + DR-3 ratchet; PRs land serially. Accept ~17× flaky-CI exposure; mitigate with `gh run rerun --failed`.
-- 022 lands after all 17 pairs; 023 closes out.
+- **The consolidation PR is the enforcement seam (DR-7, rev.5):** one PR triggers the ci-gate-required DR-2 gate (validating all 17 pairs in a single run) + DR-3 ratchet (allowlist → 0). This replaces the per-pair-PR model and removes its ~17× flaky-CI exposure (the instrumented suite runs once, not seventeen times).
+- 022 (ratchet) and 023 (closeout) ride in the same consolidation PR; the ratchet passes because all 17 relocations are present on PR-HEAD.
 
 ### Completion checklist
 

--- a/scripts/audit/check-base-substrate.test.ts
+++ b/scripts/audit/check-base-substrate.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { checkBaseSubstrate, type SubstrateCheckDeps } from './check-base-substrate.js';
 
@@ -60,8 +61,10 @@ describe('checkBaseSubstrate', () => {
       },
     });
     checkBaseSubstrate(deps, '/custom/repo');
-    expect(fileChecks).toContainEqual('/custom/repo/servers/exarchos-mcp/coverage-baseline.json');
-    expect(fileChecks).toContainEqual('/custom/repo/scripts/check-coverage-ratchet.mjs');
+    // Build expected paths with path.join so the assertion matches the source's
+    // native separators on every OS (Windows uses `\`, not `/`) — #1699 lane fix.
+    expect(fileChecks).toContainEqual(path.join('/custom/repo', 'servers', 'exarchos-mcp', 'coverage-baseline.json'));
+    expect(fileChecks).toContainEqual(path.join('/custom/repo', 'scripts', 'check-coverage-ratchet.mjs'));
   });
 
   it('logs a clear message naming each missing file', () => {

--- a/scripts/audit/check-no-duplicate-suites.mjs
+++ b/scripts/audit/check-no-duplicate-suites.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * check-no-duplicate-suites.mjs — duplicate-location ratchet (DR-1, Task 022).
+ *
+ * An (area, basename)-qualified intersection guard: it FAILS on any legacy
+ * `src/__tests__/<area>/<base>.test.ts` twin of a co-located `src/<area>/
+ * <base>.test.ts` subject that is not in the allowlist. Enumeration reuses
+ * Task 001's `enumeratePairs` (`consolidate-suite.mjs`) so the ratchet and the
+ * tool share ONE (area, basename) directory-intersection definition — never a
+ * divergent copy and never a brace-glob (`git ls-files '{a,b}'` never expands
+ * the braces → vacuously green).
+ *
+ * The pair identity key is strictly `(area, basename)`, so `workflow/schemas`
+ * and `event-store/schemas` are DISTINCT subjects (likewise `workflow/tools`
+ * vs `event-store/tools`). An allowlist keyed on basename alone would conflate
+ * them — the allowlist is keyed on the full `<area>/<basename>` pair id.
+ *
+ * THE ALLOWLIST IS EMPTY. All 17 pairs relocate in the de-divergence campaign;
+ * the consolidated end-state has ZERO twins. The allowlist is intentionally
+ * NOT seeded with the current 17 — seeding it would ratchet in the very defect
+ * this campaign removes. It exists only as the shrink-to-zero seam the design
+ * describes (DR-1): a temporary future twin could be parked here with a reason,
+ * but the steady state is `[]`.
+ *
+ * The pure `findViolations` core is exported so the ratchet is unit-testable
+ * against a synthetic tree without spawning a subprocess.
+ */
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import process from 'node:process';
+import {
+  enumeratePairs,
+  DEFAULT_SRC_ROOT,
+  EXIT_OK,
+  EXIT_FINDING,
+  EXIT_USAGE,
+} from './consolidate-suite.mjs';
+
+export { EXIT_OK, EXIT_FINDING, EXIT_USAGE };
+
+/**
+ * The shrink-to-zero allowlist of `<area>/<basename>` pair ids permitted to
+ * still have a legacy `__tests__` twin. EMPTY by design — the consolidated
+ * end-state has no twins. Frozen so no import can mutate it.
+ * @type {readonly string[]}
+ */
+export const ALLOWLIST = Object.freeze([]);
+
+/**
+ * Every enumerated (area, basename) twin whose pair id is not in `allowlist`.
+ * A pure set-difference over the tool's enumeration — the ratchet's whole
+ * decision. Keyed on the full `<area>/<basename>` id so a same-basename pair in
+ * a different area is never accidentally waived.
+ * @param {{ id: string, legacyPath: string, canonicalPath: string }[]} pairs
+ * @param {readonly string[]} allowlist
+ * @returns {{ id: string, legacyPath: string, canonicalPath: string }[]}
+ */
+export function findViolations(pairs, allowlist) {
+  const allowed = new Set(allowlist);
+  return pairs.filter((p) => !allowed.has(p.id));
+}
+
+const USAGE = `check-no-duplicate-suites — duplicate-location ratchet (DR-1)
+
+Usage:
+  check-no-duplicate-suites [--src <dir>] [--json]
+
+Fails (exit 1) if any co-located subject still has a legacy __tests__ twin that
+is not in the (empty) allowlist. Passes (exit 0) on a twin-free tree.
+
+Options:
+  --src <dir>   override the governed source root (default: the MCP src tree).
+  --json        emit the violation list as JSON.
+  --help        show this help.
+`;
+
+/**
+ * @param {string[]} argv
+ * @returns {{ src?: string, json: boolean, help: boolean }}
+ */
+function parseArgs(argv) {
+  /** @type {{ src?: string, json: boolean, help: boolean }} */
+  const out = { json: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (tok === '--src') out.src = argv[++i];
+    else if (tok === '--json') out.json = true;
+    else if (tok === '--help') out.help = true;
+  }
+  return out;
+}
+
+/**
+ * In-process CLI body. Returns an exit code; never calls `process.exit` so it
+ * is unit-testable. All I/O goes through the injected `log`/`errlog`.
+ * @param {string[]} argv
+ * @param {{ srcRoot?: string, log?: (m: string) => void, errlog?: (m: string) => void }} [opts]
+ * @returns {number}
+ */
+export function run(argv, opts = {}) {
+  const log = opts.log ?? ((m) => process.stdout.write(`${m}\n`));
+  const errlog = opts.errlog ?? ((m) => process.stderr.write(`${m}\n`));
+  const args = parseArgs(argv);
+  if (args.help) {
+    log(USAGE);
+    return EXIT_OK;
+  }
+  const srcRoot = args.src ? path.resolve(args.src) : (opts.srcRoot ?? DEFAULT_SRC_ROOT);
+
+  const pairs = enumeratePairs(srcRoot);
+  const violations = findViolations(pairs, ALLOWLIST);
+
+  if (args.json) {
+    log(JSON.stringify(violations.map((v) => v.id), null, 2));
+  }
+
+  if (violations.length === 0) {
+    if (!args.json) log('[no-duplicate-suites] OK — no legacy __tests__ twin of any co-located subject.');
+    return EXIT_OK;
+  }
+
+  errlog(
+    `[no-duplicate-suites] FAIL: ${violations.length} co-located subject(s) still have a legacy __tests__ twin ` +
+      `(allowlist has ${ALLOWLIST.length} entr${ALLOWLIST.length === 1 ? 'y' : 'ies'}):`,
+  );
+  for (const v of violations) errlog(`    ${v.id}`);
+  errlog('    Each must be consolidated (merged or relocated) so its legacy twin is removed.');
+  return EXIT_FINDING;
+}
+
+/** True when this module is the process entry point (not an import). */
+function invokedAsCli() {
+  const entry = process.argv[1];
+  return entry !== undefined && path.resolve(entry) === fileURLToPath(import.meta.url);
+}
+
+if (invokedAsCli()) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/scripts/audit/check-no-duplicate-suites.test.ts
+++ b/scripts/audit/check-no-duplicate-suites.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { enumeratePairs } from './consolidate-suite.mjs';
+import {
+  findViolations,
+  run,
+  ALLOWLIST,
+  EXIT_OK,
+  EXIT_FINDING,
+} from './check-no-duplicate-suites.mjs';
+
+// A synthetic src tree mirroring the real layout: legacy copies under
+// `__tests__/<area>/`, co-located copies under `<area>/`. A "twin" is a subject
+// present in BOTH. The ratchet fails on any twin not in the allowlist.
+describe('check-no-duplicate-suites (DR-1 ratchet)', () => {
+  let root: string;
+  let srcRoot: string;
+
+  const writeFile = (rel: string, content = 'it("x", () => {});') => {
+    const full = path.join(srcRoot, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  };
+
+  const writeTwin = (area: string, base: string) => {
+    writeFile(`__tests__/${area}/${base}.test.ts`);
+    writeFile(`${area}/${base}.test.ts`);
+  };
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'no-dup-suites-'));
+    srcRoot = path.join(root, 'src');
+    mkdirSync(srcRoot, { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  const opts = (out: string[], err: string[]) => ({
+    srcRoot,
+    log: (m: string) => out.push(m),
+    errlog: (m: string) => err.push(m),
+  });
+
+  // ── the shipped allowlist is EMPTY (the consolidated end-state) ─────────────
+  it('ships an EMPTY allowlist (not seeded with the current 17 twins)', () => {
+    expect(ALLOWLIST).toEqual([]);
+  });
+
+  // ── fails on a twin not in the allowlist ────────────────────────────────────
+  it('FAILS (exit 1) on a twin that is not in the allowlist', () => {
+    writeTwin('workflow', 'guards');
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = run([], opts(out, err));
+    expect(code).toBe(EXIT_FINDING);
+    expect(err.join('\n')).toContain('workflow/guards');
+  });
+
+  // ── cross-area collision: key on (area, basename), NOT basename alone ────────
+  it('keys on (area, basename): the two `schemas` twins are DISTINCT violations', () => {
+    writeTwin('workflow', 'schemas');
+    writeTwin('event-store', 'schemas');
+    const out: string[] = [];
+    const code = run(['--json'], opts(out, []));
+    expect(code).toBe(EXIT_FINDING);
+    const ids = JSON.parse(out.join('\n')) as string[];
+    // Both present as separate ids — a basename-only key would collapse them to one.
+    expect(ids).toContain('workflow/schemas');
+    expect(ids).toContain('event-store/schemas');
+    expect(ids.filter((id) => id.endsWith('/schemas'))).toHaveLength(2);
+  });
+
+  it('keys on (area, basename): the two `tools` twins are DISTINCT violations', () => {
+    writeTwin('workflow', 'tools');
+    writeTwin('event-store', 'tools');
+    const out: string[] = [];
+    const code = run(['--json'], opts(out, []));
+    expect(code).toBe(EXIT_FINDING);
+    const ids = JSON.parse(out.join('\n')) as string[];
+    expect(ids).toContain('workflow/tools');
+    expect(ids).toContain('event-store/tools');
+    expect(ids.filter((id) => id.endsWith('/tools'))).toHaveLength(2);
+  });
+
+  // ── a clean (twin-free) tree PASSES ─────────────────────────────────────────
+  it('PASSES (exit 0) on a twin-free tree — co-located files with no legacy mirror', () => {
+    // Co-located subjects only; a legacy file with NO co-located twin is not a pair.
+    writeFile('workflow/guards.test.ts');
+    writeFile('event-store/schemas.test.ts');
+    writeFile('__tests__/stack/legacy-only.test.ts'); // legacy-only → not a twin
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = run([], opts(out, err));
+    expect(code).toBe(EXIT_OK);
+    expect(err).toEqual([]);
+    expect(out.join('\n')).toContain('OK');
+  });
+
+  // ── the allowlist waiver is honored (both directions of the set-difference) ──
+  it('findViolations honors the allowlist by full (area, basename) id, not basename', () => {
+    writeTwin('workflow', 'schemas');
+    writeTwin('event-store', 'schemas');
+    const pairs = enumeratePairs(srcRoot);
+
+    // Waiving ONLY workflow/schemas must leave event-store/schemas flagged
+    // (a basename-only allowlist would wrongly waive both).
+    const waiveOne = findViolations(pairs, ['workflow/schemas']);
+    expect(waiveOne.map((v) => v.id)).toEqual(['event-store/schemas']);
+
+    // Waiving both by full id clears the ratchet.
+    const waiveBoth = findViolations(pairs, ['workflow/schemas', 'event-store/schemas']);
+    expect(waiveBoth).toEqual([]);
+
+    // Empty allowlist (the shipped state) flags both.
+    expect(findViolations(pairs, []).map((v) => v.id).sort()).toEqual([
+      'event-store/schemas',
+      'workflow/schemas',
+    ]);
+  });
+});

--- a/scripts/audit/consolidate-suite.mjs
+++ b/scripts/audit/consolidate-suite.mjs
@@ -44,8 +44,11 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
 /** The source root the tool governs (repo-relative default; overridable for tests). */
 export const DEFAULT_SRC_ROOT = path.join(REPO_ROOT, 'servers', 'exarchos-mcp', 'src');
-/** Against the live tree the enumeration MUST find exactly this many pairs. */
-export const EXPECTED_PAIR_COUNT = 17;
+/**
+ * Against the live tree the enumeration MUST find exactly this many remaining pairs.
+ * 0 since the wave-3b de-divergence campaign (#1705) consolidated all 17 duplicate-location pairs.
+ */
+export const EXPECTED_PAIR_COUNT = 0;
 
 export const EXIT_OK = 0;
 /** A real finding: a lost/unproven case (verify) or a divergence needing action. */

--- a/scripts/audit/consolidate-suite.test.ts
+++ b/scripts/audit/consolidate-suite.test.ts
@@ -445,27 +445,19 @@ describe('run (CLI dispatch)', () => {
 
 // ─── integration against the LIVE tree (HIGH tier) ───────────────────────────
 
+// The wave-3b campaign (#1705) de-diverged all 17 duplicate-location pairs, so the
+// live tree now enumerates ZERO remaining pairs. This block is the completion /
+// regression guard; per-mode tool behavior (merge/relocate classification, emit,
+// verify) is covered by the fixture describes above.
 describe('integration (live tree)', () => {
-  it('enumerates EXACTLY the expected number of real pairs', () => {
+  it('enumerates no remaining duplicate-location pairs (all 17 consolidated)', () => {
     expect(enumeratePairs(DEFAULT_SRC_ROOT)).toHaveLength(EXPECTED_PAIR_COUNT);
   });
 
-  it('--enumerate on the live tree reports the expected count via the CLI', () => {
+  it('--enumerate on the live tree reports zero remaining pairs via the CLI', () => {
     const out: string[] = [];
     const code = run(['--enumerate'], { log: (m) => out.push(m) });
     expect(code).toBe(EXIT_OK);
     expect(out).toContain(`# ${EXPECTED_PAIR_COUNT} pairs`);
-    // Distinct-key sanity: both schemas pairs are present as separate ids.
-    expect(out).toContain('workflow/schemas');
-    expect(out).toContain('event-store/schemas');
-  });
-
-  it('--plan on a real pair (workflow/guards) runs end-to-end and classifies it', () => {
-    const out: string[] = [];
-    const code = run(['--plan', 'workflow/guards'], { log: (m) => out.push(m) });
-    expect(code).toBe(EXIT_OK);
-    // These files have genuinely drifted imports/preamble → relocate.
-    expect(out.join('\n')).toMatch(/workflow\/guards: (merge|relocate)/);
-    expect(out.join('\n')).toContain('relocate');
   });
 });

--- a/scripts/audit/manifest-gate-ci.mjs
+++ b/scripts/audit/manifest-gate-ci.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+/**
+ * manifest-gate-ci.mjs — the DR-2 textual-identity CI gate (Task 004).
+ *
+ * The primary, ci-gate-wired guarantee of the de-divergence campaign: on each
+ * consolidation PR, prove that NO pre-image test case was lost. It is
+ * bidirectional — every case in EITHER pre-image (the legacy `__tests__` copy
+ * AND the co-located canonical copy at the merge-base) must survive into the
+ * PR-HEAD result (the merged file or the relocated `<base>.legacy.test.ts`
+ * sibling) verbatim modulo import-path rewrites, or be a textually-proven
+ * duplicate. Equivalence is TEXTUAL only (no semantic hash), so a divergent
+ * `vi.mock`/`vi.hoisted`/env preamble forces relocate, never a silent drop.
+ *
+ * Flow (mirrors the spec's "merge-base reconstruction, fetch-depth: 0"):
+ *   1. merge-base = `git merge-base <base> <head>` (base defaults to origin/main).
+ *   2. changed = `git diff --name-only <merge-base> <head>` — the PR's own edits.
+ *   3. touched pairs = the (area, basename) subjects those changed files belong
+ *      to (legacy copy, canonical copy, OR relocated sibling).
+ *   4. For each touched pair, reconstruct BOTH pre-images from the merge-base
+ *      (`git show <merge-base>:<path>`) and run the tool's verify logic against
+ *      the PR-HEAD result files. A pair counts only when BOTH pre-images existed
+ *      at the merge-base — i.e. it was a genuine two-directory pair. That guard
+ *      is what stops the bidirectional check from false-blocking an ordinary PR
+ *      that legitimately edits a lone co-located test with no legacy twin.
+ *   5. Any lost/unproven case fails the gate (exit 1).
+ *
+ * REUSE, not reimplementation: the case extraction + textual-equivalence check
+ * is the tool's exported `verifyCases` (the exact function `consolidate-suite
+ * --verify` wraps). This gate owns only the git plumbing — with an INJECTABLE
+ * git runner + repo root — so the whole gate is unit-testable against a
+ * fixture/temp-git repo. (`consolidate-suite --verify` pins its git cwd + paths
+ * to the tool's own REPO_ROOT, which cannot be pointed at a fixture repo; the
+ * exported function is the same logic without that coupling.)
+ *
+ * The pure helpers (`deriveTouchedPairIds`, `resolvePairPaths`) and the git
+ * primitives (`mergeBase`, `changedPaths`, `showAtRef`) are exported for tests.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+import { verifyCases, EXIT_OK, EXIT_FINDING, EXIT_USAGE } from './consolidate-suite.mjs';
+
+export { EXIT_OK, EXIT_FINDING, EXIT_USAGE };
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+/** The tool's repo root (scripts/audit/ → repo). Overridable for fixture tests. */
+export const REPO_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
+/** The governed source root, repo-RELATIVE (POSIX) — the pair-path prefix. */
+export const SRC_ROOT_REL = 'servers/exarchos-mcp/src';
+
+/** @param {string} p */
+function toPosix(p) {
+  return p.split(path.sep).join('/');
+}
+
+/**
+ * The default git runner: `git <args>` in `cwd`, capturing stdout/status.
+ * @param {string[]} args
+ * @param {string} cwd
+ * @returns {{ status: number, stdout: string, stderr: string }}
+ */
+function defaultGit(args, cwd) {
+  const res = spawnSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return { status: res.status ?? 1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+/**
+ * @typedef {(args: string[], cwd: string) => { status: number, stdout: string, stderr: string }} GitRunner
+ */
+
+/**
+ * The merge-base of `base` and `head`, or undefined when git cannot resolve one.
+ * @param {string} base @param {string} head
+ * @param {{ repoRoot: string, git: GitRunner }} ctx
+ * @returns {string | undefined}
+ */
+export function mergeBase(base, head, ctx) {
+  const res = ctx.git(['merge-base', base, head], ctx.repoRoot);
+  if (res.status !== 0) return undefined;
+  const sha = res.stdout.trim();
+  return sha.length > 0 ? sha : undefined;
+}
+
+/**
+ * Repo-relative POSIX paths changed between `fromRef` and `toRef`.
+ * @param {string} fromRef @param {string} toRef
+ * @param {{ repoRoot: string, git: GitRunner }} ctx
+ * @returns {string[]}
+ */
+export function changedPaths(fromRef, toRef, ctx) {
+  const res = ctx.git(['diff', '--name-only', fromRef, toRef], ctx.repoRoot);
+  if (res.status !== 0) return [];
+  return res.stdout.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+}
+
+/**
+ * The blob at `ref:relPath`, or undefined when it did not exist at that ref.
+ * @param {string} ref @param {string} relPath
+ * @param {{ repoRoot: string, git: GitRunner }} ctx
+ * @returns {string | undefined}
+ */
+export function showAtRef(ref, relPath, ctx) {
+  const res = ctx.git(['show', `${ref}:${relPath}`], ctx.repoRoot);
+  if (res.status !== 0) return undefined;
+  return res.stdout;
+}
+
+/**
+ * Map the PR's changed files to the set of `(area, basename)` pair ids they
+ * belong to. A file participates in pair `<area>/<base>` when it is:
+ *   - the legacy copy   `<srcRootRel>/__tests__/<area>/<base>.test.ts`,
+ *   - the canonical copy `<srcRootRel>/<area>/<base>.test.ts`, or
+ *   - the relocated sibling `<srcRootRel>/<area>/<base>.legacy.test.ts`.
+ * A bare `<srcRootRel>/<base>.test.ts` (no area subdir) has no legacy mirror and
+ * is skipped. Keyed strictly on `(area, basename)`. Pure.
+ * @param {string[]} paths          Repo-relative POSIX changed paths.
+ * @param {string} srcRootRel       e.g. `servers/exarchos-mcp/src`.
+ * @returns {string[]}              Sorted, de-duplicated pair ids.
+ */
+export function deriveTouchedPairIds(paths, srcRootRel) {
+  const legacyPrefix = `${srcRootRel}/__tests__/`;
+  const srcPrefix = `${srcRootRel}/`;
+  /** @type {Set<string>} */
+  const ids = new Set();
+  for (const raw of paths) {
+    const p = toPosix(raw);
+    if (!p.endsWith('.test.ts')) continue;
+
+    if (p.startsWith(legacyPrefix)) {
+      const rel = p.slice(legacyPrefix.length); // <area>/<base>.test.ts
+      const area = path.posix.dirname(rel);
+      if (area === '.') continue; // bare __tests__/<base>.test.ts — no co-located mirror
+      const base = path.posix.basename(rel, '.test.ts');
+      ids.add(`${area}/${base}`);
+      continue;
+    }
+
+    if (p.startsWith(srcPrefix)) {
+      const rel = p.slice(srcPrefix.length);
+      const area = path.posix.dirname(rel);
+      if (area === '.') continue; // bare co-located test at the src root — no pair
+      let base = path.posix.basename(rel, '.test.ts');
+      // A relocated sibling `<base>.legacy.test.ts` belongs to pair `<area>/<base>`.
+      if (base.endsWith('.legacy')) base = base.slice(0, -'.legacy'.length);
+      ids.add(`${area}/${base}`);
+    }
+  }
+  return [...ids].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * @typedef {Object} PairPaths
+ * @property {string} id
+ * @property {string} area
+ * @property {string} basename
+ * @property {string} legacyRel        Repo-relative legacy `__tests__` copy.
+ * @property {string} canonicalRel     Repo-relative co-located copy.
+ * @property {string} relocatedRel     Repo-relative relocated `<base>.legacy.test.ts` sibling.
+ * @property {string} legacyAbsDir     Absolute legacy dir (for import normalization).
+ * @property {string} canonicalAbsDir  Absolute co-located dir.
+ */
+
+/**
+ * Resolve a pair id to every path the gate needs (relative for git, absolute
+ * dir for import normalization). Pure.
+ * @param {string} id @param {string} srcRootRel @param {string} repoRoot
+ * @returns {PairPaths}
+ */
+export function resolvePairPaths(id, srcRootRel, repoRoot) {
+  const area = path.posix.dirname(id);
+  const basename = path.posix.basename(id);
+  const legacyRel = `${srcRootRel}/__tests__/${id}.test.ts`;
+  const canonicalRel = `${srcRootRel}/${id}.test.ts`;
+  const relocatedRel = `${srcRootRel}/${area}/${basename}.legacy.test.ts`;
+  return {
+    id,
+    area,
+    basename,
+    legacyRel,
+    canonicalRel,
+    relocatedRel,
+    legacyAbsDir: path.join(repoRoot, srcRootRel, '__tests__', area),
+    canonicalAbsDir: path.join(repoRoot, srcRootRel, area),
+  };
+}
+
+/**
+ * @typedef {Object} PairResult
+ * @property {string} id
+ * @property {'ok'|'lost'|'skipped'} status
+ * @property {{ side: 'legacy'|'canonical', text: string }[]} lost
+ * @property {number} preimageCases
+ * @property {number} resultCases
+ */
+
+/**
+ * Verify a single touched pair: reconstruct both pre-images from `base`, gather
+ * the PR-HEAD result files from disk, and run the tool's `verifyCases`. Returns
+ * `skipped` when the pair was not a genuine two-directory pair at the base
+ * (either pre-image missing) — nothing to prove.
+ * @param {PairPaths} pp @param {string} base
+ * @param {{ repoRoot: string, git: GitRunner }} ctx
+ * @returns {PairResult}
+ */
+function verifyPair(pp, base, ctx) {
+  const legacyPre = showAtRef(base, pp.legacyRel, ctx);
+  const canonicalPre = showAtRef(base, pp.canonicalRel, ctx);
+  // A genuine pair existed in BOTH directories at the base. If either is
+  // missing this is an ordinary edit to a lone test, not a consolidation —
+  // running the bidirectional check would false-block a legitimate case
+  // deletion, so skip it.
+  if (legacyPre === undefined || canonicalPre === undefined) {
+    return { id: pp.id, status: 'skipped', lost: [], preimageCases: 0, resultCases: 0 };
+  }
+
+  /** @type {{ text: string, absDir: string }[]} */
+  const resultFiles = [];
+  const canonicalAbs = path.join(ctx.repoRoot, pp.canonicalRel);
+  if (existsSync(canonicalAbs)) {
+    resultFiles.push({ text: readFileSync(canonicalAbs, 'utf8'), absDir: pp.canonicalAbsDir });
+  }
+  const relocatedAbs = path.join(ctx.repoRoot, pp.relocatedRel);
+  if (existsSync(relocatedAbs)) {
+    resultFiles.push({ text: readFileSync(relocatedAbs, 'utf8'), absDir: pp.canonicalAbsDir });
+  }
+
+  const report = verifyCases(
+    { text: legacyPre, absDir: pp.legacyAbsDir },
+    { text: canonicalPre, absDir: pp.canonicalAbsDir },
+    resultFiles,
+  );
+  return {
+    id: pp.id,
+    status: report.ok ? 'ok' : 'lost',
+    lost: report.lost,
+    preimageCases: report.preimageCases,
+    resultCases: report.resultCases,
+  };
+}
+
+/**
+ * Run the gate. Returns an exit code; never calls `process.exit`. All I/O goes
+ * through the injected `log`/`errlog`, and all git through the injected runner,
+ * so the whole gate is unit-testable against a fixture repo.
+ * @param {{
+ *   base?: string,
+ *   head?: string,
+ *   repoRoot?: string,
+ *   srcRootRel?: string,
+ *   git?: GitRunner,
+ *   log?: (m: string) => void,
+ *   errlog?: (m: string) => void,
+ * }} [opts]
+ * @returns {number}
+ */
+export function run(opts = {}) {
+  const log = opts.log ?? ((m) => process.stdout.write(`${m}\n`));
+  const errlog = opts.errlog ?? ((m) => process.stderr.write(`${m}\n`));
+  const base = opts.base ?? 'origin/main';
+  const head = opts.head ?? 'HEAD';
+  const repoRoot = opts.repoRoot ?? REPO_ROOT;
+  const srcRootRel = opts.srcRootRel ?? SRC_ROOT_REL;
+  const git = opts.git ?? defaultGit;
+  const ctx = { repoRoot, git };
+
+  const mb = mergeBase(base, head, ctx);
+  if (!mb) {
+    errlog(`[manifest-gate] could not compute merge-base of ${base}..${head} — cannot run the gate.`);
+    return EXIT_USAGE;
+  }
+
+  const changed = changedPaths(mb, head, ctx);
+  const touched = deriveTouchedPairIds(changed, srcRootRel);
+  if (touched.length === 0) {
+    log(`[manifest-gate] OK — no consolidation pair touched in ${base}..${head} (merge-base ${mb.slice(0, 12)}).`);
+    return EXIT_OK;
+  }
+
+  /** @type {PairResult[]} */
+  const failed = [];
+  let verified = 0;
+  for (const id of touched) {
+    const result = verifyPair(resolvePairPaths(id, srcRootRel, repoRoot), mb, ctx);
+    if (result.status === 'skipped') continue;
+    verified++;
+    if (result.status === 'lost') failed.push(result);
+    else log(`[manifest-gate] ${id}: OK — ${result.preimageCases} pre-image case(s) preserved.`);
+  }
+
+  if (failed.length === 0) {
+    log(`[manifest-gate] OK — ${verified} touched consolidation pair(s) preserved every pre-image case.`);
+    return EXIT_OK;
+  }
+
+  errlog(`[manifest-gate] FAIL — ${failed.length} pair(s) dropped a pre-image case (merge-base ${mb.slice(0, 12)}):`);
+  for (const f of failed) {
+    errlog(`  ${f.id}: ${f.lost.length} lost/unproven case(s)`);
+    for (const c of f.lost) errlog(`    (${c.side}) ${c.text.split('\n')[0].slice(0, 120)}`);
+  }
+  return EXIT_FINDING;
+}
+
+/**
+ * Parse `--base <ref>` / `--head <ref>` / `--src <repo-rel-dir>` from argv.
+ * @param {string[]} argv
+ * @returns {{ base?: string, head?: string, srcRootRel?: string }}
+ */
+function parseArgs(argv) {
+  /** @type {{ base?: string, head?: string, srcRootRel?: string }} */
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--base') out.base = argv[++i];
+    else if (argv[i] === '--head') out.head = argv[++i];
+    else if (argv[i] === '--src') out.srcRootRel = argv[++i];
+  }
+  return out;
+}
+
+/** True when this module is the process entry point (not an import). */
+function invokedAsCli() {
+  const entry = process.argv[1];
+  return entry !== undefined && path.resolve(entry) === fileURLToPath(import.meta.url);
+}
+
+if (invokedAsCli()) {
+  process.exit(run(parseArgs(process.argv.slice(2))));
+}

--- a/scripts/audit/manifest-gate-ci.mjs
+++ b/scripts/audit/manifest-gate-ci.mjs
@@ -56,6 +56,19 @@ function toPosix(p) {
 }
 
 /**
+ * Thrown when a git command fails UNEXPECTEDLY (not a benign absent path/ref).
+ * The gate must fail CLOSED on these rather than treat the failure as "nothing
+ * to verify" — a silently-passing gate is the exact failure mode it exists to
+ * prevent.
+ */
+export class GitGateError extends Error {}
+
+/** git's stderr for a path that is absent at an (otherwise valid) ref. */
+function isAbsentAtRef(stderr) {
+  return /does not exist in |exists on disk, but not in /.test(stderr);
+}
+
+/**
  * The default git runner: `git <args>` in `cwd`, capturing stdout/status.
  * @param {string[]} args
  * @param {string} cwd
@@ -91,7 +104,14 @@ export function mergeBase(base, head, ctx) {
  */
 export function changedPaths(fromRef, toRef, ctx) {
   const res = ctx.git(['diff', '--name-only', fromRef, toRef], ctx.repoRoot);
-  if (res.status !== 0) return [];
+  if (res.status !== 0) {
+    // Both refs are already resolved (fromRef is the merge-base SHA, toRef the
+    // validated head), so a non-zero diff is an unexpected/transient git failure,
+    // NOT "no changes" — fail CLOSED rather than mistake it for an empty diff.
+    throw new GitGateError(
+      `git diff --name-only ${fromRef} ${toRef} failed (status ${res.status}): ${res.stderr.trim()}`,
+    );
+  }
   return res.stdout.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
 }
 
@@ -103,8 +123,14 @@ export function changedPaths(fromRef, toRef, ctx) {
  */
 export function showAtRef(ref, relPath, ctx) {
   const res = ctx.git(['show', `${ref}:${relPath}`], ctx.repoRoot);
-  if (res.status !== 0) return undefined;
-  return res.stdout;
+  if (res.status === 0) return res.stdout;
+  // Distinguish a genuinely-absent path at an (otherwise valid) ref — the file
+  // simply did not exist there, a benign "not a two-directory pair" signal —
+  // from an unexpected git failure, which must fail CLOSED.
+  if (isAbsentAtRef(res.stderr)) return undefined;
+  throw new GitGateError(
+    `git show ${ref}:${relPath} failed (status ${res.status}): ${res.stderr.trim()}`,
+  );
 }
 
 /**
@@ -265,41 +291,51 @@ export function run(opts = {}) {
   const git = opts.git ?? defaultGit;
   const ctx = { repoRoot, git };
 
-  const mb = mergeBase(base, head, ctx);
-  if (!mb) {
-    errlog(`[manifest-gate] could not compute merge-base of ${base}..${head} — cannot run the gate.`);
-    return EXIT_USAGE;
-  }
+  try {
+    const mb = mergeBase(base, head, ctx);
+    if (!mb) {
+      errlog(`[manifest-gate] could not compute merge-base of ${base}..${head} — cannot run the gate.`);
+      return EXIT_USAGE;
+    }
 
-  const changed = changedPaths(mb, head, ctx);
-  const touched = deriveTouchedPairIds(changed, srcRootRel);
-  if (touched.length === 0) {
-    log(`[manifest-gate] OK — no consolidation pair touched in ${base}..${head} (merge-base ${mb.slice(0, 12)}).`);
-    return EXIT_OK;
-  }
+    const changed = changedPaths(mb, head, ctx);
+    const touched = deriveTouchedPairIds(changed, srcRootRel);
+    if (touched.length === 0) {
+      log(`[manifest-gate] OK — no consolidation pair touched in ${base}..${head} (merge-base ${mb.slice(0, 12)}).`);
+      return EXIT_OK;
+    }
 
-  /** @type {PairResult[]} */
-  const failed = [];
-  let verified = 0;
-  for (const id of touched) {
-    const result = verifyPair(resolvePairPaths(id, srcRootRel, repoRoot), mb, ctx);
-    if (result.status === 'skipped') continue;
-    verified++;
-    if (result.status === 'lost') failed.push(result);
-    else log(`[manifest-gate] ${id}: OK — ${result.preimageCases} pre-image case(s) preserved.`);
-  }
+    /** @type {PairResult[]} */
+    const failed = [];
+    let verified = 0;
+    for (const id of touched) {
+      const result = verifyPair(resolvePairPaths(id, srcRootRel, repoRoot), mb, ctx);
+      if (result.status === 'skipped') continue;
+      verified++;
+      if (result.status === 'lost') failed.push(result);
+      else log(`[manifest-gate] ${id}: OK — ${result.preimageCases} pre-image case(s) preserved.`);
+    }
 
-  if (failed.length === 0) {
-    log(`[manifest-gate] OK — ${verified} touched consolidation pair(s) preserved every pre-image case.`);
-    return EXIT_OK;
-  }
+    if (failed.length === 0) {
+      log(`[manifest-gate] OK — ${verified} touched consolidation pair(s) preserved every pre-image case.`);
+      return EXIT_OK;
+    }
 
-  errlog(`[manifest-gate] FAIL — ${failed.length} pair(s) dropped a pre-image case (merge-base ${mb.slice(0, 12)}):`);
-  for (const f of failed) {
-    errlog(`  ${f.id}: ${f.lost.length} lost/unproven case(s)`);
-    for (const c of f.lost) errlog(`    (${c.side}) ${c.text.split('\n')[0].slice(0, 120)}`);
+    errlog(`[manifest-gate] FAIL — ${failed.length} pair(s) dropped a pre-image case (merge-base ${mb.slice(0, 12)}):`);
+    for (const f of failed) {
+      errlog(`  ${f.id}: ${f.lost.length} lost/unproven case(s)`);
+      for (const c of f.lost) errlog(`    (${c.side}) ${c.text.split('\n')[0].slice(0, 120)}`);
+    }
+    return EXIT_FINDING;
+  } catch (e) {
+    // A git command failed unexpectedly — fail CLOSED. Never let a transient git
+    // error read as "no pairs touched" / "case absent" and pass the gate silently.
+    if (e instanceof GitGateError) {
+      errlog(`[manifest-gate] FAIL (fail-closed) — ${e.message}`);
+      return EXIT_USAGE;
+    }
+    throw e;
   }
-  return EXIT_FINDING;
 }
 
 /**

--- a/scripts/audit/manifest-gate-ci.test.ts
+++ b/scripts/audit/manifest-gate-ci.test.ts
@@ -259,4 +259,49 @@ describe('guards', () => {
     expect(code).toBe(EXIT_USAGE);
     expect(err).toContain('merge-base');
   });
+
+  // ── fail-CLOSED on unexpected git failures (a transient error must never
+  //    read as "no pairs touched" / "case absent" and pass the gate silently) ──
+  const rawGit = (args: string[], cwd: string) => {
+    const res = spawnSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+    return { status: res.status ?? 1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+  };
+
+  it('fails CLOSED when `git diff` errors — not silently treated as an empty diff', () => {
+    const base = seedMergeBase();
+    const failingDiff = (args: string[], cwd: string) =>
+      args[0] === 'diff'
+        ? { status: 128, stdout: '', stderr: 'fatal: bad revision (simulated transient failure)' }
+        : rawGit(args, cwd);
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = run({
+      base, head: 'HEAD', repoRoot: dir, srcRootRel: SRC,
+      git: failingDiff, log: (m) => out.push(m), errlog: (m) => err.push(m),
+    });
+    expect(code).toBe(EXIT_USAGE);
+    expect(err.join('\n')).toMatch(/fail-closed/);
+    expect(out.join('\n')).not.toContain('no consolidation pair touched');
+  });
+
+  it('fails CLOSED when `git show` errors for a reason other than an absent path', () => {
+    const base = seedMergeBase();
+    // A real consolidation edit so a pair IS touched → verifyPair calls git show.
+    write(`${SRC}/workflow/guards.test.ts`, CANON_MERGE);
+    del(`${SRC}/__tests__/workflow/guards.test.ts`);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'touch guards pair');
+    const failingShow = (args: string[], cwd: string) =>
+      args[0] === 'show'
+        ? { status: 128, stdout: '', stderr: 'fatal: unable to read tree object (simulated corruption)' }
+        : rawGit(args, cwd);
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = run({
+      base, head: 'HEAD', repoRoot: dir, srcRootRel: SRC,
+      git: failingShow, log: (m) => out.push(m), errlog: (m) => err.push(m),
+    });
+    expect(code).toBe(EXIT_USAGE);
+    expect(err.join('\n')).toMatch(/fail-closed/);
+  });
 });

--- a/scripts/audit/manifest-gate-ci.test.ts
+++ b/scripts/audit/manifest-gate-ci.test.ts
@@ -1,0 +1,262 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  run,
+  deriveTouchedPairIds,
+  EXIT_OK,
+  EXIT_FINDING,
+  EXIT_USAGE,
+} from './manifest-gate-ci.mjs';
+
+const SRC = 'servers/exarchos-mcp/src';
+
+// ── pure pair-derivation (no git) ────────────────────────────────────────────
+describe('deriveTouchedPairIds', () => {
+  it('maps legacy, canonical, and relocated-sibling paths to the same (area, base) pair', () => {
+    expect(
+      deriveTouchedPairIds(
+        [
+          `${SRC}/__tests__/workflow/guards.test.ts`, // legacy copy
+          `${SRC}/workflow/state-store.test.ts`, // canonical copy
+          `${SRC}/workflow/compensation.legacy.test.ts`, // relocated sibling
+          `${SRC}/workflow/guards.ts`, // not a .test.ts — ignored
+          `${SRC}/foo.test.ts`, // bare (no area subdir) — ignored
+          'README.md', // unrelated — ignored
+        ],
+        SRC,
+      ),
+    ).toEqual(['workflow/compensation', 'workflow/guards', 'workflow/state-store']);
+  });
+
+  it('keys on (area, basename): same basename in two areas → two distinct pairs', () => {
+    expect(
+      deriveTouchedPairIds(
+        [`${SRC}/__tests__/workflow/schemas.test.ts`, `${SRC}/event-store/schemas.test.ts`],
+        SRC,
+      ),
+    ).toEqual(['event-store/schemas', 'workflow/schemas']);
+  });
+});
+
+// ── the gate against a real temp git repo (fixture-based, NOT the live tree) ──
+describe('manifest-gate-ci (temp-git fixtures)', () => {
+  let dir: string;
+
+  const git = (...args: string[]) => {
+    const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    if (res.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${res.stderr}`);
+    }
+    return res.stdout.trim();
+  };
+
+  const write = (rel: string, content: string) => {
+    const full = path.join(dir, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  };
+  const del = (rel: string) => rmSync(path.join(dir, rel), { force: true });
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'manifest-gate-'));
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'gate@test');
+    git('config', 'user.name', 'gate');
+    git('config', 'commit.gpgsign', 'false');
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const runGate = (base: string) => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = run({
+      base,
+      head: 'HEAD',
+      repoRoot: dir,
+      srcRootRel: SRC,
+      log: (m) => out.push(m),
+      errlog: (m) => err.push(m),
+    });
+    return { code, out: out.join('\n'), err: err.join('\n') };
+  };
+
+  // Base state for the merge scenarios: legacy + canonical with IDENTICAL
+  // preambles (modulo import path), so the pair is a legitimate merge target.
+  const LEGACY_MERGE = `import { describe, it, expect } from 'vitest';
+import { guards } from '../../workflow/guards.js';
+describe('guards', () => {
+  it('shared_case', () => { expect(guards()).toBe(1); });
+  it('legacy_only', () => { expect(guards()).toBe(3); });
+});
+`;
+  const CANON_MERGE = `import { describe, it, expect } from 'vitest';
+import { guards } from './guards.js';
+describe('guards', () => {
+  it('shared_case', () => { expect(guards()).toBe(1); });
+  it('canonical_only', () => { expect(guards()).toBe(2); });
+});
+`;
+
+  const seedMergeBase = () => {
+    write(`${SRC}/__tests__/workflow/guards.test.ts`, LEGACY_MERGE);
+    write(`${SRC}/workflow/guards.test.ts`, CANON_MERGE);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'base: legacy + canonical guards pair');
+    const baseSha = git('rev-parse', 'HEAD');
+    git('checkout', '-q', '-b', 'pr');
+    return baseSha;
+  };
+
+  it('clean merge (every pre-image case carried into the canonical) → PASSES', () => {
+    const base = seedMergeBase();
+    // Merge: canonical gains legacy_only; legacy copy removed.
+    write(
+      `${SRC}/workflow/guards.test.ts`,
+      `import { describe, it, expect } from 'vitest';
+import { guards } from './guards.js';
+describe('guards', () => {
+  it('shared_case', () => { expect(guards()).toBe(1); });
+  it('canonical_only', () => { expect(guards()).toBe(2); });
+  it('legacy_only', () => { expect(guards()).toBe(3); });
+});
+`,
+    );
+    del(`${SRC}/__tests__/workflow/guards.test.ts`);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'consolidate workflow/guards (merge)');
+
+    const { code, out } = runGate(base);
+    expect(code).toBe(EXIT_OK);
+    expect(out).toContain('workflow/guards: OK');
+  });
+
+  it('dropping a LEGACY case (no surviving twin) → FAILS', () => {
+    const base = seedMergeBase();
+    // legacy_only is silently dropped from the merge result.
+    write(
+      `${SRC}/workflow/guards.test.ts`,
+      `import { describe, it, expect } from 'vitest';
+import { guards } from './guards.js';
+describe('guards', () => {
+  it('shared_case', () => { expect(guards()).toBe(1); });
+  it('canonical_only', () => { expect(guards()).toBe(2); });
+});
+`,
+    );
+    del(`${SRC}/__tests__/workflow/guards.test.ts`);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'consolidate workflow/guards (drops legacy_only)');
+
+    const { code, err } = runGate(base);
+    expect(code).toBe(EXIT_FINDING);
+    expect(err).toContain('legacy_only');
+    expect(err).toMatch(/\(legacy\)/);
+  });
+
+  it('dropping a pre-existing CANONICAL case → FAILS (bidirectional)', () => {
+    const base = seedMergeBase();
+    // canonical_only is dropped — the gate must catch loss on the canonical
+    // side too, not only the legacy side.
+    write(
+      `${SRC}/workflow/guards.test.ts`,
+      `import { describe, it, expect } from 'vitest';
+import { guards } from './guards.js';
+describe('guards', () => {
+  it('shared_case', () => { expect(guards()).toBe(1); });
+  it('legacy_only', () => { expect(guards()).toBe(3); });
+});
+`,
+    );
+    del(`${SRC}/__tests__/workflow/guards.test.ts`);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'consolidate workflow/guards (drops canonical_only)');
+
+    const { code, err } = runGate(base);
+    expect(code).toBe(EXIT_FINDING);
+    expect(err).toContain('canonical_only');
+    expect(err).toMatch(/\(canonical\)/);
+  });
+
+  it('clean relocate (legacy moved to a rewritten sibling) → PASSES', () => {
+    // Base with a DIVERGENT legacy preamble (extra vi.mock) → relocate, not merge.
+    const legacyDivergent = `import { describe, it, expect, vi } from 'vitest';
+import { guards } from '../../workflow/guards.js';
+vi.mock('../../workflow/guards.js', () => ({ guards: () => 9 }));
+describe('guards', () => {
+  it('legacy_mock_case', () => { expect(guards()).toBe(9); });
+});
+`;
+    write(`${SRC}/__tests__/workflow/guards.test.ts`, legacyDivergent);
+    write(`${SRC}/workflow/guards.test.ts`, CANON_MERGE);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'base: divergent legacy + canonical');
+    const base = git('rev-parse', 'HEAD');
+    git('checkout', '-q', '-b', 'pr');
+
+    // Relocate: legacy content moved to <base>.legacy.test.ts with imports
+    // rewritten from ../../workflow/ to ./ ; legacy __tests__ copy removed;
+    // canonical untouched.
+    write(
+      `${SRC}/workflow/guards.legacy.test.ts`,
+      `import { describe, it, expect, vi } from 'vitest';
+import { guards } from './guards.js';
+vi.mock('./guards.js', () => ({ guards: () => 9 }));
+describe('guards', () => {
+  it('legacy_mock_case', () => { expect(guards()).toBe(9); });
+});
+`,
+    );
+    del(`${SRC}/__tests__/workflow/guards.test.ts`);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'consolidate workflow/guards (relocate)');
+
+    const { code, out } = runGate(base);
+    expect(code).toBe(EXIT_OK);
+    expect(out).toContain('workflow/guards: OK');
+  });
+
+  it('a PR touching no consolidation pair → PASSES trivially', () => {
+    const base = seedMergeBase();
+    write(`${SRC}/workflow/unrelated.ts`, 'export const x = 1;\n');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'unrelated change');
+
+    const { code, out } = runGate(base);
+    expect(code).toBe(EXIT_OK);
+    expect(out).toContain('no consolidation pair touched');
+  });
+
+  it('a lone co-located test with NO legacy twin is SKIPPED (not false-blocked)', () => {
+    // Only a canonical file at base — never a two-directory pair.
+    write(`${SRC}/workflow/solo.test.ts`, CANON_MERGE);
+    git('add', '-A');
+    git('commit', '-q', '-m', 'base: solo co-located test (no legacy twin)');
+    const base = git('rev-parse', 'HEAD');
+    git('checkout', '-q', '-b', 'pr');
+    // Legitimately delete a case from this non-pair file — must NOT fail the gate.
+    write(
+      `${SRC}/workflow/solo.test.ts`,
+      `import { describe, it, expect } from 'vitest';
+import { guards } from './guards.js';
+describe('guards', () => {
+  it('shared_case', () => { expect(guards()).toBe(1); });
+});
+`,
+    );
+    git('add', '-A');
+    git('commit', '-q', '-m', 'edit solo test (drops a case, but it is not a pair)');
+
+    const { code } = runGate(base);
+    expect(code).toBe(EXIT_OK);
+  });
+
+  it('returns a usage exit code when the merge-base cannot be resolved', () => {
+    seedMergeBase();
+    const { code, err } = runGate('does-not-exist-ref');
+    expect(code).toBe(EXIT_USAGE);
+    expect(err).toContain('merge-base');
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/schemas.legacy.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.legacy.test.ts
@@ -27,9 +27,9 @@ import {
   ResolvedGateFamilySchema,
   PhaseEnteredPostureSchema,
   type EventType,
-} from '../../event-store/schemas.js';
-import { extendWorkflowTypeEnum, unextendWorkflowTypeEnum } from '../../workflow/schemas.js';
-import { KIND_OBLIGATIONS, resolveGateSet, type PhaseKind } from '../../workflow/phase-kind.js';
+} from './schemas.js';
+import { extendWorkflowTypeEnum, unextendWorkflowTypeEnum } from '../workflow/schemas.js';
+import { KIND_OBLIGATIONS, resolveGateSet, type PhaseKind } from '../workflow/phase-kind.js';
 
 // ─── Base Event Schema ──────────────────────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/event-store/tools.legacy.test.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.legacy.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { EventStore } from '../../event-store/store.js';
+import { EventStore } from './store.js';
 import {
   handleEventAppend,
   handleEventQuery,
   EVENT_QUERY_DEFAULT_LIMIT,
   type EventQueryPage,
-} from '../../event-store/tools.js';
-import type { ToolResult } from '../../format.js';
-import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+} from './tools.js';
+import type { ToolResult } from '../format.js';
+import { rmrfAsync } from '../test-helpers/temp-dir.js';
 
 // DR-5: `event query` returns `{ events, page }`; unwrap here so the shape lives
 // in one place.

--- a/servers/exarchos-mcp/src/sync/outbox.legacy.test.ts
+++ b/servers/exarchos-mcp/src/sync/outbox.legacy.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { Outbox } from '../../sync/outbox.js';
-import type { EventSender } from '../../sync/types.js';
-import type { WorkflowEvent } from '../../event-store/schemas.js';
+import { Outbox } from './outbox.js';
+import type { EventSender } from './types.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
 
 function makeEvent(overrides?: Partial<WorkflowEvent>): WorkflowEvent {
   return {

--- a/servers/exarchos-mcp/src/utils/process.legacy.test.ts
+++ b/servers/exarchos-mcp/src/utils/process.legacy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPidAlive } from '../../utils/process.js';
+import { isPidAlive } from './process.js';
 
 describe('isPidAlive', () => {
   it('IsPidAlive_CurrentProcess_ReturnsTrue', () => {

--- a/servers/exarchos-mcp/src/views/handlers.legacy.test.ts
+++ b/servers/exarchos-mcp/src/views/handlers.legacy.test.ts
@@ -3,15 +3,15 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { EventStore } from '../../event-store/store.js';
+import { EventStore } from '../event-store/store.js';
 import {
   handleViewWorkflowStatus,
   handleViewTasks,
   handleViewPipeline,
   resetMaterializerCache,
   getOrCreateMaterializer,
-} from '../../views/tools.js';
-import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+} from './tools.js';
+import { rmrfAsync } from '../test-helpers/temp-dir.js';
 
 let tempDir: string;
 let store: EventStore;

--- a/servers/exarchos-mcp/src/views/materializer.legacy.test.ts
+++ b/servers/exarchos-mcp/src/views/materializer.legacy.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { ViewMaterializer } from '../../views/materializer.js';
-import { SnapshotStore } from '../../views/snapshot-store.js';
-import type { ViewProjection } from '../../views/materializer.js';
-import type { WorkflowEvent } from '../../event-store/schemas.js';
+import { ViewMaterializer } from './materializer.js';
+import { SnapshotStore } from './snapshot-store.js';
+import type { ViewProjection } from './materializer.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
 
 // ─── Test View: simple counter ─────────────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/views/pipeline-view.legacy.test.ts
+++ b/servers/exarchos-mcp/src/views/pipeline-view.legacy.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ViewMaterializer } from '../../views/materializer.js';
+import { ViewMaterializer } from './materializer.js';
 import {
   pipelineProjection,
   PIPELINE_VIEW,
-} from '../../views/pipeline-view.js';
-import type { PipelineViewState } from '../../views/pipeline-view.js';
-import type { WorkflowEvent } from '../../event-store/schemas.js';
+} from './pipeline-view.js';
+import type { PipelineViewState } from './pipeline-view.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
 
 function makeEvent(
   seq: number,

--- a/servers/exarchos-mcp/src/views/snapshot-store.legacy.test.ts
+++ b/servers/exarchos-mcp/src/views/snapshot-store.legacy.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { SnapshotStore } from '../../views/snapshot-store.js';
-import type { SnapshotData } from '../../views/snapshot-store.js';
-import { EVENT_SCHEMA_VERSION } from '../../event-store/event-migration.js';
+import { SnapshotStore } from './snapshot-store.js';
+import type { SnapshotData } from './snapshot-store.js';
+import { EVENT_SCHEMA_VERSION } from '../event-store/event-migration.js';
 
 // ─── Snapshot Store Tests ──────────────────────────────────────────────────
 
@@ -141,13 +141,13 @@ describe('SnapshotStore', () => {
   describe('getSnapshotPath_PathTraversal_ThrowsError', () => {
     it('should throw when streamId contains path traversal sequence', async () => {
       await expect(
-        store.save('../escape', 'view', {}, 0),
+        store.save('../__tests__/escape', 'view', {}, 0),
       ).rejects.toThrow(/Invalid streamId/);
     });
 
     it('should throw when viewName contains path traversal sequence', async () => {
       await expect(
-        store.save('valid-stream', '../escape', {}, 0),
+        store.save('valid-stream', '../__tests__/escape', {}, 0),
       ).rejects.toThrow(/Invalid viewName/);
     });
 

--- a/servers/exarchos-mcp/src/views/task-detail-view.legacy.test.ts
+++ b/servers/exarchos-mcp/src/views/task-detail-view.legacy.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ViewMaterializer } from '../../views/materializer.js';
+import { ViewMaterializer } from './materializer.js';
 import {
   taskDetailProjection,
   TASK_DETAIL_VIEW,
-} from '../../views/task-detail-view.js';
-import type { TaskDetailViewState } from '../../views/task-detail-view.js';
-import type { WorkflowEvent } from '../../event-store/schemas.js';
+} from './task-detail-view.js';
+import type { TaskDetailViewState } from './task-detail-view.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
 
 function makeEvent(
   seq: number,

--- a/servers/exarchos-mcp/src/workflow/checkpoint.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/checkpoint.legacy.test.ts
@@ -9,8 +9,8 @@ import {
   createInitialCheckpoint,
   CHECKPOINT_OPERATION_THRESHOLD,
   STALE_AFTER_MINUTES,
-} from '../../workflow/checkpoint.js';
-import type { CheckpointState } from '../../workflow/types.js';
+} from './checkpoint.js';
+import type { CheckpointState } from './types.js';
 
 // Helper to create a checkpoint state at a known time
 function makeCheckpoint(overrides: Partial<CheckpointState> = {}): CheckpointState {

--- a/servers/exarchos-mcp/src/workflow/compensation.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/compensation.legacy.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Event } from '../../workflow/types.js';
+import type { Event } from './types.js';
 import type {
   CompensationAction,
   CompensationCheckpoint,
   CompensationOptions,
   CompensationActionResult,
   CompensationResult,
-} from '../../workflow/compensation.js';
-import { executeCompensation } from '../../workflow/compensation.js';
+} from './compensation.js';
+import { executeCompensation } from './compensation.js';
 
 // Mock child_process so no real shell commands run
 vi.mock('child_process', () => ({

--- a/servers/exarchos-mcp/src/workflow/guards.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.legacy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { guards, PASSED_STATUSES, FAILED_STATUSES, type GuardResult, type GuardFailure } from '../../workflow/guards.js';
+import { guards, PASSED_STATUSES, FAILED_STATUSES, type GuardResult, type GuardFailure } from './guards.js';
 
 // ─── Task 1: GuardFailure type extension ─────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/workflow/migration.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/migration.legacy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { migrateState, CURRENT_VERSION } from '../../workflow/migration.js';
-import { readStateFile } from '../../workflow/state-store.js';
+import { migrateState, CURRENT_VERSION } from './migration.js';
+import { readStateFile } from './state-store.js';
 import * as path from 'node:path';
 import { mkdtemp, rm, writeFile, readFile, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/servers/exarchos-mcp/src/workflow/schemas.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.legacy.test.ts
@@ -30,9 +30,9 @@ import {
   WorkflowTypeSchema,
   extendWorkflowTypeEnum,
   unextendWorkflowTypeEnum,
-} from '../../workflow/schemas.js';
-import { EventTypes } from '../../event-store/schemas.js';
-import { TOOL_REGISTRY } from '../../registry.js';
+} from './schemas.js';
+import { EventTypes } from '../event-store/schemas.js';
+import { TOOL_REGISTRY } from '../registry.js';
 
 // Helper to create a minimal valid checkpoint state
 function makeCheckpointState() {

--- a/servers/exarchos-mcp/src/workflow/state-machine.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.legacy.test.ts
@@ -7,9 +7,9 @@ import {
   findTransition,
   registerWorkflowType,
   unregisterWorkflowType,
-} from '../../workflow/state-machine.js';
-import type { HSMDefinition, State, Transition, WorkflowDefinition } from '../../workflow/state-machine.js';
-import { guards } from '../../workflow/guards.js';
+} from './state-machine.js';
+import type { HSMDefinition, State, Transition, WorkflowDefinition } from './state-machine.js';
+import { guards } from './guards.js';
 
 // ─── Task 003: HSM State/Transition Definitions ─────────────────────────────
 

--- a/servers/exarchos-mcp/src/workflow/state-store.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.legacy.test.ts
@@ -32,10 +32,10 @@ import {
   reconcileFromEvents,
   StateStoreError,
   VersionConflictError,
-} from '../../workflow/state-store.js';
-import { ErrorCode } from '../../workflow/schemas.js';
-import { EventStore } from '../../event-store/store.js';
-import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+} from './state-store.js';
+import { ErrorCode } from './schemas.js';
+import { EventStore } from '../event-store/store.js';
+import { rmrfAsync } from '../test-helpers/temp-dir.js';
 
 let tmpDir: string;
 

--- a/servers/exarchos-mcp/src/workflow/tools.legacy.test.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.legacy.test.ts
@@ -15,14 +15,14 @@ import {
   configureWorkflowMaterializer,
   isEventSourced,
   CURRENT_ES_VERSION,
-} from '../../workflow/tools.js';
-import { initStateFile, readStateFile, writeStateFile, VersionConflictError } from '../../workflow/state-store.js';
-import { EventStore } from '../../event-store/store.js';
-import { ViewMaterializer } from '../../views/materializer.js';
-import { workflowStateProjection, WORKFLOW_STATE_VIEW } from '../../views/workflow-state-projection.js';
-import { reconcileTasks } from '../../workflow/query.js';
-import type { WorkflowState } from '../../workflow/types.js';
-import { rmrfAsync } from '../../test-helpers/temp-dir.js';
+} from './tools.js';
+import { initStateFile, readStateFile, writeStateFile, VersionConflictError } from './state-store.js';
+import { EventStore } from '../event-store/store.js';
+import { ViewMaterializer } from '../views/materializer.js';
+import { workflowStateProjection, WORKFLOW_STATE_VIEW } from '../views/workflow-state-projection.js';
+import { reconcileTasks } from './query.js';
+import type { WorkflowState } from './types.js';
+import { rmrfAsync } from '../test-helpers/temp-dir.js';
 
 let tmpDir: string;
 
@@ -1878,7 +1878,7 @@ describe('Diagnostic Event Emission', () => {
     // Inject 3 fix-cycle events into JSONL store to trigger circuit breaker
     for (let i = 0; i < 3; i++) {
       await eventStore.append('circuit-diag', {
-        type: 'workflow.fix-cycle' as import('../../event-store/schemas.js').EventType,
+        type: 'workflow.fix-cycle' as import('../event-store/schemas.js').EventType,
         correlationId: 'circuit-diag',
         source: 'workflow',
         data: {
@@ -2071,7 +2071,7 @@ describe('CAS Retry Duplicate Event Prevention', () => {
 
     // Mock writeStateFile to fail with VersionConflictError on first attempt,
     // then succeed on second attempt
-    const stateStoreMod = await import('../../workflow/state-store.js');
+    const stateStoreMod = await import('./state-store.js');
     let writeAttempt = 0;
     const originalWrite = stateStoreMod.writeStateFile;
     const writeSpy = vi.spyOn(stateStoreMod, 'writeStateFile').mockImplementation(
@@ -2189,7 +2189,7 @@ describe('B5: Event-First Mutation Ordering', () => {
 
 describe('Store-Based Event Consumers', () => {
   it('getFixCycleCountFromStore_ReturnsCorrectCount', async () => {
-    const { getFixCycleCountFromStore } = await import('../../workflow/events.js');
+    const { getFixCycleCountFromStore } = await import('./events.js');
     const eventStore = new EventStore(tmpDir);
 
     // Append a compound-entry event
@@ -2217,7 +2217,7 @@ describe('Store-Based Event Consumers', () => {
   });
 
   it('getRecentEventsFromStore_ReturnsLastN', async () => {
-    const { getRecentEventsFromStore } = await import('../../workflow/events.js');
+    const { getRecentEventsFromStore } = await import('./events.js');
     const eventStore = new EventStore(tmpDir);
 
     await eventStore.append('recent-test', { type: 'workflow.started' });
@@ -2575,7 +2575,7 @@ describe('handleSet_EventFirst', () => {
 
     // Mock writeStateFile to fail with VersionConflictError on first attempt,
     // then succeed on second attempt
-    const stateStoreMod = await import('../../workflow/state-store.js');
+    const stateStoreMod = await import('./state-store.js');
     let writeAttempt = 0;
     const originalWrite = stateStoreMod.writeStateFile;
     const writeSpy = vi.spyOn(stateStoreMod, 'writeStateFile').mockImplementation(
@@ -2913,7 +2913,7 @@ describe('HandleSet CAS Diagnostic', () => {
     );
 
     // Mock writeStateFile to always throw VersionConflictError (exhaust all retries)
-    const stateStoreMod = await import('../../workflow/state-store.js');
+    const stateStoreMod = await import('./state-store.js');
     const writeSpy = vi.spyOn(stateStoreMod, 'writeStateFile').mockImplementation(
       async (_stateFile, _state, options) => {
         if (options?.expectedVersion !== undefined) {
@@ -2955,7 +2955,7 @@ describe('HandleSet CAS Diagnostic', () => {
     );
 
     // Mock writeStateFile to always throw VersionConflictError (exhaust retries)
-    const stateStoreMod = await import('../../workflow/state-store.js');
+    const stateStoreMod = await import('./state-store.js');
     const writeSpy = vi.spyOn(stateStoreMod, 'writeStateFile').mockImplementation(
       async (_stateFile, _state, options) => {
         if (options?.expectedVersion !== undefined) {
@@ -2975,7 +2975,7 @@ describe('HandleSet CAS Diagnostic', () => {
       }
 
       // Assert: Validate the event shape matches WorkflowCasFailedData
-      const { WorkflowCasFailedData } = await import('../../event-store/schemas.js');
+      const { WorkflowCasFailedData } = await import('../event-store/schemas.js');
       const events = await eventStore.query('cas-shape');
       const casFailedEvents = events.filter(e => e.type === 'workflow.cas-failed');
       expect(casFailedEvents).toHaveLength(1);


### PR DESCRIPTION
## Summary

Wave-3b test-suite **de-divergence** campaign (#1705) — collapses all 17 duplicate-location test pairs to a single co-located directory each, locked with a CI ratchet. This is **PR-2 of 2** (PR-1 = #1728, foundation tooling + spec, already merged); per the rev.5 consolidation it lands the **entire remaining campaign in one PR** instead of ~20 per-pair PRs.

**Realized operation: all 17 pairs RELOCATE (0 merge)** — no pair had textually-identical module-scope preambles, so each legacy `src/__tests__/<area>/<base>.test.ts` moved to a co-located `src/<area>/<base>.legacy.test.ts` sibling (import-path rewrite only). **1,580 pre-image test cases preserved, 0 dropped**, proven by the DR-2 textual gate.

Closes #1705.

## Changes

- **17 relocations** (`servers/exarchos-mcp/src/__tests__/{workflow,views,event-store,sync,utils}/*.test.ts` → co-located `*.legacy.test.ts`): workflow/{guards, state-machine, tools, compensation, state-store, checkpoint, migration, schemas}, views/{handlers, materializer, pipeline-view, snapshot-store, task-detail-view}, event-store/{schemas, tools}, sync/outbox, utils/process.
- **DR-2 manifest gate** (Task 004): `scripts/audit/manifest-gate-ci.mjs` reconstructs both pre-images from the merge-base (`git show`, `fetch-depth: 0`) and asserts every pre-image case survives (verbatim modulo import rewrites, or a textually-proven duplicate); wired into `ci-gate.needs` as a required check.
- **DR-1 duplicate-location ratchet** (Task 022): `scripts/audit/check-no-duplicate-suites.mjs`, area-qualified `(area, basename)`, empty allowlist; wired into `grep-gates`.
- **Spec rev.5** (Task 023): DR-7 revised from per-pair PRs → consolidated campaign PR; closeout records the realized split + #1720 mutation-re-enablement handoff.

## Test Plan

- **DR-2 gate:** `manifest-gate-ci.mjs` → all 17 touched pairs preserved every pre-image case (1,580 total).
- **Ratchet:** `check-no-duplicate-suites.mjs` → PASS (0 `__tests__` twins remain for the 17 subjects).
- **Protected keep-class guard:** `check-protected.mjs` → 0 keep-class files touched.
- **Full MCP suite:** all 17 relocated `.legacy.test.ts` suites green. The 26 `merge-orchestrate.*` / `store.race` failures seen on a fresh local install are the documented **local-red baseline** — those files are byte-identical to origin/main (empty diff) and are local-only (green on CI), so the campaign introduces zero new failures.
- **Typecheck:** root + `servers/exarchos-mcp` both clean.
- **New gate tests:** 15 pass (manifest-gate 9 + ratchet 6); ci-topology conformance 6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjQW9bxuH2opiN5TojWRYY
