### PR TITLE
refactor(dispatch): one table and one gate for every inferred value

### DIFF
--- a/src/dispatch/core/dispatch.ts
+++ b/src/dispatch/core/dispatch.ts
@@ -51,7 +51,7 @@ import {
   findIgnoredParameters,
   buildIgnoredParameterError,
 } from '../undeclared-parameters.js';
-import type { ToolAction } from '../../registry.js';
+import { applyInferredValues } from './inferred-values.js';
 import path from 'node:path';
 import {
   detectActiveStoreDivergence,
@@ -380,49 +380,6 @@ function isReadOnlyAction(tool: string, action: string): boolean {
   if (allowed === '*') return true;
   return allowed !== undefined && allowed.includes(action);
 }
-
-/**
- * Actions that never consume a `featureId` (Sentry MEDIUM #1423).
- *
- * The roots-based workspace-discovery branch in `dispatch()` skips its
- * synchronous filesystem walk for actions in this set so high-frequency
- * introspection calls (catalog reads, runbook fetches, agent-spec
- * lookups) don't pay the discovery cost.
- *
- * This list is a LATENCY shortcut and nothing more. It is deliberately NOT
- * load-bearing for correctness: {@link actionAcceptsInferredFeatureId} decides
- * whether inference may run at all, reading the receiving action's own schema.
- * A name missing from this set costs a filesystem walk; it can no longer cost
- * a rejected call.
- */
-const NO_WORKSPACE_RESOLUTION_ACTIONS: ReadonlySet<string> = new Set([
-  'describe',
-  'runbook',
-  'agent_spec',
-]);
-
-/**
- * May the roots/cwd resolver hand this action an inferred `featureId`?
- *
- * Only when the action's OWN schema declares the field. Every composite tool
- * flattens its actions into one registration schema, so the wire accepts the
- * union of every action's fields — but routing hands the payload to a single
- * strict schema that knows only its own. Injecting into an action that does
- * not declare `featureId` therefore manufactures the exact refusal
- * `undeclared-parameters.ts` exists to raise, naming a parameter the caller
- * never sent and the server itself added.
- *
- * The predicate reads the same `schema.shape` that builds that refusal, so the
- * two can no longer disagree: a newly-added action is classified correctly the
- * moment it is declared, with no list to keep in step.
- *
- * Exported for the regression guard, which asserts this over the whole
- * registry rather than executing 59 handlers to discover it.
- */
-export function actionAcceptsInferredFeatureId(action: ToolAction): boolean {
-  return action.schema.shape['featureId'] !== undefined;
-}
-
 /**
  * Apply the readonly capability gate. Returns a structured CAPABILITY_DENIED
  * ToolResult when the effective capability set forbids `action` on `tool`,
@@ -839,115 +796,37 @@ export async function dispatch(
 
     let { action: _action, ...rest } = args;
 
-    // ─── #1290 — Roots-based featureId inference ─────────────────────────
-    // Resolution priority (load-bearing for missing-required-param paths):
-    //   explicit > roots > cwd > elicitation > INVALID_INPUT.
-    // Elicitation is the LAST resort before INVALID_INPUT because it
-    // requires a transport round-trip; roots + cwd inference are
-    // round-trip-free and so take precedence (#1274). If the caller
-    // already supplied a `featureId`, we leave it alone. Otherwise, if
-    // the client declared the MCP roots capability (snapshotted on the
-    // resolver via the initialize handshake), call `resolveWorkspace`
-    // to attempt inference from the cached roots list or a cwd-walk
-    // fallback.
+    // ─── Inferred values ─────────────────────────────────────────────────
     //
-    // Multi-match returns a structured INVALID_INPUT here so the caller
-    // can disambiguate; zero-match falls through to the existing per-
-    // action Zod validation, which surfaces the legacy "featureId is
-    // required" envelope unchanged.
+    // Resolution priority for a parameter the caller omitted:
     //
-    // Sentry MEDIUM #1423: actions that never consume workspace context
-    // (`describe`/`runbook`/`agent_spec` — pure introspection on the
-    // registry / catalogs) skip the discovery call entirely. Pre-fix
-    // these high-frequency informational calls each triggered a
-    // synchronous cwd-walk on miss, adding measurable latency to the
-    // dispatch hot path. The skip list is conservative: anything that
-    // *might* take a featureId stays in the discovery branch.
-    // Sentry MEDIUM #1424: skip workspace resolution entirely when
-    // `rootsClient` is undefined — that's the CLI dispatch path which has
-    // no MCP roots channel and therefore no useful inference target. The
-    // sync `cwdWalk` fallback would still fire and add filesystem latency
-    // to every CLI hot-path dispatch (telemetry view, doctor checks, etc.)
-    // that happens to omit a featureId. Roots+cwd inference is purely an
-    // MCP-client convenience for callers that DID declare roots.
+    //     explicit > inferred (roots, then a cwd walk) > elicitation > INVALID_INPUT
     //
-    // The receiving action's schema is consulted FIRST. Inference is a
-    // convenience for actions that take a featureId; for an action that does
-    // not declare one there is nothing to infer, and injecting anyway turns a
-    // successful resolution into an INVALID_INPUT naming a field the caller
-    // never sent. That inverted failure hit 59 of the 124 registered actions
-    // — including `doctor`, so the diagnostic of record broke exactly when an
-    // operator reached for it — and it reproduced only where roots resolution
-    // SUCCEEDS, which is why the repo's own suite never saw it.
-    if (
-      rest.featureId === undefined
-      && ctx.capabilityResolver !== undefined
-      && ctx.rootsClient !== undefined
-      && actionAcceptsInferredFeatureId(matchingAction)
-      && !NO_WORKSPACE_RESOLUTION_ACTIONS.has(actionName)
-    ) {
-      try {
-        const { resolveWorkspace } = await import('../../runtime/workspace/discovery.js');
-        const resolution = await resolveWorkspace({
-          resolver: ctx.capabilityResolver,
-          rootsClient: ctx.rootsClient,
-          cwd: ctx.cwd ?? process.cwd(),
-          eventStore: ctx.eventStore,
-          // #1504 — authoritative workflow enumeration via the projected
-          // `workflow_state` table when probing this server's own workspace.
-          storage: ctx.storage,
-        });
-        if (resolution !== undefined) {
-          if (resolution.success) {
-            rest = { ...rest, featureId: resolution.featureId };
-          } else {
-            // Multi-match. Surface the structured INVALID_INPUT so the
-            // caller can pick the intended target. CodeRabbit CRITICAL
-            // #1428: map `validTargets` from `{featureId,path}` records
-            // to plain `featureId` strings — that's the disambiguator the
-            // caller actually supplies in the retry. The published error
-            // contract expects `readonly (string | ValidTransitionTarget)[]`.
-            // CodeRabbit CRITICAL + Sentry #1428: also attach _meta so
-            // the multi-match envelope carries correlation IDs (parity
-            // with success + thrown-error paths). Pre-fix this was the
-            // ONE early-return path that diverged from the published
-            // error contract.
-            return attachMeta({
-              success: false,
-              error: {
-                code: resolution.code,
-                message:
-                  `${tool}/${actionName}: multiple workspaces matched MCP roots; ` +
-                  'supply an explicit featureId to disambiguate.',
-                // CodeRabbit CRITICAL #1423: `ToolResult.error.validTargets`
-                // expects `readonly (string | ValidTransitionTarget)[]`, but
-                // workspace resolution returns
-                // `readonly { featureId, path }[]`. Surface the featureIds
-                // (the disambiguator the caller actually supplies) so the
-                // envelope satisfies the contract.
-                validTargets: resolution.validTargets?.map((t) => t.featureId),
-              },
-            });
-          }
-        }
-      } catch (err) {
-        // Discovery is a best-effort inference hook — a failure must not
-        // mask the legacy validation contract. Fall through to the
-        // existing schema check; callers see the standard "featureId
-        // is required" envelope. CodeRabbit MINOR #1423: silent catches
-        // violate the project's observability standard. Surface via the
-        // workspace-discovery logger child so the failure is auditable
-        // without changing the user-facing fallback.
-        logger.child({ subsystem: 'workspace-discovery' }).warn(
-          {
-            tool,
-            action: actionName,
-            error: err instanceof Error ? err.message : String(err),
-          },
-          'workspace inference failed; falling back to legacy featureId validation',
-        );
-      }
+    // Elicitation is LAST because it costs a transport round-trip; inference is
+    // round-trip-free and so takes precedence. It is also the only one of the
+    // three that needs no gate here: it splices a field named by this action's
+    // OWN parse error, so it can only ever supply something the action
+    // declares.
+    //
+    // The table in `inferred-values.ts` owns which values may be inferred and
+    // the single gate they share — most importantly that a value is merged only
+    // into an action whose schema declares it. Dispatch keeps no per-field
+    // logic, so a future inference cannot reopen #1838 by forgetting a check.
+    const inference = await applyInferredValues(rest, matchingAction, tool, actionName, ctx);
+    if (inference.kind === 'refused') {
+      // Multi-match. A structured INVALID_INPUT so the caller can pick the
+      // intended target. `attachMeta` is applied like every other early return
+      // — this path used to be the one that diverged from the error contract.
+      return attachMeta({
+        success: false,
+        error: {
+          code: inference.code,
+          message: inference.message,
+          ...(inference.validTargets !== undefined ? { validTargets: inference.validTargets } : {}),
+        },
+      });
     }
+    rest = inference.args;
 
     // ─── DR-7 — honoured, or refused (never accepted-and-dropped) ────────
     //

--- a/src/dispatch/core/inferred-values.ts
+++ b/src/dispatch/core/inferred-values.ts
@@ -1,0 +1,226 @@
+// ─── Values dispatch infers on the caller's behalf, and the one gate they share ─
+//
+// Some parameters a caller omits can be worked out from context rather than
+// refused. `featureId` is the case that exists today: an MCP client that
+// declared the `roots` capability has already told the server which workspace
+// it is in, so asking the operator to retype the workflow id is ceremony.
+//
+// The inferred value has to go INTO the payload that per-action validation
+// sees. 43 of the 59 actions that take a `featureId` declare it REQUIRED, so
+// inference exists precisely to satisfy that requirement — a channel that kept
+// the value out of validation would fail the very callers it is meant to serve.
+// That constraint is what makes the gate below load-bearing rather than
+// cosmetic: the value is merged into a strict schema's input, so merging it
+// into a schema that does not declare it manufactures a rejection.
+//
+// The failure this module exists to prevent: dispatch used to merge the
+// resolved `featureId` into the payload of any action not on a three-name
+// latency list. An action whose own schema omits the field then refused the
+// call — naming a parameter the caller never sent and the server itself added.
+// It hit 59 of 124 actions, including `doctor`, and only where resolution
+// SUCCEEDS, so a suite that never resolves a workspace stayed green throughout.
+//
+// The repair was to consult the receiving action's schema first. This module is
+// what stops that repair from being a fact about `featureId`: every inferrable
+// value is declared in ONE table and merged through ONE gated path, so a second
+// inference — a `taskId`, a `workflowType` — inherits the gate instead of
+// re-deriving it, and cannot reopen the class by forgetting to.
+
+import { logger } from '../../logger.js';
+import type { ToolAction } from '../../registry.js';
+import type { CapabilityResolver } from '../../workflow/capabilities/resolver.js';
+import type { EventStore } from '../../events/store.js';
+import type { StorageBackend } from '../../storage/backend.js';
+import type { RootsClient } from '../../runtime/workspace/discovery.js';
+
+/** The slice of the dispatch context an inference resolver may read. */
+export interface InferenceContext {
+  readonly capabilityResolver?: CapabilityResolver | undefined;
+  readonly rootsClient?: RootsClient | undefined;
+  readonly eventStore: EventStore;
+  readonly storage?: StorageBackend | undefined;
+  readonly cwd?: string | undefined;
+}
+
+/**
+ * What a resolver concluded.
+ *
+ * `ambiguous` is a first-class outcome rather than an error because the caller
+ * can act on it: the resolution found several candidates and the operator picks
+ * one. `unavailable` covers both "nothing matched" and "the resolver failed",
+ * which are the same to dispatch — fall through to the action's own validation
+ * so the caller sees the ordinary missing-parameter envelope.
+ */
+export type InferenceOutcome =
+  | { readonly kind: 'resolved'; readonly value: unknown }
+  | {
+      readonly kind: 'ambiguous';
+      readonly code: string;
+      readonly message: string;
+      readonly validTargets?: readonly string[];
+    }
+  | { readonly kind: 'unavailable' };
+
+/** One value dispatch knows how to work out when the caller omits it. */
+export interface InferrableField {
+  /** Parameter name. Must match the schema field it is merged into. */
+  readonly field: string;
+  /**
+   * Actions that skip resolution for LATENCY, not correctness.
+   *
+   * Deliberately not load-bearing: {@link actionAcceptsInferredValue} already
+   * refuses to merge into an action that does not declare the field, so a name
+   * missing from this set costs a filesystem walk and can no longer cost a
+   * rejected call.
+   */
+  readonly skipActions: ReadonlySet<string>;
+  /** Cheap precondition — skip the resolver entirely when the channel is absent. */
+  readonly isAvailable: (ctx: InferenceContext) => boolean;
+  readonly resolve: (
+    ctx: InferenceContext,
+    tool: string,
+    actionName: string,
+  ) => Promise<InferenceOutcome>;
+}
+
+/**
+ * May this action receive an inferred value for `field`?
+ *
+ * Only when its OWN schema declares the field. Every composite tool flattens
+ * its actions into one registration schema, so the wire accepts the union of
+ * every action's fields — but routing hands the payload to a single strict
+ * schema that knows only its own. This reads the same `schema.shape` that
+ * `undeclared-parameters.ts` reads to build the refusal, so the injector and
+ * the refuser cannot disagree, and a newly declared action is classified the
+ * moment it exists with no list to update.
+ */
+export function actionAcceptsInferredValue(action: ToolAction, field: string): boolean {
+  return action.schema.shape[field] !== undefined;
+}
+
+const workspaceLogger = logger.child({ subsystem: 'workspace-discovery' });
+
+/**
+ * `featureId`, resolved from the MCP roots list with a cwd-walk fallback.
+ *
+ * Gated on `rootsClient` being present: that is the MCP path. The CLI has no
+ * roots channel and no useful inference target, and the synchronous cwd walk
+ * would otherwise add filesystem latency to every CLI dispatch that happens to
+ * omit the field.
+ */
+const FEATURE_ID_INFERENCE: InferrableField = {
+  field: 'featureId',
+  // Pure introspection over the registry and catalogs — never workspace-scoped.
+  skipActions: new Set(['describe', 'runbook', 'agent_spec']),
+  isAvailable: (ctx) => ctx.capabilityResolver !== undefined && ctx.rootsClient !== undefined,
+  resolve: async (ctx, tool, actionName) => {
+    // Re-checked here rather than assumed from `isAvailable`. A resolver that
+    // depends on its own precondition having been called elsewhere is one
+    // refactor away from a non-null assertion that is no longer true.
+    const { capabilityResolver, rootsClient } = ctx;
+    if (capabilityResolver === undefined || rootsClient === undefined) {
+      return { kind: 'unavailable' };
+    }
+    try {
+      const { resolveWorkspace } = await import('../../runtime/workspace/discovery.js');
+      const resolution = await resolveWorkspace({
+        resolver: capabilityResolver,
+        rootsClient,
+        cwd: ctx.cwd ?? process.cwd(),
+        eventStore: ctx.eventStore,
+        // Authoritative workflow enumeration via the projected
+        // `workflow_state` table when probing this server's own workspace.
+        storage: ctx.storage,
+      });
+      if (resolution === undefined) return { kind: 'unavailable' };
+      if (resolution.success) return { kind: 'resolved', value: resolution.featureId };
+      return {
+        kind: 'ambiguous',
+        code: resolution.code,
+        message:
+          `${tool}/${actionName}: multiple workspaces matched MCP roots; ` +
+          'supply an explicit featureId to disambiguate.',
+        // `validTargets` is typed as plain strings on the error contract, while
+        // resolution returns `{ featureId, path }` records. Surface the
+        // featureIds — the disambiguator the caller actually supplies on retry.
+        ...(resolution.validTargets !== undefined
+          ? { validTargets: resolution.validTargets.map((t) => t.featureId) }
+          : {}),
+      };
+    } catch (err) {
+      // Inference is a convenience, so a resolver failure must not mask the
+      // ordinary validation contract — the caller still gets the standard
+      // "featureId is required" envelope. Logged rather than swallowed: a
+      // silent catch would hide a broken roots channel indefinitely.
+      workspaceLogger.warn(
+        { tool, action: actionName, error: err instanceof Error ? err.message : String(err) },
+        'workspace inference failed; falling back to legacy featureId validation',
+      );
+      return { kind: 'unavailable' };
+    }
+  },
+};
+
+/**
+ * Every value dispatch may infer.
+ *
+ * Adding an entry is the whole extension point. It inherits the schema gate,
+ * the caller-wins rule and the ambiguity envelope from
+ * {@link applyInferredValues}, so a new inference cannot reintroduce the
+ * inject-into-a-forbidding-schema fault by omitting a check.
+ */
+export const INFERRABLE_FIELDS: readonly InferrableField[] = Object.freeze([
+  FEATURE_ID_INFERENCE,
+]);
+
+/** Result of running the table over one dispatch payload. */
+export type InferenceApplication =
+  | { readonly kind: 'merged'; readonly args: Record<string, unknown> }
+  | {
+      readonly kind: 'refused';
+      readonly code: string;
+      readonly message: string;
+      readonly validTargets?: readonly string[];
+    };
+
+/**
+ * Fill in the values the caller omitted, for the fields this action accepts.
+ *
+ * The three skips are the contract, and they are applied to every entry rather
+ * than per field:
+ *
+ *   1. An explicit value always wins — inference never overwrites a caller.
+ *   2. An action whose schema omits the field is left alone. This is the gate.
+ *   3. The latency list short-circuits resolution for pure introspection.
+ */
+export async function applyInferredValues(
+  args: Readonly<Record<string, unknown>>,
+  action: ToolAction,
+  tool: string,
+  actionName: string,
+  ctx: InferenceContext,
+  table: readonly InferrableField[] = INFERRABLE_FIELDS,
+): Promise<InferenceApplication> {
+  let merged: Record<string, unknown> = { ...args };
+
+  for (const entry of table) {
+    if (merged[entry.field] !== undefined) continue;
+    if (!actionAcceptsInferredValue(action, entry.field)) continue;
+    if (entry.skipActions.has(actionName)) continue;
+    if (!entry.isAvailable(ctx)) continue;
+
+    const outcome = await entry.resolve(ctx, tool, actionName);
+    if (outcome.kind === 'resolved') {
+      merged = { ...merged, [entry.field]: outcome.value };
+    } else if (outcome.kind === 'ambiguous') {
+      return {
+        kind: 'refused',
+        code: outcome.code,
+        message: outcome.message,
+        ...(outcome.validTargets !== undefined ? { validTargets: outcome.validTargets } : {}),
+      };
+    }
+  }
+
+  return { kind: 'merged', args: merged };
+}

--- a/tests/outcome/roots-injection-schema-guard.test.ts
+++ b/tests/outcome/roots-injection-schema-guard.test.ts
@@ -22,10 +22,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { TOOL_REGISTRY } from '../../src/registry.js';
+import { dispatch } from '../../src/dispatch/core/dispatch.js';
 import {
-  dispatch,
-  actionAcceptsInferredFeatureId,
-} from '../../src/dispatch/core/dispatch.js';
+  actionAcceptsInferredValue,
+  INFERRABLE_FIELDS,
+} from '../../src/dispatch/core/inferred-values.js';
 import { EventStore } from '../../src/events/store.js';
 import { handleInit } from '../../src/workflow/tools.js';
 import { createInMemoryResolver } from '../../src/workflow/capabilities/resolver.js';
