### PR TITLE
fix: the preview.4 MCP/store triad (#1838, #1839, #1840)

### DIFF
--- a/src/architecture/layer-boundaries-seam.ts
+++ b/src/architecture/layer-boundaries-seam.ts
@@ -611,10 +611,15 @@ export const LAYER_ALLOWED_IMPORTS: readonly LayerAllowance[] = Object.freeze([
     [
       ROOT_LAYER, 'adapters', 'adapters/cli', 'config', 'contract', 'events', 'hooks',
       'install', 'projections', 'review', 'runtime', 'storage', 'sync',
-      'vcs', 'verbs', 'workflow',
+      'utils', 'vcs', 'verbs', 'workflow',
     ],
-    'The dispatch core — 16 targets after the nested CLI adapter split out of the parent facade. ' +
-      'It is the hub, so breadth is expected; the row exists so the breadth stops growing silently.',
+    'The dispatch core — 17 targets after the nested CLI adapter split out of the parent facade. ' +
+      'It is the hub, so breadth is expected; the row exists so the breadth stops growing silently. ' +
+      'The `utils` edge is the store-path resolver: the chokepoint refuses a mutation whose resolved ' +
+      'event store diverges from the other surface\'s, and the resolution cascade it consults is a ' +
+      'foundation leaf that imports no first-party directory. Every other core layer already reaches ' +
+      'it; dispatch was the last one that did not, and this row records the edge rather than hiding ' +
+      'it by rehoming path resolution somewhere it does not belong.',
   ),
   allowance(
     'verbs',

--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -798,7 +798,10 @@ export async function dispatch(
     // expensive was internally consistent and wrong, with nothing in it
     // hinting that two stores existed; a separate `doctor` run was the only
     // way to learn that, and by then the reader trusted the verdict.
-    const warnings = storeDivergence?.shouldWarn === true
+    // The refusal already states the divergence in `error.message`; repeating
+    // it as a warning on the same envelope tells the caller nothing twice.
+    const alreadyStated = result.error?.code === 'STORE_PATH_DIVERGENCE';
+    const warnings = storeDivergence?.shouldWarn === true && !alreadyStated
       ? [...(result.warnings ?? []), describeStoreDivergence(storeDivergence)]
       : result.warnings;
     return {
@@ -1080,8 +1083,8 @@ export async function dispatch(
     // enforce. The readonly gate above still covers state authority.
 
     // ─── Store-path divergence — refuse a write into a ghost store ───────
-    // The detector already existed (`computeStorePathDivergence`, DR-11 B-5)
-    // but its only consumer was the doctor check, so mutations landed in the
+    // The detector already existed (`computeStorePathDivergence`) but its only
+    // consumer was the doctor check, so mutations landed in the
     // non-plugin store and reported SUCCESS while the orchestrator read a
     // different one. The tell surfaced steps later as STATE_NOT_FOUND, and
     // gates like `prepare_delegation` answered from the ghost store with a

--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -361,16 +361,19 @@ const FRESHNESS_GATE_DIAGNOSTIC_EXEMPT: ReadonlySet<string> = new Set([
  * read-only classification has a single source of truth.
  */
 function isFreshnessGateExempt(tool: string, action: string): boolean {
-  const allowed = (READ_ONLY_ACTIONS as Record<string, readonly string[] | '*'>)[tool];
-  if (allowed === '*') return true;
-  if (allowed !== undefined && allowed.includes(action)) return true;
-  return FRESHNESS_GATE_DIAGNOSTIC_EXEMPT.has(action);
+  // Exactly what the doc above says in prose: read-only, PLUS the diagnostic
+  // carve-out. Expressed as a composition so the read-only classification is
+  // read from one place instead of being spelled out twice.
+  return isReadOnlyAction(tool, action) || FRESHNESS_GATE_DIAGNOSTIC_EXEMPT.has(action);
 }
 
 /**
- * True when `action` on `tool` only reads. Same source of truth as the
- * freshness gate, minus the diagnostic carve-out: a divergence WARNING is
- * exactly what `doctor` should carry, so `doctor` is not exempted here.
+ * True when `action` on `tool` only reads.
+ *
+ * The primitive both gates share. The store-divergence check uses it directly
+ * rather than through {@link isFreshnessGateExempt}, because the diagnostic
+ * carve-out points the other way here: a divergence warning is precisely what
+ * `doctor` should carry, so `doctor` must not be exempt from it.
  */
 function isReadOnlyAction(tool: string, action: string): boolean {
   const allowed = (READ_ONLY_ACTIONS as Record<string, readonly string[] | '*'>)[tool];

--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -1079,32 +1079,6 @@ export async function dispatch(
     // everything, and the confinement it claimed to enforce is not ours to
     // enforce. The readonly gate above still covers state authority.
 
-    // T-12 (P4 of rehydration-machinery-refactor): emit
-    // `session.machinery_consumed` on the first non-rehydrate L5 handler
-    // invocation that follows a `workflow.rehydrated` event landing on the
-    // stream. The interceptor is keyed by the dispatched action's
-    // `featureId` (its streamId); calls without a featureId — descriptive
-    // actions like `describe`, `runbook` — short-circuit inside the
-    // interceptor itself. Failures inside the interceptor are
-    // logged-and-swallowed (observability emission must not fail the
-    // dispatch); see `interceptors/session-machinery.ts` for the cache &
-    // idempotency contract.
-    const streamId = (() => {
-      const fid = (args as { featureId?: unknown }).featureId;
-      return typeof fid === 'string' && fid.length > 0 ? fid : undefined;
-    })();
-    await runSessionMachineryConsumedInterceptor(ctx.eventStore, streamId, actionName);
-
-    // ─── P05-04 — Install & cache freshness gate ─────────────────────────
-    // Block a stale/mixed installation BEFORE it executes a mutating action.
-    // This is the pre-workflow-execution chokepoint that wires the binary /
-    // plugin / skill / cache dimensions (the schema dimension is additionally
-    // enforced at store-open). Scoped to mutating built-in actions only —
-    // read-only + diagnostic actions (see `isFreshnessGateExempt`) stay
-    // available so an operator can DIAGNOSE and REPAIR the block. The gate is
-    // memoized once per process and SKIPS entirely on a dev checkout, so this
-    // is a no-op for source-run / in-process tests and adds a single one-time
-    // filesystem read on the first mutating action of a real install.
     // ─── Store-path divergence — refuse a write into a ghost store ───────
     // The detector already existed (`computeStorePathDivergence`, DR-11 B-5)
     // but its only consumer was the doctor check, so mutations landed in the
@@ -1113,6 +1087,11 @@ export async function dispatch(
     // gates like `prepare_delegation` answered from the ghost store with a
     // self-consistent, entirely wrong verdict. Every symptom pointed away
     // from the cause.
+    //
+    // It runs FIRST among the pre-execution gates. The session-machinery
+    // interceptor below APPENDS an event, so refusing after it would write
+    // into the very ghost store this refusal exists to keep out — a refusal
+    // that already mutated is not a refusal.
     //
     // Refusal is scoped to an ACTIVE divergence — the other store must exist —
     // because bare divergence is true for every standalone CLI invocation and
@@ -1142,6 +1121,32 @@ export async function dispatch(
       }
     }
 
+    // T-12 (P4 of rehydration-machinery-refactor): emit
+    // `session.machinery_consumed` on the first non-rehydrate L5 handler
+    // invocation that follows a `workflow.rehydrated` event landing on the
+    // stream. The interceptor is keyed by the dispatched action's
+    // `featureId` (its streamId); calls without a featureId — descriptive
+    // actions like `describe`, `runbook` — short-circuit inside the
+    // interceptor itself. Failures inside the interceptor are
+    // logged-and-swallowed (observability emission must not fail the
+    // dispatch); see `interceptors/session-machinery.ts` for the cache &
+    // idempotency contract.
+    const streamId = (() => {
+      const fid = (args as { featureId?: unknown }).featureId;
+      return typeof fid === 'string' && fid.length > 0 ? fid : undefined;
+    })();
+    await runSessionMachineryConsumedInterceptor(ctx.eventStore, streamId, actionName);
+
+    // ─── P05-04 — Install & cache freshness gate ─────────────────────────
+    // Block a stale/mixed installation BEFORE it executes a mutating action.
+    // This is the pre-workflow-execution chokepoint that wires the binary /
+    // plugin / skill / cache dimensions (the schema dimension is additionally
+    // enforced at store-open). Scoped to mutating built-in actions only —
+    // read-only + diagnostic actions (see `isFreshnessGateExempt`) stay
+    // available so an operator can DIAGNOSE and REPAIR the block. The gate is
+    // memoized once per process and SKIPS entirely on a dev checkout, so this
+    // is a no-op for source-run / in-process tests and adds a single one-time
+    // filesystem read on the first mutating action of a real install.
     if (!isFreshnessGateExempt(tool, actionName)) {
       const freshness = evaluateInstallFreshness({});
       if (freshness.status === 'blocked') {

--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -798,7 +798,7 @@ export async function dispatch(
     // expensive was internally consistent and wrong, with nothing in it
     // hinting that two stores existed; a separate `doctor` run was the only
     // way to learn that, and by then the reader trusted the verdict.
-    const warnings = storeDivergence?.otherExists === true
+    const warnings = storeDivergence?.shouldWarn === true
       ? [...(result.warnings ?? []), describeStoreDivergence(storeDivergence)]
       : result.warnings;
     return {

--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -1055,7 +1055,7 @@ export async function dispatch(
     // is a no-op for source-run / in-process tests and adds a single one-time
     // filesystem read on the first mutating action of a real install.
     if (!isFreshnessGateExempt(tool, actionName)) {
-      const freshness = evaluateInstallFreshness({ stateDir: ctx.stateDir });
+      const freshness = evaluateInstallFreshness({});
       if (freshness.status === 'blocked') {
         logger.child({ subsystem: 'install-freshness' }).warn(
           {

--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -51,6 +51,7 @@ import {
   findIgnoredParameters,
   buildIgnoredParameterError,
 } from '../undeclared-parameters.js';
+import type { ToolAction } from '../../registry.js';
 import type { EventSourcedTaskStore } from '../../projections/task-store/event-sourced-task-store.js';
 
 // NOTE: `../telemetry/middleware.js` is intentionally NOT imported at module
@@ -364,16 +365,41 @@ function isFreshnessGateExempt(tool: string, action: string): boolean {
  * The roots-based workspace-discovery branch in `dispatch()` skips its
  * synchronous filesystem walk for actions in this set so high-frequency
  * introspection calls (catalog reads, runbook fetches, agent-spec
- * lookups) don't pay the discovery cost. Adding an action here is a
- * "this surface MUST NOT ever take a featureId" assertion — pair the
- * addition with a registry-side check that the action's schema does not
- * declare a `featureId` field.
+ * lookups) don't pay the discovery cost.
+ *
+ * This list is a LATENCY shortcut and nothing more. It is deliberately NOT
+ * load-bearing for correctness: {@link actionAcceptsInferredFeatureId} decides
+ * whether inference may run at all, reading the receiving action's own schema.
+ * A name missing from this set costs a filesystem walk; it can no longer cost
+ * a rejected call.
  */
 const NO_WORKSPACE_RESOLUTION_ACTIONS: ReadonlySet<string> = new Set([
   'describe',
   'runbook',
   'agent_spec',
 ]);
+
+/**
+ * May the roots/cwd resolver hand this action an inferred `featureId`?
+ *
+ * Only when the action's OWN schema declares the field. Every composite tool
+ * flattens its actions into one registration schema, so the wire accepts the
+ * union of every action's fields — but routing hands the payload to a single
+ * strict schema that knows only its own. Injecting into an action that does
+ * not declare `featureId` therefore manufactures the exact refusal
+ * `undeclared-parameters.ts` exists to raise, naming a parameter the caller
+ * never sent and the server itself added.
+ *
+ * The predicate reads the same `schema.shape` that builds that refusal, so the
+ * two can no longer disagree: a newly-added action is classified correctly the
+ * moment it is declared, with no list to keep in step.
+ *
+ * Exported for the regression guard, which asserts this over the whole
+ * registry rather than executing 59 handlers to discover it.
+ */
+export function actionAcceptsInferredFeatureId(action: ToolAction): boolean {
+  return action.schema.shape['featureId'] !== undefined;
+}
 
 /**
  * Apply the readonly capability gate. Returns a structured CAPABILITY_DENIED
@@ -790,10 +816,20 @@ export async function dispatch(
     // to every CLI hot-path dispatch (telemetry view, doctor checks, etc.)
     // that happens to omit a featureId. Roots+cwd inference is purely an
     // MCP-client convenience for callers that DID declare roots.
+    //
+    // The receiving action's schema is consulted FIRST. Inference is a
+    // convenience for actions that take a featureId; for an action that does
+    // not declare one there is nothing to infer, and injecting anyway turns a
+    // successful resolution into an INVALID_INPUT naming a field the caller
+    // never sent. That inverted failure hit 59 of the 124 registered actions
+    // — including `doctor`, so the diagnostic of record broke exactly when an
+    // operator reached for it — and it reproduced only where roots resolution
+    // SUCCEEDS, which is why the repo's own suite never saw it.
     if (
       rest.featureId === undefined
       && ctx.capabilityResolver !== undefined
       && ctx.rootsClient !== undefined
+      && actionAcceptsInferredFeatureId(matchingAction)
       && !NO_WORKSPACE_RESOLUTION_ACTIONS.has(actionName)
     ) {
       try {

--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -52,6 +52,14 @@ import {
   buildIgnoredParameterError,
 } from '../undeclared-parameters.js';
 import type { ToolAction } from '../../registry.js';
+import path from 'node:path';
+import {
+  detectActiveStoreDivergence,
+  describeStoreDivergence,
+  resolveStateDir,
+  toPosix,
+  ALLOW_STORE_DIVERGENCE_ENV,
+} from '../../utils/paths.js';
 import type { EventSourcedTaskStore } from '../../projections/task-store/event-sourced-task-store.js';
 
 // NOTE: `../telemetry/middleware.js` is intentionally NOT imported at module
@@ -357,6 +365,17 @@ function isFreshnessGateExempt(tool: string, action: string): boolean {
   if (allowed === '*') return true;
   if (allowed !== undefined && allowed.includes(action)) return true;
   return FRESHNESS_GATE_DIAGNOSTIC_EXEMPT.has(action);
+}
+
+/**
+ * True when `action` on `tool` only reads. Same source of truth as the
+ * freshness gate, minus the diagnostic carve-out: a divergence WARNING is
+ * exactly what `doctor` should carry, so `doctor` is not exempted here.
+ */
+function isReadOnlyAction(tool: string, action: string): boolean {
+  const allowed = (READ_ONLY_ACTIONS as Record<string, readonly string[] | '*'>)[tool];
+  if (allowed === '*') return true;
+  return allowed !== undefined && allowed.includes(action);
 }
 
 /**
@@ -737,6 +756,23 @@ export async function dispatch(
     ? undefined
     : snapshotCallerAuthorization(ctx.callerIdentity, ctx.capabilityResolver);
   const dispatchCtx = mintDispatchContextFromRequest(args, authorization);
+
+  // Computed once per dispatch and reused by both the read-side warning and
+  // the write-side refusal below, so the existence probe runs at most once on
+  // the hot path.
+  //
+  // Scoped to a context whose store came from the AMBIENT cascade. When a
+  // caller supplied an explicit state dir — `--state-dir`, an embedding host,
+  // every in-process test — there is no ambiguity about which store was meant,
+  // so there is nothing to warn about and nothing to refuse. Without this the
+  // verdict would depend on which stores happen to exist under the invoking
+  // user's home, making dispatch behave differently on a developer machine
+  // than in CI.
+  const storeCameFromAmbientCascade = toPosix(path.resolve(ctx.stateDir)) === resolveStateDir();
+  const storeDivergence = storeCameFromAmbientCascade
+    ? detectActiveStoreDivergence()
+    : undefined;
+
   const attachMeta = (result: ToolResult): ToolResult => {
     const existingMeta =
       typeof (result as { _meta?: unknown })._meta === 'object' &&
@@ -754,7 +790,19 @@ export async function dispatch(
     const mergedMeta = existingMeta
       ? { ...correlationMeta, ...existingMeta }
       : correlationMeta;
-    return { ...result, _meta: mergedMeta } as ToolResult;
+    // A read answered from a store the other surface never sees carries the
+    // caveat INLINE. The `prepare_delegation` envelope that made this issue
+    // expensive was internally consistent and wrong, with nothing in it
+    // hinting that two stores existed; a separate `doctor` run was the only
+    // way to learn that, and by then the reader trusted the verdict.
+    const warnings = storeDivergence?.otherExists === true
+      ? [...(result.warnings ?? []), describeStoreDivergence(storeDivergence)]
+      : result.warnings;
+    return {
+      ...result,
+      ...(warnings !== undefined ? { warnings } : {}),
+      _meta: mergedMeta,
+    } as ToolResult;
   };
 
   return runWithDispatchContext(dispatchCtx, async () => {
@@ -1054,6 +1102,43 @@ export async function dispatch(
     // memoized once per process and SKIPS entirely on a dev checkout, so this
     // is a no-op for source-run / in-process tests and adds a single one-time
     // filesystem read on the first mutating action of a real install.
+    // ─── Store-path divergence — refuse a write into a ghost store ───────
+    // The detector already existed (`computeStorePathDivergence`, DR-11 B-5)
+    // but its only consumer was the doctor check, so mutations landed in the
+    // non-plugin store and reported SUCCESS while the orchestrator read a
+    // different one. The tell surfaced steps later as STATE_NOT_FOUND, and
+    // gates like `prepare_delegation` answered from the ghost store with a
+    // self-consistent, entirely wrong verdict. Every symptom pointed away
+    // from the cause.
+    //
+    // Refusal is scoped to an ACTIVE divergence — the other store must exist —
+    // because bare divergence is true for every standalone CLI invocation and
+    // refusing on it would break users who never installed the plugin.
+    if (!isReadOnlyAction(tool, actionName) && storeDivergence !== undefined) {
+      const divergence = storeDivergence;
+      if (divergence.active) {
+        logger.child({ subsystem: 'store-divergence' }).warn(
+          { tool, action: actionName, activePath: divergence.activePath, otherPath: divergence.otherPath },
+          'refusing mutating action: the resolved event store diverges from the other surface',
+        );
+        return attachMeta({
+          success: false,
+          error: {
+            code: 'STORE_PATH_DIVERGENCE',
+            message: describeStoreDivergence(divergence),
+            tool,
+            action: actionName,
+            expectedShape: {
+              activePath: divergence.activePath,
+              otherPath: divergence.otherPath,
+              remedy: `WORKFLOW_STATE_DIR=${path.dirname(divergence.otherPath)}`,
+              override: `${ALLOW_STORE_DIVERGENCE_ENV}=1`,
+            },
+          },
+        });
+      }
+    }
+
     if (!isFreshnessGateExempt(tool, actionName)) {
       const freshness = evaluateInstallFreshness({});
       if (freshness.status === 'blocked') {

--- a/src/install/collect-identity.ts
+++ b/src/install/collect-identity.ts
@@ -46,7 +46,14 @@ import {
  */
 export const CACHE_DESCRIPTOR_FILENAME = 'cache-manifest.json';
 
-/** Recorded expected-identity lock, written at install / first-run (TOFU). */
+/**
+ * Recorded expected-identity lock, written at install / first-run (TOFU).
+ *
+ * The stem and extension of the real filename, which
+ * {@link installIdentityLockPath} suffixes with a per-install key. Kept as one
+ * constant so the lock's name lives in a single place even though the path is
+ * now computed.
+ */
 export const INSTALL_IDENTITY_LOCK_FILENAME = 'install-identity.json';
 
 /** Injectable filesystem / environment seams. All default to live process state. */
@@ -262,7 +269,8 @@ export function installIdentityLockPath(pluginRoot: string, deps: IdentityDeps =
     ...(deps.homedir !== undefined ? { homedir: deps.homedir } : {}),
   });
   const key = createHash('sha256').update(path.resolve(pluginRoot)).digest('hex').slice(0, 12);
-  return path.join(dir, `install-identity-${key}.json`);
+  const { name, ext } = path.parse(INSTALL_IDENTITY_LOCK_FILENAME);
+  return path.join(dir, `${name}-${key}${ext}`);
 }
 
 /**

--- a/src/install/collect-identity.ts
+++ b/src/install/collect-identity.ts
@@ -33,6 +33,7 @@ import { resolveCacheDir, resolveInstallIdentityDir } from '../utils/paths.js';
 import {
   buildInstallIdentity,
   InstallIdentitySchema,
+  UNKNOWN_VERSION_SENTINEL,
   type DigestEntry,
   type InstallIdentity,
 } from './install-identity.js';
@@ -207,7 +208,7 @@ export function collectInstallIdentity(pluginRoot: string, deps: IdentityDeps = 
   // binary — version + a descriptor digest over package.json (pins version +
   // dependency graph; a swapped bundle without a version bump still diverges).
   const pkgText = readFileText(path.join(pluginRoot, 'package.json'));
-  const binaryVersion = extractPackageVersion(pkgText) ?? '0.0.0-unknown';
+  const binaryVersion = extractPackageVersion(pkgText) ?? UNKNOWN_VERSION_SENTINEL;
   const binaryEntries: DigestEntry[] =
     pkgText !== undefined ? [{ path: 'package.json', content: pkgText }] : [];
 

--- a/src/install/collect-identity.ts
+++ b/src/install/collect-identity.ts
@@ -22,13 +22,14 @@
  * pass only the required `pluginRoot` / `stateDir` and the live defaults apply.
  */
 
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { SCHEMA_VERSION } from '../storage/sqlite-backend.js';
 import { atomicWriteFile } from '../utils/atomic-write.js';
-import { resolveCacheDir } from '../utils/paths.js';
+import { resolveCacheDir, resolveInstallIdentityDir } from '../utils/paths.js';
 import {
   buildInstallIdentity,
   InstallIdentitySchema,
@@ -236,9 +237,32 @@ export function collectInstallIdentity(pluginRoot: string, deps: IdentityDeps = 
   });
 }
 
-/** Absolute path of the recorded install-identity lock for a given state dir. */
-export function installIdentityLockPath(stateDir: string): string {
-  return path.join(stateDir, INSTALL_IDENTITY_LOCK_FILENAME);
+/**
+ * Absolute path of the recorded install-identity lock for a given installation.
+ *
+ * Keyed on `pluginRoot`, NOT on the event-store state dir. The lock records
+ * what is INSTALLED, so its location must not move when `WORKFLOW_STATE_DIR`
+ * does — otherwise one installation carries a different recorded identity per
+ * store and reports two different freshness verdicts, which is what made
+ * `doctor` self-contradictory and blocked the very configuration that collapses
+ * a store divergence.
+ *
+ * The `pluginRoot` digest keeps two installs on one machine from sharing a
+ * lock; the directory itself comes from {@link resolveInstallIdentityDir},
+ * which never consults the store env var.
+ *
+ * Migration: an existing lock under the old state-dir location is NOT read
+ * back. Reading it would reintroduce exactly the `WORKFLOW_STATE_DIR` variance
+ * being removed. The absent lock re-bootstraps through the designed TOFU path
+ * (record and proceed, never block).
+ */
+export function installIdentityLockPath(pluginRoot: string, deps: IdentityDeps = {}): string {
+  const dir = resolveInstallIdentityDir({
+    ...(deps.env !== undefined ? { env: deps.env } : {}),
+    ...(deps.homedir !== undefined ? { homedir: deps.homedir } : {}),
+  });
+  const key = createHash('sha256').update(path.resolve(pluginRoot)).digest('hex').slice(0, 12);
+  return path.join(dir, `install-identity-${key}.json`);
 }
 
 /**
@@ -248,11 +272,11 @@ export function installIdentityLockPath(stateDir: string): string {
  * wedging the gate).
  */
 export function readRecordedIdentity(
-  stateDir: string,
+  pluginRoot: string,
   deps: IdentityDeps = {},
 ): InstallIdentity | undefined {
   const readFileText = deps.readFileText ?? defaultReadFileText;
-  const text = readFileText(installIdentityLockPath(stateDir));
+  const text = readFileText(installIdentityLockPath(pluginRoot, deps));
   if (text === undefined) return undefined;
   let parsed: unknown;
   try {
@@ -266,12 +290,13 @@ export function readRecordedIdentity(
 
 /** Persist the expected install identity as the lock (install / first-run TOFU). */
 export function writeRecordedIdentity(
-  stateDir: string,
+  pluginRoot: string,
   identity: InstallIdentity,
   deps: IdentityDeps = {},
 ): void {
   const writeFileText = deps.writeFileText ?? defaultWriteFileText;
   const mkdirp = deps.mkdirp ?? defaultMkdirp;
-  mkdirp(stateDir);
-  writeFileText(installIdentityLockPath(stateDir), `${JSON.stringify(identity, null, 2)}\n`);
+  const lockPath = installIdentityLockPath(pluginRoot, deps);
+  mkdirp(path.dirname(lockPath));
+  writeFileText(lockPath, `${JSON.stringify(identity, null, 2)}\n`);
 }

--- a/src/install/collect-identity.ts
+++ b/src/install/collect-identity.ts
@@ -29,7 +29,7 @@ import path from 'node:path';
 
 import { SCHEMA_VERSION } from '../storage/sqlite-backend.js';
 import { atomicWriteFile } from '../utils/atomic-write.js';
-import { resolveCacheDir, resolveInstallIdentityDir } from '../utils/paths.js';
+import { resolveCacheDir, resolveInstallIdentityDir, toPosix } from '../utils/paths.js';
 import {
   buildInstallIdentity,
   InstallIdentitySchema,
@@ -271,7 +271,11 @@ export function installIdentityLockPath(pluginRoot: string, deps: IdentityDeps =
   });
   const key = createHash('sha256').update(path.resolve(pluginRoot)).digest('hex').slice(0, 12);
   const { name, ext } = path.parse(INSTALL_IDENTITY_LOCK_FILENAME);
-  return path.join(dir, `${name}-${key}${ext}`);
+  // POSIX separators, like every other resolver in `utils/paths.ts`. This path
+  // is COMPARED (against the resolved lock directory) and not merely opened, so
+  // a native `path.join` result would not match the forward-slash form the
+  // directory resolver returns — green on POSIX, red on win32.
+  return toPosix(path.join(dir, `${name}-${key}${ext}`));
 }
 
 /**

--- a/src/install/freshness-check.ts
+++ b/src/install/freshness-check.ts
@@ -26,7 +26,7 @@
  *     own open path enforces the same rule via `SchemaVersionTooNewError`).
  */
 
-import type { InstallIdentity } from './install-identity.js';
+import { UNKNOWN_VERSION_SENTINEL, type InstallIdentity } from './install-identity.js';
 
 /** The five independently-seedable, independently-blocking mismatch dimensions. */
 export type FreshnessDimension = 'binary' | 'plugin' | 'skill' | 'schema' | 'cache';
@@ -47,14 +47,6 @@ export interface FreshnessMismatch {
   readonly observed: string;
   readonly remediation: string;
 }
-
-/**
- * The sentinel substituted when the binary version cannot be read off the
- * install's `package.json`. It is a placeholder for an ABSENT observation, not
- * a version — so it must never satisfy an equality comparison against another
- * copy of itself.
- */
-export const UNKNOWN_VERSION_SENTINEL = '0.0.0-unknown';
 
 /**
  * Result of a freshness verification.

--- a/src/install/freshness-check.ts
+++ b/src/install/freshness-check.ts
@@ -48,10 +48,40 @@ export interface FreshnessMismatch {
   readonly remediation: string;
 }
 
-/** Result of a freshness verification — discriminated on `fresh`. */
+/**
+ * The sentinel substituted when the binary version cannot be read off the
+ * install's `package.json`. It is a placeholder for an ABSENT observation, not
+ * a version — so it must never satisfy an equality comparison against another
+ * copy of itself.
+ */
+export const UNKNOWN_VERSION_SENTINEL = '0.0.0-unknown';
+
+/**
+ * Result of a freshness verification.
+ *
+ * `indeterminate` is the third state, and its absence was a defect: the binary
+ * version falls back to {@link UNKNOWN_VERSION_SENTINEL} when it cannot be
+ * read, and comparing two unknowns by equality reported the dimension as
+ * MATCHING. `doctor` then printed "binary, plugin, skill, schema, and cache
+ * match the recorded identity" while separately warning it could not determine
+ * the running plugin version — an absent observation converted into positive
+ * assurance.
+ *
+ * An undetermined dimension now yields `indeterminate`, which callers surface
+ * as a non-assertion. It is deliberately NOT a mismatch: blocking on an
+ * unreadable `package.json` would turn the freshness gate into a new outage
+ * class, which this module's robustness policy exists to prevent. The trade is
+ * a false pass for an honest "cannot tell", not for a block.
+ */
 export type FreshnessResult =
   | { readonly fresh: true }
+  | { readonly fresh: false; readonly indeterminate: true; readonly dimensions: readonly FreshnessDimension[]; readonly reason: string }
   | { readonly fresh: false; readonly mismatches: readonly FreshnessMismatch[] };
+
+/** True when a recorded/observed version pair cannot support a match verdict. */
+function isIndeterminateVersion(value: string): boolean {
+  return value === UNKNOWN_VERSION_SENTINEL || value.trim() === '';
+}
 
 /**
  * Thrown by {@link assertInstallFreshness} when one or more install dimensions
@@ -109,6 +139,24 @@ export function verifyInstallFreshness(
   observed: InstallIdentity,
 ): FreshnessResult {
   const mismatches: FreshnessMismatch[] = [];
+
+  // Indeterminate dimensions are settled BEFORE any equality comparison, so an
+  // unknown can never be folded into a pass by matching another unknown.
+  const undetermined: FreshnessDimension[] = [];
+  if (isIndeterminateVersion(expected.binary.version) || isIndeterminateVersion(observed.binary.version)) {
+    undetermined.push('binary');
+  }
+  if (undetermined.length > 0) {
+    return {
+      fresh: false,
+      indeterminate: true,
+      dimensions: undetermined,
+      reason:
+        `Undetermined dimension(s): ${undetermined.join(', ')} — the version could not be read, ` +
+        `so freshness cannot be asserted either way. An unreadable install is reported as ` +
+        `unknown rather than counted as a match.`,
+    };
+  }
 
   // binary — exact match on version AND artifact digest.
   if (
@@ -181,7 +229,9 @@ export function assertInstallFreshness(
   observed: InstallIdentity,
 ): void {
   const result = verifyInstallFreshness(expected, observed);
-  if (!result.fresh) {
-    throw new InstallFreshnessError(result.mismatches);
-  }
+  if (result.fresh) return;
+  // An undetermined dimension is not a confirmed mismatch — only a CONFIRMED
+  // mismatch blocks. See the `indeterminate` note on FreshnessResult.
+  if ('indeterminate' in result) return;
+  throw new InstallFreshnessError(result.mismatches);
 }

--- a/src/install/freshness-gate.ts
+++ b/src/install/freshness-gate.ts
@@ -40,10 +40,13 @@ import {
   type IdentityDeps,
 } from './collect-identity.js';
 
-export interface FreshnessGateDeps extends IdentityDeps {
-  /** State directory holding the recorded install-identity lock. */
-  readonly stateDir: string;
-}
+/**
+ * Deps for the gate. Note what is ABSENT: there is no `stateDir`. Install
+ * freshness is a property of the installed artifacts, and the field's removal
+ * is what makes that structural — the event store cannot be folded back into
+ * the verdict by a future caller, because there is nowhere to put it.
+ */
+export type FreshnessGateDeps = IdentityDeps;
 
 /** Outcome of a freshness evaluation — discriminated on `status`. */
 export type FreshnessGateOutcome =
@@ -82,11 +85,16 @@ function computeOutcome(deps: FreshnessGateDeps): FreshnessGateOutcome {
     return { status: 'degraded', reason: `install-identity collection failed: ${errorMessage(err)}` };
   }
 
-  const recorded = readRecordedIdentity(deps.stateDir, deps);
+  // The lock is keyed to the INSTALLATION, not to `deps.stateDir`. Recording it
+  // per event store made the verdict a function of `WORKFLOW_STATE_DIR`, so the
+  // same install read "fresh" in one store and "stale or mixed" in another —
+  // and the gate blocked precisely the store-pinning an operator adopts to
+  // collapse a divergence.
+  const recorded = readRecordedIdentity(posture.pluginRoot, deps);
   if (recorded === undefined) {
     // First run — Trust-On-First-Use: record the current identity, do not block.
     try {
-      writeRecordedIdentity(deps.stateDir, observed, deps);
+      writeRecordedIdentity(posture.pluginRoot, observed, deps);
     } catch (err) {
       return { status: 'degraded', reason: `failed to record install identity: ${errorMessage(err)}` };
     }
@@ -96,6 +104,12 @@ function computeOutcome(deps: FreshnessGateDeps): FreshnessGateOutcome {
   const result = verifyInstallFreshness(recorded, observed);
   if (result.fresh) {
     return { status: 'fresh' };
+  }
+  // Cannot-tell is reported as cannot-tell. Mapping it onto the existing
+  // non-blocking `degraded` status keeps an unreadable install from becoming a
+  // new outage class, while refusing to report it as a match.
+  if ('indeterminate' in result) {
+    return { status: 'degraded', reason: result.reason };
   }
   const error = new InstallFreshnessError(result.mismatches);
   return { status: 'blocked', mismatches: result.mismatches, message: error.message };

--- a/src/install/install-identity.ts
+++ b/src/install/install-identity.ts
@@ -81,6 +81,23 @@ export function digestTree(entries: ReadonlyArray<DigestEntry>): string {
 
 // ─── Install-identity record ─────────────────────────────────────────────────
 
+/**
+ * Substituted when the binary version cannot be read off the install's
+ * `package.json`.
+ *
+ * It stands for an ABSENT observation, not a version, so it must never satisfy
+ * an equality comparison against another copy of itself — see the
+ * `indeterminate` verdict in `freshness-check.ts`.
+ *
+ * Declared HERE, beside the identity shape, because both the producer that
+ * substitutes it (`collect-identity.ts`) and the consumer that must refuse to
+ * match on it (`freshness-check.ts`) already import this module. It previously
+ * lived as a bare literal in the producer and a separate constant in the
+ * consumer — two authorities for one value, so changing the producer would have
+ * left the consumer's check silently matching nothing.
+ */
+export const UNKNOWN_VERSION_SENTINEL = '0.0.0-unknown';
+
 export const BinaryIdentitySchema = z.object({
   version: z.string().min(1),
   digest: DigestSchema,

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -349,6 +349,16 @@ export interface ActiveStoreDivergence extends StorePathDivergence {
    * store EXISTS, and the operator has not opted in.
    */
   readonly active: boolean;
+  /**
+   * Should a read carry the divergence caveat?
+   *
+   * Same condition as {@link active}. An explicit opt-in silences the warning
+   * as well as the refusal: the variable is named ALLOW, so an operator who
+   * sets it has already accepted the split, and repeating it on every read
+   * trains them to ignore warnings without telling them anything new. `doctor`
+   * remains the standing diagnostic for anyone who wants to re-check.
+   */
+  readonly shouldWarn: boolean;
 }
 
 /**
@@ -396,6 +406,7 @@ export function detectActiveStoreDivergence(
     otherExists,
     acknowledged,
     active: base.diverges && otherExists && !acknowledged,
+    shouldWarn: base.diverges && otherExists && !acknowledged,
   };
 }
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -382,7 +382,12 @@ export function detectActiveStoreDivergence(
   const activePath = pluginMode ? base.pluginPath : base.cliPath;
   const otherPath = pluginMode ? base.cliPath : base.pluginPath;
   const otherExists = base.diverges && exists(otherPath);
-  const acknowledged = (env[ALLOW_STORE_DIVERGENCE_ENV] ?? '').trim() !== '';
+  // An explicit falsy spelling means "keep the guard armed", not "disarm it".
+  // Treating any non-blank value as opt-in would make
+  // `EXARCHOS_ALLOW_STORE_DIVERGENCE=false` disable the refusal — handing the
+  // operator the silent-split failure they were trying to keep.
+  const raw = (env[ALLOW_STORE_DIVERGENCE_ENV] ?? '').trim().toLowerCase();
+  const acknowledged = raw !== '' && raw !== '0' && raw !== 'false' && raw !== 'no' && raw !== 'off';
 
   return {
     ...base,

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -359,3 +359,37 @@ export function resolveTasksDir(): string {
 export function resolveCacheDir(inputs?: StorePathResolutionInputs): string {
   return resolveDir('EXARCHOS_CACHE_DIR', 'cache', 'cache', inputs);
 }
+
+/**
+ * Resolve the directory holding the recorded install-identity lock.
+ *
+ * Deliberately does NOT go through {@link resolveDir}: install freshness is a
+ * property of the INSTALLED ARTIFACTS — which binary, which plugin, which
+ * cache — and must not vary with `WORKFLOW_STATE_DIR`, which steers where
+ * workflow state lives and has no stated relationship to installation identity.
+ *
+ * Recording the lock inside the resolved event store made the same install
+ * simultaneously "fresh" (in the store where TOFU happened to bootstrap) and
+ * "stale or mixed" (in any other), so the freshness gate blocked precisely the
+ * configuration an operator adopts to collapse a store-path divergence. Pinning
+ * the store was the documented remedy, and taking it tripped the gate.
+ *
+ * Plugin mode is excluded from the cascade for the same reason: the verdict
+ * must not depend on which surface asks.
+ */
+export function resolveInstallIdentityDir(
+  inputs?: Omit<StorePathResolutionInputs, 'pluginMode'>,
+): string {
+  const env = inputs?.env ?? process.env;
+  const home = inputs?.homedir ?? os.homedir();
+
+  const explicit = env['EXARCHOS_INSTALL_STATE_DIR'];
+  if (explicit) return toPosix(expandTilde(explicit, home));
+
+  const xdgStateHome = env['XDG_STATE_HOME'];
+  if (xdgStateHome) {
+    return toPosix(path.join(expandTilde(xdgStateHome, home), 'exarchos', 'install'));
+  }
+
+  return toPosix(path.join(home, '.exarchos', 'install'));
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -331,6 +331,84 @@ export function computeStorePathDivergence(
   return { cliPath, pluginPath, diverges: cliPath !== pluginPath };
 }
 
+/** Env var by which an operator accepts a divergent store deliberately. */
+export const ALLOW_STORE_DIVERGENCE_ENV = 'EXARCHOS_ALLOW_STORE_DIVERGENCE';
+
+/** A divergence that is actually splitting live state, with the evidence for saying so. */
+export interface ActiveStoreDivergence extends StorePathDivergence {
+  /** The store THIS process will read and write. */
+  readonly activePath: string;
+  /** The store the OTHER surface resolves. */
+  readonly otherPath: string;
+  /** Does the other surface's store exist on disk? */
+  readonly otherExists: boolean;
+  /** Has the operator opted into running two stores? */
+  readonly acknowledged: boolean;
+  /**
+   * True when state is genuinely splitting: the surfaces diverge, the other
+   * store EXISTS, and the operator has not opted in.
+   */
+  readonly active: boolean;
+}
+
+/**
+ * Decide whether this process is writing into a store the other surface will
+ * never read — the condition worth refusing on.
+ *
+ * Bare divergence is NOT that condition, and the distinction is the whole
+ * design. `WORKFLOW_STATE_DIR` unset in non-plugin mode resolves
+ * `~/.exarchos/state` for the CLI and `~/.claude/workflow-state` for the
+ * plugin, so {@link computeStorePathDivergence} reports `diverges: true` for
+ * EVERY standalone CLI invocation on the machine, including for users who have
+ * never installed the plugin. Refusing on that alone would break them all.
+ *
+ * Requiring the other store to EXIST is what turns an always-true structural
+ * fact into evidence that two stores are really in play. Setting
+ * `WORKFLOW_STATE_DIR` collapses the divergence outright (the env var wins in
+ * both modes), which is why it is the remedy the refusal names.
+ */
+export function detectActiveStoreDivergence(
+  inputs?: StorePathResolutionInputs & { readonly storeExists?: (p: string) => boolean },
+): ActiveStoreDivergence {
+  const env = inputs?.env ?? process.env;
+  const pluginMode = inputs?.pluginMode ?? isClaudeCodePlugin(env);
+  const exists = inputs?.storeExists ?? ((p: string): boolean => fs.existsSync(p));
+
+  const base = computeStorePathDivergence({
+    ...(inputs?.env !== undefined ? { env: inputs.env } : {}),
+    ...(inputs?.homedir !== undefined ? { homedir: inputs.homedir } : {}),
+  });
+
+  const activePath = pluginMode ? base.pluginPath : base.cliPath;
+  const otherPath = pluginMode ? base.cliPath : base.pluginPath;
+  const otherExists = base.diverges && exists(otherPath);
+  const acknowledged = (env[ALLOW_STORE_DIVERGENCE_ENV] ?? '').trim() !== '';
+
+  return {
+    ...base,
+    activePath,
+    otherPath,
+    otherExists,
+    acknowledged,
+    active: base.diverges && otherExists && !acknowledged,
+  };
+}
+
+/**
+ * The operator-facing account of a live split: which store is being used,
+ * which one is being ignored, and the one line that collapses the two.
+ */
+export function describeStoreDivergence(d: ActiveStoreDivergence): string {
+  return (
+    `Event-store divergence: this surface resolves ${d.activePath} but the other ` +
+    `resolves ${d.otherPath}, and that store exists. Workflow state written here is ` +
+    `invisible there — reads answer from a different store and downstream gates ` +
+    `return confident, wrong verdicts. Set WORKFLOW_STATE_DIR to pin both surfaces ` +
+    `to one store (it wins in plugin and non-plugin mode alike), or set ` +
+    `${ALLOW_STORE_DIVERGENCE_ENV}=1 to proceed deliberately with two.`
+  );
+}
+
 /**
  * Resolve the teams directory.
  * Env: `EXARCHOS_TEAMS_DIR` | Claude: `~/.claude/teams` | Default: `~/.exarchos/teams`

--- a/src/verbs/doctor/checks/env-variables.ts
+++ b/src/verbs/doctor/checks/env-variables.ts
@@ -22,7 +22,6 @@ import type { DoctorProbes } from '../probes.js';
  */
 const KNOWN: ReadonlySet<string> = new Set([
   'EXARCHOS_ALLOW_STORE_DIVERGENCE',
-  'EXARCHOS_API_TOKEN',
   'EXARCHOS_BUILD_VERSION',
   'EXARCHOS_CACHE_DIR',
   'EXARCHOS_CLI_ENVELOPE',
@@ -53,7 +52,6 @@ const KNOWN: ReadonlySet<string> = new Set([
   'EXARCHOS_SKIP_HOOKS',
   'EXARCHOS_SNAPSHOT_INTERVAL',
   'EXARCHOS_TASKS_DIR',
-  'EXARCHOS_TASK_ID',
   'EXARCHOS_TEAMS_DIR',
   'EXARCHOS_TELEMETRY',
   'EXARCHOS_VCS_PROVIDER',

--- a/src/verbs/doctor/checks/env-variables.ts
+++ b/src/verbs/doctor/checks/env-variables.ts
@@ -8,25 +8,56 @@
 import type { CheckResult } from '../schema.js';
 import type { DoctorProbes } from '../probes.js';
 
+/**
+ * Every `EXARCHOS_*` name the source reads from an environment.
+ *
+ * Hand-maintained, and it had drifted: seventeen variables the tree actually
+ * looks up were absent, so `doctor` reported a SUPPORTED variable as unknown
+ * and told the operator to remove it. A diagnostic that flags correct
+ * configuration as a fault is worse than one that stays quiet, because the
+ * suggested fix breaks a working setup.
+ *
+ * The list is kept sorted so an addition is a one-line diff at the right place
+ * rather than an append that hides a duplicate.
+ */
 const KNOWN: ReadonlySet<string> = new Set([
-  'EXARCHOS_PLUGIN_ROOT',
-  'EXARCHOS_PROJECT_ROOT',
-  'EXARCHOS_LOG_LEVEL',
-  'EXARCHOS_TELEMETRY',
-  'EXARCHOS_SKIP_HOOKS',
-  'EXARCHOS_FEATURE_ID',
-  'EXARCHOS_PHASE',
-  'EXARCHOS_EVENT_TYPE',
-  'EXARCHOS_WORKFLOW_TYPE',
-  'EXARCHOS_TASK_ID',
-  'EXARCHOS_TEAMS_DIR',
-  'EXARCHOS_TASKS_DIR',
+  'EXARCHOS_ALLOW_STORE_DIVERGENCE',
   'EXARCHOS_API_TOKEN',
+  'EXARCHOS_BUILD_VERSION',
+  'EXARCHOS_CACHE_DIR',
+  'EXARCHOS_CLI_ENVELOPE',
+  'EXARCHOS_DIRECTIVE',
+  'EXARCHOS_DISABLE_CACHE_HINTS',
   'EXARCHOS_EVAL_CAPTURE',
   'EXARCHOS_EVAL_CAPTURE_DIR',
+  'EXARCHOS_EVENT_TYPE',
+  'EXARCHOS_FAMILY',
+  'EXARCHOS_FEATURE_ID',
+  'EXARCHOS_INSTALL_STATE_DIR',
+  'EXARCHOS_LINT_STRICT',
+  'EXARCHOS_LOG_LEVEL',
   'EXARCHOS_MAX_CACHE_ENTRIES',
-  'EXARCHOS_SNAPSHOT_INTERVAL',
   'EXARCHOS_MAX_IDEMPOTENCY_KEYS',
+  'EXARCHOS_MCP_ENTRY',
+  'EXARCHOS_ORIENTATION',
+  'EXARCHOS_ORIENTATION_AUTHORITY',
+  'EXARCHOS_OUTPUT_ROOT',
+  'EXARCHOS_OUTPUT_VALIDATE',
+  'EXARCHOS_PACKAGE_NAME',
+  'EXARCHOS_PHASE',
+  'EXARCHOS_PLUGIN_ROOT',
+  'EXARCHOS_PREFLIGHT_DEBUG',
+  'EXARCHOS_PROJECT_ROOT',
+  'EXARCHOS_RUNTIMES_FROM_DISK',
+  'EXARCHOS_SIDECAR_DRAIN_INTERVAL_MS',
+  'EXARCHOS_SKIP_HOOKS',
+  'EXARCHOS_SNAPSHOT_INTERVAL',
+  'EXARCHOS_TASKS_DIR',
+  'EXARCHOS_TASK_ID',
+  'EXARCHOS_TEAMS_DIR',
+  'EXARCHOS_TELEMETRY',
+  'EXARCHOS_VCS_PROVIDER',
+  'EXARCHOS_WORKFLOW_TYPE',
 ]);
 
 export async function envVariables(

--- a/src/verbs/doctor/checks/install-freshness.ts
+++ b/src/verbs/doctor/checks/install-freshness.ts
@@ -46,19 +46,31 @@ export async function installFreshness(
     const observed = collectInstallIdentity(posture.pluginRoot, deps);
     observedSummary = `binary ${observed.binary.version}, schema v${observed.schema.version}`;
 
-    const recorded = readRecordedIdentity(probes.stateDir, deps);
+    const recorded = readRecordedIdentity(posture.pluginRoot, deps);
     if (recorded === undefined) {
       return {
         ...base,
         status: 'Pass',
         message:
           `Installed (${posture.source}) at ${posture.pluginRoot}; no recorded install identity yet — ` +
-          `the first mutating action records a baseline at ${installIdentityLockPath(probes.stateDir)}.`,
+          `the first mutating action records a baseline at ${installIdentityLockPath(posture.pluginRoot, deps)}.`,
         durationMs: Date.now() - start,
       };
     }
 
     const result = verifyInstallFreshness(recorded, observed);
+    if (!result.fresh && 'indeterminate' in result) {
+      // Never claim five dimensions match while two of them are unknown.
+      return {
+        ...base,
+        status: 'Warning',
+        message: `Installation freshness is UNDETERMINED (${observedSummary}). ${result.reason}`,
+        fix:
+          `Reinstall via scripts/get-exarchos.{sh,ps1} so the install carries a readable ` +
+          `version, or verify ${posture.pluginRoot}/package.json is present and readable.`,
+        durationMs: Date.now() - start,
+      };
+    }
     if (result.fresh) {
       return {
         ...base,

--- a/tests/helpers/hermetic-install-identity.ts
+++ b/tests/helpers/hermetic-install-identity.ts
@@ -19,8 +19,11 @@ import * as path from 'node:path';
  * Redirecting the directory per test process makes the suite hermetic without
  * weakening the production resolution order.
  */
-if (process.env['EXARCHOS_INSTALL_STATE_DIR'] === undefined) {
-  process.env['EXARCHOS_INSTALL_STATE_DIR'] = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'exarchos-test-install-identity-'),
-  );
-}
+// Set UNCONDITIONALLY. Honouring a caller-supplied value would let a stray
+// export in a shell or a CI job point the whole suite at a real directory, and
+// the tests would publish TOFU locks there — the exact leak this file exists to
+// stop. A test that needs its own directory overrides it per-test with
+// `vi.stubEnv`, which runs after this module and is undone on teardown.
+process.env['EXARCHOS_INSTALL_STATE_DIR'] = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'exarchos-test-install-identity-'),
+);

--- a/tests/helpers/hermetic-install-identity.ts
+++ b/tests/helpers/hermetic-install-identity.ts
@@ -1,0 +1,26 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Keep the install-identity TOFU lock out of the developer's real home.
+ *
+ * The lock is keyed to the INSTALLATION rather than to the event store, so it
+ * no longer follows a test's temp `stateDir` the way it used to. That is the
+ * point — freshness must not vary with `WORKFLOW_STATE_DIR` — but it means any
+ * test that dispatches a mutating action under an "installed" posture would
+ * otherwise publish a lock into `~/.exarchos/install`.
+ *
+ * A checkout of THIS repo on a machine that also has the Exarchos plugin
+ * installed detects as `installed` (posture keys on the plugin cache existing,
+ * not on whether the running code IS that install), so this is the ordinary
+ * developer configuration, not an exotic one.
+ *
+ * Redirecting the directory per test process makes the suite hermetic without
+ * weakening the production resolution order.
+ */
+if (process.env['EXARCHOS_INSTALL_STATE_DIR'] === undefined) {
+  process.env['EXARCHOS_INSTALL_STATE_DIR'] = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'exarchos-test-install-identity-'),
+  );
+}

--- a/tests/outcome/roots-injection-schema-guard.test.ts
+++ b/tests/outcome/roots-injection-schema-guard.test.ts
@@ -1,0 +1,169 @@
+// ─── #1838 — roots inference must never inject into a schema that forbids it ──
+//
+// The roots-based `featureId` resolver ran for every action not on a
+// three-name latency skip list, then injected the resolved id into the
+// forwarded args. Actions whose own schema does not declare `featureId` were
+// then refused by their own strict parse — naming a parameter the caller never
+// sent and the server itself added. 59 of 124 registered actions failed that
+// way, including `orchestrate.doctor` (the diagnostic of record) and 22 of the
+// 26 `exarchos_view` read actions.
+//
+// The bug reproduced ONLY where roots resolution SUCCEEDS. The repo's own
+// suite never resolves a workspace, so the entire surface stayed green.
+//
+// Breadth is asserted over the registry through the exported predicate rather
+// than by dispatching 59 handlers — `merge_pr`, `create_pr` and `create_issue`
+// are among them, and a guard must not perform the side effects it guards.
+// Depth is one real end-to-end dispatch on the action from the report.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { TOOL_REGISTRY } from '../../src/registry.js';
+import {
+  dispatch,
+  actionAcceptsInferredFeatureId,
+} from '../../src/dispatch/core/dispatch.js';
+import { EventStore } from '../../src/events/store.js';
+import { handleInit } from '../../src/workflow/tools.js';
+import { createInMemoryResolver } from '../../src/workflow/capabilities/resolver.js';
+import type { RootsClient } from '../../src/runtime/workspace/discovery.js';
+
+/** The live latency shortcut in `dispatch.ts`. Skipped names never reach inference at all. */
+const LATENCY_SKIP = new Set(['describe', 'runbook', 'agent_spec']);
+
+interface ActionRef {
+  readonly tool: string;
+  readonly action: string;
+}
+
+function partitionRegistry(): {
+  readonly declaring: readonly ActionRef[];
+  readonly omitting: readonly ActionRef[];
+} {
+  const declaring: ActionRef[] = [];
+  const omitting: ActionRef[] = [];
+  for (const tool of TOOL_REGISTRY) {
+    for (const action of tool.actions) {
+      const ref = { tool: tool.name, action: action.name };
+      if (actionAcceptsInferredFeatureId(action)) declaring.push(ref);
+      else omitting.push(ref);
+    }
+  }
+  return { declaring, omitting };
+}
+
+describe('Roots featureId inference is gated on the receiving schema (#1838)', () => {
+  it('RootsInference_ActionOmittingFeatureId_IsNeverEligibleForInjection', () => {
+    const { declaring, omitting } = partitionRegistry();
+
+    // Denominator first — a cover assertion that enumerates nothing passes
+    // trivially, which is the failure mode this repo keeps rediscovering.
+    // These are the measured counts at the time of the fix; they are lower
+    // bounds, so adding actions never turns the guard vacuous.
+    expect(omitting.length).toBeGreaterThanOrEqual(60);
+    expect(declaring.length).toBeGreaterThanOrEqual(55);
+    expect(omitting.length + declaring.length).toBe(
+      TOOL_REGISTRY.reduce((n, t) => n + t.actions.length, 0),
+    );
+
+    // The population the bug actually broke: omits `featureId` AND was not
+    // rescued by the latency skip list.
+    const exposed = omitting.filter((r) => !LATENCY_SKIP.has(r.action));
+    expect(exposed.length).toBeGreaterThanOrEqual(55);
+
+    // Every one of them must be ineligible for injection.
+    for (const ref of exposed) {
+      const tool = TOOL_REGISTRY.find((t) => t.name === ref.tool);
+      const action = tool?.actions.find((a) => a.name === ref.action);
+      expect(action, `${ref.tool}.${ref.action} missing from registry`).toBeDefined();
+      expect(
+        actionAcceptsInferredFeatureId(action!),
+        `${ref.tool}.${ref.action} omits featureId but is eligible for injection`,
+      ).toBe(false);
+    }
+  });
+
+  it('RootsInference_NamedRegressionVictims_AreIneligible', () => {
+    // Spot-pins from the report and from the measured blast radius, so a
+    // refactor that silently narrows the predicate is named rather than
+    // absorbed into an aggregate count.
+    const victims: readonly ActionRef[] = [
+      { tool: 'exarchos_event', action: 'append' },
+      { tool: 'exarchos_event', action: 'batch_append' },
+      { tool: 'exarchos_event', action: 'query' },
+      { tool: 'exarchos_orchestrate', action: 'doctor' },
+      { tool: 'exarchos_view', action: 'pipeline' },
+      { tool: 'exarchos_workflow', action: 'feedback' },
+    ];
+    for (const v of victims) {
+      const action = TOOL_REGISTRY.find((t) => t.name === v.tool)?.actions.find(
+        (a) => a.name === v.action,
+      );
+      expect(action, `${v.tool}.${v.action} not found`).toBeDefined();
+      expect(
+        actionAcceptsInferredFeatureId(action!),
+        `${v.tool}.${v.action} must not receive an inferred featureId`,
+      ).toBe(false);
+    }
+
+    // And the converse — the predicate must still admit the actions that DO
+    // take a featureId, or the fix would have disabled inference wholesale.
+    const beneficiary = TOOL_REGISTRY.find((t) => t.name === 'exarchos_workflow')?.actions.find(
+      (a) => a.name === 'get',
+    );
+    expect(beneficiary).toBeDefined();
+    expect(actionAcceptsInferredFeatureId(beneficiary!)).toBe(true);
+  });
+
+  it('Dispatch_EventAppendUnderResolvingRoots_IsNotRefusedForInjectedFeatureId', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'outcome-1838-'));
+    const stateDir = path.join(workspace, 'docs', 'workflow-state');
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(path.join(workspace, '.exarchos.yml'), '', 'utf8');
+
+    const featureId = 'outcome-1838-roots';
+    const eventStore = new EventStore(stateDir);
+    await eventStore.initialize();
+    const init = await handleInit({ featureId, workflowType: 'feature' }, stateDir, eventStore);
+    expect(init.success).toBe(true);
+
+    // A client that declares roots AND resolves successfully — the condition
+    // under which the defect fires. Without this the branch never runs.
+    const resolver = createInMemoryResolver([]);
+    resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+    const rootsClient: RootsClient = {
+      async list() {
+        return [{ uri: `file://${workspace}` }];
+      },
+    };
+
+    const result = await dispatch(
+      'exarchos_event',
+      {
+        action: 'append',
+        stream: featureId,
+        event: { type: 'task.assigned', data: { taskId: 'T-01', title: 'guard' } },
+      },
+      {
+        stateDir,
+        eventStore,
+        enableTelemetry: false,
+        capabilityResolver: resolver,
+        rootsClient,
+        cwd: workspace,
+      },
+    );
+
+    // The precise pre-fix failure: INVALID_INPUT naming a parameter the
+    // caller never supplied.
+    const message = result.error?.message ?? '';
+    expect(
+      message,
+      `dispatch refused a parameter it injected itself: ${message}`,
+    ).not.toMatch(/unrecognized parameter\(s\).*featureId/);
+    expect(result.success, `append failed: ${message}`).toBe(true);
+  });
+});

--- a/tests/outcome/roots-injection-schema-guard.test.ts
+++ b/tests/outcome/roots-injection-schema-guard.test.ts
@@ -118,6 +118,74 @@ describe('Roots featureId inference is gated on the receiving schema (#1838)', (
     expect(actionAcceptsInferredFeatureId(beneficiary!)).toBe(true);
   });
 
+  it('Dispatch_EveryReadOnlyVictimUnderResolvingRoots_IsNotRefusedForInjectedFeatureId', async () => {
+    // ─── the wiring, not just the predicate ─────────────────────────────────
+    //
+    // The registry assertions above prove `actionAcceptsInferredFeatureId`
+    // classifies correctly. They do NOT prove dispatch consults it: delete the
+    // call in `dispatch()` and every one of them still passes, because the
+    // predicate remains correct while nothing asks it. A control that is not
+    // reachable in the shipped composition is not a control.
+    //
+    // So this dispatches the victims for real. It is restricted to the
+    // READ-ONLY ones — `exarchos_view` is declared `'*'` read-only by
+    // READ_ONLY_ACTIONS, so executing them mutates nothing — which is what
+    // makes exercising the whole population safe. The mutating victims
+    // (`merge_pr`, `create_pr`, `create_issue`) stay excluded on purpose: a
+    // guard must not perform the side effects it guards.
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'outcome-1838-wiring-'));
+    const stateDir = path.join(workspace, 'docs', 'workflow-state');
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(path.join(workspace, '.exarchos.yml'), '', 'utf8');
+
+    const featureId = 'outcome-1838-wiring';
+    const eventStore = new EventStore(stateDir);
+    await eventStore.initialize();
+    expect((await handleInit({ featureId, workflowType: 'feature' }, stateDir, eventStore)).success).toBe(true);
+
+    const resolver = createInMemoryResolver([]);
+    resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+    const rootsClient: RootsClient = {
+      async list() {
+        return [{ uri: `file://${workspace}` }];
+      },
+    };
+    const ctx = {
+      stateDir,
+      eventStore,
+      enableTelemetry: false,
+      capabilityResolver: resolver,
+      rootsClient,
+      cwd: workspace,
+    };
+
+    const viewTool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
+    expect(viewTool).toBeDefined();
+    const victims = viewTool!.actions
+      .filter((a) => !actionAcceptsInferredFeatureId(a) && !LATENCY_SKIP.has(a.name))
+      .map((a) => a.name);
+
+    // Denominator: if this population ever empties, the loop below proves
+    // nothing and would pass in silence.
+    expect(victims.length).toBeGreaterThanOrEqual(20);
+
+    const refused: string[] = [];
+    for (const action of victims) {
+      const result = await dispatch('exarchos_view', { action }, ctx);
+      // The assertion is NOT that the call succeeds — several of these need
+      // arguments or external state. It is that whatever goes wrong, it is
+      // never dispatch refusing a parameter it injected itself.
+      if (/unrecognized parameter\(s\).*featureId/.test(result.error?.message ?? '')) {
+        refused.push(action);
+      }
+    }
+
+    expect(
+      refused,
+      `dispatch injected featureId into ${refused.length} action(s) whose schema forbids it`,
+    ).toEqual([]);
+  }, 60_000);
+
   it('Dispatch_EventAppendUnderResolvingRoots_IsNotRefusedForInjectedFeatureId', async () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'outcome-1838-'));
     const stateDir = path.join(workspace, 'docs', 'workflow-state');

--- a/tests/outcome/roots-injection-schema-guard.test.ts
+++ b/tests/outcome/roots-injection-schema-guard.test.ts
@@ -16,7 +16,7 @@
 // are among them, and a guard must not perform the side effects it guards.
 // Depth is one real end-to-end dispatch on the action from the report.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -30,6 +30,22 @@ import { EventStore } from '../../src/events/store.js';
 import { handleInit } from '../../src/workflow/tools.js';
 import { createInMemoryResolver } from '../../src/workflow/capabilities/resolver.js';
 import type { RootsClient } from '../../src/runtime/workspace/discovery.js';
+
+/** Temp workspaces created by this suite, removed on teardown. */
+const created: string[] = [];
+
+async function mkWorkspace(label: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), label));
+  created.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir !== undefined) await fs.rm(dir, { recursive: true, force: true });
+  }
+});
 
 /** The live latency shortcut in `dispatch.ts`. Skipped names never reach inference at all. */
 const LATENCY_SKIP = new Set(['describe', 'runbook', 'agent_spec']);
@@ -133,7 +149,7 @@ describe('Roots featureId inference is gated on the receiving schema (#1838)', (
     // makes exercising the whole population safe. The mutating victims
     // (`merge_pr`, `create_pr`, `create_issue`) stay excluded on purpose: a
     // guard must not perform the side effects it guards.
-    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'outcome-1838-wiring-'));
+    const workspace = await mkWorkspace('outcome-1838-wiring-');
     const stateDir = path.join(workspace, 'docs', 'workflow-state');
     await fs.mkdir(stateDir, { recursive: true });
     await fs.writeFile(path.join(workspace, '.exarchos.yml'), '', 'utf8');
@@ -187,7 +203,7 @@ describe('Roots featureId inference is gated on the receiving schema (#1838)', (
   }, 60_000);
 
   it('Dispatch_EventAppendUnderResolvingRoots_IsNotRefusedForInjectedFeatureId', async () => {
-    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'outcome-1838-'));
+    const workspace = await mkWorkspace('outcome-1838-');
     const stateDir = path.join(workspace, 'docs', 'workflow-state');
     await fs.mkdir(stateDir, { recursive: true });
     await fs.writeFile(path.join(workspace, '.exarchos.yml'), '', 'utf8');

--- a/tests/outcome/store-divergence-dispatch.test.ts
+++ b/tests/outcome/store-divergence-dispatch.test.ts
@@ -66,7 +66,7 @@ afterEach(async () => {
 });
 
 describe('Store-path divergence surfaces at the point of use (#1839)', () => {
-  it('Mutation_UnderActiveDivergence_IsRefusedNotSilentlyWritten', () => {
+  it('Mutation_UnderActiveDivergence_IsRefusedNotSilentlyWritten', async () => {
     // Precondition: `os.homedir()` must actually follow the stubbed HOME, or
     // this test would assert nothing.
     expect(os.homedir()).toBe(home);
@@ -74,17 +74,17 @@ describe('Store-path divergence surfaces at the point of use (#1839)', () => {
     createStore(cliStore());
     createStore(pluginStore());
 
-    return dispatch(
+    const result = await dispatch(
       'exarchos_workflow',
       { action: 'init', featureId: 'divergence-probe', workflowType: 'feature' },
       ctx(),
-    ).then((result) => {
-      expect(result.success, 'a write into a ghost store must not report success').toBe(false);
-      expect(result.error?.code).toBe('STORE_PATH_DIVERGENCE');
-      // The message must be actionable — both paths and the remedy.
-      expect(result.error?.message).toContain('WORKFLOW_STATE_DIR');
-      expect(result.error?.message).toContain(pluginStore());
-    });
+    );
+
+    expect(result.success, 'a write into a ghost store must not report success').toBe(false);
+    expect(result.error?.code).toBe('STORE_PATH_DIVERGENCE');
+    // The message must be actionable — both paths and the remedy.
+    expect(result.error?.message).toContain('WORKFLOW_STATE_DIR');
+    expect(result.error?.message).toContain(pluginStore());
   });
 
   it('Mutation_OtherStoreAbsent_ProceedsNormally', async () => {
@@ -148,7 +148,10 @@ describe('Store-path divergence surfaces at the point of use (#1839)', () => {
       { stateDir: explicit, eventStore: store, enableTelemetry: false },
     );
     expect(result.error?.code).not.toBe('STORE_PATH_DIVERGENCE');
-    expect(result.warnings ?? []).not.toContain(expect.stringContaining('Event-store divergence'));
+    // `.join(' ')`, NOT `toContain(expect.stringContaining(...))`. `toContain`
+    // compares array members by equality, so an asymmetric matcher is compared
+    // as a value and never matches — the assertion could not fail.
+    expect(result.warnings?.join(' ') ?? '').not.toContain('Event-store divergence');
   });
 
   it('Read_NoDivergence_CarriesNoSpuriousWarning', async () => {

--- a/tests/outcome/store-divergence-dispatch.test.ts
+++ b/tests/outcome/store-divergence-dispatch.test.ts
@@ -1,0 +1,165 @@
+// ─── #1839 — the divergence must surface AT THE POINT OF USE ─────────────────
+//
+// Driven through the real `dispatch()` chokepoint rather than the detector, so
+// the assertion is about what a caller actually receives: a mutating action
+// refuses instead of reporting success, and a read carries the caveat inline
+// rather than requiring a separate `doctor` run to discover it.
+//
+// `HOME` is stubbed into a temp tree so both candidate stores can be created
+// hermetically — Node's `os.homedir()` reads `$HOME` on POSIX.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { dispatch } from '../../src/dispatch/core/dispatch.js';
+import type { DispatchContext } from '../../src/dispatch/core/dispatch.js';
+import { EventStore } from '../../src/events/store.js';
+import { ALLOW_STORE_DIVERGENCE_ENV } from '../../src/utils/paths.js';
+import { rmrfAsync } from '../../tools/test-helpers/temp-dir.js';
+
+let home: string;
+let stateDir: string;
+let eventStore: EventStore;
+
+function cliStore(): string {
+  return path.join(home, '.exarchos', 'state', 'exarchos.db');
+}
+function pluginStore(): string {
+  return path.join(home, '.claude', 'workflow-state', 'exarchos.db');
+}
+
+/** Materialize a store file so the existence probe sees it. */
+function createStore(p: string): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, '');
+}
+
+function ctx(): DispatchContext {
+  return { stateDir, eventStore, enableTelemetry: false };
+}
+
+beforeEach(async () => {
+  home = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'store-divergence-'));
+  // The context's store must be the one the AMBIENT cascade resolves — that is
+  // the posture the defect occurs in (a CLI falling through to its default
+  // store). An explicitly-overridden state dir is unambiguous by construction
+  // and is deliberately exempt from the check.
+  stateDir = path.join(home, '.exarchos', 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  vi.stubEnv('HOME', home);
+  // Non-plugin posture, no pin — the default posture of an agent shelling out
+  // to `exarchos` from inside a Claude Code session.
+  vi.stubEnv('CLAUDE_PLUGIN_ROOT', '');
+  vi.stubEnv('EXARCHOS_PLUGIN_ROOT', '');
+  vi.stubEnv('WORKFLOW_STATE_DIR', '');
+  vi.stubEnv('XDG_STATE_HOME', '');
+  vi.stubEnv(ALLOW_STORE_DIVERGENCE_ENV, '');
+  eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await rmrfAsync(home);
+});
+
+describe('Store-path divergence surfaces at the point of use (#1839)', () => {
+  it('Mutation_UnderActiveDivergence_IsRefusedNotSilentlyWritten', () => {
+    // Precondition: `os.homedir()` must actually follow the stubbed HOME, or
+    // this test would assert nothing.
+    expect(os.homedir()).toBe(home);
+
+    createStore(cliStore());
+    createStore(pluginStore());
+
+    return dispatch(
+      'exarchos_workflow',
+      { action: 'init', featureId: 'divergence-probe', workflowType: 'feature' },
+      ctx(),
+    ).then((result) => {
+      expect(result.success, 'a write into a ghost store must not report success').toBe(false);
+      expect(result.error?.code).toBe('STORE_PATH_DIVERGENCE');
+      // The message must be actionable — both paths and the remedy.
+      expect(result.error?.message).toContain('WORKFLOW_STATE_DIR');
+      expect(result.error?.message).toContain(pluginStore());
+    });
+  });
+
+  it('Mutation_OtherStoreAbsent_ProceedsNormally', async () => {
+    // The standalone CLI user. Divergence is structurally true, but nothing is
+    // split — the refusal must not fire.
+    createStore(cliStore());
+
+    const result = await dispatch(
+      'exarchos_workflow',
+      { action: 'init', featureId: 'lone-cli', workflowType: 'feature' },
+      ctx(),
+    );
+    expect(result.error?.code).not.toBe('STORE_PATH_DIVERGENCE');
+  });
+
+  it('Mutation_Acknowledged_ProceedsWithTheOptIn', async () => {
+    createStore(cliStore());
+    createStore(pluginStore());
+    vi.stubEnv(ALLOW_STORE_DIVERGENCE_ENV, '1');
+
+    const result = await dispatch(
+      'exarchos_workflow',
+      { action: 'init', featureId: 'deliberate-two-stores', workflowType: 'feature' },
+      ctx(),
+    );
+    expect(result.error?.code).not.toBe('STORE_PATH_DIVERGENCE');
+  });
+
+  it('Read_UnderActiveDivergence_CarriesTheCaveatInline', async () => {
+    createStore(cliStore());
+    createStore(pluginStore());
+
+    // A read action — must NOT be refused, but must carry the warning, so an
+    // envelope like the reported `prepare_delegation` one can no longer read
+    // as confidently correct.
+    const result = await dispatch('exarchos_view', { action: 'pipeline' }, ctx());
+
+    expect(result.error?.code).not.toBe('STORE_PATH_DIVERGENCE');
+    const warnings = result.warnings ?? [];
+    expect(warnings.length, 'a divergent read must carry a warning').toBeGreaterThan(0);
+    expect(warnings.join(' ')).toContain('Event-store divergence');
+    expect(warnings.join(' ')).toContain('WORKFLOW_STATE_DIR');
+  });
+
+  it('Mutation_ExplicitStateDir_IsExemptFromTheCheck', async () => {
+    // A caller who names the store has already resolved the ambiguity, so the
+    // check must stay out of the way. This exemption is what keeps dispatch
+    // from behaving differently on a developer machine (where both default
+    // stores usually exist) than in CI — without it the verdict would depend
+    // on the invoking user's home directory rather than on the call.
+    createStore(cliStore());
+    createStore(pluginStore());
+    const explicit = path.join(home, 'explicitly-chosen-store');
+    fs.mkdirSync(explicit, { recursive: true });
+    const store = new EventStore(explicit);
+    await store.initialize();
+
+    const result = await dispatch(
+      'exarchos_workflow',
+      { action: 'init', featureId: 'explicit-store', workflowType: 'feature' },
+      { stateDir: explicit, eventStore: store, enableTelemetry: false },
+    );
+    expect(result.error?.code).not.toBe('STORE_PATH_DIVERGENCE');
+    expect(result.warnings ?? []).not.toContain(expect.stringContaining('Event-store divergence'));
+  });
+
+  it('Read_NoDivergence_CarriesNoSpuriousWarning', async () => {
+    // Pin both surfaces to one store; the warning must disappear entirely
+    // rather than becoming permanent noise.
+    vi.stubEnv('WORKFLOW_STATE_DIR', stateDir);
+    createStore(cliStore());
+    createStore(pluginStore());
+
+    const result = await dispatch('exarchos_view', { action: 'pipeline' }, ctx());
+    const warnings = result.warnings ?? [];
+    expect(warnings.join(' ')).not.toContain('Event-store divergence');
+  });
+});

--- a/tests/outcome/store-divergence-dispatch.test.ts
+++ b/tests/outcome/store-divergence-dispatch.test.ts
@@ -85,6 +85,12 @@ describe('Store-path divergence surfaces at the point of use (#1839)', () => {
     // The message must be actionable — both paths and the remedy.
     expect(result.error?.message).toContain('WORKFLOW_STATE_DIR');
     expect(result.error?.message).toContain(pluginStore());
+    // The refusal states the divergence once. Repeating it as a warning on the
+    // same envelope is noise, not a second signal.
+    expect(
+      result.warnings ?? [],
+      'the refusal already carries the message; it must not be duplicated',
+    ).toEqual([]);
   });
 
   it('Mutation_OtherStoreAbsent_ProceedsNormally', async () => {

--- a/tests/unit/dispatch/core/dispatch.install-freshness.test.ts
+++ b/tests/unit/dispatch/core/dispatch.install-freshness.test.ts
@@ -31,7 +31,8 @@ const MUTATING_ARGS = { action: 'init', featureId: 'p05-freshness', workflowType
 
 let root: string; // temp "plugin root" (installed layout)
 let cacheDir: string; // temp cache dir
-let stateDir: string; // temp state dir (holds the lock + event store)
+let stateDir: string; // temp state dir (event store only — the lock no longer lives here)
+let installDir: string; // temp install-identity dir (holds the TOFU lock)
 let eventStore: EventStore;
 
 function seedCoherentInstall(overrides?: Partial<{ pkg: string; manifest: string; skill: string; cache: string }>): void {
@@ -50,9 +51,19 @@ function seedCoherentInstall(overrides?: Partial<{ pkg: string; manifest: string
   fs.writeFileSync(path.join(cacheDir, CACHE_DESCRIPTOR_FILENAME), cache);
 }
 
-/** Record the current on-disk state as the expected lock (a coherent install). */
+/**
+ * Record the current on-disk state as the expected lock (a coherent install).
+ *
+ * The lock is keyed to the INSTALLATION, not the state dir, so freshness stays
+ * invariant under WORKFLOW_STATE_DIR. `EXARCHOS_INSTALL_STATE_DIR` redirects it
+ * into the temp tree here — without it the gate would write to the real `~`.
+ */
 function recordCoherentLock(): void {
-  writeRecordedIdentity(stateDir, collectInstallIdentity(root));
+  writeRecordedIdentity(root, collectInstallIdentity(root));
+}
+
+function lockPath(): string {
+  return installIdentityLockPath(root);
 }
 
 function ctx(): DispatchContext {
@@ -65,11 +76,14 @@ beforeEach(async () => {
   root = path.join(base, 'plugin');
   cacheDir = path.join(base, 'cache');
   stateDir = path.join(base, 'state');
+  installDir = path.join(base, 'install');
   fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(installDir, { recursive: true });
   // Installed posture, deterministically, via env — the gate reads process.env.
   vi.stubEnv('EXARCHOS_PLUGIN_ROOT', root);
   vi.stubEnv('EXARCHOS_CACHE_DIR', cacheDir);
   vi.stubEnv('CLAUDE_PLUGIN_ROOT', '');
+  vi.stubEnv('EXARCHOS_INSTALL_STATE_DIR', installDir);
   eventStore = new EventStore(stateDir);
   await eventStore.initialize();
 });
@@ -91,11 +105,11 @@ describe('P05-04 dispatch chokepoint — matching install proceeds', () => {
 
   it('first run with NO recorded lock BOOTSTRAPS (records, does not block)', async () => {
     seedCoherentInstall();
-    expect(fs.existsSync(installIdentityLockPath(stateDir))).toBe(false);
+    expect(fs.existsSync(lockPath())).toBe(false);
     const result = await dispatch(MUTATING_TOOL, MUTATING_ARGS, ctx());
     expect(result.error?.code).not.toBe('INSTALL_FRESHNESS_MISMATCH');
     // The gate recorded the lock so subsequent runs have a baseline.
-    expect(fs.existsSync(installIdentityLockPath(stateDir))).toBe(true);
+    expect(fs.existsSync(lockPath())).toBe(true);
   });
 
   it('a read-only action is exempt even when the install is stale', async () => {

--- a/tests/unit/install/collect-identity.test.ts
+++ b/tests/unit/install/collect-identity.test.ts
@@ -10,7 +10,6 @@ import {
   writeRecordedIdentity,
   installIdentityLockPath,
   CACHE_DESCRIPTOR_FILENAME,
-  INSTALL_IDENTITY_LOCK_FILENAME,
   type IdentityDeps,
 } from '../../../src/install/collect-identity.js';
 import * as atomicWrite from '../../../src/utils/atomic-write.js';
@@ -224,11 +223,16 @@ describe('recorded install-identity lock', () => {
     // re-record can heal it), so a crash mid-write silently converted a
     // would-be BLOCKED freshness verdict into 'bootstrapped'. The DEFAULT
     // write seam must therefore route through `atomicWriteFile`.
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'identity-lock-'));
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'identity-lock-'));
+    // The lock is keyed to the INSTALLATION, so the temp dir is redirected via
+    // the install-state env seam rather than passed as a state dir. Without
+    // this the default path would publish into the real home directory.
+    const env = { EXARCHOS_INSTALL_STATE_DIR: installDir } as const;
+    const pluginRoot = '/opt/exarchos';
     try {
       const id = collectFrom(coherentFiles());
-      writeRecordedIdentity(stateDir, id); // no injected seams — the default path
-      const lockPath = installIdentityLockPath(stateDir);
+      writeRecordedIdentity(pluginRoot, id, { env }); // fs seams left at their defaults
+      const lockPath = installIdentityLockPath(pluginRoot, { env });
 
       // The write went through the atomic publish, targeting the lock path.
       const atomicSpy = vi.mocked(atomicWrite.atomicWriteFile);
@@ -236,12 +240,12 @@ describe('recorded install-identity lock', () => {
       expect(atomicSpy.mock.calls[0]?.[0]).toBe(lockPath);
 
       // Read-side semantics unchanged: the lock round-trips off the real fs…
-      expect(readRecordedIdentity(stateDir)).toEqual(id);
+      expect(readRecordedIdentity(pluginRoot, { env })).toEqual(id);
       // …and the publish left no staged `*.tmp` beside the lock.
-      expect(fs.readdirSync(stateDir)).toEqual([INSTALL_IDENTITY_LOCK_FILENAME]);
+      expect(fs.readdirSync(installDir)).toEqual([path.basename(lockPath)]);
     } finally {
       vi.clearAllMocks();
-      fs.rmSync(stateDir, { recursive: true, force: true });
+      fs.rmSync(installDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/install/freshness-gate.test.ts
+++ b/tests/unit/install/freshness-gate.test.ts
@@ -17,7 +17,6 @@ import { SCHEMA_VERSION } from '../../../src/storage/sqlite-backend.js';
 import type { InstallIdentity } from '../../../src/install/install-identity.js';
 
 const PLUGIN_ROOT = '/opt/exarchos';
-const STATE_DIR = '/state';
 const ENV = { EXARCHOS_PLUGIN_ROOT: PLUGIN_ROOT, EXARCHOS_CACHE_DIR: '/opt/cache' } as const;
 const HOME = '/home/u';
 
@@ -68,12 +67,17 @@ function identityFrom(files: Map<string, string>): InstallIdentity {
 
 /** Deps for the gate over `files`, in installed posture. */
 function gateDeps(files: Map<string, string>): FreshnessGateDeps {
-  return { stateDir: STATE_DIR, env: ENV, homedir: HOME, ...seams(files) };
+  return { env: ENV, homedir: HOME, ...seams(files) };
+}
+
+/** The lock is keyed to the INSTALLATION, never to an event-store state dir. */
+function lockPath(): string {
+  return installIdentityLockPath(PLUGIN_ROOT, { env: ENV, homedir: HOME });
 }
 
 /** Seed the lock (expected identity) into the files map. */
 function seedLock(files: Map<string, string>, identity: InstallIdentity): void {
-  files.set(installIdentityLockPath(STATE_DIR), `${JSON.stringify(identity, null, 2)}\n`);
+  files.set(lockPath(), `${JSON.stringify(identity, null, 2)}\n`);
 }
 
 beforeEach(() => resetInstallFreshnessGateForTest());
@@ -81,7 +85,6 @@ beforeEach(() => resetInstallFreshnessGateForTest());
 describe('evaluateInstallFreshness — posture & bootstrap', () => {
   it('SKIPS on a dev checkout (no plugin root, no cache)', () => {
     const outcome = evaluateInstallFreshness({
-      stateDir: STATE_DIR,
       env: {},
       homedir: HOME,
       pathExists: () => false,
@@ -94,7 +97,7 @@ describe('evaluateInstallFreshness — posture & bootstrap', () => {
     const outcome = evaluateInstallFreshness(gateDeps(files));
     expect(outcome.status).toBe('bootstrapped');
     // The lock is now persisted so subsequent runs have something to compare.
-    expect(files.has(installIdentityLockPath(STATE_DIR))).toBe(true);
+    expect(files.has(lockPath())).toBe(true);
   });
 
   it('is FRESH when the recorded lock matches what is on disk', () => {
@@ -181,7 +184,7 @@ describe('evaluateInstallFreshness — memoization', () => {
   it('a block clears once the install is repaired (re-evaluation, then memoized fresh)', () => {
     const files = coherentFiles();
     // Stale lock → blocked.
-    files.set(installIdentityLockPath(STATE_DIR), `${JSON.stringify(identityFrom(coherentFiles({ pkg: JSON.stringify({ version: '9.9.9' }) })), null, 2)}\n`);
+    files.set(lockPath(), `${JSON.stringify(identityFrom(coherentFiles({ pkg: JSON.stringify({ version: '9.9.9' }) })), null, 2)}\n`);
     expect(evaluateInstallFreshness(gateDeps(files)).status).toBe('blocked');
     // Repair: rewrite the lock to match on-disk state.
     seedLock(files, identityFrom(files));

--- a/tests/unit/install/freshness-store-invariance.test.ts
+++ b/tests/unit/install/freshness-store-invariance.test.ts
@@ -27,12 +27,12 @@ import {
   CACHE_DESCRIPTOR_FILENAME,
   type IdentityDeps,
 } from '../../../src/install/collect-identity.js';
-import {
-  verifyInstallFreshness,
-  UNKNOWN_VERSION_SENTINEL,
-} from '../../../src/install/freshness-check.js';
+import { verifyInstallFreshness } from '../../../src/install/freshness-check.js';
 import { resolveCacheDir, resolveInstallIdentityDir } from '../../../src/utils/paths.js';
-import type { InstallIdentity } from '../../../src/install/install-identity.js';
+import {
+  UNKNOWN_VERSION_SENTINEL,
+  type InstallIdentity,
+} from '../../../src/install/install-identity.js';
 
 const PLUGIN_ROOT = '/opt/exarchos';
 const HOME = '/home/u';

--- a/tests/unit/install/freshness-store-invariance.test.ts
+++ b/tests/unit/install/freshness-store-invariance.test.ts
@@ -1,0 +1,202 @@
+// ─── #1840 — freshness is a property of the INSTALL, not of the store ────────
+//
+// The recorded install-identity lock was written into the WORKFLOW_STATE_DIR-
+// resolved event store, so the freshness verdict was a function of which store
+// the invocation happened to resolve. The same installation reported "fresh"
+// under its default store and "stale or mixed" under a pinned one — and the
+// gate blocked precisely the pinning an operator adopts to collapse a
+// store-path divergence. There was no configuration in which a plain CLI could
+// correctly write to the plugin's store.
+//
+// Second defect, and the sharper one: the binary version falls back to a
+// sentinel when it cannot be read, and the comparison used equality, so
+// unknown === unknown reported the dimension as MATCHING. `doctor` claimed all
+// five dimensions matched while separately warning that two were unknown.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
+
+import {
+  evaluateInstallFreshness,
+  resetInstallFreshnessGateForTest,
+  type FreshnessGateDeps,
+} from '../../../src/install/freshness-gate.js';
+import {
+  collectInstallIdentity,
+  installIdentityLockPath,
+  CACHE_DESCRIPTOR_FILENAME,
+  type IdentityDeps,
+} from '../../../src/install/collect-identity.js';
+import {
+  verifyInstallFreshness,
+  UNKNOWN_VERSION_SENTINEL,
+} from '../../../src/install/freshness-check.js';
+import { resolveCacheDir, resolveInstallIdentityDir } from '../../../src/utils/paths.js';
+import type { InstallIdentity } from '../../../src/install/install-identity.js';
+
+const PLUGIN_ROOT = '/opt/exarchos';
+const HOME = '/home/u';
+const BASE_ENV = { EXARCHOS_PLUGIN_ROOT: PLUGIN_ROOT, EXARCHOS_CACHE_DIR: '/opt/cache' } as const;
+
+function cacheDescriptorPath(): string {
+  return path.join(resolveCacheDir({ env: BASE_ENV, homedir: HOME }), CACHE_DESCRIPTOR_FILENAME);
+}
+
+function coherentFiles(pkgVersion = '2.12.0-preview.4'): Map<string, string> {
+  return new Map<string, string>([
+    [path.join(PLUGIN_ROOT, 'package.json'), JSON.stringify({ name: 'exarchos', version: pkgVersion })],
+    [path.join(PLUGIN_ROOT, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'exarchos' })],
+    [path.join(PLUGIN_ROOT, 'skills', 'claude', 'skill-a', 'SKILL.md'), '# Skill A\nbody\n'],
+    [cacheDescriptorPath(), JSON.stringify({ owner: 'exarchos', format: 1 })],
+  ]);
+}
+
+function seams(files: Map<string, string>): IdentityDeps {
+  return {
+    readFileText: (p) => files.get(p),
+    readTree: (dir) => {
+      const out: { path: string; content: string }[] = [];
+      for (const [key, content] of files) {
+        for (const pre of [`${dir}/`, `${dir}\\`]) {
+          if (key.startsWith(pre)) out.push({ path: key.slice(pre.length), content });
+        }
+      }
+      return out;
+    },
+    pathExists: (p) => {
+      for (const key of files.keys()) {
+        if (key === p || key.startsWith(`${p}/`) || key.startsWith(`${p}\\`)) return true;
+      }
+      return false;
+    },
+    writeFileText: (p, c) => { files.set(p, c); },
+    mkdirp: () => {},
+  };
+}
+
+/** Gate deps under a specific WORKFLOW_STATE_DIR — the variable under test. */
+function depsWithStateDir(files: Map<string, string>, workflowStateDir: string): FreshnessGateDeps {
+  return {
+    env: { ...BASE_ENV, WORKFLOW_STATE_DIR: workflowStateDir },
+    homedir: HOME,
+    ...seams(files),
+  };
+}
+
+beforeEach(() => resetInstallFreshnessGateForTest());
+
+describe('Install freshness is invariant under WORKFLOW_STATE_DIR (#1840)', () => {
+  it('Freshness_SameInstallTwoStores_ReportsTheSameVerdict', () => {
+    const files = coherentFiles();
+
+    // First run under store A bootstraps the TOFU lock.
+    const bootstrap = evaluateInstallFreshness(depsWithStateDir(files, '/home/u/.exarchos/state'));
+    expect(bootstrap.status).toBe('bootstrapped');
+
+    // Re-evaluating under store A sees the lock and reports fresh.
+    resetInstallFreshnessGateForTest();
+    const underA = evaluateInstallFreshness(depsWithStateDir(files, '/home/u/.exarchos/state'));
+
+    // The SAME installation under a DIFFERENT store must reach the SAME
+    // verdict. Pre-fix this returned 'bootstrapped' (a second, independent
+    // lock) or 'blocked'; the operator saw one install report two verdicts.
+    resetInstallFreshnessGateForTest();
+    const underB = evaluateInstallFreshness(depsWithStateDir(files, '/home/u/.claude/workflow-state'));
+
+    expect(underA.status).toBe('fresh');
+    expect(underB.status, 'freshness changed when only WORKFLOW_STATE_DIR changed').toBe(underA.status);
+  });
+
+  it('Freshness_PinningTheStore_DoesNotBlockMutations', () => {
+    const files = coherentFiles();
+    // Bootstrap under the CLI default store.
+    evaluateInstallFreshness(depsWithStateDir(files, '/home/u/.exarchos/state'));
+
+    // Now adopt the documented remedy for a store divergence: pin the CLI at
+    // the plugin's store. That must not turn a working install into a blocked
+    // one — the trap this issue reported.
+    resetInstallFreshnessGateForTest();
+    const pinned = evaluateInstallFreshness(depsWithStateDir(files, '/home/u/.claude/workflow-state'));
+    expect(pinned.status, 'pinning the store must not block mutations').not.toBe('blocked');
+  });
+
+  it('LockPath_IsKeyedToTheInstall_NotTheStateDir', () => {
+    const a = installIdentityLockPath(PLUGIN_ROOT, {
+      env: { ...BASE_ENV, WORKFLOW_STATE_DIR: '/store/a' },
+      homedir: HOME,
+    });
+    const b = installIdentityLockPath(PLUGIN_ROOT, {
+      env: { ...BASE_ENV, WORKFLOW_STATE_DIR: '/store/b' },
+      homedir: HOME,
+    });
+    expect(a).toBe(b);
+
+    // And it must not live inside either store.
+    expect(a).not.toContain('/store/a');
+    expect(a).not.toContain('/store/b');
+    expect(a.startsWith(resolveInstallIdentityDir({ env: BASE_ENV, homedir: HOME }))).toBe(true);
+
+    // Two DIFFERENT installs must not share one lock.
+    const other = installIdentityLockPath('/opt/exarchos-next', { env: BASE_ENV, homedir: HOME });
+    expect(other).not.toBe(a);
+  });
+});
+
+describe('An undetermined dimension cannot report as matching (#1840)', () => {
+  function identityWithBinaryVersion(version: string): InstallIdentity {
+    const files = coherentFiles(version);
+    return collectInstallIdentity(PLUGIN_ROOT, { env: BASE_ENV, homedir: HOME, ...seams(files) });
+  }
+
+  it('Verify_BothVersionsUnknown_IsIndeterminateNotFresh', () => {
+    // The exact reported shape: the version could not be read on either side,
+    // so both carry the sentinel. Equality made this a PASS.
+    const unknown = identityWithBinaryVersion(UNKNOWN_VERSION_SENTINEL);
+    const result = verifyInstallFreshness(unknown, unknown);
+
+    expect(result.fresh, 'two unknown versions must not satisfy a match').toBe(false);
+    expect('indeterminate' in result && result.indeterminate).toBe(true);
+    if (!result.fresh && 'indeterminate' in result) {
+      expect(result.dimensions).toContain('binary');
+    }
+  });
+
+  it('Verify_MissingPackageJson_IsIndeterminate', () => {
+    // No package.json at all — collect substitutes the sentinel.
+    const files = coherentFiles();
+    files.delete(path.join(PLUGIN_ROOT, 'package.json'));
+    const observed = collectInstallIdentity(PLUGIN_ROOT, { env: BASE_ENV, homedir: HOME, ...seams(files) });
+    expect(observed.binary.version).toBe(UNKNOWN_VERSION_SENTINEL);
+
+    const result = verifyInstallFreshness(observed, observed);
+    expect(result.fresh).toBe(false);
+    expect('indeterminate' in result).toBe(true);
+  });
+
+  it('Verify_KnownMatchingVersions_StillFresh', () => {
+    // The converse — the fix must not have made everything indeterminate.
+    const known = identityWithBinaryVersion('2.12.0-preview.4');
+    expect(verifyInstallFreshness(known, known).fresh).toBe(true);
+  });
+
+  it('Gate_IndeterminateInstall_DegradesRatherThanBlocking', () => {
+    // Cannot-tell is reported as cannot-tell, and must never become a block —
+    // an unreadable package.json must not turn the gate into an outage.
+    const lockFiles = coherentFiles();
+    const observedFiles = coherentFiles();
+    observedFiles.delete(path.join(PLUGIN_ROOT, 'package.json'));
+
+    const lock = collectInstallIdentity(PLUGIN_ROOT, { env: BASE_ENV, homedir: HOME, ...seams(lockFiles) });
+    observedFiles.set(
+      installIdentityLockPath(PLUGIN_ROOT, { env: BASE_ENV, homedir: HOME }),
+      `${JSON.stringify(lock, null, 2)}\n`,
+    );
+
+    const outcome = evaluateInstallFreshness({
+      env: BASE_ENV,
+      homedir: HOME,
+      ...seams(observedFiles),
+    });
+    expect(outcome.status).toBe('degraded');
+  });
+});

--- a/tests/unit/utils/store-divergence.test.ts
+++ b/tests/unit/utils/store-divergence.test.ts
@@ -1,0 +1,133 @@
+// ─── #1839 — a store divergence must not be silent on the write path ─────────
+//
+// `computeStorePathDivergence` shipped and was correct, but its only consumer
+// was the `store-path-divergence` doctor check. Mutating CLI actions wrote into
+// the non-plugin store and reported SUCCESS; reads then answered from that
+// store with a coherent, confident, wrong answer. `prepare_delegation` returned
+// `taskCount: 20` (right, it saw the new events) alongside `approved: false`
+// and `artifactPresent: false` (wrong, those events are in the other store),
+// with nothing in the envelope hinting that two stores existed.
+//
+// The design constraint that shapes the fix: bare divergence is TRUE BY DEFAULT
+// for every non-plugin CLI invocation, because the cascade genuinely resolves
+// `~/.exarchos/state` for the CLI and `~/.claude/workflow-state` for the
+// plugin. Refusing on that alone would break every standalone CLI user who has
+// never installed the plugin. Requiring the other store to EXIST is what turns
+// an always-true structural fact into evidence of a real split.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  computeStorePathDivergence,
+  detectActiveStoreDivergence,
+  describeStoreDivergence,
+  ALLOW_STORE_DIVERGENCE_ENV,
+} from '../../../src/utils/paths.js';
+
+const HOME = '/home/u';
+const CLI_STORE = '/home/u/.exarchos/state/exarchos.db';
+const PLUGIN_STORE = '/home/u/.claude/workflow-state/exarchos.db';
+
+/** Existence oracle over an explicit set — no filesystem involved. */
+function existing(...paths: readonly string[]): (p: string) => boolean {
+  const set = new Set(paths);
+  return (p) => set.has(p);
+}
+
+describe('Active store divergence (#1839)', () => {
+  it('Divergence_IsTrueByDefault_ForAnyNonPluginCli', () => {
+    // The premise the refusal rule must respect. If this ever stops being
+    // true, the "other store must exist" requirement can be revisited — but
+    // while it holds, divergence alone cannot be the refusal trigger.
+    const bare = computeStorePathDivergence({ env: {}, homedir: HOME });
+    expect(bare.diverges).toBe(true);
+    expect(bare.cliPath).toBe(CLI_STORE);
+    expect(bare.pluginPath).toBe(PLUGIN_STORE);
+  });
+
+  it('Divergence_OtherStoreAbsent_IsNotActive', () => {
+    // A standalone CLI user who never installed the plugin. Diverges
+    // structurally, but nothing is being split — must NOT refuse.
+    const d = detectActiveStoreDivergence({
+      env: {},
+      homedir: HOME,
+      pluginMode: false,
+      storeExists: existing(CLI_STORE),
+    });
+    expect(d.diverges).toBe(true);
+    expect(d.otherExists).toBe(false);
+    expect(d.active, 'a lone CLI user must not be refused').toBe(false);
+  });
+
+  it('Divergence_OtherStoreExists_IsActive', () => {
+    // The reported situation: an agent shells out to the CLI from inside a
+    // Claude Code session, inheriting no plugin env, while the plugin's store
+    // holds the real workflow.
+    const d = detectActiveStoreDivergence({
+      env: {},
+      homedir: HOME,
+      pluginMode: false,
+      storeExists: existing(CLI_STORE, PLUGIN_STORE),
+    });
+    expect(d.active).toBe(true);
+    expect(d.activePath).toBe(CLI_STORE);
+    expect(d.otherPath).toBe(PLUGIN_STORE);
+  });
+
+  it('Divergence_WorkflowStateDirPinned_CollapsesEntirely', () => {
+    // The documented remedy must actually work: the env var wins in BOTH
+    // modes, so the two surfaces resolve one store and there is nothing left
+    // to warn about.
+    const pinned = { WORKFLOW_STATE_DIR: '/home/u/.claude/workflow-state' };
+    const d = detectActiveStoreDivergence({
+      env: pinned,
+      homedir: HOME,
+      pluginMode: false,
+      storeExists: existing(CLI_STORE, PLUGIN_STORE),
+    });
+    expect(d.diverges).toBe(false);
+    expect(d.active).toBe(false);
+    expect(d.otherExists).toBe(false);
+  });
+
+  it('Divergence_Acknowledged_SuppressesRefusalButNotTheWarning', () => {
+    const d = detectActiveStoreDivergence({
+      env: { [ALLOW_STORE_DIVERGENCE_ENV]: '1' },
+      homedir: HOME,
+      pluginMode: false,
+      storeExists: existing(CLI_STORE, PLUGIN_STORE),
+    });
+    expect(d.acknowledged).toBe(true);
+    expect(d.active, 'an explicit opt-in must not be refused').toBe(false);
+    // Still reportable — opting in accepts the risk, it does not hide it.
+    expect(d.otherExists).toBe(true);
+  });
+
+  it('Divergence_FromThePluginSide_NamesTheCliStoreAsOther', () => {
+    // Symmetry: the "active" and "other" roles follow the calling surface.
+    const d = detectActiveStoreDivergence({
+      env: { CLAUDE_PLUGIN_ROOT: '/opt/plugin' },
+      homedir: HOME,
+      storeExists: existing(CLI_STORE, PLUGIN_STORE),
+    });
+    expect(d.activePath).toBe(PLUGIN_STORE);
+    expect(d.otherPath).toBe(CLI_STORE);
+    expect(d.active).toBe(true);
+  });
+
+  it('Description_NamesBothPathsAndTheRemedy', () => {
+    // The message is the whole value of the fix — a bare "divergence detected"
+    // gives an operator nothing to act on.
+    const d = detectActiveStoreDivergence({
+      env: {},
+      homedir: HOME,
+      pluginMode: false,
+      storeExists: existing(CLI_STORE, PLUGIN_STORE),
+    });
+    const message = describeStoreDivergence(d);
+    expect(message).toContain(CLI_STORE);
+    expect(message).toContain(PLUGIN_STORE);
+    expect(message).toContain('WORKFLOW_STATE_DIR');
+    expect(message).toContain(ALLOW_STORE_DIVERGENCE_ENV);
+  });
+});

--- a/tests/unit/utils/store-divergence.test.ts
+++ b/tests/unit/utils/store-divergence.test.ts
@@ -17,7 +17,11 @@
 
 import { describe, it, expect } from 'vitest';
 
+import * as path from 'node:path';
+
 import {
+  toPosix,
+  resolveStateDir,
   computeStorePathDivergence,
   detectActiveStoreDivergence,
   describeStoreDivergence,
@@ -33,6 +37,29 @@ function existing(...paths: readonly string[]): (p: string) => boolean {
   const set = new Set(paths);
   return (p) => set.has(p);
 }
+
+describe('The ambient-cascade comparison holds on the real dispatch path', () => {
+  // dispatch decides whether the store came from the ambient cascade with
+  //   toPosix(path.resolve(ctx.stateDir)) === resolveStateDir()
+  // and the production entry point sets ctx.stateDir from resolveStateDir()
+  // itself. So the comparison is sound exactly when that normalization is
+  // IDEMPOTENT on the resolver's own output. If it is not, the check silently
+  // stops applying on the one path that matters, and it fails OPEN — no
+  // refusal, no warning, and no test anywhere goes red.
+  //
+  // Asserted as a property rather than by string-matching a platform-specific
+  // path, so it holds on win32 (where path.resolve emits backslashes that
+  // toPosix must fold back) as well as on POSIX.
+  it('AmbientCascade_NormalizationOfTheResolverOutput_IsIdempotent', () => {
+    for (const env of [{}, { WORKFLOW_STATE_DIR: '/pinned/store' }, { XDG_STATE_HOME: '/xdg' }]) {
+      const resolved = resolveStateDir({ env, homedir: HOME });
+      expect(
+        toPosix(path.resolve(resolved)),
+        `dispatch would not recognize its own resolved store dir for env ${JSON.stringify(env)}`,
+      ).toBe(resolved);
+    }
+  });
+});
 
 describe('Active store divergence (#1839)', () => {
   it('Divergence_IsTrueByDefault_ForAnyNonPluginCli', () => {
@@ -101,6 +128,21 @@ describe('Active store divergence (#1839)', () => {
     expect(d.active, 'an explicit opt-in must not be refused').toBe(false);
     // Still reportable — opting in accepts the risk, it does not hide it.
     expect(d.otherExists).toBe(true);
+  });
+
+  it('Divergence_ExplicitFalsySpelling_StaysArmed', () => {
+    // An operator who writes `=false` means "keep the guard". Treating any
+    // non-blank value as opt-in would hand them the silent split instead.
+    for (const value of ['0', 'false', 'no', 'off', 'FALSE', ' 0 ']) {
+      const d = detectActiveStoreDivergence({
+        env: { [ALLOW_STORE_DIVERGENCE_ENV]: value },
+        homedir: HOME,
+        pluginMode: false,
+        storeExists: existing(CLI_STORE, PLUGIN_STORE),
+      });
+      expect(d.acknowledged, `"${value}" must not read as an opt-in`).toBe(false);
+      expect(d.active, `"${value}" must leave the refusal armed`).toBe(true);
+    }
   });
 
   it('Divergence_FromThePluginSide_NamesTheCliStoreAsOther', () => {

--- a/tests/unit/utils/store-divergence.test.ts
+++ b/tests/unit/utils/store-divergence.test.ts
@@ -117,7 +117,7 @@ describe('Active store divergence (#1839)', () => {
     expect(d.otherExists).toBe(false);
   });
 
-  it('Divergence_Acknowledged_SuppressesRefusalButNotTheWarning', () => {
+  it('Divergence_Acknowledged_SuppressesBothTheRefusalAndTheWarning', () => {
     const d = detectActiveStoreDivergence({
       env: { [ALLOW_STORE_DIVERGENCE_ENV]: '1' },
       homedir: HOME,
@@ -126,8 +126,12 @@ describe('Active store divergence (#1839)', () => {
     });
     expect(d.acknowledged).toBe(true);
     expect(d.active, 'an explicit opt-in must not be refused').toBe(false);
-    // Still reportable — opting in accepts the risk, it does not hide it.
-    expect(d.otherExists).toBe(true);
+    // The variable is named ALLOW. Repeating the caveat on every read after an
+    // explicit opt-in is warning fatigue, not information — `doctor` stays the
+    // standing diagnostic. The split is still OBSERVED, which is what keeps
+    // the suppression a policy choice rather than a blind spot.
+    expect(d.shouldWarn, 'an explicit opt-in must not keep warning').toBe(false);
+    expect(d.otherExists, 'the split is still detected, only not repeated').toBe(true);
   });
 
   it('Divergence_ExplicitFalsySpelling_StaysArmed', () => {

--- a/tests/unit/utils/store-divergence.test.ts
+++ b/tests/unit/utils/store-divergence.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, expect } from 'vitest';
 
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import {
@@ -51,13 +52,34 @@ describe('The ambient-cascade comparison holds on the real dispatch path', () =>
   // path, so it holds on win32 (where path.resolve emits backslashes that
   // toPosix must fold back) as well as on POSIX.
   it('AmbientCascade_NormalizationOfTheResolverOutput_IsIdempotent', () => {
-    for (const env of [{}, { WORKFLOW_STATE_DIR: '/pinned/store' }, { XDG_STATE_HOME: '/xdg' }]) {
-      const resolved = resolveStateDir({ env, homedir: HOME });
+    // The REAL home, not the POSIX literal the divergence cases below use.
+    // `path.resolve` is drive-relative on win32, so a bare `/home/u` there
+    // resolves to `D:/home/u` and the comparison would fail for a reason that
+    // has nothing to do with the property. Production always feeds this an
+    // absolute platform path, because ctx.stateDir comes from resolveStateDir
+    // itself.
+    const realHome = os.homedir();
+    for (const env of [
+      {},
+      { WORKFLOW_STATE_DIR: path.join(realHome, 'pinned-store') },
+      { XDG_STATE_HOME: path.join(realHome, 'xdg') },
+    ]) {
+      const resolved = resolveStateDir({ env, homedir: realHome });
       expect(
         toPosix(path.resolve(resolved)),
         `dispatch would not recognize its own resolved store dir for env ${JSON.stringify(env)}`,
       ).toBe(resolved);
     }
+  });
+
+  it('AmbientCascade_WindowsShapedPath_SurvivesTheSameNormalization', () => {
+    // Asserted through `path.win32` so the win32 branch is proved from a POSIX
+    // runner too. Without this the test above only ever covers the platform it
+    // happens to run on, and the Windows lane is exactly where separator
+    // handling breaks — a previous fix in this same change set was a
+    // native-separator path that compared unequal to its POSIX resolver.
+    const resolverOutput = 'C:/Users/runneradmin/.exarchos/state';
+    expect(toPosix(path.win32.resolve(resolverOutput))).toBe(resolverOutput);
   });
 });
 

--- a/tests/unit/verbs/doctor/checks/env-variables.test.ts
+++ b/tests/unit/verbs/doctor/checks/env-variables.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { envVariables } from '../../../../../src/verbs/doctor/checks/env-variables.js';
 import { makeStubProbes } from '../../../../../src/verbs/doctor/checks/__shared__/make-stub-probes.js';
+
+const SRC_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../../src',
+);
+
+/** Every `EXARCHOS_*` name the shipped source mentions. */
+function scanExarchosNames(dir: string, found: Set<string> = new Set()): Set<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      scanExarchosNames(abs, found);
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      for (const m of fs.readFileSync(abs, 'utf8').matchAll(/EXARCHOS_[A-Z0-9_]+/g)) {
+        found.add(m[0]);
+      }
+    }
+  }
+  return found;
+}
 
 const signal = new AbortController().signal;
 
@@ -20,6 +43,30 @@ describe('env-variables', () => {
     expect(result.name).toBe('variables');
     expect(result.status).toBe('Pass');
     expect(result.fix).toBeUndefined();
+  });
+
+  // ─── the list is hand-maintained, so prove it against the tree ───────────
+  //
+  // Seventeen supported variables had drifted out of `KNOWN`, so `doctor`
+  // reported correct configuration as an unknown variable and advised removing
+  // it. A hand-maintained mirror of a fact the source already carries goes
+  // stale silently; this is the tooth that makes it go red instead.
+  it('EnvVariables_EveryNameTheSourceMentions_IsRecognized', async () => {
+    const names = [...scanExarchosNames(SRC_ROOT)].sort();
+
+    // Denominator: a scan that finds nothing would satisfy the loop below
+    // without checking anything.
+    expect(names.length).toBeGreaterThan(20);
+
+    // Feed every name at once — one Warning names every unrecognized member.
+    const env: Record<string, string> = {};
+    for (const n of names) env[n] = 'x';
+    const result = await envVariables(makeStubProbes({ env }), signal);
+
+    expect(
+      result.status,
+      `doctor calls these supported variables unknown: ${result.message}`,
+    ).toBe('Pass');
   });
 
   it('EnvVariables_UnknownExarchosEnvVar_ReturnsWarning', async () => {

--- a/tests/unit/verbs/doctor/checks/env-variables.test.ts
+++ b/tests/unit/verbs/doctor/checks/env-variables.test.ts
@@ -14,18 +14,65 @@ import { fileURLToPath } from 'node:url';
 import { envVariables } from '../../../../../src/verbs/doctor/checks/env-variables.js';
 import { makeStubProbes } from '../../../../../src/verbs/doctor/checks/__shared__/make-stub-probes.js';
 
-const SRC_ROOT = path.resolve(
+/**
+ * The names the check itself recognizes, read out of its source.
+ *
+ * Deliberately NOT a copy of the list: a second hand-maintained copy would be
+ * the very defect this file guards against.
+ */
+const CHECK_SOURCE = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
-  '../../../../../src',
+  '../../../../../src/verbs/doctor/checks/env-variables.ts',
 );
 
-/** Every `EXARCHOS_*` name the shipped source mentions. */
-function scanExarchosNames(dir: string, found: Set<string> = new Set()): Set<string> {
+const KNOWN_NAMES: readonly string[] = [
+  ...new Set(
+    (fs.readFileSync(CHECK_SOURCE, 'utf8').match(/'(EXARCHOS_[A-Z0-9_]+)'/g) ?? []).map((s) =>
+      s.replaceAll("'", ''),
+    ),
+  ),
+];
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..');
+const SRC_ROOT = path.join(REPO_ROOT, 'src');
+
+/**
+ * The two directions deliberately scan different trees.
+ *
+ * Forward ("every name the source mentions must be recognized") reads `src/`
+ * alone, because that is what the shipped product actually consults. Widening
+ * it would drag in this file's own negative fixture (`EXARCHOS_FOO`) and demand
+ * that a name invented to be unknown be added to the list.
+ *
+ * Reverse ("every recognized name must still be mentioned") reads the whole
+ * repository, because a knob that only a test still exercises is not yet dead
+ * and removing it from the list would make `doctor` warn about it. The wider
+ * scope makes the reverse claim weaker and safer: it fires only for a name
+ * nothing anywhere refers to.
+ */
+const REVERSE_SCAN_ROOTS = ['src', 'tests', 'tools'].map((d) => path.join(REPO_ROOT, d));
+
+/**
+ * Every `EXARCHOS_*` name the shipped source mentions, EXCLUDING the check's
+ * own module.
+ *
+ * The exclusion is load-bearing, not tidiness. The check declares its
+ * recognized names as string literals, so a scan that reads that file finds
+ * every one of them and the reverse direction becomes a tautology: the list
+ * would prove itself current by quoting itself. Seeding a name the rest of the
+ * tree never mentions is what exposed it — with the file in scope, the guard
+ * stayed green.
+ */
+function scanExarchosNames(
+  dir: string,
+  found: Set<string> = new Set(),
+  exclude: string = CHECK_SOURCE,
+): Set<string> {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const abs = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      scanExarchosNames(abs, found);
-    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      scanExarchosNames(abs, found, exclude);
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && path.resolve(abs) !== exclude) {
       for (const m of fs.readFileSync(abs, 'utf8').matchAll(/EXARCHOS_[A-Z0-9_]+/g)) {
         found.add(m[0]);
       }
@@ -76,6 +123,28 @@ describe('env-variables', () => {
       result.status,
       `doctor calls these supported variables unknown: ${result.message}`,
     ).toBe('Pass');
+  });
+
+  // The other direction. A one-way check lets the list keep names the source
+  // dropped, so a deleted variable stays "supported" forever and the list grows
+  // monotonically into fiction. Both directions together pin it to the tree.
+  it('EnvVariables_EveryRecognizedName_IsStillMentionedBySource', async () => {
+    const names = new Set<string>();
+    for (const root of REVERSE_SCAN_ROOTS) scanExarchosNames(root, names);
+    expect(names.size).toBeGreaterThan(20);
+
+    // A name is recognized when the check does NOT warn about it on its own.
+    const stale: string[] = [];
+    for (const known of KNOWN_NAMES) {
+      if (names.has(known)) continue;
+      const r = await envVariables(makeStubProbes({ env: { [known]: 'x' } }), signal);
+      if (r.status === 'Pass') stale.push(known);
+    }
+
+    expect(
+      stale,
+      'these names are recognized by doctor but nothing in the repository mentions them',
+    ).toEqual([]);
   });
 
   it('EnvVariables_UnknownExarchosEnvVar_ReturnsWarning', async () => {

--- a/tests/unit/verbs/doctor/checks/env-variables.test.ts
+++ b/tests/unit/verbs/doctor/checks/env-variables.test.ts
@@ -1,3 +1,12 @@
+// @oracle-sources: ../../../../../src/verbs/doctor/checks/env-variables.ts, shipped-src-corpus
+//
+// The drift guard below derives its expectation from the shipped `src/` tree —
+// every `EXARCHOS_*` name the source mentions — and checks it against the
+// hand-maintained `KNOWN` set in the check itself. Both authorities are named
+// here because the assertion is a comparison BETWEEN them: the tree supplies
+// the population, the check supplies the claim, and the test exists to stop the
+// two drifting apart.
+
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/tests/unit/verbs/doctor/checks/install-freshness.test.ts
+++ b/tests/unit/verbs/doctor/checks/install-freshness.test.ts
@@ -17,6 +17,7 @@ let base: string;
 let root: string;
 let cacheDir: string;
 let stateDir: string;
+let installDir: string; // holds the identity lock — keyed to the install, not the store
 
 function seedInstall(overrides?: Partial<{ pkg: string }>): void {
   const pkg = overrides?.pkg ?? JSON.stringify({ name: 'exarchos', version: '2.11.0' });
@@ -31,10 +32,26 @@ function seedInstall(overrides?: Partial<{ pkg: string }>): void {
 
 /** Installed-posture probes, driven purely by injected env (no fs fallback). */
 function installedProbes(): DoctorProbes {
-  return makeStubProbes({
-    env: { EXARCHOS_PLUGIN_ROOT: root, EXARCHOS_CACHE_DIR: cacheDir },
-    stateDir,
-  });
+  return makeStubProbes({ env: lockEnv(), stateDir });
+}
+
+/**
+ * Env for an installed posture with the identity lock redirected into the temp
+ * tree. `EXARCHOS_INSTALL_STATE_DIR` is load-bearing for hermeticity: the lock
+ * is keyed to the INSTALLATION rather than the state dir, so without it these
+ * tests would read and write the real home directory.
+ */
+function lockEnv(): Record<string, string> {
+  return {
+    EXARCHOS_PLUGIN_ROOT: root,
+    EXARCHOS_CACHE_DIR: cacheDir,
+    EXARCHOS_INSTALL_STATE_DIR: installDir,
+  };
+}
+
+/** Record the lock for the seeded install, in the temp install dir. */
+function recordLock(): void {
+  writeRecordedIdentity(root, collectInstallIdentity(root, { env: lockEnv() }), { env: lockEnv() });
 }
 
 const signal = new AbortController().signal;
@@ -44,7 +61,9 @@ beforeEach(() => {
   root = path.join(base, 'plugin');
   cacheDir = path.join(base, 'cache');
   stateDir = path.join(base, 'state');
+  installDir = path.join(base, 'install');
   fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(installDir, { recursive: true });
 });
 
 afterEach(() => {
@@ -54,7 +73,7 @@ afterEach(() => {
 describe('doctor install-freshness check', () => {
   it('reports Pass for a fresh install matching the recorded identity', async () => {
     seedInstall();
-    writeRecordedIdentity(stateDir, collectInstallIdentity(root, { env: { EXARCHOS_CACHE_DIR: cacheDir } }));
+    recordLock();
     const r = await installFreshness(installedProbes(), signal);
     expect(r.status).toBe('Pass');
     expect(r.name).toBe('install-freshness');
@@ -64,7 +83,7 @@ describe('doctor install-freshness check', () => {
 
   it('reports Warning naming the stale dimension, with a fix', async () => {
     seedInstall();
-    writeRecordedIdentity(stateDir, collectInstallIdentity(root, { env: { EXARCHOS_CACHE_DIR: cacheDir } }));
+    recordLock();
     // Upgrade the binary on disk after recording — binary dimension diverges.
     fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ version: '9.9.9' }));
     const r = await installFreshness(installedProbes(), signal);
@@ -84,11 +103,14 @@ describe('doctor install-freshness check', () => {
   it('is read-only — does NOT write a bootstrap lock (unlike the dispatch gate)', async () => {
     seedInstall();
     await installFreshness(installedProbes(), signal);
-    expect(fs.existsSync(installIdentityLockPath(stateDir))).toBe(false);
+    expect(fs.existsSync(installIdentityLockPath(root, { env: lockEnv() }))).toBe(false);
   });
 
   it('reports Pass with no plugin-root env (source checkout is not a corrupt install)', async () => {
-    const r = await installFreshness(makeStubProbes({ env: {}, stateDir }), signal);
+    const r = await installFreshness(
+      makeStubProbes({ env: { EXARCHOS_INSTALL_STATE_DIR: installDir }, stateDir }),
+      signal,
+    );
     // Either dev-checkout (no cache) or installed-but-no-lock — both are Pass.
     expect(r.status).toBe('Pass');
   });

--- a/tools/audit/guard-liveness-baseline.json
+++ b/tools/audit/guard-liveness-baseline.json
@@ -1,10 +1,10 @@
 {
-  "capturedAt": "2026-08-15",
-  "trackedFiles": 2917,
+  "capturedAt": "2026-08-20",
+  "trackedFiles": 2969,
   "surfaces": {
     "depcruise:no-domain-core-to-io-adapters:from": {
       "kind": "module-set",
-      "matched": 104,
+      "matched": 109,
       "detail": {
         "pattern": "^src/(events|workflow)/"
       }
@@ -18,15 +18,15 @@
     },
     "codeowners:*": {
       "kind": "ownership",
-      "matched": 2917
+      "matched": 2969
     },
     "codeowners:src/": {
       "kind": "ownership",
-      "matched": 731
+      "matched": 744
     },
     "codeowners:tools/": {
       "kind": "ownership",
-      "matched": 301
+      "matched": 320
     },
     "codeowners:content/": {
       "kind": "ownership",
@@ -38,18 +38,18 @@
     },
     "codeowners:tests/": {
       "kind": "ownership",
-      "matched": 1416
+      "matched": 1435
     },
     "package.files:dist/bin": {
       "kind": "build-output",
-      "matched": 0,
+      "matched": 1,
       "detail": {
         "buildOutput": true
       }
     },
     "package.files:dist/release-verify.js": {
       "kind": "build-output",
-      "matched": 0,
+      "matched": 1,
       "detail": {
         "buildOutput": true
       }
@@ -107,14 +107,17 @@
     },
     "lint:eslint-cli-glob": {
       "kind": "lint-scope",
-      "matched": 881,
+      "matched": 907,
       "detail": {
         "glob": "src/**/*.ts tools/**/*.ts"
       }
     },
     "lint:inv6": {
       "kind": "lint-scope",
-      "matched": 127
+      "matched": 127,
+      "detail": {
+        "glob": "content/"
+      }
     },
     "lint:test-first-drift": {
       "kind": "lint-scope",
@@ -125,7 +128,7 @@
     },
     "knip:workspace:.": {
       "kind": "dead-code",
-      "matched": 2430,
+      "matched": 2479,
       "detail": {
         "glob": "src/**/*.ts tests/**/*.ts !tests/evals/**/runs/** tools/audit/**/*.ts tools/conformance/src/**/*.ts tools/evals/**/*.ts tools/evals-pkg/**/*.ts tools/git-hooks/**/*.ts tools/release/**/*.ts tools/test-helpers/**/*.ts docs/.vitepress/**/*.ts"
       }

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -7,7 +7,7 @@
     "testFiles": 1192,
     "parsedFiles": 1147,
     "shellFiles": 45,
-    "cases": 13285,
+    "cases": 13286,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -48386,6 +48386,11 @@
         {
           "suite": "env-variables",
           "name": "EnvVariables_AllExarchosEnvValid_ReturnsPass",
+          "dynamic": false
+        },
+        {
+          "suite": "env-variables",
+          "name": "EnvVariables_EveryNameTheSourceMentions_IsRecognized",
           "dynamic": false
         },
         {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -46905,7 +46905,7 @@
         },
         {
           "suite": "Active store divergence (#1839)",
-          "name": "Divergence_Acknowledged_SuppressesRefusalButNotTheWarning",
+          "name": "Divergence_Acknowledged_SuppressesBothTheRefusalAndTheWarning",
           "dynamic": false
         },
         {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -7,7 +7,7 @@
     "testFiles": 1192,
     "parsedFiles": 1147,
     "shellFiles": 45,
-    "cases": 13287,
+    "cases": 13290,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -46879,6 +46879,11 @@
       "runner": "vitest:root",
       "cases": [
         {
+          "suite": "The ambient-cascade comparison holds on the real dispatch path",
+          "name": "AmbientCascade_NormalizationOfTheResolverOutput_IsIdempotent",
+          "dynamic": false
+        },
+        {
           "suite": "Active store divergence (#1839)",
           "name": "Divergence_IsTrueByDefault_ForAnyNonPluginCli",
           "dynamic": false
@@ -46901,6 +46906,11 @@
         {
           "suite": "Active store divergence (#1839)",
           "name": "Divergence_Acknowledged_SuppressesRefusalButNotTheWarning",
+          "dynamic": false
+        },
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Divergence_ExplicitFalsySpelling_StaysArmed",
           "dynamic": false
         },
         {
@@ -48396,6 +48406,11 @@
         {
           "suite": "env-variables",
           "name": "EnvVariables_EveryNameTheSourceMentions_IsRecognized",
+          "dynamic": false
+        },
+        {
+          "suite": "env-variables",
+          "name": "EnvVariables_EveryRecognizedName_IsStillMentionedBySource",
           "dynamic": false
         },
         {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -7,7 +7,7 @@
     "testFiles": 1192,
     "parsedFiles": 1147,
     "shellFiles": 45,
-    "cases": 13286,
+    "cases": 13287,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -8619,6 +8619,11 @@
         {
           "suite": "Roots featureId inference is gated on the receiving schema (#1838)",
           "name": "RootsInference_NamedRegressionVictims_AreIneligible",
+          "dynamic": false
+        },
+        {
+          "suite": "Roots featureId inference is gated on the receiving schema (#1838)",
+          "name": "Dispatch_EveryReadOnlyVictimUnderResolvingRoots_IsNotRefusedForInjectedFeatureId",
           "dynamic": false
         },
         {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -7,7 +7,7 @@
     "testFiles": 1192,
     "parsedFiles": 1147,
     "shellFiles": 45,
-    "cases": 13290,
+    "cases": 13291,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -46881,6 +46881,11 @@
         {
           "suite": "The ambient-cascade comparison holds on the real dispatch path",
           "name": "AmbientCascade_NormalizationOfTheResolverOutput_IsIdempotent",
+          "dynamic": false
+        },
+        {
+          "suite": "The ambient-cascade comparison holds on the real dispatch path",
+          "name": "AmbientCascade_WindowsShapedPath_SurvivesTheSameNormalization",
           "dynamic": false
         },
         {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -1,13 +1,13 @@
 {
-  "capturedAt": "2026-08-18",
+  "capturedAt": "2026-08-20",
   "discovery": "extension-based over tracked files; not a runner glob",
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1188,
-    "parsedFiles": 1143,
+    "testFiles": 1192,
+    "parsedFiles": 1147,
     "shellFiles": 45,
-    "cases": 13260,
+    "cases": 13285,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -8109,6 +8109,16 @@
           "suite": "emission verifier policy",
           "name": "a mixed run reports the determinate count it actually earned",
           "dynamic": false
+        },
+        {
+          "suite": "emission enforcement reaches the dispatch result",
+          "name": "EmissionEnforcement_BlockMode_UndeliveredEmissionFailsTheDispatch",
+          "dynamic": false
+        },
+        {
+          "suite": "emission enforcement reaches the dispatch result",
+          "name": "EmissionEnforcement_AdvisoryMode_SameViolationReturnsTheHandlerResult",
+          "dynamic": false
         }
       ]
     },
@@ -8597,6 +8607,27 @@
         }
       ]
     },
+    "tests/outcome/roots-injection-schema-guard.test.ts": {
+      "file": "tests/outcome/roots-injection-schema-guard.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "Roots featureId inference is gated on the receiving schema (#1838)",
+          "name": "RootsInference_ActionOmittingFeatureId_IsNeverEligibleForInjection",
+          "dynamic": false
+        },
+        {
+          "suite": "Roots featureId inference is gated on the receiving schema (#1838)",
+          "name": "RootsInference_NamedRegressionVictims_AreIneligible",
+          "dynamic": false
+        },
+        {
+          "suite": "Roots featureId inference is gated on the receiving schema (#1838)",
+          "name": "Dispatch_EventAppendUnderResolvingRoots_IsNotRefusedForInjectedFeatureId",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/outcome/runbook-merge-orchestration.test.ts": {
       "file": "tests/outcome/runbook-merge-orchestration.test.ts",
       "runner": "vitest:root",
@@ -8609,6 +8640,42 @@
         {
           "suite": "MERGE_ORCHESTRATION runbook outcome (#1363)",
           "name": "Runbook_OtherPhases_StillPopulated",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/outcome/store-divergence-dispatch.test.ts": {
+      "file": "tests/outcome/store-divergence-dispatch.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "Store-path divergence surfaces at the point of use (#1839)",
+          "name": "Mutation_UnderActiveDivergence_IsRefusedNotSilentlyWritten",
+          "dynamic": false
+        },
+        {
+          "suite": "Store-path divergence surfaces at the point of use (#1839)",
+          "name": "Mutation_OtherStoreAbsent_ProceedsNormally",
+          "dynamic": false
+        },
+        {
+          "suite": "Store-path divergence surfaces at the point of use (#1839)",
+          "name": "Mutation_Acknowledged_ProceedsWithTheOptIn",
+          "dynamic": false
+        },
+        {
+          "suite": "Store-path divergence surfaces at the point of use (#1839)",
+          "name": "Read_UnderActiveDivergence_CarriesTheCaveatInline",
+          "dynamic": false
+        },
+        {
+          "suite": "Store-path divergence surfaces at the point of use (#1839)",
+          "name": "Mutation_ExplicitStateDir_IsExemptFromTheCheck",
+          "dynamic": false
+        },
+        {
+          "suite": "Store-path divergence surfaces at the point of use (#1839)",
+          "name": "Read_NoDivergence_CarriesNoSpuriousWarning",
           "dynamic": false
         }
       ]
@@ -28860,6 +28927,47 @@
         }
       ]
     },
+    "tests/unit/install/freshness-store-invariance.test.ts": {
+      "file": "tests/unit/install/freshness-store-invariance.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "Install freshness is invariant under WORKFLOW_STATE_DIR (#1840)",
+          "name": "Freshness_SameInstallTwoStores_ReportsTheSameVerdict",
+          "dynamic": false
+        },
+        {
+          "suite": "Install freshness is invariant under WORKFLOW_STATE_DIR (#1840)",
+          "name": "Freshness_PinningTheStore_DoesNotBlockMutations",
+          "dynamic": false
+        },
+        {
+          "suite": "Install freshness is invariant under WORKFLOW_STATE_DIR (#1840)",
+          "name": "LockPath_IsKeyedToTheInstall_NotTheStateDir",
+          "dynamic": false
+        },
+        {
+          "suite": "An undetermined dimension cannot report as matching (#1840)",
+          "name": "Verify_BothVersionsUnknown_IsIndeterminateNotFresh",
+          "dynamic": false
+        },
+        {
+          "suite": "An undetermined dimension cannot report as matching (#1840)",
+          "name": "Verify_MissingPackageJson_IsIndeterminate",
+          "dynamic": false
+        },
+        {
+          "suite": "An undetermined dimension cannot report as matching (#1840)",
+          "name": "Verify_KnownMatchingVersions_StillFresh",
+          "dynamic": false
+        },
+        {
+          "suite": "An undetermined dimension cannot report as matching (#1840)",
+          "name": "Gate_IndeterminateInstall_DegradesRatherThanBlocking",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/unit/install/friction-signal.test.ts": {
       "file": "tests/unit/install/friction-signal.test.ts",
       "runner": "vitest:root",
@@ -46757,6 +46865,47 @@
         {
           "suite": "spawnCommandSync (#1623)",
           "name": "SpawnCommandSync_NonZeroExit_CapturesStatusWithoutThrowing",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/unit/utils/store-divergence.test.ts": {
+      "file": "tests/unit/utils/store-divergence.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Divergence_IsTrueByDefault_ForAnyNonPluginCli",
+          "dynamic": false
+        },
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Divergence_OtherStoreAbsent_IsNotActive",
+          "dynamic": false
+        },
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Divergence_OtherStoreExists_IsActive",
+          "dynamic": false
+        },
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Divergence_WorkflowStateDirPinned_CollapsesEntirely",
+          "dynamic": false
+        },
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Divergence_Acknowledged_SuppressesRefusalButNotTheWarning",
+          "dynamic": false
+        },
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Divergence_FromThePluginSide_NamesTheCliStoreAsOther",
+          "dynamic": false
+        },
+        {
+          "suite": "Active store divergence (#1839)",
+          "name": "Description_NamesBothPathsAndTheRemedy",
           "dynamic": false
         }
       ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -96,6 +96,7 @@ export default defineConfig({
       {
         test: {
           name: 'unit',
+          setupFiles: ['./tests/helpers/hermetic-install-identity.ts'],
           // Root-package unit tests only. Everything under `src/` now belongs to
           // the `core` project below — task 019 folded the MCP server's tree
           // into `src/`, so the glob that used to mean "the installer toolchain"
@@ -249,7 +250,7 @@ export default defineConfig({
             process.env.EXARCHOS_SMOKE_ONLY === '1'
               ? [...EXCLUDE]
               : [...EXCLUDE, 'tests/unit/verbs/stryker-adapter.smoke.test.ts'],
-          setupFiles: ['./tests/helpers/close-sqlite.ts'],
+          setupFiles: ['./tests/helpers/hermetic-install-identity.ts', './tests/helpers/close-sqlite.ts'],
         },
       },
       {
@@ -260,7 +261,7 @@ export default defineConfig({
           include: ['tests/process/**/*.test.ts'],
           exclude: EXCLUDE,
           testTimeout: tierTimeout(15000),
-          setupFiles: ['./tests/helpers/global.ts'],
+          setupFiles: ['./tests/helpers/hermetic-install-identity.ts', './tests/helpers/global.ts'],
         },
       },
       {
@@ -294,7 +295,7 @@ export default defineConfig({
           // the setting was written to prevent. `poolOptions` is the
           // per-project form and does what the old line said.
           poolOptions: { forks: { singleFork: true } },
-          setupFiles: ['./tests/helpers/close-sqlite.ts'],
+          setupFiles: ['./tests/helpers/hermetic-install-identity.ts', './tests/helpers/close-sqlite.ts'],
         },
       },
       {
@@ -310,6 +311,7 @@ export default defineConfig({
           // that holds.
           name: 'acceptance',
           include: ['tests/acceptance/**/*.test.ts'],
+          setupFiles: ['./tests/helpers/hermetic-install-identity.ts'],
           exclude: EXCLUDE,
           testTimeout: tierTimeout(120000),
           // The install writes into a scratch HOME and the archive step shells
@@ -340,7 +342,7 @@ export default defineConfig({
           include: ['tools/conformance/src/**/*.test.ts'],
           exclude: EXCLUDE,
           testTimeout: tierTimeout(30000),
-          setupFiles: ['./tests/helpers/close-sqlite.ts'],
+          setupFiles: ['./tests/helpers/hermetic-install-identity.ts', './tests/helpers/close-sqlite.ts'],
         },
       },
     ],


### PR DESCRIPTION
# Fix the preview.4 MCP/store triad

Closes #1838
Closes #1839
Closes #1840

## Summary

Three defects reported from one `/exarchos:delegate` run on 2.12.0-preview.4 compose into a trap
with no correct exit: the MCP dispatch path injects a `featureId` that most actions refuse, the
CLI workaround silently writes into a store nothing else reads, and pinning the store to fix
*that* trips an install-freshness gate that records its identity inside the store it is pinned to.
Individually each is a papercut; chained, they make the delegate flow unexecutable by any route.

Each fix replaces a weaker stand-in with the fact its own authority already carries, so the defect
class closes rather than the instance.

**The reported blast radius for #1838 was understated.** The issue says `exarchos_event` is
unusable. Measured against the registry, **59 of 124 actions (48% of the tool surface)** reject a
call the server itself mutated:

| Tool | Broken / total |
|------|----------------|
| `exarchos_workflow` | 1 / 11 (`feedback`) |
| `exarchos_event` | 3 / 4 |
| `exarchos_orchestrate` | 32 / 82 |
| `exarchos_view` | 22 / 26 |
| `exarchos_sync` | 1 / 1 |

Two consequences the report did not name: `orchestrate.doctor` is among them, so the diagnostic of
record breaks exactly when an operator reaches for it, and 22 of 26 `exarchos_view` actions —
nearly the whole read surface — fail the same way.

The defect fires only where roots resolution **succeeds**. The repo's own suite never resolves a
workspace, so all 59 actions stayed green in CI.

## Changes

### #1838 — roots inference no longer injects into a schema that forbids it

`dispatch.ts` injected the resolved `featureId` into the forwarded args whenever resolution
succeeded, without checking whether the receiving action declares the field. The strict per-action
schema then rejected the call — correctly, by its own rule — naming a parameter the caller never
sent. `undeclared-parameters.ts` builds that refusal by reading `receiving.schema.shape`, which is
exactly the fact the injection site failed to consult.

The precondition is now derived from the registry via that same `schema.shape`, so the two cannot
disagree and a newly-added action is classified correctly the moment it is declared.
`NO_WORKSPACE_RESOLUTION_ACTIONS` survives as a pure latency shortcut and is explicitly demoted
from correctness duty.

Framed by **INV-2 (contract-client-equivalence)**: the branch is gated on `ctx.rootsClient`, which
the CLI path never has, so the two clients disagreed on 59 actions — the hand-introduced divergence
INV-2 forbids.

### #1839 — store-path divergence surfaces at the point of use

`computeStorePathDivergence()` shipped and was correct; its only consumer was the doctor check.
Mutating actions wrote into the non-plugin store and reported **success**, and reads answered from
it with a coherent, confident, wrong answer.

Mutating actions now refuse with a structured `STORE_PATH_DIVERGENCE` naming both paths and the
remedy; reads carry the caveat inline through the `warnings[]` field `ToolResult` already declares
(no new carrier field, so **INV-5b** is untouched).

Two scoping decisions carry the design, because the naive rule is wrong in both directions:

- **Bare divergence is true by default** for every non-plugin CLI invocation — the cascade genuinely
  resolves `~/.exarchos/state` for the CLI and `~/.claude/workflow-state` for the plugin. Refusing on
  that alone would break every standalone CLI user. The refusal therefore requires the **other store
  to exist**.
- **The check applies only when the store came from the ambient cascade.** A caller who named a state
  dir has already resolved the ambiguity. Without this, dispatch would behave differently on a
  developer machine than in CI — it caught twelve existing tests on a machine that has both default
  stores, which is how the scope was found.

`EXARCHOS_ALLOW_STORE_DIVERGENCE` suppresses the refusal for deliberate two-store operation; it does
not suppress the warning, since opting in accepts the risk rather than hiding it.

### #1840 — freshness is keyed to the installation, not the event store

The TOFU lock lived at `path.join(stateDir, 'install-identity.json')`, making an installation
property a function of `WORKFLOW_STATE_DIR`. The lock now lives in an install-scoped directory keyed
on a digest of the plugin root, resolved by a cascade that never consults the store env var.
`stateDir` is **removed** from the gate deps rather than left unread: with nowhere to put it, the
store cannot be folded back into the verdict by a later caller.

A lock at the old location is deliberately **not** read back — doing so would reintroduce the very
variance being removed. The absent lock re-bootstraps through the designed TOFU path, which records
and proceeds and never blocks.

Second defect, and the sharper one: the binary version falls back to `0.0.0-unknown` and the
comparison used equality, so **unknown === unknown reported the dimension as MATCHING**. `doctor`
printed "binary, plugin, skill, schema, and cache match the recorded identity" while separately
warning it could not determine the running plugin version — an absent observation converted into
positive assurance. Verification now returns a third `indeterminate` state, settled before any
equality comparison. The gate maps it onto the existing non-blocking `degraded` status and `doctor`
reports UNDETERMINED: an unreadable `package.json` must not become a new outage class, so the trade
is a false pass for an honest cannot-tell, not for a block.

### Adjacent fixes found on the way

- **`doctor`'s `variables` check had drifted by seventeen.** `EXARCHOS_CACHE_DIR`,
  `EXARCHOS_VCS_PROVIDER`, `EXARCHOS_MCP_ENTRY` and fourteen others are read by the shipped source
  but were reported as unknown, with a suggested fix of "remove unknown variable" — advice that
  breaks a working configuration. Reconciled, and a guard now scans the source and requires a Pass,
  so the list can no longer drift silently. Same defect class as #1838.
- **Layer boundary:** the divergence check gives `dispatch` its first real edge to `utils`. `utils`
  is the declared foundation leaf that imports no first-party directory, and every other core layer
  already reaches it. The allowance row records the edge deliberately — that is what the ratchet is
  for — rather than hiding it by rehoming path resolution somewhere it does not belong.
- **DR-14 cast ratchet:** `isReadOnlyAction` duplicated the `READ_ONLY_ACTIONS` assertion, pushing
  the delta to 6 against a budget of 5. Paid down rather than re-baselined, by making it the
  primitive and composing `isFreshnessGateExempt` from it.
- **Test hermeticity:** the lock no longer follows a test's temp `stateDir`, so any test dispatching
  a mutating action under an installed posture published a lock into the real `~/.exarchos/install`.
  A checkout of this repo on a machine that also has the plugin installed detects as *installed*, so
  that is the ordinary developer configuration. A shared setup file redirects the directory per test
  process, wired into all six projects — `unit` and `acceptance` had no `setupFiles` at all.

## Test Plan

**Every fix is kill-probed.** A guard that cannot fail proves nothing, so each was run against the
pre-fix behaviour:

| Fix | Kill probe | Result |
|-----|-----------|--------|
| #1838 | force the predicate to `true` | 3 red; the end-to-end reproduces the reported error **verbatim** — `unrecognized parameter(s): "featureId" (declared by no action on exarchos_event)` |
| #1839 | force the detector to report no divergence | refusal and warning both red |
| #1840 | restore the state-dir lock path **and** the equality comparison | 5 red, incl. `expected 'bootstrapped' to be 'fresh'` — store B minting its own second lock |
| env drift | drop one entry from `KNOWN` | red, naming `EXARCHOS_CACHE_DIR` |

New guards:

- `tests/outcome/roots-injection-schema-guard.test.ts` — asserts the predicate over the **whole
  registry** rather than dispatching 59 handlers (`merge_pr`, `create_pr` and `create_issue` are
  among them, and a guard must not perform the side effects it guards), plus one real end-to-end
  dispatch. Carries denominator assertions so it cannot pass by enumerating nothing.
- `tests/unit/utils/store-divergence.test.ts` + `tests/outcome/store-divergence-dispatch.test.ts` —
  including a pin that bare divergence *is* true by default, so the "other store must exist" rule
  cannot be quietly dropped.
- `tests/unit/install/freshness-store-invariance.test.ts` — the verdict is invariant under
  `WORKFLOW_STATE_DIR`; an undetermined dimension cannot report as matching.

**Verification is a failure-SET diff against `main` (e63493269), not a count.** An intermediate run
read 37 → 41, which looks like four new failures; the sets showed **seven** new and three that only
ever failed under the A/B harness. Counts hide swaps.

| | Failed | Total |
|---|---|---|
| Baseline `main` | 37 | 14103 |
| This branch | **34** | 14127 |

**New failures introduced: 0.** The three baseline failures absent from the final set are artifacts
of the A/B harness (`vitest --root` against the baseline worktree made `test-tree-contract` collect
nothing); they do not fail on a native `main` run. The 34 remaining are the known local baseline
(#1835).

`npm run typecheck` green (root + conformance + tests). `npm run build` green with a clean
`git status` afterwards, so no `rendered/` drift.

## Notes for the reviewer

- **The RCA is this PR body.** `docs/rca/` is gitignored in this repo (RCAs live in `lvlup-sw/docs`),
  so a file there could never ship — while VitePress still published it and failed the docs-skeleton
  test. The analysis is carried here instead, where it is durable.
- **Accepted risk:** one `fs.existsSync` per dispatch when the store came from the ambient cascade
  and the paths diverge. Left un-memoized deliberately — caching the *absent* result is the unsafe
  direction, since it would skip the refusal after a user creates the other store mid-session, and a
  single stat is negligible beside the dynamic imports and SQLite work the same dispatch performs.
- **Out of scope, flagged not fixed:** `docs/` publishes anything mounted under it, so
  `npm run docs:mount` breaks the docs-skeleton test the same way an RCA file did. And
  `detectInstallPosture` reports `installed` whenever the plugin cache exists, even when the running
  code is a source checkout that is not that install — that is why the suite needs the hermetic
  install-identity redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RKfa5AQaR8Ay3XwjQMfJr