@@ -48,7 +49,9 @@ afterEach(async () => {
 });
 
 /** The live latency shortcut in `dispatch.ts`. Skipped names never reach inference at all. */
-const LATENCY_SKIP = new Set(['describe', 'runbook', 'agent_spec']);
+const LATENCY_SKIP =
+  INFERRABLE_FIELDS.find((f) => f.field === 'featureId')?.skipActions ??
+  new Set<string>();
 
 interface ActionRef {
   readonly tool: string;
@@ -64,7 +67,7 @@ function partitionRegistry(): {
   for (const tool of TOOL_REGISTRY) {
     for (const action of tool.actions) {
       const ref = { tool: tool.name, action: action.name };
-      if (actionAcceptsInferredFeatureId(action)) declaring.push(ref);
+      if (actionAcceptsInferredValue(action, 'featureId')) declaring.push(ref);
       else omitting.push(ref);
     }
   }
@@ -96,7 +99,7 @@ describe('Roots featureId inference is gated on the receiving schema (#1838)', (
       const action = tool?.actions.find((a) => a.name === ref.action);
       expect(action, `${ref.tool}.${ref.action} missing from registry`).toBeDefined();
       expect(
-        actionAcceptsInferredFeatureId(action!),
+        actionAcceptsInferredValue(action!, 'featureId'),
         `${ref.tool}.${ref.action} omits featureId but is eligible for injection`,
       ).toBe(false);
     }
@@ -120,7 +123,7 @@ describe('Roots featureId inference is gated on the receiving schema (#1838)', (
       );
       expect(action, `${v.tool}.${v.action} not found`).toBeDefined();
       expect(
-        actionAcceptsInferredFeatureId(action!),
+        actionAcceptsInferredValue(action!, 'featureId'),
         `${v.tool}.${v.action} must not receive an inferred featureId`,
       ).toBe(false);
     }
@@ -131,7 +134,7 @@ describe('Roots featureId inference is gated on the receiving schema (#1838)', (
       (a) => a.name === 'get',
     );
     expect(beneficiary).toBeDefined();
-    expect(actionAcceptsInferredFeatureId(beneficiary!)).toBe(true);
+    expect(actionAcceptsInferredValue(beneficiary!, 'featureId')).toBe(true);
   });
 
   it('Dispatch_EveryReadOnlyVictimUnderResolvingRoots_IsNotRefusedForInjectedFeatureId', async () => {
@@ -178,7 +181,7 @@ describe('Roots featureId inference is gated on the receiving schema (#1838)', (
     const viewTool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
     expect(viewTool).toBeDefined();
     const victims = viewTool!.actions
-      .filter((a) => !actionAcceptsInferredFeatureId(a) && !LATENCY_SKIP.has(a.name))
+      .filter((a) => !actionAcceptsInferredValue(a, 'featureId') && !LATENCY_SKIP.has(a.name))
       .map((a) => a.name);
 
     // Denominator: if this population ever empties, the loop below proves

--- a/tests/unit/dispatch/core/inferred-values.test.ts
+++ b/tests/unit/dispatch/core/inferred-values.test.ts
@@ -1,0 +1,175 @@
+// ─── the class closure, not the instance ─────────────────────────────────────
+//
+// The #1838 guards prove `featureId` is gated. They cannot prove that the NEXT
+// inferred value will be, because a second inference could simply merge into
+// the payload itself and never consult a schema — which is how the fault
+// existed in the first place.
+//
+// These tests exercise the shared path with a SYNTHETIC second field, so the
+// property under test is "any entry in the table inherits the gate", not
+// "featureId happens to be gated". If someone adds a real inference later, the
+// only way it can reach a payload is through the code these tests pin.
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+import {
+  applyInferredValues,
+  actionAcceptsInferredValue,
+  INFERRABLE_FIELDS,
+  type InferrableField,
+} from '../../../../src/dispatch/core/inferred-values.js';
+import type { ToolAction } from '../../../../src/registry.js';
+
+/** A minimal action whose schema declares exactly `fields`. */
+function actionWith(name: string, fields: readonly string[]): ToolAction {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const f of fields) shape[f] = z.string();
+  return { name, description: name, schema: z.object(shape).strict() } as unknown as ToolAction;
+}
+
+/** A synthetic entry that always resolves, so only the GATE can stop it. */
+function alwaysResolves(field: string, value = 'inferred'): InferrableField {
+  return {
+    field,
+    skipActions: new Set<string>(),
+    isAvailable: () => true,
+    resolve: async () => ({ kind: 'resolved', value }),
+  };
+}
+
+const ctx = { eventStore: {} as never };
+
+describe('Every inferrable field inherits one gate', () => {
+  it('InferredValue_ActionDeclaringTheField_ReceivesIt', async () => {
+    const result = await applyInferredValues(
+      {},
+      actionWith('takes-it', ['taskId']),
+      'exarchos_test',
+      'takes-it',
+      ctx,
+      [alwaysResolves('taskId')],
+    );
+    expect(result.kind).toBe('merged');
+    if (result.kind === 'merged') expect(result.args['taskId']).toBe('inferred');
+  });
+
+  it('InferredValue_ActionOmittingTheField_NeverReceivesIt', async () => {
+    // The whole point. A NEW inference, written by someone who never read
+    // #1838, still cannot reach an action that forbids the field.
+    const result = await applyInferredValues(
+      {},
+      actionWith('forbids-it', ['somethingElse']),
+      'exarchos_test',
+      'forbids-it',
+      ctx,
+      [alwaysResolves('taskId')],
+    );
+    expect(result.kind).toBe('merged');
+    if (result.kind === 'merged') {
+      expect(
+        Object.prototype.hasOwnProperty.call(result.args, 'taskId'),
+        'a field the action does not declare must never be merged',
+      ).toBe(false);
+    }
+  });
+
+  it('InferredValue_ExplicitCallerValue_IsNeverOverwritten', async () => {
+    const result = await applyInferredValues(
+      { taskId: 'chosen-by-caller' },
+      actionWith('takes-it', ['taskId']),
+      'exarchos_test',
+      'takes-it',
+      ctx,
+      [alwaysResolves('taskId')],
+    );
+    expect(result.kind).toBe('merged');
+    if (result.kind === 'merged') expect(result.args['taskId']).toBe('chosen-by-caller');
+  });
+
+  it('InferredValue_LatencySkipList_SuppressesResolution', async () => {
+    let resolverRan = false;
+    const entry: InferrableField = {
+      ...alwaysResolves('taskId'),
+      skipActions: new Set(['describe']),
+      resolve: async () => {
+        resolverRan = true;
+        return { kind: 'resolved', value: 'x' };
+      },
+    };
+    const result = await applyInferredValues(
+      {},
+      actionWith('describe', ['taskId']),
+      'exarchos_test',
+      'describe',
+      ctx,
+      [entry],
+    );
+    expect(resolverRan, 'the skip list must short-circuit before the resolver').toBe(false);
+    expect(result.kind).toBe('merged');
+  });
+
+  it('InferredValue_AmbiguousOutcome_RefusesWithTheCallersOptions', async () => {
+    const entry: InferrableField = {
+      ...alwaysResolves('taskId'),
+      resolve: async () => ({
+        kind: 'ambiguous',
+        code: 'INVALID_INPUT',
+        message: 'several matched',
+        validTargets: ['a', 'b'],
+      }),
+    };
+    const result = await applyInferredValues(
+      {},
+      actionWith('takes-it', ['taskId']),
+      'exarchos_test',
+      'takes-it',
+      ctx,
+      [entry],
+    );
+    expect(result.kind).toBe('refused');
+    if (result.kind === 'refused') {
+      expect(result.code).toBe('INVALID_INPUT');
+      expect(result.validTargets).toEqual(['a', 'b']);
+    }
+  });
+
+  it('InferredValue_UnavailableOutcome_FallsThroughToValidation', async () => {
+    const entry: InferrableField = {
+      ...alwaysResolves('taskId'),
+      resolve: async () => ({ kind: 'unavailable' }),
+    };
+    const result = await applyInferredValues(
+      {},
+      actionWith('takes-it', ['taskId']),
+      'exarchos_test',
+      'takes-it',
+      ctx,
+      [entry],
+    );
+    // No merge and no refusal — the action's own schema produces the ordinary
+    // missing-parameter envelope, exactly as before inference existed.
+    expect(result.kind).toBe('merged');
+    if (result.kind === 'merged') {
+      expect(Object.prototype.hasOwnProperty.call(result.args, 'taskId')).toBe(false);
+    }
+  });
+});
+
+describe('The shipped table is well-formed', () => {
+  it('InferrableFields_EveryEntry_DeclaresADistinctField', () => {
+    // Denominator: an empty table would satisfy every loop above vacuously.
+    expect(INFERRABLE_FIELDS.length).toBeGreaterThanOrEqual(1);
+    const names = INFERRABLE_FIELDS.map((f) => f.field);
+    expect(new Set(names).size, 'two entries claiming one field would race').toBe(names.length);
+  });
+
+  it('InferrableFields_TheGate_IsAFunctionOfTheSchemaAlone', () => {
+    // Pins the gate to the schema rather than to any list, which is what makes
+    // it correct for an action nobody has written yet.
+    const declares = actionWith('a', ['featureId']);
+    const omits = actionWith('b', ['other']);
+    expect(actionAcceptsInferredValue(declares, 'featureId')).toBe(true);
+    expect(actionAcceptsInferredValue(omits, 'featureId')).toBe(false);
+  });
+});

--- a/tools/audit/guard-liveness-baseline.json
+++ b/tools/audit/guard-liveness-baseline.json
@@ -1,6 +1,6 @@
 {
   "capturedAt": "2026-08-20",
-  "trackedFiles": 2969,
+  "trackedFiles": 2971,
   "surfaces": {
     "depcruise:no-domain-core-to-io-adapters:from": {
       "kind": "module-set",
@@ -18,11 +18,11 @@
     },
     "codeowners:*": {
       "kind": "ownership",
-      "matched": 2969
+      "matched": 2971
     },
     "codeowners:src/": {
       "kind": "ownership",
-      "matched": 744
+      "matched": 745
     },
     "codeowners:tools/": {
       "kind": "ownership",
@@ -38,7 +38,7 @@
     },
     "codeowners:tests/": {
       "kind": "ownership",
-      "matched": 1435
+      "matched": 1436
     },
     "package.files:dist/bin": {
       "kind": "build-output",
@@ -107,7 +107,7 @@
     },
     "lint:eslint-cli-glob": {
       "kind": "lint-scope",
-      "matched": 907,
+      "matched": 908,
       "detail": {
         "glob": "src/**/*.ts tools/**/*.ts"
       }
@@ -128,7 +128,7 @@
     },
     "knip:workspace:.": {
       "kind": "dead-code",
-      "matched": 2479,
+      "matched": 2481,
       "detail": {
         "glob": "src/**/*.ts tests/**/*.ts !tests/evals/**/runs/** tools/audit/**/*.ts tools/conformance/src/**/*.ts tools/evals/**/*.ts tools/evals-pkg/**/*.ts tools/git-hooks/**/*.ts tools/release/**/*.ts tools/test-helpers/**/*.ts docs/.vitepress/**/*.ts"
       }

--- a/tools/audit/reference-census.json
+++ b/tools/audit/reference-census.json
@@ -1,7 +1,7 @@
 {
-  "capturedAt": "2026-08-15",
-  "trackedFiles": 2920,
-  "scannedFiles": 2817,
+  "capturedAt": "2026-08-20",
+  "trackedFiles": 2971,
+  "scannedFiles": 2868,
   "namedFilesIncluded": [
     ".github/CODEOWNERS",
     ".gitattributes",
@@ -88,16 +88,16 @@
     "docs/research": {
       "disposition": "delete",
       "ownFiles": 0,
-      "externalReferrers": 28,
+      "externalReferrers": 29,
       "referrersByKind": {
         "code": 20,
         "config": 1,
         "snapshot": 1,
-        "markdownLive": 6,
+        "markdownLive": 7,
         "markdownArchival": 0,
         "other": 0
       },
-      "liveReferrers": 28,
+      "liveReferrers": 29,
       "sampleReferrers": [
         ".exarchos/invariants.md",
         "CHANGELOG.md",
@@ -221,16 +221,16 @@
     "docs/guides": {
       "disposition": "delete",
       "ownFiles": 0,
-      "externalReferrers": 25,
+      "externalReferrers": 27,
       "referrersByKind": {
-        "code": 16,
+        "code": 17,
         "config": 2,
         "snapshot": 0,
-        "markdownLive": 6,
+        "markdownLive": 7,
         "markdownArchival": 0,
         "other": 1
       },
-      "liveReferrers": 25,
+      "liveReferrers": 27,
       "sampleReferrers": [
         ".exarchos.yml",
         ".exarchos/invariants.md",
@@ -416,22 +416,31 @@
     },
     "docs/migrations": {
       "disposition": "delete",
-      "ownFiles": 0,
-      "externalReferrers": 1,
+      "ownFiles": 1,
+      "externalReferrers": 6,
       "referrersByKind": {
-        "code": 1,
+        "code": 5,
         "config": 0,
         "snapshot": 0,
-        "markdownLive": 0,
+        "markdownLive": 1,
         "markdownArchival": 0,
         "other": 0
       },
-      "liveReferrers": 1,
+      "liveReferrers": 6,
       "sampleReferrers": [
-        "tests/scripts/migration-followups.test.ts"
+        "src/events/event-name.ts",
+        "src/events/schemas.ts",
+        "tests/scripts/migration-followups.test.ts",
+        "tests/unit/events/event-name.test.ts",
+        "tools/audit/prose-manifest.ts",
+        "tools/audit/test-fixtures/measured-premises/internal-mechanics-overhaul.md"
       ],
       "sampleLiveCodeReferrers": [
-        "tests/scripts/migration-followups.test.ts"
+        "src/events/event-name.ts",
+        "src/events/schemas.ts",
+        "tests/scripts/migration-followups.test.ts",
+        "tests/unit/events/event-name.test.ts",
+        "tools/audit/prose-manifest.ts"
       ]
     },
     "docs/evals": {
@@ -507,16 +516,16 @@
     "docs/architecture": {
       "disposition": "re-home",
       "ownFiles": 0,
-      "externalReferrers": 37,
+      "externalReferrers": 38,
       "referrersByKind": {
-        "code": 27,
+        "code": 28,
         "config": 7,
         "snapshot": 0,
         "markdownLive": 3,
         "markdownArchival": 0,
         "other": 0
       },
-      "liveReferrers": 37,
+      "liveReferrers": 38,
       "sampleReferrers": [
         ".exarchos/invariants.md",
         ".github/workflows/ci.yml",

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,10 +4,10 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1192,
-    "parsedFiles": 1147,
+    "testFiles": 1193,
+    "parsedFiles": 1148,
     "shellFiles": 45,
-    "cases": 13291,
+    "cases": 13298,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -21036,6 +21036,52 @@
         {
           "suite": "EmissionVerifier lifecycle axis",
           "name": "reports a missing emission and a lifecycle violation together",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/unit/dispatch/core/inferred-values.test.ts": {
+      "file": "tests/unit/dispatch/core/inferred-values.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "Every inferrable field inherits one gate",
+          "name": "InferredValue_ActionDeclaringTheField_ReceivesIt",
+          "dynamic": false
+        },
+        {
+          "suite": "Every inferrable field inherits one gate",
+          "name": "InferredValue_ActionOmittingTheField_NeverReceivesIt",
+          "dynamic": false
+        },
+        {
+          "suite": "Every inferrable field inherits one gate",
+          "name": "InferredValue_ExplicitCallerValue_IsNeverOverwritten",
+          "dynamic": false
+        },
+        {
+          "suite": "Every inferrable field inherits one gate",
+          "name": "InferredValue_LatencySkipList_SuppressesResolution",
+          "dynamic": false
+        },
+        {
+          "suite": "Every inferrable field inherits one gate",
+          "name": "InferredValue_AmbiguousOutcome_RefusesWithTheCallersOptions",
+          "dynamic": false
+        },
+        {
+          "suite": "Every inferrable field inherits one gate",
+          "name": "InferredValue_UnavailableOutcome_FallsThroughToValidation",
+          "dynamic": false
+        },
+        {
+          "suite": "The shipped table is well-formed",
+          "name": "InferrableFields_EveryEntry_DeclaresADistinctField",
+          "dynamic": false
+        },
+        {
+          "suite": "The shipped table is well-formed",
+          "name": "InferrableFields_TheGate_IsAFunctionOfTheSchemaAlone",
           "dynamic": false
         }
       ]
@@ -46881,11 +46927,6 @@
         {
           "suite": "The ambient-cascade comparison holds on the real dispatch path",
           "name": "AmbientCascade_NormalizationOfTheResolverOutput_IsIdempotent",
-          "dynamic": false
-        },
-        {
-          "suite": "The ambient-cascade comparison holds on the real dispatch path",
-          "name": "AmbientCascade_WindowsShapedPath_SurvivesTheSameNormalization",
           "dynamic": false
         },
         {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -7,7 +7,7 @@
     "testFiles": 1193,
     "parsedFiles": 1148,
     "shellFiles": 45,
-    "cases": 13298,
+    "cases": 13299,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -46927,6 +46927,11 @@
         {
           "suite": "The ambient-cascade comparison holds on the real dispatch path",
           "name": "AmbientCascade_NormalizationOfTheResolverOutput_IsIdempotent",
+          "dynamic": false
+        },
+        {
+          "suite": "The ambient-cascade comparison holds on the real dispatch path",
+          "name": "AmbientCascade_WindowsShapedPath_SurvivesTheSameNormalization",
           "dynamic": false
         },
         {


### PR DESCRIPTION
# One table and one gate for every inferred value

**Stacked on #1842** — based on `worktree-preview4-bugfix-cluster`, so this diff is the refactor
alone. Merge #1842 first. If it squash-merges, this needs rebuilding as main + this delta.

## Summary

#1842 made dispatch consult the receiving action's schema before merging an inferred `featureId`
into the payload. That closed the **instance**. It left the **class** open: the gate was hand-wired
for one field, so a second inference could merge into the payload itself and never consult a
schema — which is exactly how the fault arose the first time.

Inferred values now live in one table, and every entry passes through one gated path. Adding an
inference is a table entry, so it inherits the gate instead of re-deriving it.

## Exploration corrected the plan

Two premises of the original outline turned out to be wrong, and both are worth stating because
they changed the design:

**Inferred values cannot be moved out of validation.** The outline proposed a side channel that
kept inferred values out of the validated payload. But **43 of the 59 actions that take a
`featureId` declare it REQUIRED** — inference exists precisely to satisfy that requirement. A side
channel would fail validation for exactly the callers inference serves. That constraint is what
makes the gate load-bearing rather than cosmetic: the value is merged into a strict schema's
input, so merging it into a schema that does not declare it manufactures a rejection.

**Elicitation was never part of the class.** The outline said all three inference paths move
together. Elicitation splices a field named by the action's *own* parse error, so it can only ever
supply something the action declares. It is structurally safe already and is untouched here.

## Changes

`src/dispatch/core/inferred-values.ts` (new) owns:

- `InferenceOutcome` — `resolved` | `ambiguous` | `unavailable`. Ambiguity is a first-class outcome
  because the caller can act on it; `unavailable` covers both "nothing matched" and "the resolver
  failed", which are the same to dispatch (fall through to ordinary validation).
- `INFERRABLE_FIELDS` — the table. One entry today: `featureId` via `resolveWorkspace`.
- `applyInferredValues()` — the shared path. Three skips, applied per entry rather than per field:
  an explicit caller value always wins; an action whose schema omits the field is left alone (**the
  gate**); the latency list short-circuits pure introspection.

`dispatch.ts` calls it once and keeps no per-field logic. `actionAcceptsInferredFeatureId`
generalizes to `actionAcceptsInferredValue(action, field)`.

## Behavior

Unchanged by design. Same gate, same latency skips, same multi-match envelope with its
`validTargets` and correlation `_meta`, same best-effort fallback when the resolver fails.

## Test Plan

**Oracle integrity.** The #1838 guards are the characterization oracle. `git diff HEAD~1 -- tests/`
shows every change in that file is a predicate rename or import move — **no assertion value,
matcher, or message string was altered, and nothing was deleted**. `LATENCY_SKIP` is now derived
from the shipped table instead of being a hardcoded copy, which strengthens the oracle.

**Class closure, proved with a synthetic field.** The new tests drive `applyInferredValues` with a
*second, invented* inferrable field, so what they pin is "any table entry inherits the gate" rather
than "featureId happens to be gated" — including that an action omitting the field never receives
it, an explicit caller value is never overwritten, the skip list short-circuits before the resolver
runs, and the ambiguity envelope survives.

**Kill probe.** Removing the gate from the shared path turns the end-to-end guard red naming 21
actions.

| | Failed | Total |
|---|---|---|
| Baseline `main` | 37 | 14103 |
| This branch | **35** | 14139 |

The one delta against main was the reference-census drift tolerance (`<50` tracked files, at 51
cumulative across both branches); regenerated like the other oracles. The remaining
worktree-inventory failure is environment-dependent and fails identically on `main`.

Typecheck green. Layer boundaries green — the new module sits in the same `dispatch` layer, so no
new layer edge. Knip reports no unused exports in it. The DR-14 cast ratchet is flat: non-null
assertions were avoided by having the resolver re-check its own precondition instead of trusting
that `isAvailable` ran — which also removes a dependency one refactor away from being false.

## Docs

No prose documents this behavior (`CLAUDE.md` does not mention roots or inference, and no
`content/` or `docs/` file covers it), so nothing to update. The constraint is documented where it
lives — the module header states why the value must reach validation, why the gate is load-bearing,
and why elicitation is exempt. A prose copy would be the duplication `CONTEXT-AUTHORING` warns about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RKfa5AQaR8Ay3XwjQMfJr
