### PR TITLE
feat(events): emission as a precondition of planning an effect (anchor 028, 3/4)

### DIFF
--- a/src/dispatch/core/effect-carrier.ts
+++ b/src/dispatch/core/effect-carrier.ts
@@ -115,6 +115,66 @@ export interface EffectEmission {
 }
 
 /**
+ * A plan that genuinely records no fact, and the reason it does not.
+ *
+ * This arm exists so that "records nothing" and "nobody decided" are different
+ * values rather than the same absence. An optional field could not tell them
+ * apart: a missing `emits` meant both, which is what let a plan promise no
+ * record by saying nothing at all.
+ *
+ * `because` is required for the same reason the arm is: an abstention with no
+ * stated reason is indistinguishable from an oversight, and the whole point of
+ * naming the abstention is that somebody had to decide it.
+ */
+export interface RecordsNothing {
+  readonly kind: 'records-nothing';
+  readonly because: string;
+}
+
+/**
+ * A plan that records, carrying the emissions it promises.
+ *
+ * The tuple type is non-empty by construction, so `records()` with nothing in
+ * it does not compile. An empty emission list is an abstention wearing the
+ * declaring arm's clothes, and it would reintroduce exactly the ambiguity
+ * {@link RecordsNothing} exists to remove.
+ */
+export interface RecordsEmissions {
+  readonly kind: 'records';
+  readonly emissions: readonly [EffectEmission, ...EffectEmission[]];
+}
+
+/**
+ * What a plan promises to record. Required on every {@link EffectPlan}: an
+ * effect that cannot say what records it is a state mutation that is not an
+ * event, which is the hole INV-1 names.
+ */
+export type PlanEmissions = RecordsEmissions | RecordsNothing;
+
+/** Declare the emissions a plan records. At least one, by type. */
+export function records(
+  first: EffectEmission,
+  ...rest: readonly EffectEmission[]
+): RecordsEmissions {
+  return { kind: 'records', emissions: [first, ...rest] };
+}
+
+/** Declare that a plan records nothing, and why. */
+export function recordsNothing(because: string): RecordsNothing {
+  return { kind: 'records-nothing', because };
+}
+
+/**
+ * The emissions a plan declares, flattened across both arms.
+ *
+ * The one accessor every consumer reads, so the arm distinction stays inside
+ * this module rather than spreading a `kind` check through every caller.
+ */
+export function declaredEmissions(plan: EffectPlan): readonly EffectEmission[] {
+  return plan.emits.kind === 'records' ? plan.emits.emissions : [];
+}
+
+/**
  * The typed plan for a single effect. It encodes the three things the plan
  * mandates for every effect:
  *   - `owner`        — the single typed owner accountable for the effect;
@@ -141,12 +201,17 @@ export interface EffectPlan {
    * to tell "the intent landed" from "a terminal landed" — the exact
    * distinction that says whether an interrupted run needs convergence.
    *
-   * Optional, so a plan that records nothing stays a legal plan and every
-   * construction site that predates the emission axis still compiles. An
-   * undeclared `emits` means "this plan promises no record", never "the record
-   * is inferred from `effectClass` or `owner`"; see the vocabulary note above.
+   * REQUIRED. A plan cannot be built without saying what records it, because a
+   * plan that records nothing by saying nothing is the INV-1 hole: an effect
+   * that lands without its event is a state mutation that is not an event.
+   *
+   * An effect that genuinely records nothing is still expressible — it declares
+   * {@link recordsNothing} and carries its reason. What is no longer
+   * expressible is the silence that used to mean both that and "nobody
+   * decided". Nothing here is inferred from `effectClass` or `owner`; see the
+   * vocabulary note above.
    */
-  readonly emits?: readonly EffectEmission[];
+  readonly emits: PlanEmissions;
 }
 
 /**
@@ -160,7 +225,7 @@ export function emissionsWhen(
   plan: EffectPlan,
   when: EmissionCondition,
 ): readonly EffectEmission[] {
-  return (plan.emits ?? []).filter((emission) => emission.when === when);
+  return declaredEmissions(plan).filter((emission) => emission.when === when);
 }
 
 /**
@@ -387,10 +452,12 @@ export class UnrecordedEmissionError extends Error {
  * Record every emission a plan declares for one condition, in order, and return
  * the receipts.
  *
- * A plan declaring nothing for the condition records nothing and needs no
- * capability — that is what keeps a plan with no `emits` inert. Once a plan does
- * declare, though, the run may only continue on evidence: one minted receipt per
- * declared emission. Anything less throws.
+ * A plan declaring nothing for THIS condition records nothing for it — which is
+ * ordinary: an intent-only plan reaches its terminals with nothing to append.
+ * That is a statement about one condition, not about the plan: every plan now
+ * declares, and a plan that records nothing at all says so in its own arm.
+ * Once a condition does declare, the run may only continue on evidence: one
+ * minted receipt per declared emission. Anything less throws.
  */
 async function recordEmissions(
   plan: EffectPlan,
@@ -431,19 +498,21 @@ async function recordEmissions(
  * `runEffect` never rejects for an effect failure. Only the thunk sits inside
  * the `try`, so a terminal record cannot be mistaken for the effect failing.
  *
- * A plan declaring no emissions records nothing, needs no capability, and leaves
- * the three-arm carrier exactly as it is. A plan that DOES declare gets the
- * commit gate: the effect is refused up front unless a real
- * {@link EmissionRecorder} was supplied — so the thunk does not run either — and
- * the `return` below is reached only after the terminal record produced one
- * minted receipt per declared emission. There is no path from a no-op to a
- * committed value; the record is not merely expected, it is on the way.
+ * Every plan declares, so every live run gets the commit gate: the effect is
+ * refused up front unless a real {@link EmissionRecorder} was supplied — so the
+ * thunk does not run either — and the `return` below is reached only after the
+ * terminal record produced one minted receipt per declared emission. A plan
+ * that declares {@link recordsNothing} still needs the capability, because
+ * "this effect records nothing" is a claim its owner must be equipped to stand
+ * behind rather than a way to opt out of being asked. There is no path from a
+ * no-op to a committed value; the record is not merely expected, it is on the
+ * way.
  */
 export async function runEffect<T>(
   mode: EffectMode,
   plan: EffectPlan,
   execute: () => Promise<T>,
-  recorder?: EmissionRecorder,
+  recorder: EmissionRecorder,
 ): Promise<EffectOutcome<T>> {
   if (mode.kind === 'dry-run') {
     return plannedDryRun(plan);
@@ -451,9 +520,15 @@ export async function runEffect<T>(
   // Refused BEFORE the thunk, not at the terminal: an owner that cannot record
   // must not perform the effect at all, and a plan whose only emission is a
   // terminal would otherwise mutate the world before discovering that.
-  const declaredCount = plan.emits?.length ?? 0;
-  if (declaredCount > 0 && !isEmissionRecorder(recorder)) {
-    throw new UnrecordedEmissionError(plan, 'before', 0, declaredCount);
+  //
+  // Refused UNCONDITIONALLY, not only when the plan declares something. Gating
+  // the demand on a non-empty declaration was the same abstention hole one
+  // level down: it let a plan that records nothing skip the capability, so the
+  // one kind of plan nobody had to equip was the one making the strongest
+  // claim. The parameter is required at the type level too; this check is what
+  // holds at a boundary the type system does not govern.
+  if (!isEmissionRecorder(recorder)) {
+    throw new UnrecordedEmissionError(plan, 'before', 0, declaredEmissions(plan).length);
   }
   await recordEmissions(plan, 'before', recorder);
 
@@ -588,12 +663,14 @@ export type _EffectCarrier_PlainRecord_IsNotAnEmissionReceipt = Expect<
 
 /**
  * **The unreachability proof.** `runEffect`'s recorder parameter is EXACTLY the
- * minted capability (or nothing at all — the inert case, for a plan that
- * declares no emissions and therefore has no record to be missing). Read with
- * the three negative proofs above, this is the chain: the only value that can
- * occupy that parameter is one {@link emissionRecorder} produced, and the
- * runtime gate then refuses a committed value until that capability has minted a
- * receipt per declared emission.
+ * minted capability — no longer "or nothing at all". The inert case is gone
+ * because there are no inert plans: every plan declares, and one that records
+ * nothing says so in its own arm rather than by omission, so there is no plan
+ * for which the capability could be excused. Read with the three negative
+ * proofs above, this is the chain: the only value that can occupy that
+ * parameter is one {@link emissionRecorder} produced, and the runtime gate then
+ * refuses a committed value until that capability has minted a receipt per
+ * declared emission.
  *
  * Falsifier: widen the parameter back to a function type — {@link EmissionSink}
  * or anything else a lambda satisfies — and the two sides stop matching. That is
@@ -607,10 +684,15 @@ export type _EffectCarrier_PlainRecord_IsNotAnEmissionReceipt = Expect<
  * level can tell that sink from a durable one. The runtime half covers it: the
  * behavior test asserts that an OMITTED recorder refuses to commit, which a
  * defaulted no-op would turn red.
+ *
+ * Second falsifier, added when the parameter stopped being optional: widen it
+ * back to `EmissionRecorder | undefined` and this alias goes false. That is the
+ * regression which would let a caller omit the capability entirely, and it is
+ * the compile-time half of the unconditional demand the runtime gate makes.
  * @proof
  */
 export type _EffectCarrier_CommittedValue_IsUnreachableWithoutTheCapability = Expect<
-  MutuallyAssignable<Parameters<typeof runEffect>[3], EmissionRecorder | undefined>
+  MutuallyAssignable<Parameters<typeof runEffect>[3], EmissionRecorder>
 >;
 
 /**

--- a/src/dispatch/core/effect-carrier.ts
+++ b/src/dispatch/core/effect-carrier.ts
@@ -800,3 +800,108 @@ export type _EffectCarrier_Record_YieldsAMintedReceipt = Expect<
 export type _EffectCarrier_Constructor_MintsTheCapability = Expect<
   ReturnType<typeof emissionRecorder> extends EmissionRecorder ? true : false
 >;
+
+// ─── DR-1 / DR-2 compile claims ──────────────────────────────────────────────
+//
+// These live HERE, in a `src/` module, for the reason the block above already
+// states: the root `tsconfig.json` includes only `src/**` and excludes
+// `**/*.test.ts`, and `tests/tsconfig.json` excludes the unit and integration
+// tiers outright. A claim of this kind written in the co-located test would be
+// read by no compiler and executed by no runner — it would pass by never being
+// checked, which is the failure mode these claims exist to prevent.
+
+/**
+ * **A plan cannot omit what records it.** The pre-DR-1 shape — everything a
+ * plan needs except the emission declaration — is no longer an
+ * {@link EffectPlan}.
+ *
+ * This is the compile-time half of INV-1: an effect that lands without naming
+ * its record is a state mutation that is not an event, and the omission is a
+ * build failure rather than a runtime discovery.
+ *
+ * Falsifier: make `emits` optional again and this alias stops being `true`.
+ * @proof
+ */
+export type _EffectCarrier_PlanWithoutEmissions_IsNotAnEffectPlan = Expect<
+  IsNotAssignable<
+    {
+      readonly effectClass: EffectClass;
+      readonly owner: string;
+      readonly description: string;
+      readonly idempotent: boolean;
+    },
+    EffectPlan
+  >
+>;
+
+/**
+ * …and the abstention really is expressible, so the proof above rejects the
+ * OMISSION rather than rejecting every plan. Without this line, narrowing
+ * `emits` to something nothing can satisfy would leave the alias above passing
+ * while making the type useless — a guard that rejects everything measures as
+ * little as one that rejects nothing.
+ * @proof
+ */
+export type _EffectCarrier_RecordsNothing_IsALegalDeclaration = Expect<
+  ReturnType<typeof recordsNothing> extends PlanEmissions ? true : false
+>;
+
+/**
+ * **An empty declaration is not a declaration.** A `records` arm carrying no
+ * emissions cannot be built, so an abstention cannot be smuggled in wearing the
+ * declaring arm's clothes — which would restore the ambiguity between "records
+ * nothing" and "nobody decided" one level down.
+ *
+ * Falsifier: widen `emissions` to `readonly EffectEmission[]` and this goes
+ * false.
+ * @proof
+ */
+export type _EffectCarrier_EmptyEmissionList_IsNotADeclaringArm = Expect<
+  IsNotAssignable<{ readonly kind: 'records'; readonly emissions: readonly [] }, RecordsEmissions>
+>;
+
+/**
+ * **A committed value cannot be built without evidence.** The success arm minus
+ * its evidence is not an outcome, so `T` is unreachable from a value that does
+ * not already say the append happened.
+ *
+ * This is the criterion's `Committed<T>` in the shape this carrier actually
+ * has: the guarantee is carried by the arm rather than by the good behaviour of
+ * whoever constructs it.
+ *
+ * Falsifier: make `evidence` optional on the success arm and this stops being
+ * `true`.
+ * @proof
+ */
+export type _EffectCarrier_SuccessWithoutEvidence_IsNotAnOutcome = Expect<
+  IsNotAssignable<{ readonly kind: 'success'; readonly value: number }, EffectOutcome<number>>
+>;
+
+/**
+ * **The witness is unforgeable on the receipt's terms.** A plain object naming
+ * the replayed event is not {@link EmissionEvidence}, so the replay arm cannot
+ * become the way around the commit gate.
+ *
+ * This is the proof the second evidence arm needed and did not have when it was
+ * first sketched: an unbranded witness would have let an owner buy a committed
+ * value with an object literal, which is exactly the hole the branded port
+ * closed on the recorder side.
+ *
+ * Falsifier: drop the brand from the evidence arms and this goes false.
+ * @proof
+ */
+export type _EffectCarrier_PlainWitness_IsNotEmissionEvidence = Expect<
+  IsNotAssignable<
+    { readonly kind: 'replayed'; readonly event: EventType; readonly source: string },
+    EmissionEvidence
+  >
+>;
+
+/**
+ * …and the witness constructor really does mint the brand, so the negative
+ * above rejects the forgery rather than rejecting everything.
+ * @proof
+ */
+export type _EffectCarrier_ReplayConstructor_MintsEvidence = Expect<
+  ReturnType<typeof replayedEvidence> extends EmissionEvidence ? true : false
+>;

--- a/src/dispatch/core/effect-carrier.ts
+++ b/src/dispatch/core/effect-carrier.ts
@@ -147,7 +147,7 @@ export interface RecordsEmissions {
 /**
  * What a plan promises to record. Required on every {@link EffectPlan}: an
  * effect that cannot say what records it is a state mutation that is not an
- * event, which is the hole INV-1 names.
+ * event — a change to the world that the event log does not know happened.
  */
 export type PlanEmissions = RecordsEmissions | RecordsNothing;
 
@@ -202,8 +202,9 @@ export interface EffectPlan {
    * distinction that says whether an interrupted run needs convergence.
    *
    * REQUIRED. A plan cannot be built without saying what records it, because a
-   * plan that records nothing by saying nothing is the INV-1 hole: an effect
-   * that lands without its event is a state mutation that is not an event.
+   * plan that records nothing by saying nothing is the hole this closes: an
+   * effect that lands without its event is a state mutation that is not an
+   * event, and nothing downstream can replay or reconcile it.
    *
    * An effect that genuinely records nothing is still expressible — it declares
    * {@link recordsNothing} and carries its reason. What is no longer
@@ -241,8 +242,8 @@ export type EffectOutcome<T> =
 /**
  * Construct a `success` carrier.
  *
- * Evidence is REQUIRED, which is the whole of DR-2: a success carrier cannot be
- * built without something that says the record exists, so obtaining `T` from
+ * Evidence is REQUIRED, and that is the whole point: a success carrier cannot
+ * be built without something that says the record exists, so obtaining `T` from
  * one means the append already happened.
  */
 export function succeeded<T>(value: T, evidence: EmissionEvidence): EffectOutcome<T> {
@@ -811,7 +812,7 @@ export type _EffectCarrier_Constructor_MintsTheCapability = Expect<
   ReturnType<typeof emissionRecorder> extends EmissionRecorder ? true : false
 >;
 
-// ─── DR-1 / DR-2 compile claims ──────────────────────────────────────────────
+// ─── Emission-declaration compile claims ─────────────────────────────────────
 //
 // These live HERE, in a `src/` module, for the reason the block above already
 // states: the root `tsconfig.json` includes only `src/**` and excludes
@@ -821,13 +822,12 @@ export type _EffectCarrier_Constructor_MintsTheCapability = Expect<
 // checked, which is the failure mode these claims exist to prevent.
 
 /**
- * **A plan cannot omit what records it.** The pre-DR-1 shape — everything a
- * plan needs except the emission declaration — is no longer an
- * {@link EffectPlan}.
+ * **A plan cannot omit what records it.** The older shape — everything a plan
+ * needs except the emission declaration — is no longer an {@link EffectPlan}.
  *
- * This is the compile-time half of INV-1: an effect that lands without naming
- * its record is a state mutation that is not an event, and the omission is a
- * build failure rather than a runtime discovery.
+ * This is the compile-time half of the guarantee: an effect that lands without
+ * naming its record is a state mutation that is not an event, and the omission
+ * is a build failure rather than a runtime discovery.
  *
  * Falsifier: make `emits` optional again and this alias stops being `true`.
  * @proof

--- a/src/dispatch/core/effect-carrier.ts
+++ b/src/dispatch/core/effect-carrier.ts
@@ -411,12 +411,22 @@ export interface ReplayedEvidence {
  * arm, so reaching `T` means the append happened — on this run or an earlier
  * one.
  *
- * **The trust model, stated rather than implied.** A branded witness is exactly
- * as strong as {@link emissionRecorder} and no stronger. This module cannot
- * verify that a witness corresponds to a real append, just as it cannot verify
- * that a sink really wrote — it trusts the fold-reader on the same terms it
- * already trusts the sink, and the brand is what makes that trust a decision
- * somebody made rather than a shape anybody can produce.
+ * **The trust model, stated rather than implied — and the two arms are NOT
+ * equally strong.** The brand stops an object literal from becoming evidence,
+ * so neither arm can be forged by shape. But {@link emissionRecorder} is
+ * strictly stronger than {@link replayedEvidence}: it forces the caller to
+ * supply a sink that {@link runEffect} invokes and awaits before a receipt is
+ * minted, whereas the witness constructor takes two strings, performs no IO and
+ * consults nothing. Any module that can import it can mint one.
+ *
+ * That asymmetry is deliberate and is the price of the replay path — a run that
+ * performed no effect has no append of its own to evidence, so something has to
+ * vouch for an earlier one. It is written down here because the alternative is
+ * a reader assuming the arms are interchangeable and reaching for the witness
+ * as a way to skip wiring a recorder. **They are not interchangeable: the
+ * witness is for replaying a terminal this owner has read from its own ledger,
+ * and nothing else.** The runtime gate does not cover this arm, so the
+ * constraint lives in review rather than in the type.
  */
 export type EmissionEvidence = RecordedEvidence | ReplayedEvidence;
 

--- a/src/dispatch/core/effect-carrier.ts
+++ b/src/dispatch/core/effect-carrier.ts
@@ -234,13 +234,19 @@ export function emissionsWhen(
  * silently ignored.
  */
 export type EffectOutcome<T> =
-  | { readonly kind: 'success'; readonly value: T }
+  | { readonly kind: 'success'; readonly value: T; readonly evidence: EmissionEvidence }
   | { readonly kind: 'error'; readonly error: EffectError }
   | { readonly kind: 'dry-run'; readonly plan: EffectPlan };
 
-/** Construct a `success` carrier. */
-export function succeeded<T>(value: T): EffectOutcome<T> {
-  return { kind: 'success', value };
+/**
+ * Construct a `success` carrier.
+ *
+ * Evidence is REQUIRED, which is the whole of DR-2: a success carrier cannot be
+ * built without something that says the record exists, so obtaining `T` from
+ * one means the append already happened.
+ */
+export function succeeded<T>(value: T, evidence: EmissionEvidence): EffectOutcome<T> {
+  return { kind: 'success', value, evidence };
 }
 
 /** Construct an `error` carrier from a structured {@link EffectError}. */
@@ -256,7 +262,7 @@ export function plannedDryRun<T>(plan: EffectPlan): EffectOutcome<T> {
 /** Narrow to the `success` arm. */
 export function isSuccess<T>(
   outcome: EffectOutcome<T>,
-): outcome is { readonly kind: 'success'; readonly value: T } {
+): outcome is { readonly kind: 'success'; readonly value: T; readonly evidence: EmissionEvidence } {
   return outcome.kind === 'success';
 }
 
@@ -346,6 +352,17 @@ const EMISSION_RECORDER_BRAND: unique symbol = Symbol('exarchos.effect.emissionR
 const EMISSION_RECEIPT_BRAND: unique symbol = Symbol('exarchos.effect.emissionReceipt');
 
 /**
+ * Module-private brand for the evidence a committed value carries.
+ *
+ * Separate from the receipt brand because evidence has TWO arms and only one of
+ * them is a receipt. Branding the union is what stops the second arm becoming
+ * the way around the first: an owner that could hand-build a witness could buy
+ * a committed value with an object literal, which is precisely the hole the
+ * branded port closed on the recorder side.
+ */
+const EMISSION_EVIDENCE_BRAND: unique symbol = Symbol('exarchos.effect.emissionEvidence');
+
+/**
  * Evidence that one declared emission was recorded.
  *
  * Minted by the capability AFTER its sink returns, so a sink that throws yields
@@ -357,6 +374,66 @@ export interface EmissionReceipt {
   readonly [EMISSION_RECEIPT_BRAND]: true;
   readonly event: EventType;
   readonly when: EmissionCondition;
+}
+
+/**
+ * This run recorded the plan's declarations, and here are the receipts.
+ *
+ * The ordinary arm: one minted receipt per declared emission, collected across
+ * the intent and the terminal that actually fired.
+ */
+export interface RecordedEvidence {
+  readonly [EMISSION_EVIDENCE_BRAND]: true;
+  readonly kind: 'recorded';
+  readonly receipts: readonly EmissionReceipt[];
+}
+
+/**
+ * A PREVIOUS run recorded the terminal, and this run is replaying it.
+ *
+ * The arm an idempotency replay needs. A replayed effect performs nothing and
+ * therefore mints nothing, but the append it would have made has already
+ * happened — the owner read it out of its own ledger fold, which is why it
+ * knows to replay at all. Forcing it to fabricate a receipt would be a lie
+ * about which run wrote the fact.
+ */
+export interface ReplayedEvidence {
+  readonly [EMISSION_EVIDENCE_BRAND]: true;
+  readonly kind: 'replayed';
+  /** The terminal a previous run recorded, as read from the ledger. */
+  readonly event: EventType;
+  /** How the caller knows it landed. Named so a reader can audit the claim. */
+  readonly source: string;
+}
+
+/**
+ * Evidence that a committed value's record exists. Carried by the `success`
+ * arm, so reaching `T` means the append happened — on this run or an earlier
+ * one.
+ *
+ * **The trust model, stated rather than implied.** A branded witness is exactly
+ * as strong as {@link emissionRecorder} and no stronger. This module cannot
+ * verify that a witness corresponds to a real append, just as it cannot verify
+ * that a sink really wrote — it trusts the fold-reader on the same terms it
+ * already trusts the sink, and the brand is what makes that trust a decision
+ * somebody made rather than a shape anybody can produce.
+ */
+export type EmissionEvidence = RecordedEvidence | ReplayedEvidence;
+
+/**
+ * The ONLY construction path for replay evidence.
+ *
+ * Exported because the owner that replays is not this module; branded because
+ * an unbranded witness would let any object literal buy a committed value, and
+ * the second arm must not become the way around the first.
+ */
+export function replayedEvidence(event: EventType, source: string): ReplayedEvidence {
+  return { [EMISSION_EVIDENCE_BRAND]: true, kind: 'replayed', event, source };
+}
+
+/** Mint evidence from receipts this run collected. Module-private on purpose. */
+function recordedEvidence(receipts: readonly EmissionReceipt[]): RecordedEvidence {
+  return { [EMISSION_EVIDENCE_BRAND]: true, kind: 'recorded', receipts };
 }
 
 /**
@@ -530,20 +607,27 @@ export async function runEffect<T>(
   if (!isEmissionRecorder(recorder)) {
     throw new UnrecordedEmissionError(plan, 'before', 0, declaredEmissions(plan).length);
   }
-  await recordEmissions(plan, 'before', recorder);
+  const intentReceipts = await recordEmissions(plan, 'before', recorder);
 
-  let outcome: EffectOutcome<T>;
+  // The value is held rather than wrapped immediately: the success carrier now
+  // requires evidence, and the terminal receipt does not exist until after the
+  // terminal record has been made. Building the carrier here would mean either
+  // constructing it without its evidence or back-filling it afterwards, and
+  // both are the convention this arm exists to replace.
+  let ran: { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: EffectError };
   let terminal: EmissionCondition;
   try {
-    outcome = succeeded(await execute());
+    ran = { ok: true, value: await execute() };
     terminal = 'on-success';
   } catch (cause) {
-    outcome = failed(toEffectError(plan, cause));
+    ran = { ok: false, error: toEffectError(plan, cause) };
     terminal = 'on-failure';
   }
 
-  await recordEmissions(plan, terminal, recorder);
-  return outcome;
+  const terminalReceipts = await recordEmissions(plan, terminal, recorder);
+  return ran.ok
+    ? succeeded(ran.value, recordedEvidence([...intentReceipts, ...terminalReceipts]))
+    : failed(ran.error);
 }
 
 // ─── Idempotency key: the stream dimension is part of construction ──────────

--- a/src/install/atomic-promotion.ts
+++ b/src/install/atomic-promotion.ts
@@ -115,6 +115,7 @@ import {
   LIVE,
   emissionRecorder,
   runEffect,
+  records,
   type EffectMode,
   type EffectOutcome,
   type EffectPlan,
@@ -770,7 +771,7 @@ export const PROMOTION_EXECUTED = 'promotion.executed';
  * complete tree, leaving the destination in the state it started in — there is
  * no partial outcome for a terminal to describe.
  */
-const PROMOTION_EMISSIONS = [{ event: PROMOTION_EXECUTED, when: 'on-success' }] as const;
+const PROMOTION_EMISSIONS = records({ event: PROMOTION_EXECUTED, when: 'on-success' });
 
 /**
  * The durable fact a completed promotion records — WHERE the tree landed, WHAT
@@ -820,8 +821,9 @@ export function promotionPlan(owner: string, target: string): EffectPlan {
  * {@link PromotionError} is captured into an `error` carrier rather than
  * propagating.
  *
- * The `recorder` is not optional in effect, only in signature. The plan declares
- * an emission, so a live call without one is REFUSED before the engine runs —
+ * The `recorder` is required in signature as well as in effect — the two used to
+ * disagree, and this header was the place that said so. The plan declares an
+ * emission, so a live call without one is REFUSED before the engine runs —
  * the promoter will not perform the one non-idempotent step of an install and
  * then discover that nothing said so. On success the carrier reaches its return
  * only after the recorder has been awaited, so a caller holding the success
@@ -831,8 +833,29 @@ export async function promoteTree(
   request: TreePromotionRequest,
   mode: EffectMode = LIVE,
   io: PromotionIo = defaultPromotionIo(),
-  recorder?: PromotionRecorder,
+  recorder: PromotionRecorder,
 ): Promise<EffectOutcome<PromotionReport>> {
+  // Checked HERE, before any IO, and not left to the carrier.
+  //
+  // The carrier refuses a live run without a capability, but this owner wraps
+  // the caller's recorder in one, so from the carrier's side a wrapper around
+  // `undefined` looks like a genuine capability and the refusal moves to the
+  // success terminal — after the tree has already been promoted. This plan
+  // declares only a terminal, which is the exact shape the carrier's own note
+  // warns about: an effect whose sole emission fires at the end would mutate
+  // the world before discovering it could not record. A type-level required
+  // argument covers every typed caller; this covers the transpiled one.
+  // LIVE only. A dry-run promotes nothing and records nothing, so it has no
+  // record to be missing — demanding the capability there would break the very
+  // guarantee the dry-run arm exists to provide, which is that a withheld
+  // effect leaves the ledger as silent as it leaves the disk.
+  if (mode.kind === 'live' && typeof recorder !== 'function') {
+    throw new TypeError(
+      'promoteTree requires a recorder in live mode: the plan declares a promotion ' +
+        'record, and a promotion that cannot be recorded must not run at all.',
+    );
+  }
+
   const owner = request.owner ?? 'install/atomic-promotion';
   const plan = promotionPlan(owner, request.target);
 
@@ -844,27 +867,30 @@ export async function promoteTree(
     return Promise.resolve(report);
   };
 
-  const ledger =
-    recorder === undefined
-      ? undefined
-      : emissionRecorder(async () => {
-          // Unreachable: the success terminal fires only after the engine
-          // returned, and the engine sets `report` before it does. Throwing
-          // rather than returning quietly matters anyway — a sink that returns
-          // still mints a receipt, so a silent skip here would buy the commit
-          // gate's approval for a record that was never written.
-          if (report === undefined) {
-            throw new Error(
-              `promotion of ${request.target} reached its success terminal with no report to record`,
-            );
-          }
-          await recorder({
-            target: report.target,
-            treeDigest: report.treeDigest,
-            owner,
-            recoveredPriorAttempt: report.recoveredPriorAttempt,
-          });
-        });
+  // Built unconditionally now that the carrier demands the capability of every
+  // live run. The branch this replaces produced `undefined` whenever the
+  // caller omitted a recorder, which was the signature disagreeing with the
+  // header directly above it: the recorder was never optional in effect,
+  // because the plan declares an emission and a live call without one was
+  // already refused. The argument is required, so the disagreement is gone.
+  const ledger = emissionRecorder(async () => {
+    // Unreachable: the success terminal fires only after the engine
+    // returned, and the engine sets `report` before it does. Throwing
+    // rather than returning quietly matters anyway — a sink that returns
+    // still mints a receipt, so a silent skip here would buy the commit
+    // gate's approval for a record that was never written.
+    if (report === undefined) {
+      throw new Error(
+        `promotion of ${request.target} reached its success terminal with no report to record`,
+      );
+    }
+    await recorder({
+      target: report.target,
+      treeDigest: report.treeDigest,
+      owner,
+      recoveredPriorAttempt: report.recoveredPriorAttempt,
+    });
+  });
 
   return runEffect(mode, plan, promoted, ledger);
 }

--- a/src/vcs/mutation-owner.ts
+++ b/src/vcs/mutation-owner.ts
@@ -54,6 +54,7 @@ import {
   failed,
   toEffectError,
   records,
+  replayedEvidence,
   type EffectMode,
   type EffectOutcome,
   type EffectPlan,
@@ -538,7 +539,15 @@ export class VcsMutationOwner {
     if (recorded !== undefined) {
       if (recorded.kind === 'executed') {
         if (request.verifyReplay === undefined || request.verifyReplay()) {
-          return succeeded<T>((recorded.result ?? {}) as T);
+          // The committed value carries evidence, and on this path the evidence
+          // is a WITNESS rather than a receipt: no effect ran, so nothing was
+          // minted, but `vcs.executed` is already in the fold — reading it is
+          // how this branch knows to replay at all. A receipt here would claim
+          // this run wrote the fact, which is exactly the wrong claim.
+          return succeeded<T>(
+            (recorded.result ?? {}) as T,
+            replayedEvidence(VCS_EXECUTED, `ledger fold terminal for ${request.idempotencyKey}`),
+          );
         }
       } else {
         return failed<T>({

--- a/src/vcs/mutation-owner.ts
+++ b/src/vcs/mutation-owner.ts
@@ -53,11 +53,13 @@ import {
   succeeded,
   failed,
   toEffectError,
+  records,
   type EffectMode,
   type EffectOutcome,
   type EffectPlan,
   type EmissionCondition,
   type EffectEmission,
+  type RecordsEmissions,
 } from '../dispatch/core/effect-carrier.js';
 import type { EventStore } from '../events/store.js';
 import type { EventType, WorkflowEvent } from '../events/schemas.js';
@@ -105,11 +107,11 @@ export const VCS_COMPENSATED = 'vcs.compensated';
  * and the two terminals are mutually exclusive because one execution either
  * returns or throws.
  */
-export const VCS_LEDGER_EMISSIONS: readonly EffectEmission[] = [
+export const VCS_LEDGER_EMISSIONS: RecordsEmissions = records(
   { event: VCS_REQUESTED, when: 'before' },
   { event: VCS_EXECUTED, when: 'on-success' },
   { event: VCS_COMPENSATED, when: 'on-failure' },
-];
+);
 
 // ─── Typed fencing error (mirrors P04-02 cancel-saga StaleEpochError) ─────────
 

--- a/tests/acceptance/effect-carrier-compile-gate.test.ts
+++ b/tests/acceptance/effect-carrier-compile-gate.test.ts
@@ -29,113 +29,31 @@
  * event name is registered. A copy is also what lets the kill probe relax the
  * guard without ever touching the live tree.
  */
-import { execFileSync } from 'node:child_process';
-import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-const here = path.dirname(fileURLToPath(import.meta.url));
-const packageRoot = path.join(here, '../..');
-const CARRIER = path.join(packageRoot, 'src/dispatch/core/effect-carrier.ts');
-
-/** Where the carrier's emission-declaration compile claims begin. */
-const PROOF_BLOCK_MARKER = '// ─── Emission-declaration compile claims';
+import {
+  CARRIER_PATH,
+  compile,
+  materializeCarrier,
+  type Relaxation,
+} from '../helpers/carrier-compile-harness.js';
 
 /**
- * Resolved rather than path-joined.
- *
- * `node_modules` is not necessarily under `packageRoot`: a git worktree resolves
- * its dependencies from the parent checkout by walking up, so a hardcoded
- * `packageRoot/node_modules/...` is absent exactly when the suite runs in one.
- * `require.resolve` follows the same walk Node does.
+ * The single relaxation this suite needs: the emission declaration becomes
+ * optional again, and the one accessor that reads it is widened to match.
  */
-const TSC_BIN = createRequire(import.meta.url).resolve('typescript/bin/tsc');
-
-const TSC_FLAGS = [
-  '--noEmit',
-  '--strict',
-  '--exactOptionalPropertyTypes',
-  '--module',
-  'NodeNext',
-  '--moduleResolution',
-  'NodeNext',
-  '--target',
-  'ES2022',
-];
-
-interface TscRun {
-  readonly accepted: boolean;
-  readonly output: string;
-}
-
-function runTsc(files: readonly string[], cwd: string): TscRun {
-  try {
-    const output = execFileSync(
-      process.execPath,
-      [TSC_BIN, ...TSC_FLAGS, ...files],
-      { cwd, encoding: 'utf8', stdio: 'pipe' },
-    );
-    return { accepted: true, output };
-  } catch (err: unknown) {
-    const streams: string[] = [];
-    if (typeof err === 'object' && err !== null) {
-      for (const key of ['stdout', 'stderr']) {
-        const value: unknown = Reflect.get(err, key);
-        if (typeof value === 'string') streams.push(value);
-        else if (value instanceof Uint8Array) streams.push(Buffer.from(value).toString('utf8'));
-      }
-    }
-    return { accepted: false, output: streams.join('') };
-  }
-}
-
-/** The carrier, standalone: its one import rewritten to a local stub. */
-function materializeCarrier(dir: string, relax: boolean): void {
-  fs.writeFileSync(
-    path.join(dir, 'schemas.ts'),
-    'export type EventType = string;\n',
-    'utf8',
-  );
-  let source = fs.readFileSync(CARRIER, 'utf8');
-  source = source.replace("from '../../events/schemas.js'", "from './schemas.js'");
-
-  if (relax) {
-    const required = '  readonly emits: PlanEmissions;';
-    if (!source.includes(required)) {
-      throw new Error(
-        'the relaxation target moved: the carrier no longer declares `readonly emits: PlanEmissions;`. ' +
-          'A probe that cannot find what it relaxes proves nothing, so this fails loudly.',
-      );
-    }
-    source = source.replace(required, '  readonly emits?: PlanEmissions;');
-    // The proof aliases assert the very property being relaxed, so they would
-    // fail the RELAXED build for the right reason and mask the fixture's own
-    // result. Drop them; the fixture is the subject here.
-    //
-    // The marker is asserted rather than assumed: `indexOf` returning -1 would
-    // make `slice` chop one character and leave both proof blocks standing, so
-    // a reworded comment would send the next reader to the fixture instead of
-    // to the string that actually moved.
-    const proofsAt = source.indexOf(PROOF_BLOCK_MARKER);
-    if (proofsAt === -1) {
-      throw new Error(
-        `the proof block marker ${JSON.stringify(PROOF_BLOCK_MARKER)} is gone from the carrier. ` +
-          'Relaxing a copy that still asserts what the relaxation removes proves nothing.',
-      );
-    }
-    source = source.slice(0, proofsAt);
-    // `declaredEmissions` reads the now-optional field.
-    source = source.replace(
-      "return plan.emits.kind === 'records' ? plan.emits.emissions : [];",
+const RELAX_REQUIRED_EMITS: readonly Relaxation[] = [
+  { find: '  readonly emits: PlanEmissions;', replace: '  readonly emits?: PlanEmissions;' },
+  {
+    find: "return plan.emits.kind === 'records' ? plan.emits.emissions : [];",
+    replace:
       "return plan.emits !== undefined && plan.emits.kind === 'records' ? plan.emits.emissions : [];",
-    );
-  }
-  fs.writeFileSync(path.join(dir, 'effect-carrier.ts'), source, 'utf8');
-}
+  },
+];
 
 /** A handler that performs an effect and does NOT say what records it. */
 const OMITTING_FIXTURE = `
@@ -164,10 +82,10 @@ describe('omission fails the build, not the run', () => {
   });
 
   it('CompileFail_EffectWithoutCommittedEvent_FailsTypecheck', () => {
-    materializeCarrier(dir, false);
+    materializeCarrier(dir, []);
     fs.writeFileSync(path.join(dir, 'fixture.ts'), OMITTING_FIXTURE, 'utf8');
 
-    const run = runTsc(['effect-carrier.ts', 'schemas.ts', 'fixture.ts'], dir);
+    const run = compile(dir, ['effect-carrier.ts', 'schemas.ts', 'fixture.ts']);
 
     expect(run.accepted, `a plan omitting its emission declaration compiled:\n${run.output}`).toBe(
       false,
@@ -182,10 +100,10 @@ describe('omission fails the build, not the run', () => {
     // The probe: the SAME fixture against a copy whose guard is relaxed. If it
     // still failed, the first assertion would be measuring a typo rather than
     // the requirement.
-    materializeCarrier(dir, true);
+    materializeCarrier(dir, RELAX_REQUIRED_EMITS);
     fs.writeFileSync(path.join(dir, 'fixture.ts'), OMITTING_FIXTURE, 'utf8');
 
-    const run = runTsc(['effect-carrier.ts', 'schemas.ts', 'fixture.ts'], dir);
+    const run = compile(dir, ['effect-carrier.ts', 'schemas.ts', 'fixture.ts']);
 
     expect(
       run.accepted,
@@ -197,7 +115,7 @@ describe('omission fails the build, not the run', () => {
     // The probes run against copies. This asserts the property rather than
     // trusting it: the real carrier still declares the required field after a
     // relaxed copy has been built from it.
-    materializeCarrier(dir, true);
-    expect(fs.readFileSync(CARRIER, 'utf8')).toContain('readonly emits: PlanEmissions;');
+    materializeCarrier(dir, RELAX_REQUIRED_EMITS);
+    expect(fs.readFileSync(CARRIER_PATH, 'utf8')).toContain('readonly emits: PlanEmissions;');
   });
 });

--- a/tests/acceptance/effect-carrier-compile-gate.test.ts
+++ b/tests/acceptance/effect-carrier-compile-gate.test.ts
@@ -1,5 +1,5 @@
 /**
- * DR-3 — a handler that effects without committing its event fails the BUILD.
+ * A handler that effects without committing its event fails the BUILD.
  *
  * ## Why this file exists, and what it does NOT carry
  *
@@ -42,8 +42,8 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(here, '../..');
 const CARRIER = path.join(packageRoot, 'src/dispatch/core/effect-carrier.ts');
 
-/** Where the carrier's DR-1/DR-2 compile claims begin. */
-const PROOF_BLOCK_MARKER = '// ─── DR-1 / DR-2 compile claims';
+/** Where the carrier's emission-declaration compile claims begin. */
+const PROOF_BLOCK_MARKER = '// ─── Emission-declaration compile claims';
 
 /**
  * Resolved rather than path-joined.
@@ -141,7 +141,7 @@ function materializeCarrier(dir: string, relax: boolean): void {
 const OMITTING_FIXTURE = `
 import type { EffectPlan } from './effect-carrier.js';
 
-// The pre-DR-1 shape: an owner, an idempotency boundary, a compensation
+// The older shape: an owner, an idempotency boundary, a compensation
 // contract — and no statement of what running this records.
 export const plan: EffectPlan = {
   effectClass: 'filesystem',
@@ -151,7 +151,7 @@ export const plan: EffectPlan = {
 };
 `;
 
-describe('DR-3 — omission fails the build, not the run', () => {
+describe('omission fails the build, not the run', () => {
   let dir: string;
 
   beforeEach(() => {

--- a/tests/acceptance/effect-carrier-compile-gate.test.ts
+++ b/tests/acceptance/effect-carrier-compile-gate.test.ts
@@ -1,0 +1,188 @@
+/**
+ * DR-3 — a handler that effects without committing its event fails the BUILD.
+ *
+ * ## Why this file exists, and what it does NOT carry
+ *
+ * The carrier's exported `@proof` aliases are the standing claim: they live in
+ * `src/`, the root `tsc` reads them on every build, and they go red the moment
+ * `src/` relaxes. That is the half that catches a regression.
+ *
+ * This file carries the other half, which an alias cannot: an alias asserts
+ * that a bad shape is *not assignable*, but only a spawned compiler shows a
+ * fixture actually FAILING. Both halves are needed and they are not
+ * interchangeable — a fixture compiled against a COPY can never redden when the
+ * real source relaxes, so nothing here should be read as guarding `src/`.
+ *
+ * ## Why the acceptance tier
+ *
+ * Not for isolation, and not because this tier is typechecked (whether the
+ * HARNESS typechecks has no bearing on whether the FIXTURE compiles). It is
+ * here because it spawns a compiler per case, which is an acceptance-shaped
+ * cost rather than a unit-shaped one.
+ *
+ * ## Why copying the carrier is tractable
+ *
+ * `effect-carrier.ts` has exactly ONE import — `import type { EventType }` —
+ * so a copy with that specifier rewritten to a local stub compiles standalone.
+ * The stub widens `EventType` to `string`, which is sound for this fixture: the
+ * subject is whether a plan may omit its emission declaration, not whether an
+ * event name is registered. A copy is also what lets the kill probe relax the
+ * guard without ever touching the live tree.
+ */
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(here, '../..');
+const CARRIER = path.join(packageRoot, 'src/dispatch/core/effect-carrier.ts');
+
+/**
+ * Resolved rather than path-joined.
+ *
+ * `node_modules` is not necessarily under `packageRoot`: a git worktree resolves
+ * its dependencies from the parent checkout by walking up, so a hardcoded
+ * `packageRoot/node_modules/...` is absent exactly when the suite runs in one.
+ * `require.resolve` follows the same walk Node does.
+ */
+const TSC_BIN = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+
+const TSC_FLAGS = [
+  '--noEmit',
+  '--strict',
+  '--exactOptionalPropertyTypes',
+  '--module',
+  'NodeNext',
+  '--moduleResolution',
+  'NodeNext',
+  '--target',
+  'ES2022',
+];
+
+interface TscRun {
+  readonly accepted: boolean;
+  readonly output: string;
+}
+
+function runTsc(files: readonly string[], cwd: string): TscRun {
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [TSC_BIN, ...TSC_FLAGS, ...files],
+      { cwd, encoding: 'utf8', stdio: 'pipe' },
+    );
+    return { accepted: true, output };
+  } catch (err: unknown) {
+    const streams: string[] = [];
+    if (typeof err === 'object' && err !== null) {
+      for (const key of ['stdout', 'stderr']) {
+        const value: unknown = Reflect.get(err, key);
+        if (typeof value === 'string') streams.push(value);
+        else if (value instanceof Uint8Array) streams.push(Buffer.from(value).toString('utf8'));
+      }
+    }
+    return { accepted: false, output: streams.join('') };
+  }
+}
+
+/** The carrier, standalone: its one import rewritten to a local stub. */
+function materializeCarrier(dir: string, relax: boolean): void {
+  fs.writeFileSync(
+    path.join(dir, 'schemas.ts'),
+    'export type EventType = string;\n',
+    'utf8',
+  );
+  let source = fs.readFileSync(CARRIER, 'utf8');
+  source = source.replace("from '../../events/schemas.js'", "from './schemas.js'");
+
+  if (relax) {
+    const required = '  readonly emits: PlanEmissions;';
+    if (!source.includes(required)) {
+      throw new Error(
+        'the relaxation target moved: the carrier no longer declares `readonly emits: PlanEmissions;`. ' +
+          'A probe that cannot find what it relaxes proves nothing, so this fails loudly.',
+      );
+    }
+    source = source.replace(required, '  readonly emits?: PlanEmissions;');
+    // The proof aliases assert the very property being relaxed, so they would
+    // fail the RELAXED build for the right reason and mask the fixture's own
+    // result. Drop them; the fixture is the subject here.
+    source = source.slice(0, source.indexOf('// ─── DR-1 / DR-2 compile claims'));
+    // `declaredEmissions` reads the now-optional field.
+    source = source.replace(
+      "return plan.emits.kind === 'records' ? plan.emits.emissions : [];",
+      "return plan.emits !== undefined && plan.emits.kind === 'records' ? plan.emits.emissions : [];",
+    );
+  }
+  fs.writeFileSync(path.join(dir, 'effect-carrier.ts'), source, 'utf8');
+}
+
+/** A handler that performs an effect and does NOT say what records it. */
+const OMITTING_FIXTURE = `
+import type { EffectPlan } from './effect-carrier.js';
+
+// The pre-DR-1 shape: an owner, an idempotency boundary, a compensation
+// contract — and no statement of what running this records.
+export const plan: EffectPlan = {
+  effectClass: 'filesystem',
+  owner: 'a-handler-that-effects-without-committing',
+  description: 'write a file and say nothing about it',
+  idempotent: true,
+};
+`;
+
+describe('DR-3 — omission fails the build, not the run', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-compile-gate-'));
+  });
+
+  afterEach(() => {
+    // Removed on BOTH paths: a throwing assertion must not leave a tree behind.
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('CompileFail_EffectWithoutCommittedEvent_FailsTypecheck', () => {
+    materializeCarrier(dir, false);
+    fs.writeFileSync(path.join(dir, 'fixture.ts'), OMITTING_FIXTURE, 'utf8');
+
+    const run = runTsc(['effect-carrier.ts', 'schemas.ts', 'fixture.ts'], dir);
+
+    expect(run.accepted, `a plan omitting its emission declaration compiled:\n${run.output}`).toBe(
+      false,
+    );
+    // Named, not merely non-zero: a fixture that fails for an unrelated reason
+    // would otherwise read as the guard working.
+    expect(run.output).toContain('fixture.ts');
+    expect(run.output).toMatch(/emits/);
+  });
+
+  it('CompileFail_FixtureCompilesWhenGuardRemoved', () => {
+    // The probe: the SAME fixture against a copy whose guard is relaxed. If it
+    // still failed, the first assertion would be measuring a typo rather than
+    // the requirement.
+    materializeCarrier(dir, true);
+    fs.writeFileSync(path.join(dir, 'fixture.ts'), OMITTING_FIXTURE, 'utf8');
+
+    const run = runTsc(['effect-carrier.ts', 'schemas.ts', 'fixture.ts'], dir);
+
+    expect(
+      run.accepted,
+      `the fixture still failed with the guard relaxed, so it is not measuring the guard:\n${run.output}`,
+    ).toBe(true);
+  });
+
+  it('CompileGate_ProbeLeavesTheLiveTreeUntouched', () => {
+    // The probes run against copies. This asserts the property rather than
+    // trusting it: the real carrier still declares the required field after a
+    // relaxed copy has been built from it.
+    materializeCarrier(dir, true);
+    expect(fs.readFileSync(CARRIER, 'utf8')).toContain('readonly emits: PlanEmissions;');
+  });
+});

--- a/tests/acceptance/effect-carrier-compile-gate.test.ts
+++ b/tests/acceptance/effect-carrier-compile-gate.test.ts
@@ -42,6 +42,9 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(here, '../..');
 const CARRIER = path.join(packageRoot, 'src/dispatch/core/effect-carrier.ts');
 
+/** Where the carrier's DR-1/DR-2 compile claims begin. */
+const PROOF_BLOCK_MARKER = '// ─── DR-1 / DR-2 compile claims';
+
 /**
  * Resolved rather than path-joined.
  *
@@ -112,7 +115,19 @@ function materializeCarrier(dir: string, relax: boolean): void {
     // The proof aliases assert the very property being relaxed, so they would
     // fail the RELAXED build for the right reason and mask the fixture's own
     // result. Drop them; the fixture is the subject here.
-    source = source.slice(0, source.indexOf('// ─── DR-1 / DR-2 compile claims'));
+    //
+    // The marker is asserted rather than assumed: `indexOf` returning -1 would
+    // make `slice` chop one character and leave both proof blocks standing, so
+    // a reworded comment would send the next reader to the fixture instead of
+    // to the string that actually moved.
+    const proofsAt = source.indexOf(PROOF_BLOCK_MARKER);
+    if (proofsAt === -1) {
+      throw new Error(
+        `the proof block marker ${JSON.stringify(PROOF_BLOCK_MARKER)} is gone from the carrier. ` +
+          'Relaxing a copy that still asserts what the relaxation removes proves nothing.',
+      );
+    }
+    source = source.slice(0, proofsAt);
     // `declaredEmissions` reads the now-optional field.
     source = source.replace(
       "return plan.emits.kind === 'records' ? plan.emits.emissions : [];",

--- a/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
+++ b/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
@@ -1,0 +1,297 @@
+/**
+ * DR-5 — every gate this slice adds is killed on purpose and observed to fail.
+ *
+ * ## What this file is for
+ *
+ * A guard with no kill probe has not been shown to measure anything. That is
+ * the finding this programme keeps re-deriving, and it is the reason the plan
+ * behind this slice was refuted three times: gates were repeatedly sited where
+ * no compiler read them and no runner ran them, so they would have passed by
+ * never being checked.
+ *
+ * Four gates land here, and each is relaxed in a COPY of the carrier before
+ * being asserted to stop failing:
+ *
+ *   1. `emits` required                — the DR-1 closure
+ *   2. evidence on the success arm     — DR-2's flagship, unprobed until now
+ *   3. the branded replay witness      — DR-2's second arm
+ *   4. the recorder required in live   — DR-2's unconditional demand
+ *
+ * The fifth gate — the compile fixture itself — is probed by the harness that
+ * owns it (`effect-carrier-compile-gate.test.ts`, second case) and is
+ * deliberately not duplicated here.
+ *
+ * ## Why copies, and never the live tree
+ *
+ * A probe that edits `src/` cannot restore cleanly across a thrown assertion, a
+ * timeout or a worker crash, and residue in the source tree reddens unrelated
+ * gates for reasons that have nothing to do with the probe. Every relaxation
+ * below is applied to text in a temp directory; the live carrier is never
+ * opened for writing, and the last case asserts exactly that.
+ *
+ * ## Why these are compile probes
+ *
+ * All four gates are type-level, so relaxing one is observable as `tsc`
+ * accepting a program it previously rejected. Each probe therefore needs only a
+ * spawned compiler, not a materialized module graph to execute.
+ */
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(here, '../..');
+const CARRIER = path.join(packageRoot, 'src/dispatch/core/effect-carrier.ts');
+const TSC_BIN = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+
+const TSC_FLAGS = [
+  '--noEmit',
+  '--strict',
+  '--exactOptionalPropertyTypes',
+  '--module',
+  'NodeNext',
+  '--moduleResolution',
+  'NodeNext',
+  '--target',
+  'ES2022',
+];
+
+function compiles(dir: string, files: readonly string[]): boolean {
+  try {
+    execFileSync(process.execPath, [TSC_BIN, ...TSC_FLAGS, ...files], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * One relaxation: the text it replaces and what it becomes.
+ *
+ * `find` is asserted present before the edit. A probe whose target has moved
+ * would otherwise silently relax NOTHING and then report that the guard still
+ * holds — a false green of exactly the kind this file exists to prevent.
+ */
+interface Relaxation {
+  readonly find: string;
+  readonly replace: string;
+}
+
+/**
+ * Where the carrier's compile-time proofs begin.
+ *
+ * The EARLIER of the two proof blocks, deliberately. The module has two — the
+ * original capability proofs and the DR-1/DR-2 claims appended after them — and
+ * truncating at the later marker leaves the first block asserting a property the
+ * probe is trying to relax, so the copy fails for the right reason and the probe
+ * reads as the guard holding.
+ */
+const PROOF_BLOCK_MARKER = '// ─── Compile-time proofs';
+
+function materialize(dir: string, relaxations: readonly Relaxation[]): void {
+  fs.writeFileSync(path.join(dir, 'schemas.ts'), 'export type EventType = string;\n', 'utf8');
+  let source = fs.readFileSync(CARRIER, 'utf8');
+  source = source.replace("from '../../events/schemas.js'", "from './schemas.js'");
+
+  // The proof aliases assert exactly the properties a relaxation removes, so a
+  // relaxed copy that kept them would fail for the RIGHT reason and mask the
+  // fixture's own result. Truncating is deliberate: commenting the block out
+  // would leave an unterminated comment and the copy would fail to parse, which
+  // reads identically to the guard holding.
+  if (relaxations.length > 0) {
+    const at = source.indexOf(PROOF_BLOCK_MARKER);
+    if (at === -1) {
+      throw new Error(
+        'the in-source proof block is gone from the carrier. A probe that cannot find it ' +
+          'would relax a copy that still asserts what the probe removes, and report a false green.',
+      );
+    }
+    source = source.slice(0, at);
+  }
+
+  for (const { find, replace } of relaxations) {
+    if (!source.includes(find)) {
+      throw new Error(
+        `probe target not found in the carrier: ${JSON.stringify(find)}. ` +
+          'The guard may have been reshaped; a probe that cannot find what it relaxes proves nothing.',
+      );
+    }
+    source = source.replace(find, replace);
+  }
+  fs.writeFileSync(path.join(dir, 'effect-carrier.ts'), source, 'utf8');
+}
+
+const FIXTURES: Record<string, string> = {
+  // A plan with no emission declaration.
+  'omits-emits.ts': `
+import type { EffectPlan } from './effect-carrier.js';
+export const plan: EffectPlan = {
+  effectClass: 'filesystem',
+  owner: 'o',
+  description: 'd',
+  idempotent: true,
+};
+`,
+  // A success carrier with no evidence.
+  'success-without-evidence.ts': `
+import type { EffectOutcome } from './effect-carrier.js';
+export const outcome: EffectOutcome<number> = { kind: 'success', value: 1 };
+`,
+  // A witness nobody minted.
+  'forged-witness.ts': `
+import type { EmissionEvidence } from './effect-carrier.js';
+export const evidence: EmissionEvidence = {
+  kind: 'replayed',
+  event: 'vcs.executed',
+  source: 'forged by hand',
+};
+`,
+  // A live run that supplies no capability.
+  'omits-recorder.ts': `
+import { runEffect, LIVE, recordsNothing } from './effect-carrier.js';
+import type { EffectPlan } from './effect-carrier.js';
+const plan: EffectPlan = {
+  effectClass: 'filesystem',
+  owner: 'o',
+  description: 'd',
+  idempotent: true,
+  emits: recordsNothing('nothing durable follows'),
+};
+export const run = (): Promise<unknown> => runEffect(LIVE, plan, () => Promise.resolve(1));
+`,
+};
+
+function write(dir: string, fixture: string): void {
+  const body = FIXTURES[fixture];
+  if (body === undefined) throw new Error(`unknown fixture ${fixture}`);
+  fs.writeFileSync(path.join(dir, fixture), body, 'utf8');
+}
+
+describe('DR-5 — kill probes: every gate is shown to fail', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-kill-probe-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('KillProbe_RequiredEmissionsRelaxed_TypecheckStopsFailing', () => {
+    write(dir, 'omits-emits.ts');
+
+    materialize(dir, []);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-emits.ts']),
+      'a plan omitting its emission declaration compiled against the REAL carrier',
+    ).toBe(false);
+
+    materialize(dir, [
+      { find: '  readonly emits: PlanEmissions;', replace: '  readonly emits?: PlanEmissions;' },
+      {
+        find: "return plan.emits.kind === 'records' ? plan.emits.emissions : [];",
+        replace:
+          "return plan.emits !== undefined && plan.emits.kind === 'records' ? plan.emits.emissions : [];",
+      },
+    ]);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-emits.ts']),
+      'relaxing the required field did not make the omission compile, so the gate measures something else',
+    ).toBe(true);
+  });
+
+  it('KillProbe_SuccessArmDropsEvidence_ValueBecomesReachable', () => {
+    write(dir, 'success-without-evidence.ts');
+
+    materialize(dir, []);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'success-without-evidence.ts']),
+      'a committed value without evidence compiled against the REAL carrier',
+    ).toBe(false);
+
+    materialize(dir, [
+      {
+        find: "| { readonly kind: 'success'; readonly value: T; readonly evidence: EmissionEvidence }",
+        replace:
+          "| { readonly kind: 'success'; readonly value: T; readonly evidence?: EmissionEvidence }",
+      },
+    ]);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'success-without-evidence.ts']),
+      'making evidence optional did not make the evidence-free value compile',
+    ).toBe(true);
+  });
+
+  it('KillProbe_WitnessUnbranded_EvidenceBecomesForgeable', () => {
+    write(dir, 'forged-witness.ts');
+
+    materialize(dir, []);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'forged-witness.ts']),
+      'a hand-built witness satisfied EmissionEvidence against the REAL carrier',
+    ).toBe(false);
+
+    materialize(dir, [
+      {
+        find: 'export interface ReplayedEvidence {\n  readonly [EMISSION_EVIDENCE_BRAND]: true;',
+        replace: 'export interface ReplayedEvidence {',
+      },
+      // The constructor mints the brand it no longer declares, so it has to be
+      // relaxed with the type. Leaving it would fail the copy on the MINT site
+      // rather than on the forgery, which is a different claim entirely.
+      {
+        find: "  return { [EMISSION_EVIDENCE_BRAND]: true, kind: 'replayed', event, source };",
+        replace: "  return { kind: 'replayed', event, source };",
+      },
+    ]);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'forged-witness.ts']),
+      'removing the brand did not make the forged witness compile',
+    ).toBe(true);
+  });
+
+  it('KillProbe_RecorderMadeOptional_LiveRunNeedsNoCapability', () => {
+    write(dir, 'omits-recorder.ts');
+
+    materialize(dir, []);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-recorder.ts']),
+      'a live run with no recorder compiled against the REAL carrier',
+    ).toBe(false);
+
+    materialize(dir, [
+      { find: '  recorder: EmissionRecorder,', replace: '  recorder?: EmissionRecorder,' },
+    ]);
+    expect(
+      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-recorder.ts']),
+      'widening the recorder parameter did not make the capability-free call compile',
+    ).toBe(true);
+  });
+
+  it('KillProbes_LeaveNoResidue_InTheirOwnWriteSet', () => {
+    // Scoped to what the probes write, NOT to repository byte-identity: this
+    // suite runs alongside tiers that legitimately write coverage, SQLite and
+    // `.exarchos/` state, so a whole-repo assertion would measure their work
+    // and fail for reasons unrelated to any probe.
+    materialize(dir, [
+      { find: '  readonly emits: PlanEmissions;', replace: '  readonly emits?: PlanEmissions;' },
+    ]);
+
+    // The live carrier still declares every guard the probes relaxed.
+    const live = fs.readFileSync(CARRIER, 'utf8');
+    expect(live).toContain('  readonly emits: PlanEmissions;');
+    expect(live).toContain('  recorder: EmissionRecorder,');
+    expect(live).toContain('readonly [EMISSION_EVIDENCE_BRAND]: true;');
+    expect(live).toContain('// ─── DR-1 / DR-2 compile claims');
+  });
+});

--- a/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
+++ b/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
@@ -134,11 +134,11 @@ interface Relaxation {
 /**
  * Where the carrier's compile-time proofs begin.
  *
- * The EARLIER of the two proof blocks, deliberately. The module has two — the
- * original capability proofs and the emission-declaration claims appended after
- * truncating at the later marker leaves the first block asserting a property the
- * probe is trying to relax, so the copy fails for the right reason and the probe
- * reads as the guard holding.
+ * The EARLIER of the two proof blocks, deliberately. The module has two: the
+ * original capability proofs, and the emission-declaration claims appended
+ * after them. Truncating at the later marker leaves the first block standing,
+ * and that block asserts a property the probe is trying to relax — so the copy
+ * fails for the right reason and the probe reads as the guard holding.
  */
 const PROOF_BLOCK_MARKER = '// ─── Compile-time proofs';
 

--- a/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
+++ b/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
@@ -29,11 +29,21 @@
  * below is applied to text in a temp directory; the live carrier is never
  * opened for writing, and the last case asserts exactly that.
  *
- * ## Why these are compile probes
+ * ## Compile probes, and the one that must EXECUTE
  *
- * All four gates are type-level, so relaxing one is observable as `tsc`
- * accepting a program it previously rejected. Each probe therefore needs only a
- * spawned compiler, not a materialized module graph to execute.
+ * Three of the four gates are type-level, so relaxing one is observable as
+ * `tsc` accepting a program it previously rejected. The fourth is NOT, and an
+ * earlier draft of this file said it was: the unconditional-recorder demand has
+ * a type-level half (the parameter) AND a runtime half (the brand check, whose
+ * own comment calls itself "the boundary the type system does not govern").
+ * Probing only the parameter leaves the runtime half unmeasured — restoring the
+ * `declaredEmissions(plan).length > 0 &&` condition reopens the abstention hole
+ * for every `records-nothing` plan while the type stays required and a
+ * compile-only probe stays green.
+ *
+ * So that gate gets both: a compile probe on the parameter, and an EXECUTING
+ * probe that emits the relaxed copy to JavaScript and runs it in a spawned
+ * node process, reading the outcome off stdout.
  */
 import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
@@ -61,17 +71,52 @@ const TSC_FLAGS = [
   'ES2022',
 ];
 
-function compiles(dir: string, files: readonly string[]): boolean {
+interface CompileResult {
+  readonly accepted: boolean;
+  readonly output: string;
+}
+
+function compile(dir: string, files: readonly string[]): CompileResult {
   try {
     execFileSync(process.execPath, [TSC_BIN, ...TSC_FLAGS, ...files], {
       cwd: dir,
       encoding: 'utf8',
       stdio: 'pipe',
     });
-    return true;
-  } catch {
-    return false;
+    return { accepted: true, output: '' };
+  } catch (err: unknown) {
+    const streams: string[] = [];
+    if (typeof err === 'object' && err !== null) {
+      for (const key of ['stdout', 'stderr']) {
+        const value: unknown = Reflect.get(err, key);
+        if (typeof value === 'string') streams.push(value);
+        else if (value instanceof Uint8Array) streams.push(Buffer.from(value).toString('utf8'));
+      }
+    }
+    return { accepted: false, output: streams.join('') };
   }
+}
+
+/**
+ * The control arm: the REAL carrier must reject the fixture, and must reject it
+ * FOR THE FIXTURE.
+ *
+ * Asserting only `accepted === false` is how both arms of a probe go vacuous at
+ * once. The two arms are asymmetric by construction — the control keeps the
+ * carrier's proof block while the treatment truncates it — so anything that
+ * makes the control fail for an unrelated reason (a proof alias that does not
+ * hold under this file's widened `EventType` stub, say) would leave the control
+ * passing on a false negative and the treatment passing on a truncation, with
+ * neither measuring the guard. Naming the fixture in the diagnostic is what
+ * rules that out.
+ */
+function expectRejectedForTheFixture(dir: string, files: readonly string[], fixture: string): void {
+  const run = compile(dir, files);
+  expect(run.accepted, `the REAL carrier accepted ${fixture}`).toBe(false);
+  expect(
+    run.output,
+    `the REAL carrier rejected something, but not ${fixture} — the control arm is measuring an unrelated error:\n${run.output}`,
+  ).toContain(fixture);
 }
 
 /**
@@ -119,15 +164,97 @@ function materialize(dir: string, relaxations: readonly Relaxation[]): void {
   }
 
   for (const { find, replace } of relaxations) {
-    if (!source.includes(find)) {
+    // Presence is not enough — the target must be UNIQUE. `String.replace` with
+    // a string edits the first match, so a `find` that occurs twice silently
+    // relaxes the wrong site and the probe then reports that the guard held.
+    // This file caught exactly that: the capability check is spelled
+    // identically in `recordEmissions` and in `runEffect`, and the first draft
+    // of the executing probe relaxed the former while asserting about the
+    // latter.
+    const occurrences = source.split(find).length - 1;
+    if (occurrences === 0) {
       throw new Error(
         `probe target not found in the carrier: ${JSON.stringify(find)}. ` +
           'The guard may have been reshaped; a probe that cannot find what it relaxes proves nothing.',
       );
     }
+    if (occurrences > 1) {
+      throw new Error(
+        `probe target is AMBIGUOUS (${occurrences} matches): ${JSON.stringify(find)}. ` +
+          'Relaxing the first match would edit a site this probe is not asserting about.',
+      );
+    }
     source = source.replace(find, replace);
   }
   fs.writeFileSync(path.join(dir, 'effect-carrier.ts'), source, 'utf8');
+}
+
+/**
+ * Emit the (possibly relaxed) carrier to JavaScript and RUN it.
+ *
+ * The recorder demand is the one gate with a runtime half, so it is the one
+ * probe a compiler cannot observe. `runEffect` is called with `undefined` where
+ * the capability belongs — the shape a transpiled or untyped caller produces,
+ * which is exactly the population the runtime brand check exists for — and the
+ * outcome is read off stdout rather than an exit code, so a crash in the
+ * harness cannot be mistaken for the effect being refused.
+ */
+function runLiveWithNoRecorder(dir: string, relaxations: readonly Relaxation[]): string {
+  materialize(dir, relaxations);
+
+  // Emit rather than type-check. The carrier's one import is type-only, so the
+  // emitted module has no imports at all and needs no resolution at runtime.
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        TSC_BIN,
+        '--module',
+        'commonjs',
+        '--target',
+        'ES2022',
+        '--skipLibCheck',
+        '--outDir',
+        'out',
+        'schemas.ts',
+        'effect-carrier.ts',
+      ],
+      { cwd: dir, encoding: 'utf8', stdio: 'pipe' },
+    );
+  } catch {
+    // tsc emits even when it reports errors; the relaxed copy is expected to
+    // produce some. The runner below is the observation, not this exit status.
+  }
+
+  fs.writeFileSync(
+    path.join(dir, 'out', 'runner.cjs'),
+    `
+const carrier = require('./effect-carrier.js');
+const plan = {
+  effectClass: 'filesystem',
+  owner: 'probe-owner',
+  description: 'an effect whose plan records nothing',
+  idempotent: true,
+  emits: carrier.recordsNothing('the probe declares an abstention'),
+};
+carrier
+  .runEffect({ kind: 'live' }, plan, () => Promise.resolve('value'), undefined)
+  .then((outcome) => { console.log('OUTCOME:committed:' + outcome.kind); })
+  .catch((err) => { console.log('OUTCOME:refused:' + (err && err.code)); });
+`,
+    'utf8',
+  );
+
+  const stdout = execFileSync(process.execPath, ['out/runner.cjs'], {
+    cwd: dir,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  const line = stdout.split('\n').find((l) => l.startsWith('OUTCOME:'));
+  if (line === undefined) {
+    throw new Error(`the runtime probe produced no outcome line:\n${stdout}`);
+  }
+  return line;
 }
 
 const FIXTURES: Record<string, string> = {
@@ -191,10 +318,7 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
     write(dir, 'omits-emits.ts');
 
     materialize(dir, []);
-    expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-emits.ts']),
-      'a plan omitting its emission declaration compiled against the REAL carrier',
-    ).toBe(false);
+    expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-emits.ts'], 'omits-emits.ts');
 
     materialize(dir, [
       { find: '  readonly emits: PlanEmissions;', replace: '  readonly emits?: PlanEmissions;' },
@@ -205,7 +329,7 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
       },
     ]);
     expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-emits.ts']),
+      compile(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-emits.ts']).accepted,
       'relaxing the required field did not make the omission compile, so the gate measures something else',
     ).toBe(true);
   });
@@ -214,10 +338,7 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
     write(dir, 'success-without-evidence.ts');
 
     materialize(dir, []);
-    expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'success-without-evidence.ts']),
-      'a committed value without evidence compiled against the REAL carrier',
-    ).toBe(false);
+    expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'success-without-evidence.ts'], 'success-without-evidence.ts');
 
     materialize(dir, [
       {
@@ -227,7 +348,7 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
       },
     ]);
     expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'success-without-evidence.ts']),
+      compile(dir, ['effect-carrier.ts', 'schemas.ts', 'success-without-evidence.ts']).accepted,
       'making evidence optional did not make the evidence-free value compile',
     ).toBe(true);
   });
@@ -236,10 +357,7 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
     write(dir, 'forged-witness.ts');
 
     materialize(dir, []);
-    expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'forged-witness.ts']),
-      'a hand-built witness satisfied EmissionEvidence against the REAL carrier',
-    ).toBe(false);
+    expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'forged-witness.ts'], 'forged-witness.ts');
 
     materialize(dir, [
       {
@@ -255,7 +373,7 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
       },
     ]);
     expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'forged-witness.ts']),
+      compile(dir, ['effect-carrier.ts', 'schemas.ts', 'forged-witness.ts']).accepted,
       'removing the brand did not make the forged witness compile',
     ).toBe(true);
   });
@@ -264,18 +382,45 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
     write(dir, 'omits-recorder.ts');
 
     materialize(dir, []);
-    expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-recorder.ts']),
-      'a live run with no recorder compiled against the REAL carrier',
-    ).toBe(false);
+    expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-recorder.ts'], 'omits-recorder.ts');
 
     materialize(dir, [
       { find: '  recorder: EmissionRecorder,', replace: '  recorder?: EmissionRecorder,' },
     ]);
     expect(
-      compiles(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-recorder.ts']),
+      compile(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-recorder.ts']).accepted,
       'widening the recorder parameter did not make the capability-free call compile',
     ).toBe(true);
+  });
+
+  it('KillProbe_RecorderMadeConditional_LiveRunProceeds', () => {
+    // The EXECUTING probe, and the reason this file no longer claims every gate
+    // is type-level. Restoring the `declaredEmissions(plan).length > 0 &&`
+    // condition leaves the PARAMETER required, so the compile probe above stays
+    // green and the type-level proof stays true — while a `records-nothing`
+    // plan silently stops needing a capability at all. That is the abstention
+    // hole DR-2 closed, and only running the code can see it reopen.
+    const refused = runLiveWithNoRecorder(dir, []);
+    expect(refused, 'the REAL carrier committed a live run with no capability').toMatch(
+      /^OUTCOME:refused:/,
+    );
+
+    const proceeded = runLiveWithNoRecorder(dir, [
+      {
+        // Two lines, because the first alone also matches `recordEmissions`.
+        find:
+          '  if (!isEmissionRecorder(recorder)) {\n' +
+          "    throw new UnrecordedEmissionError(plan, 'before', 0, declaredEmissions(plan).length);",
+        replace:
+          '  if (declaredEmissions(plan).length > 0 && !isEmissionRecorder(recorder)) {\n' +
+          "    throw new UnrecordedEmissionError(plan, 'before', 0, declaredEmissions(plan).length);",
+      },
+    ]);
+    expect(
+      proceeded,
+      'restoring the declared-count condition did not let a capability-free live run commit, ' +
+        'so this probe is not measuring the runtime half of the gate',
+    ).toMatch(/^OUTCOME:committed:success/);
   });
 
   it('KillProbes_LeaveNoResidue_InTheirOwnWriteSet', () => {

--- a/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
+++ b/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
@@ -1,5 +1,5 @@
 /**
- * DR-5 — every gate this slice adds is killed on purpose and observed to fail.
+ * Every gate this slice adds is killed on purpose and observed to fail.
  *
  * ## What this file is for
  *
@@ -12,10 +12,10 @@
  * Four gates land here, and each is relaxed in a COPY of the carrier before
  * being asserted to stop failing:
  *
- *   1. `emits` required                — the DR-1 closure
- *   2. evidence on the success arm     — DR-2's flagship, unprobed until now
- *   3. the branded replay witness      — DR-2's second arm
- *   4. the recorder required in live   — DR-2's unconditional demand
+ *   1. `emits` required
+ *   2. evidence on the success arm
+ *   3. the branded replay witness
+ *   4. the recorder required in live mode
  *
  * The fifth gate — the compile fixture itself — is probed by the harness that
  * owns it (`effect-carrier-compile-gate.test.ts`, second case) and is
@@ -135,7 +135,7 @@ interface Relaxation {
  * Where the carrier's compile-time proofs begin.
  *
  * The EARLIER of the two proof blocks, deliberately. The module has two — the
- * original capability proofs and the DR-1/DR-2 claims appended after them — and
+ * original capability proofs and the emission-declaration claims appended after
  * truncating at the later marker leaves the first block asserting a property the
  * probe is trying to relax, so the copy fails for the right reason and the probe
  * reads as the guard holding.
@@ -303,7 +303,7 @@ function write(dir: string, fixture: string): void {
   fs.writeFileSync(path.join(dir, fixture), body, 'utf8');
 }
 
-describe('DR-5 — kill probes: every gate is shown to fail', () => {
+describe('kill probes: every gate is shown to fail', () => {
   let dir: string;
 
   beforeEach(() => {
@@ -399,7 +399,8 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
     // condition leaves the PARAMETER required, so the compile probe above stays
     // green and the type-level proof stays true — while a `records-nothing`
     // plan silently stops needing a capability at all. That is the abstention
-    // hole DR-2 closed, and only running the code can see it reopen.
+    // hole the unconditional demand closed, and only running the code can see
+    // it reopen.
     const refused = runLiveWithNoRecorder(dir, []);
     expect(refused, 'the REAL carrier committed a live run with no capability').toMatch(
       /^OUTCOME:refused:/,
@@ -437,6 +438,6 @@ describe('DR-5 — kill probes: every gate is shown to fail', () => {
     expect(live).toContain('  readonly emits: PlanEmissions;');
     expect(live).toContain('  recorder: EmissionRecorder,');
     expect(live).toContain('readonly [EMISSION_EVIDENCE_BRAND]: true;');
-    expect(live).toContain('// ─── DR-1 / DR-2 compile claims');
+    expect(live).toContain('// ─── Emission-declaration compile claims');
   });
 });

--- a/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
+++ b/tests/acceptance/effect-plan-teeth-kill-probes.test.ts
@@ -46,56 +46,19 @@
  * node process, reading the outcome off stdout.
  */
 import { execFileSync } from 'node:child_process';
-import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-const here = path.dirname(fileURLToPath(import.meta.url));
-const packageRoot = path.join(here, '../..');
-const CARRIER = path.join(packageRoot, 'src/dispatch/core/effect-carrier.ts');
-const TSC_BIN = createRequire(import.meta.url).resolve('typescript/bin/tsc');
-
-const TSC_FLAGS = [
-  '--noEmit',
-  '--strict',
-  '--exactOptionalPropertyTypes',
-  '--module',
-  'NodeNext',
-  '--moduleResolution',
-  'NodeNext',
-  '--target',
-  'ES2022',
-];
-
-interface CompileResult {
-  readonly accepted: boolean;
-  readonly output: string;
-}
-
-function compile(dir: string, files: readonly string[]): CompileResult {
-  try {
-    execFileSync(process.execPath, [TSC_BIN, ...TSC_FLAGS, ...files], {
-      cwd: dir,
-      encoding: 'utf8',
-      stdio: 'pipe',
-    });
-    return { accepted: true, output: '' };
-  } catch (err: unknown) {
-    const streams: string[] = [];
-    if (typeof err === 'object' && err !== null) {
-      for (const key of ['stdout', 'stderr']) {
-        const value: unknown = Reflect.get(err, key);
-        if (typeof value === 'string') streams.push(value);
-        else if (value instanceof Uint8Array) streams.push(Buffer.from(value).toString('utf8'));
-      }
-    }
-    return { accepted: false, output: streams.join('') };
-  }
-}
+import {
+  CARRIER_PATH,
+  TSC_BIN,
+  compile,
+  materializeCarrier,
+  type Relaxation,
+} from '../helpers/carrier-compile-harness.js';
 
 /**
  * The control arm: the REAL carrier must reject the fixture, and must reject it
@@ -120,76 +83,6 @@ function expectRejectedForTheFixture(dir: string, files: readonly string[], fixt
 }
 
 /**
- * One relaxation: the text it replaces and what it becomes.
- *
- * `find` is asserted present before the edit. A probe whose target has moved
- * would otherwise silently relax NOTHING and then report that the guard still
- * holds — a false green of exactly the kind this file exists to prevent.
- */
-interface Relaxation {
-  readonly find: string;
-  readonly replace: string;
-}
-
-/**
- * Where the carrier's compile-time proofs begin.
- *
- * The EARLIER of the two proof blocks, deliberately. The module has two: the
- * original capability proofs, and the emission-declaration claims appended
- * after them. Truncating at the later marker leaves the first block standing,
- * and that block asserts a property the probe is trying to relax — so the copy
- * fails for the right reason and the probe reads as the guard holding.
- */
-const PROOF_BLOCK_MARKER = '// ─── Compile-time proofs';
-
-function materialize(dir: string, relaxations: readonly Relaxation[]): void {
-  fs.writeFileSync(path.join(dir, 'schemas.ts'), 'export type EventType = string;\n', 'utf8');
-  let source = fs.readFileSync(CARRIER, 'utf8');
-  source = source.replace("from '../../events/schemas.js'", "from './schemas.js'");
-
-  // The proof aliases assert exactly the properties a relaxation removes, so a
-  // relaxed copy that kept them would fail for the RIGHT reason and mask the
-  // fixture's own result. Truncating is deliberate: commenting the block out
-  // would leave an unterminated comment and the copy would fail to parse, which
-  // reads identically to the guard holding.
-  if (relaxations.length > 0) {
-    const at = source.indexOf(PROOF_BLOCK_MARKER);
-    if (at === -1) {
-      throw new Error(
-        'the in-source proof block is gone from the carrier. A probe that cannot find it ' +
-          'would relax a copy that still asserts what the probe removes, and report a false green.',
-      );
-    }
-    source = source.slice(0, at);
-  }
-
-  for (const { find, replace } of relaxations) {
-    // Presence is not enough — the target must be UNIQUE. `String.replace` with
-    // a string edits the first match, so a `find` that occurs twice silently
-    // relaxes the wrong site and the probe then reports that the guard held.
-    // This file caught exactly that: the capability check is spelled
-    // identically in `recordEmissions` and in `runEffect`, and the first draft
-    // of the executing probe relaxed the former while asserting about the
-    // latter.
-    const occurrences = source.split(find).length - 1;
-    if (occurrences === 0) {
-      throw new Error(
-        `probe target not found in the carrier: ${JSON.stringify(find)}. ` +
-          'The guard may have been reshaped; a probe that cannot find what it relaxes proves nothing.',
-      );
-    }
-    if (occurrences > 1) {
-      throw new Error(
-        `probe target is AMBIGUOUS (${occurrences} matches): ${JSON.stringify(find)}. ` +
-          'Relaxing the first match would edit a site this probe is not asserting about.',
-      );
-    }
-    source = source.replace(find, replace);
-  }
-  fs.writeFileSync(path.join(dir, 'effect-carrier.ts'), source, 'utf8');
-}
-
-/**
  * Emit the (possibly relaxed) carrier to JavaScript and RUN it.
  *
  * The recorder demand is the one gate with a runtime half, so it is the one
@@ -200,7 +93,7 @@ function materialize(dir: string, relaxations: readonly Relaxation[]): void {
  * harness cannot be mistaken for the effect being refused.
  */
 function runLiveWithNoRecorder(dir: string, relaxations: readonly Relaxation[]): string {
-  materialize(dir, relaxations);
+  materializeCarrier(dir, relaxations);
 
   // Emit rather than type-check. The carrier's one import is type-only, so the
   // emitted module has no imports at all and needs no resolution at runtime.
@@ -317,10 +210,10 @@ describe('kill probes: every gate is shown to fail', () => {
   it('KillProbe_RequiredEmissionsRelaxed_TypecheckStopsFailing', () => {
     write(dir, 'omits-emits.ts');
 
-    materialize(dir, []);
+    materializeCarrier(dir, []);
     expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-emits.ts'], 'omits-emits.ts');
 
-    materialize(dir, [
+    materializeCarrier(dir, [
       { find: '  readonly emits: PlanEmissions;', replace: '  readonly emits?: PlanEmissions;' },
       {
         find: "return plan.emits.kind === 'records' ? plan.emits.emissions : [];",
@@ -337,10 +230,10 @@ describe('kill probes: every gate is shown to fail', () => {
   it('KillProbe_SuccessArmDropsEvidence_ValueBecomesReachable', () => {
     write(dir, 'success-without-evidence.ts');
 
-    materialize(dir, []);
+    materializeCarrier(dir, []);
     expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'success-without-evidence.ts'], 'success-without-evidence.ts');
 
-    materialize(dir, [
+    materializeCarrier(dir, [
       {
         find: "| { readonly kind: 'success'; readonly value: T; readonly evidence: EmissionEvidence }",
         replace:
@@ -356,10 +249,10 @@ describe('kill probes: every gate is shown to fail', () => {
   it('KillProbe_WitnessUnbranded_EvidenceBecomesForgeable', () => {
     write(dir, 'forged-witness.ts');
 
-    materialize(dir, []);
+    materializeCarrier(dir, []);
     expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'forged-witness.ts'], 'forged-witness.ts');
 
-    materialize(dir, [
+    materializeCarrier(dir, [
       {
         find: 'export interface ReplayedEvidence {\n  readonly [EMISSION_EVIDENCE_BRAND]: true;',
         replace: 'export interface ReplayedEvidence {',
@@ -381,10 +274,10 @@ describe('kill probes: every gate is shown to fail', () => {
   it('KillProbe_RecorderMadeOptional_LiveRunNeedsNoCapability', () => {
     write(dir, 'omits-recorder.ts');
 
-    materialize(dir, []);
+    materializeCarrier(dir, []);
     expectRejectedForTheFixture(dir, ['effect-carrier.ts', 'schemas.ts', 'omits-recorder.ts'], 'omits-recorder.ts');
 
-    materialize(dir, [
+    materializeCarrier(dir, [
       { find: '  recorder: EmissionRecorder,', replace: '  recorder?: EmissionRecorder,' },
     ]);
     expect(
@@ -429,12 +322,12 @@ describe('kill probes: every gate is shown to fail', () => {
     // suite runs alongside tiers that legitimately write coverage, SQLite and
     // `.exarchos/` state, so a whole-repo assertion would measure their work
     // and fail for reasons unrelated to any probe.
-    materialize(dir, [
+    materializeCarrier(dir, [
       { find: '  readonly emits: PlanEmissions;', replace: '  readonly emits?: PlanEmissions;' },
     ]);
 
     // The live carrier still declares every guard the probes relaxed.
-    const live = fs.readFileSync(CARRIER, 'utf8');
+    const live = fs.readFileSync(CARRIER_PATH, 'utf8');
     expect(live).toContain('  readonly emits: PlanEmissions;');
     expect(live).toContain('  recorder: EmissionRecorder,');
     expect(live).toContain('readonly [EMISSION_EVIDENCE_BRAND]: true;');

--- a/tests/helpers/carrier-compile-harness.ts
+++ b/tests/helpers/carrier-compile-harness.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared compiler harness for the effect-carrier compile gates.
+ *
+ * Two acceptance suites spawn a real `tsc` against a materialized copy of the
+ * carrier: one proves that omitting an emission declaration fails the build,
+ * the other relaxes each shipped guard and proves the failure goes away. They
+ * had their own copies of the binary path, the flag list, the process wrapper
+ * and the materialization logic.
+ *
+ * Two copies of a flag list drift, and a drifted flag set means the two suites
+ * measure different compilers — so a guard could hold under one and not the
+ * other with nothing to say so. One copy, imported twice.
+ */
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** The carrier under test, as it lives in the source tree. */
+export const CARRIER_PATH = path.join(here, '../../src/dispatch/core/effect-carrier.ts');
+
+/**
+ * Resolved rather than path-joined.
+ *
+ * `node_modules` is not necessarily under the package root: a git worktree
+ * resolves its dependencies from the parent checkout by walking up, so a
+ * hardcoded `<root>/node_modules/...` is absent exactly when a suite runs in
+ * one. `require.resolve` follows the same walk Node does.
+ */
+export const TSC_BIN = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+
+/** The one flag list. Both suites compile under identical settings or neither does. */
+export const TSC_FLAGS: readonly string[] = [
+  '--noEmit',
+  '--strict',
+  '--exactOptionalPropertyTypes',
+  '--module',
+  'NodeNext',
+  '--moduleResolution',
+  'NodeNext',
+  '--target',
+  'ES2022',
+];
+
+/**
+ * Where the carrier's compile-time proofs begin.
+ *
+ * The EARLIER of the two proof blocks, deliberately, and one constant rather
+ * than one per suite. The module carries two blocks — the original capability
+ * proofs and the emission-declaration claims appended after them — and a
+ * relaxed copy that keeps either one still asserts a property the relaxation
+ * removes. The copy then fails for the right reason, which reads exactly like
+ * the guard holding.
+ *
+ * Truncating more than a given relaxation strictly needs is safe: the fixtures
+ * fail on the carrier's TYPES, not on its proofs, so removing proofs never
+ * makes a fixture compile on its own.
+ */
+export const PROOF_BLOCK_MARKER = '// ─── Compile-time proofs';
+
+export interface CompileResult {
+  readonly accepted: boolean;
+  readonly output: string;
+}
+
+/** Spawn `tsc` over `files` in `dir`, capturing both streams on rejection. */
+export function compile(dir: string, files: readonly string[]): CompileResult {
+  try {
+    const output = execFileSync(process.execPath, [TSC_BIN, ...TSC_FLAGS, ...files], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return { accepted: true, output };
+  } catch (err: unknown) {
+    const streams: string[] = [];
+    if (typeof err === 'object' && err !== null) {
+      for (const key of ['stdout', 'stderr']) {
+        const value: unknown = Reflect.get(err, key);
+        if (typeof value === 'string') streams.push(value);
+        else if (value instanceof Uint8Array) streams.push(Buffer.from(value).toString('utf8'));
+      }
+    }
+    return { accepted: false, output: streams.join('') };
+  }
+}
+
+/**
+ * One relaxation: the text it replaces and what it becomes.
+ *
+ * Applied only after the target is confirmed to occur EXACTLY once — see
+ * {@link materializeCarrier}.
+ */
+export interface Relaxation {
+  readonly find: string;
+  readonly replace: string;
+}
+
+/**
+ * Write a standalone copy of the carrier into `dir`, with `relaxations` applied.
+ *
+ * Tractable because the carrier has exactly ONE import — a type-only
+ * `EventType` — so rewriting that specifier to a local stub yields a module
+ * that compiles alone. The stub widens `EventType` to `string`, which is sound
+ * for these fixtures: they are about whether a field may be omitted or a brand
+ * forged, never about whether an event name is registered.
+ *
+ * Copying is also what keeps every probe off the live tree. A probe that edited
+ * `src/` could not restore cleanly across a thrown assertion, a timeout or a
+ * worker crash, and the residue would redden unrelated gates.
+ */
+export function materializeCarrier(dir: string, relaxations: readonly Relaxation[]): void {
+  fs.writeFileSync(path.join(dir, 'schemas.ts'), 'export type EventType = string;\n', 'utf8');
+  let source = fs.readFileSync(CARRIER_PATH, 'utf8');
+  source = source.replace("from '../../events/schemas.js'", "from './schemas.js'");
+
+  if (relaxations.length > 0) {
+    const at = source.indexOf(PROOF_BLOCK_MARKER);
+    if (at === -1) {
+      throw new Error(
+        `the proof block marker ${JSON.stringify(PROOF_BLOCK_MARKER)} is gone from the carrier. ` +
+          'A relaxed copy that still asserts what the relaxation removes fails for the right ' +
+          'reason, which is indistinguishable from the guard holding.',
+      );
+    }
+    source = source.slice(0, at);
+  }
+
+  for (const { find, replace } of relaxations) {
+    // Presence is not enough — the target must be UNIQUE. `String.replace` with
+    // a string edits the first match, so a `find` that occurs twice silently
+    // relaxes the wrong site and the probe then reports that the guard held.
+    // This harness caught exactly that: the capability check is spelled
+    // identically in `recordEmissions` and in `runEffect`.
+    const occurrences = source.split(find).length - 1;
+    if (occurrences === 0) {
+      throw new Error(
+        `probe target not found in the carrier: ${JSON.stringify(find)}. ` +
+          'The guard may have been reshaped; a probe that cannot find what it relaxes proves nothing.',
+      );
+    }
+    if (occurrences > 1) {
+      throw new Error(
+        `probe target is AMBIGUOUS (${occurrences} matches): ${JSON.stringify(find)}. ` +
+          'Relaxing the first match would edit a site the probe is not asserting about.',
+      );
+    }
+    source = source.replace(find, replace);
+  }
+
+  fs.writeFileSync(path.join(dir, 'effect-carrier.ts'), source, 'utf8');
+}

--- a/tests/unit/dispatch/core/effect-carrier.test.ts
+++ b/tests/unit/dispatch/core/effect-carrier.test.ts
@@ -436,7 +436,7 @@ describe('toEffectError', () => {
   });
 });
 
-describe('DR-5 — the edges that universal declaration puts pressure on', () => {
+describe('the edges that universal declaration puts pressure on', () => {
   it('DryRun_EveryPlanDeclares_StillRecordsNothing', async () => {
     // Declaration is universal now, so the arm that must record NOTHING is the
     // one carrying the new pressure: a dry-run holds a plan that declares three

--- a/tests/unit/dispatch/core/effect-carrier.test.ts
+++ b/tests/unit/dispatch/core/effect-carrier.test.ts
@@ -435,3 +435,135 @@ describe('toEffectError', () => {
     expect(err.cause).toBe(cause);
   });
 });
+
+describe('DR-5 — the edges that universal declaration puts pressure on', () => {
+  it('DryRun_EveryPlanDeclares_StillRecordsNothing', async () => {
+    // Declaration is universal now, so the arm that must record NOTHING is the
+    // one carrying the new pressure: a dry-run holds a plan that declares three
+    // emissions and a capability able to write them, and must still write none.
+    const trace: string[] = [];
+    const recorder = emissionRecorder((emission) => {
+      trace.push(emission.event);
+    });
+    const execute = vi.fn().mockResolvedValue('SHOULD NOT RUN');
+
+    const outcome = await runEffect(DRY_RUN, LEDGER_PLAN, execute, recorder);
+
+    expect(isDryRun(outcome)).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+    // The whole guarantee: a withheld effect leaves the ledger as silent as it
+    // leaves the disk.
+    expect(trace).toEqual([]);
+  });
+
+  it('DryRun_RecordsNothingPlan_IsAlsoSilent', async () => {
+    // The other plan shape, for the same arm. An abstention in dry-run must not
+    // be the case that quietly reaches the recorder.
+    const sink = vi.fn();
+    const outcome = await runEffect(DRY_RUN, PLAN, () => Promise.resolve(1), emissionRecorder(sink));
+    expect(isDryRun(outcome)).toBe(true);
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it('RecordEmissions_NonReceiptMidSet_FailsWholeEffect', async () => {
+    // A recorder that stops minting part-way through a declared set must fail
+    // the WHOLE effect rather than record a prefix and commit. The ledger plan
+    // declares one `before` emission, so the mid-set case needs a condition
+    // carrying more than one — built here rather than borrowed, so the test
+    // states its own subject.
+    const multiIntent: EffectPlan = {
+      ...LEDGER_PLAN,
+      emits: records(
+        { event: 'vcs.requested', when: 'before' },
+        { event: 'vcs.executed', when: 'before' },
+      ),
+    };
+
+    let minted = 0;
+    const genuine = emissionRecorder(() => undefined);
+    // Mints a real receipt for the first declaration, then returns a non-receipt.
+    const halfway = forgeBrandedRecorder(async (emission, plan) => {
+      minted += 1;
+      return minted === 1 ? await genuine.record(emission, plan) : { notAReceipt: true };
+    });
+
+    const execute = vi.fn().mockResolvedValue('committed');
+    await expect(runEffect(LIVE, multiIntent, execute, halfway)).rejects.toThrow(
+      UnrecordedEmissionError,
+    );
+    // Truncation is not a partial success: the effect never ran at all.
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('UnrecordedEmissionError_NamesPlanDeclarationAndCount', async () => {
+    // A failing build has to say what to fix. The diagnostic names the plan, the
+    // condition, and both counts — otherwise it reports that something is wrong
+    // without saying what.
+    const genuine = emissionRecorder(() => undefined);
+    let minted = 0;
+    const halfway = forgeBrandedRecorder(async (emission, plan) => {
+      minted += 1;
+      return minted === 1 ? await genuine.record(emission, plan) : { notAReceipt: true };
+    });
+    const multiIntent: EffectPlan = {
+      ...LEDGER_PLAN,
+      emits: records(
+        { event: 'vcs.requested', when: 'before' },
+        { event: 'vcs.executed', when: 'before' },
+      ),
+    };
+
+    const error = await runEffect(LIVE, multiIntent, () => Promise.resolve(1), halfway).catch(
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(UnrecordedEmissionError);
+    if (error instanceof UnrecordedEmissionError) {
+      expect(error.plan.description).toBe(multiIntent.description);
+      expect(error.when).toBe('before');
+      expect(error.declared).toBe(2);
+      expect(error.appended).toBe(1);
+      expect(error.message).toContain(multiIntent.owner);
+      expect(error.message).toContain('2');
+    }
+  });
+
+  it('SuccessArm_CarriesAReceiptPerDeclaredEmission', async () => {
+    // The evidence is not decorative: it holds one minted receipt for each
+    // declaration that fired — the intent and exactly one terminal.
+    const outcome = await runEffect(
+      LIVE,
+      LEDGER_PLAN,
+      () => Promise.resolve('committed'),
+      emissionRecorder(() => undefined),
+    );
+
+    expect(isSuccess(outcome)).toBe(true);
+    if (isSuccess(outcome) && outcome.evidence.kind === 'recorded') {
+      expect(outcome.evidence.receipts.map((receipt) => receipt.event)).toEqual([
+        'vcs.requested',
+        'vcs.executed',
+      ]);
+    } else {
+      expect.unreachable('a live ledger run must carry recorded evidence');
+    }
+  });
+
+  it('SuccessArm_RecordsNothingPlan_CarriesEmptyRecordedEvidence', async () => {
+    // An abstention still commits through the `recorded` arm — with nothing in
+    // it. That is the honest shape: this run recorded, and what it recorded was
+    // nothing. Reaching for the replay witness here would claim a prior append
+    // that never happened.
+    const outcome = await runEffect(
+      LIVE,
+      PLAN,
+      () => Promise.resolve('committed'),
+      emissionRecorder(() => undefined),
+    );
+    expect(isSuccess(outcome)).toBe(true);
+    if (isSuccess(outcome)) {
+      expect(outcome.evidence.kind).toBe('recorded');
+      if (outcome.evidence.kind === 'recorded') expect(outcome.evidence.receipts).toEqual([]);
+    }
+  });
+});

--- a/tests/unit/dispatch/core/effect-carrier.test.ts
+++ b/tests/unit/dispatch/core/effect-carrier.test.ts
@@ -8,6 +8,7 @@ import {
   declaredEmissions,
   records,
   recordsNothing,
+  replayedEvidence,
   emissionRecorder,
   effectIdempotencyKey,
   isSuccess,
@@ -105,11 +106,17 @@ function forgeBrandedRecorder(
 
 describe('effect carrier constructors + guards', () => {
   it('succeeded builds a success arm that only isSuccess narrows', () => {
-    const outcome = succeeded(42);
+    const outcome = succeeded(42, replayedEvidence('vcs.executed', 'a prior run'));
     expect(isSuccess(outcome)).toBe(true);
     expect(isError(outcome)).toBe(false);
     expect(isDryRun(outcome)).toBe(false);
-    if (isSuccess(outcome)) expect(outcome.value).toBe(42);
+    if (isSuccess(outcome)) {
+      expect(outcome.value).toBe(42);
+      // The value does not arrive alone: a success carrier cannot be built
+      // without evidence, which is what makes reaching `T` mean the append
+      // happened.
+      expect(outcome.evidence.kind).toBe('replayed');
+    }
   });
 
   it('failed builds an error arm carrying the structured error', () => {

--- a/tests/unit/dispatch/core/effect-carrier.test.ts
+++ b/tests/unit/dispatch/core/effect-carrier.test.ts
@@ -5,6 +5,9 @@ import {
   failed,
   plannedDryRun,
   emissionsWhen,
+  declaredEmissions,
+  records,
+  recordsNothing,
   emissionRecorder,
   effectIdempotencyKey,
   isSuccess,
@@ -27,6 +30,9 @@ const PLAN: EffectPlan = {
   description: 'write a marker file',
   idempotent: true,
   compensation: 'delete the marker file',
+  // The abstention is DECLARED now. It used to be expressed by saying nothing,
+  // which is the same thing an author who never considered it would have written.
+  emits: recordsNothing('the marker file is scratch state; nothing durable follows from it'),
 };
 
 /**
@@ -39,11 +45,11 @@ const LEDGER_PLAN: EffectPlan = {
   description: 'create a worktree',
   idempotent: true,
   compensation: 'remove the worktree and delete the branch',
-  emits: [
+  emits: records(
     { event: 'vcs.requested', when: 'before' },
     { event: 'vcs.executed', when: 'on-success' },
     { event: 'vcs.compensated', when: 'on-failure' },
-  ],
+  ),
 };
 
 /** The tree-promotion shape: one terminal, no intent — a different subset. */
@@ -52,8 +58,17 @@ const PROMOTION_PLAN: EffectPlan = {
   owner: 'install/atomic-promotion',
   description: 'atomically promote a staged tree',
   idempotent: true,
-  emits: [{ event: 'promotion.executed', when: 'on-success' }],
+  emits: records({ event: 'promotion.executed', when: 'on-success' }),
 };
+
+/**
+ * A genuine capability for runs whose subject is NOT the commit gate.
+ *
+ * Every live run needs one now, including a plan that records nothing: the
+ * demand is unconditional, so tests about unrelated behaviour have to satisfy
+ * it before they can reach the behaviour they are about.
+ */
+const inertRecorder = (): EmissionRecorder => emissionRecorder(() => undefined);
 
 const names = (emissions: readonly EffectEmission[]): readonly string[] =>
   emissions.map((emission) => emission.event);
@@ -113,7 +128,7 @@ describe('effect carrier constructors + guards', () => {
 describe('runEffect — live mode', () => {
   it('invokes execute and wraps the value in a success carrier', async () => {
     const execute = vi.fn().mockResolvedValue('done');
-    const outcome = await runEffect(LIVE, PLAN, execute);
+    const outcome = await runEffect(LIVE, PLAN, execute, inertRecorder());
     expect(execute).toHaveBeenCalledTimes(1);
     expect(outcome.kind).toBe('success');
     if (isSuccess(outcome)) expect(outcome.value).toBe('done');
@@ -121,7 +136,7 @@ describe('runEffect — live mode', () => {
 
   it('captures a thrown error into an error carrier instead of rejecting', async () => {
     const execute = vi.fn().mockRejectedValue(new Error('disk full'));
-    const outcome = await runEffect(LIVE, PLAN, execute);
+    const outcome = await runEffect(LIVE, PLAN, execute, inertRecorder());
     expect(outcome.kind).toBe('error');
     if (isError(outcome)) {
       expect(outcome.error.message).toBe('disk full');
@@ -133,7 +148,7 @@ describe('runEffect — live mode', () => {
 describe('runEffect — dry-run mode (provably no real effect)', () => {
   it('does NOT invoke execute and returns the withheld plan', async () => {
     const execute = vi.fn().mockResolvedValue('SHOULD NOT RUN');
-    const outcome = await runEffect(DRY_RUN, PLAN, execute);
+    const outcome = await runEffect(DRY_RUN, PLAN, execute, inertRecorder());
 
     // The load-bearing guarantee: the effect thunk is never reached in dry-run.
     expect(execute).not.toHaveBeenCalled();
@@ -147,7 +162,7 @@ describe('runEffect — dry-run mode (provably no real effect)', () => {
     const execute = vi.fn().mockImplementation(() => {
       throw new Error('this effect must never run in dry-run');
     });
-    const outcome = await runEffect(DRY_RUN, PLAN, execute);
+    const outcome = await runEffect(DRY_RUN, PLAN, execute, inertRecorder());
     expect(execute).not.toHaveBeenCalled();
     expect(outcome.kind).toBe('dry-run');
   });
@@ -168,7 +183,7 @@ describe('EffectPlan emissions', () => {
       names(emissionsWhen(LEDGER_PLAN, when)),
     );
     expect(new Set(perCondition).size).toBe(perCondition.length);
-    expect(perCondition).toHaveLength(LEDGER_PLAN.emits?.length ?? 0);
+    expect(perCondition).toHaveLength(declaredEmissions(LEDGER_PLAN).length);
 
     // Not a fixed intent+two-terminals triple either: a plan may condition a
     // single terminal and nothing else, and the empty conditions read empty
@@ -186,7 +201,7 @@ describe('EffectPlan emissions', () => {
   it('resolves every declared name against the registered event catalog', () => {
     const registered = new Set<string>(EventTypes);
     for (const plan of [LEDGER_PLAN, PROMOTION_PLAN]) {
-      for (const emission of plan.emits ?? []) {
+      for (const emission of declaredEmissions(plan)) {
         expect(registered.has(emission.event)).toBe(true);
       }
     }
@@ -329,20 +344,35 @@ describe('runEffect — the record is on the way to a committed value', () => {
     expect(recorded).toEqual(['vcs.requested', 'vcs.executed']);
   });
 
-  it('leaves a plan that declares no emissions inert — no capability required', async () => {
-    // The owners that predate the emission axis pass no recorder at all. Nothing
-    // is declared, so nothing is missing, and the carrier behaves as it always
-    // did. Gating THIS case would break them.
-    const outcome = await runEffect(LIVE, PLAN, () => Promise.resolve('committed'));
+  it('RunEffect_RecordsNothingPlanWithNoRecorder_RefusesInLiveMode', async () => {
+    // INVERTED, deliberately. This case used to commit: nothing was declared,
+    // so nothing was missing, and the carrier waved it through. That was the
+    // abstention hole one level down — the plan making the strongest claim
+    // ("this effect records nothing") was the only one nobody had to equip to
+    // stand behind it. The demand is unconditional now.
+    const execute = vi.fn().mockResolvedValue('committed');
+    await expect(
+      runEffect(LIVE, PLAN, execute, undefined as unknown as EmissionRecorder),
+    ).rejects.toThrow(UnrecordedEmissionError);
+    // Refused BEFORE the thunk: nothing was mutated on the way to the refusal.
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('RunEffect_RecordsNothingPlanWithRecorder_CommitsAndRecordsNothing', async () => {
+    // The other half: declaring an abstention is legal and stays inert. The
+    // capability is required, and then never used.
+    const sink = vi.fn();
+    const outcome = await runEffect(LIVE, PLAN, () => Promise.resolve('committed'), emissionRecorder(sink));
     expect(isSuccess(outcome)).toBe(true);
     if (isSuccess(outcome)) expect(outcome.value).toBe('committed');
+    expect(sink).not.toHaveBeenCalled();
   });
 
   it('withholds the refusal in dry-run — neither thunk nor capability is reached', async () => {
     // The dry-run guarantee outranks the commit gate: a withheld effect records
     // nothing, so it cannot be missing a record either.
     const execute = vi.fn().mockResolvedValue('SHOULD NOT RUN');
-    const outcome = await runEffect(DRY_RUN, LEDGER_PLAN, execute);
+    const outcome = await runEffect(DRY_RUN, LEDGER_PLAN, execute, inertRecorder());
     expect(execute).not.toHaveBeenCalled();
     expect(isDryRun(outcome)).toBe(true);
   });

--- a/tests/unit/events/schemas.test.ts
+++ b/tests/unit/events/schemas.test.ts
@@ -108,7 +108,7 @@ import {
   type WorkflowEvent,
 } from '../../../src/events/schemas.js';
 import * as mutationOwner from '../../../src/vcs/mutation-owner.js';
-import { promoteTree, promotionPlan } from '../../../src/install/atomic-promotion.js';
+import { promoteTree, promotionPlan, defaultPromotionIo } from '../../../src/install/atomic-promotion.js';
 import { digestTree } from '../../../src/install/install-identity.js';
 import { DRY_RUN, isDryRun } from '../../../src/dispatch/core/effect-carrier.js';
 import { workflowStateProjection } from '../../../src/projections/views/workflow-state-projection.js';
@@ -4397,7 +4397,13 @@ describe('WLM operational-core merge lease schemas', () => {
     // Dry-run: the engine is structurally unreachable, so this asks the site for its plan
     // without touching a byte of the filesystem. The owner therefore comes from the site's own
     // default, not from a literal spelled here.
-    const outcome = await promoteTree({ target, entries }, DRY_RUN);
+    // The recorder is a required argument now, so a dry-run has to spell one
+    // even though the withheld arm never reaches it. Passing a throwing sink is
+    // the honest choice here: if the dry-run guarantee ever regressed, this
+    // call would fail loudly instead of silently recording.
+    const outcome = await promoteTree({ target, entries }, DRY_RUN, defaultPromotionIo(), () => {
+      throw new Error('a dry-run promotion must never record');
+    });
     expect(isDryRun(outcome), 'the promotion site did not withhold the effect').toBe(true);
     if (!isDryRun(outcome)) return;
     const plan = outcome.plan;

--- a/tests/unit/install/atomic-promotion.test.ts
+++ b/tests/unit/install/atomic-promotion.test.ts
@@ -39,6 +39,7 @@ import {
   recoverInterruptedPromotion,
   type PromotionExecutedRecord,
   type PromotionIo,
+  type PromotionRecorder,
 } from '../../../src/install/atomic-promotion.js';
 import { PromotionExecutedData } from '../../../src/events/schemas.js';
 
@@ -512,9 +513,10 @@ describe('promoteTree — effect carrier', () => {
     // The owner on the record is the plan's own, so the two cannot drift.
     expect(record?.owner).toBe(promotionPlan('install/atomic-promotion', target).owner);
     // The site declares exactly this name, on success only.
-    expect(promotionPlan('install/atomic-promotion', target).emits).toEqual([
-      { event: PROMOTION_EXECUTED, when: 'on-success' },
-    ]);
+    expect(promotionPlan('install/atomic-promotion', target).emits).toEqual({
+      kind: 'records',
+      emissions: [{ event: PROMOTION_EXECUTED, when: 'on-success' }],
+    });
     // The tree really did land — the record describes a promotion that happened.
     expect(diskDigest(target)).toBe(NEW_DIGEST);
   });
@@ -528,9 +530,21 @@ describe('promoteTree — effect carrier', () => {
     // record it is refused UP FRONT. The refusal propagates rather than
     // arriving as an error carrier: an unrecordable fact is a wiring fault in
     // the caller, not a failure of the promotion.
-    await expect(promoteTree({ target, entries: NEW_TREE }, LIVE, io)).rejects.toThrow(
-      /EMISSION_NOT_RECORDED|declares 1/,
-    );
+    //
+    // The refusal now comes from this owner's own guard rather than from the
+    // carrier. It has to: the owner WRAPS the caller's recorder in a real
+    // capability, so a wrapper around nothing satisfies the carrier's brand
+    // check and the refusal would otherwise land at the success terminal —
+    // after the tree had moved. The invariant this test exists for is the last
+    // two assertions, and they are unchanged.
+    await expect(
+      promoteTree(
+        { target, entries: NEW_TREE },
+        LIVE,
+        io,
+        undefined as unknown as PromotionRecorder,
+      ),
+    ).rejects.toThrow(/requires a recorder|EMISSION_NOT_RECORDED/);
 
     // The one thing that must be true of a refusal: nothing moved.
     expect(touched).toBe(false);

--- a/tests/unit/vcs/mutation-owner.test.ts
+++ b/tests/unit/vcs/mutation-owner.test.ts
@@ -394,6 +394,19 @@ describe('VCS mutation owner (P04-05)', () => {
     expect(isSuccess(second)).toBe(true);
     if (isSuccess(first) && isSuccess(second)) {
       expect(second.value).toEqual(first.value); // replayed the recorded outcome
+
+      // The two runs commit on DIFFERENT evidence, and the distinction is the
+      // whole point of the second arm. The first run minted receipts; the
+      // second performed no effect and minted nothing, so it carries a witness
+      // naming the terminal a previous run recorded. Asserting the arm and the
+      // event together is what stops a refactor pointing the witness at an
+      // event the ledger never wrote for this key.
+      expect(first.evidence.kind).toBe('recorded');
+      expect(second.evidence.kind).toBe('replayed');
+      if (second.evidence.kind === 'replayed') {
+        expect(second.evidence.event).toBe(VCS_EXECUTED);
+        expect(second.evidence.source).toContain(input.idempotencyKey);
+      }
     }
   });
 

--- a/tests/unit/vcs/worktree-provisioner.test.ts
+++ b/tests/unit/vcs/worktree-provisioner.test.ts
@@ -7,7 +7,7 @@
 // whether the report reads "created", "already exists", or "failed".
 
 import { describe, it, expect } from 'vitest';
-import { failed, plannedDryRun, succeeded } from '../../../src/dispatch/core/effect-carrier.js';
+import { failed, plannedDryRun, succeeded, replayedEvidence } from '../../../src/dispatch/core/effect-carrier.js';
 import type { WorktreeCreateResult } from '../../../src/vcs/mutation-owner.js';
 import { mapWorktreeOutcome } from '../../../src/vcs/worktree-provisioner.js';
 
@@ -25,7 +25,7 @@ describe('mapWorktreeOutcome', () => {
       branch: 'feature/x',
       createdBranch: true,
       createdWorktree: true,
-    });
+    }, replayedEvidence('vcs.executed', 'test fixture'));
     expect(mapWorktreeOutcome(outcome)).toEqual({
       ok: true,
       branchCreated: true,
@@ -39,7 +39,7 @@ describe('mapWorktreeOutcome', () => {
       branch: 'feature/x',
       createdBranch: false,
       createdWorktree: false,
-    });
+    }, replayedEvidence('vcs.executed', 'test fixture'));
     expect(mapWorktreeOutcome(outcome)).toEqual({
       ok: true,
       branchCreated: false,

--- a/tests/unit/vcs/worktree-provisioner.test.ts
+++ b/tests/unit/vcs/worktree-provisioner.test.ts
@@ -7,15 +7,23 @@
 // whether the report reads "created", "already exists", or "failed".
 
 import { describe, it, expect } from 'vitest';
-import { failed, plannedDryRun, succeeded, replayedEvidence } from '../../../src/dispatch/core/effect-carrier.js';
+import {
+  failed,
+  plannedDryRun,
+  succeeded,
+  replayedEvidence,
+  records,
+  type EffectPlan,
+} from '../../../src/dispatch/core/effect-carrier.js';
 import type { WorktreeCreateResult } from '../../../src/vcs/mutation-owner.js';
 import { mapWorktreeOutcome } from '../../../src/vcs/worktree-provisioner.js';
 
-const plan = {
-  effectClass: 'vcs' as const,
+const plan: EffectPlan = {
+  effectClass: 'vcs',
   owner: 'vcs-mutation-owner',
   description: 'create worktree',
   idempotent: true,
+  emits: records({ event: 'vcs.executed', when: 'on-success' }),
 };
 
 describe('mapWorktreeOutcome', () => {

--- a/tools/audit/core/authority-live-proof.ts
+++ b/tools/audit/core/authority-live-proof.ts
@@ -998,12 +998,14 @@ export function measureEmissionSinks(source: string, file: string): readonly Mea
 /**
  * The commit gate, measured rather than assumed.
  *
- * `EffectPlan.emits` is only an AUTHORITY because a plan that declares one
- * cannot produce a committed value without a receipt for it — that is what
+ * `EffectPlan.emits` is only an AUTHORITY because a plan cannot produce a
+ * committed value without a receipt for what it declared — that is what
  * `UnrecordedEmissionError` enforces, and without it the field would be a
- * comment. Deleting the gate must therefore take the authority claim with it,
- * so its presence is a fail-closed precondition of the measurement rather than a
- * sentence in the row's prose.
+ * comment. The field is required now, so the claim covers every plan rather
+ * than only the ones that opted in; a plan may still declare that it records
+ * nothing, but it may no longer decline to say. Deleting the gate must take the
+ * authority claim with it, so its presence is a fail-closed precondition of the
+ * measurement rather than a sentence in the row's prose.
  */
 function requireCommitGate(source: string, file: string): number {
   const sourceFile = parseOrThrow(source, file, LABEL);

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,10 +4,10 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1193,
-    "parsedFiles": 1148,
+    "testFiles": 1195,
+    "parsedFiles": 1150,
     "shellFiles": 45,
-    "cases": 13299,
+    "cases": 13314,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -4551,6 +4551,58 @@
     }
   ],
   "files": {
+    "tests/acceptance/effect-carrier-compile-gate.test.ts": {
+      "file": "tests/acceptance/effect-carrier-compile-gate.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "DR-3 — omission fails the build, not the run",
+          "name": "CompileFail_EffectWithoutCommittedEvent_FailsTypecheck",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-3 — omission fails the build, not the run",
+          "name": "CompileFail_FixtureCompilesWhenGuardRemoved",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-3 — omission fails the build, not the run",
+          "name": "CompileGate_ProbeLeavesTheLiveTreeUntouched",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/acceptance/effect-plan-teeth-kill-probes.test.ts": {
+      "file": "tests/acceptance/effect-plan-teeth-kill-probes.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "name": "KillProbe_RequiredEmissionsRelaxed_TypecheckStopsFailing",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "name": "KillProbe_SuccessArmDropsEvidence_ValueBecomesReachable",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "name": "KillProbe_WitnessUnbranded_EvidenceBecomesForgeable",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "name": "KillProbe_RecorderMadeOptional_LiveRunNeedsNoCapability",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "name": "KillProbes_LeaveNoResidue_InTheirOwnWriteSet",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/acceptance/fresh-install.test.ts": {
       "file": "tests/acceptance/fresh-install.test.ts",
       "runner": "vitest:root",
@@ -20984,7 +21036,12 @@
         },
         {
           "suite": "runEffect — the record is on the way to a committed value",
-          "name": "leaves a plan that declares no emissions inert — no capability required",
+          "name": "RunEffect_RecordsNothingPlanWithNoRecorder_RefusesInLiveMode",
+          "dynamic": false
+        },
+        {
+          "suite": "runEffect — the record is on the way to a committed value",
+          "name": "RunEffect_RecordsNothingPlanWithRecorder_CommitsAndRecordsNothing",
           "dynamic": false
         },
         {
@@ -21005,6 +21062,36 @@
         {
           "suite": "toEffectError",
           "name": "derives a class-scoped code and preserves the cause",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "name": "DryRun_EveryPlanDeclares_StillRecordsNothing",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "name": "DryRun_RecordsNothingPlan_IsAlsoSilent",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "name": "RecordEmissions_NonReceiptMidSet_FailsWholeEffect",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "name": "UnrecordedEmissionError_NamesPlanDeclarationAndCount",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "name": "SuccessArm_CarriesAReceiptPerDeclaredEmission",
+          "dynamic": false
+        },
+        {
+          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "name": "SuccessArm_RecordsNothingPlan_CarriesEmptyRecordedEvidence",
           "dynamic": false
         }
       ]

--- a/tools/conformance/src/authority-topology.ts
+++ b/tools/conformance/src/authority-topology.ts
@@ -596,8 +596,10 @@ export const AUTHORITY_TOPOLOGY: Readonly<Record<ContractBoundaryId, AuthorityTo
         whyNotDerivable:
           'The representations are the carrier plus one sink per declaring owner, and no enumerable ' +
           'domain generates that set. `EffectClass` (`dispatch/core/effect-carrier.ts`) is a union, but it ' +
-          'enumerates effect KINDS, not representations of this boundary, and `emits` is optional on ' +
-          'a plan — so no type obliges an owner to appear here. Deriving the row from either would be ' +
+          'enumerates effect KINDS, not representations of this boundary. `emits` is REQUIRED on a plan ' +
+          'now, which narrows the gap without closing it: every plan must say what records it, but a ' +
+          'plan may still say `records-nothing`, and nothing enumerates the owners that build plans — ' +
+          'so no type obliges an owner to appear here. Deriving the row from either would still be ' +
           'a fabricated bridge that reports a totality it does not have.',
       }),
       measured:


### PR DESCRIPTION
## Summary

Finishes **three of anchor 028's four acceptance criteria** ([#1765](https://github.com/lvlup-sw/exarchos/issues/1765)).

**On the two downstream epics, stated precisely.** [#1823](https://github.com/lvlup-sw/exarchos/issues/1823) and [#1825](https://github.com/lvlup-sw/exarchos/issues/1825) both name anchor 028 as their blocker, and 028 is **not fully closed** here. #1825 enumerates four "structural teeth" it is waiting on; this PR delivers three of them (`emits` required, a `Committed<T>`-shaped return, compile-time failure). The fourth it names — *"no `role` discriminator exists"* — is the premise that turned out false. Whether three of four is enough to start 032 and 041 is for those anchors' owners to judge, and this PR does not claim it for them. The fourth — the primary-owner bijection — is **deferred on measured evidence** and recorded below as a named residual rather than reported as met.

PR #1832 built the effect↔event coupling and it works. What was missing was the *obligation*: `emits` was optional, so the guarantee held by the good behaviour of two call sites rather than by construction, and the third call site nobody has written yet was free to skip it. This closes that.

- **`EffectPlan.emits` is required**, as a tagged union — `records(...)` (non-empty by type) or `recordsNothing(because)`. "Records nothing" and "nobody decided" are now different values instead of the same silence.
- **The committed value carries its evidence.** The success arm cannot be built without something saying the record exists, so obtaining `T` means the append happened.
- **The recorder is demanded of every live run** and its parameter narrows to a required `EmissionRecorder`, so omission is a compile error rather than a runtime throw. The throws stay as defence in depth.

## Changes

| Area | What |
|---|---|
| `dispatch/core/effect-carrier.ts` | Required `emits`; `records`/`recordsNothing`/`declaredEmissions`; two-armed branded `EmissionEvidence`; recorder narrowed; 6 new `@proof` aliases |
| `vcs/mutation-owner.ts` | Ledger set migrated; the idempotency-replay arm carries a **witness** instead of a fabricated receipt |
| `install/atomic-promotion.ts` | Promotion set migrated; recorder required; live-mode guard clause |
| `tools/conformance`, `tools/audit` | Two live authority modules re-trued — both asserted `emits` was optional |
| `tests/acceptance/*` (new ×2) | Spawned-`tsc` compile gate; kill-probe suite |
| `tests/unit/dispatch/core/effect-carrier.test.ts` | DR-5 edge tests; two shipped tests inverted |

### Three things worth review attention

**The replay path had no defined semantics, and it is the interesting part.** `mutation-owner.ts` returns a committed value for a terminal recorded on a *previous* run, where no receipt can be minted. Forcing it to fabricate one would claim this run wrote the fact. It carries a witness read from the ledger fold instead — and that witness is **branded by the carrier**, because an unbranded one would let any object literal buy a committed value, reopening the exact hole the branded port closed. The trust model is stated in the module rather than implied — including the part that is NOT parity: the brand stops an object literal from becoming evidence, but `emissionRecorder` is strictly stronger, because it forces a sink to be invoked and awaited while the witness constructor takes two strings and consults nothing. That asymmetry is the price of the replay path, and it is written down rather than glossed.

**`promoteTree` needed a guard clause.** The owner wraps its caller's recorder in a capability, so a wrapper around nothing satisfies the carrier's brand check and the refusal would have landed at the *success terminal* — after the tree had already been promoted. Scoped to live mode: a dry-run promotes nothing and records nothing, so demanding the capability there would break the dry-run guarantee.

**The compile claims live in `src/`, not in a test.** `tests/unit/**` is read by no `tsc` program — the root config excludes `**/*.test.ts` and `tests/tsconfig.json` excludes `unit/**`. Measured both ways: a deliberate type error in `tests/acceptance/` reddens `npm run typecheck`; the identical error in `tests/unit/` passes it clean. Every compile assertion is therefore an exported `@proof` alias in the source module.

## Anchor 028 — criteria re-run and measured

| Criterion | Result |
|---|---|
| `EffectPlan` gains a **required** `emits` | ✅ `readonly emits: PlanEmissions` (`effect-carrier.ts:214`) |
| `T` unreachable without the append | ✅ success arm carries required `evidence` |
| Effecting without committing **fails to compile** | ✅ 13 `@proof` aliases + a spawned-`tsc` fixture |
| Every T1 event has one **primary** owner | ⛔ **DEFERRED — named residual** |

### Why the fourth is deferred, and who owns it

The requirement was authored on a false premise: it claimed `role: 'primary' \| 'recovery'` "appears nowhere in the tree". It does — `AutoEmissionRole` (`registry/gate-metadata.ts:24`), with **86 live edges** carrying both `role` and `owner` across 54 events. The gap was never the discriminator; it was the bijection, and the bijection has two possible populations and both fail:

- **Over the plan-declared events** it is **vacuous**. Zero `autoEmits` anywhere name `vcs.*` or `promotion.executed`, so this slice would author all four triples itself and then have the producers derive from that same table. A gate whose input its own slice authors cannot fail by drift.
- **Over the live 86 edges** it is **red on arrival and probably mis-keyed**: 1 event with zero primaries (`merge.recovered`) and 4 with more than one — `gate.executed` carrying **24**. That 24 looks correct, not broken: many gates each emit it, each the primary emitter of its own occurrence. The criterion keys on event *type*; the catalog keys on event *occurrence*.

Deciding that key is a modelling question about the real catalog. **Owner: the emission-denominator slice.**

## Test Plan

Every gate added here was **killed on purpose and observed to fail** before being kept — the property this programme keeps failing to establish.

- `npm run typecheck` — clean across all three programs (root, `tools/conformance`, `tests`)
- `npm run build` — clean; no git drift, so `render:guard`'s render half is satisfied
- `npx vitest run tests/unit/{dispatch,vcs,install}` + `events/schemas` — **1708 passed**
- `npx vitest run tests/unit/events tests/unit/verbs/team` — passed
- `npm run test:conformance` — authority suites pass (28)
- `npx vitest run tests/architecture` — 230/232 (see below)
- New: `tests/acceptance/effect-carrier-compile-gate.test.ts` (3), `tests/acceptance/effect-plan-teeth-kill-probes.test.ts` (6)

**Kill probes, each asserting both sides** — the real carrier rejects the bad program, and a relaxed copy accepts it:

| Relaxation | Observed |
|---|---|
| `emits` back to optional | the omission compiles |
| `evidence` optional on success arm | an evidence-free value compiles |
| brand removed from the witness | a hand-built witness compiles |
| recorder back to `\| undefined` | a capability-free live call compiles |
| `declaredCount > 0` condition restored | **a capability-free live run COMMITS** (executing probe, spawned node) |
| truncation guard removed | 3 unit tests redden |
| dry-run early return removed | 6 unit tests redden |

No probe touches the live tree; all relax text in a temp directory, and a case asserts the source still declares every guard afterwards.

### Known-red, verified not caused by this change

- `tests/unit/events/store.race.test.ts` — fails **identically with baseline sources reverted** (checked out `e63493269` for the three changed files and re-ran). Known local merge-orchestrate redness.
- `tests/architecture/worktree-inventory.test.ts` — counts live worktrees on the machine; drifts with concurrent sessions.
- `render:guard` — fails in a git worktree only, looking for `node_modules/tsx/dist/cli.mjs` under the worktree root while resolution walks up to the parent checkout. Unrelated to this diff.

## Adversarial review — failed once, remediated

A fresh-context reviewer failed the first pass on **1 HIGH + 3 MEDIUM + 2 LOW**. All six are fixed in `75b48ba60`; the HIGH is worth reading.

**The recorder gate had a runtime half that no probe measured.** DR-5's probe for it was compile-only, and the probe file's header claimed all four gates were type-level. That is false for this one: the parameter is the type-level half, but `effect-carrier.ts`'s brand check is the runtime half — its own comment calls itself *"the boundary the type system does not govern"*. Restoring `declaredEmissions(plan).length > 0 &&` keeps the parameter required, so the compile probe and the type proof both stay green **while the abstention hole reopens for every `records-nothing` plan**. There is now an **executing** probe: it emits the relaxed copy to JavaScript, runs it in a spawned node process, and reads the outcome off stdout. Real carrier → `refused`; relaxed copy → `committed`.

Writing that probe exposed a defect in the probe harness itself. The capability check is spelled **identically** in `recordEmissions` and in `runEffect`, and `String.replace` takes the first match — so the probe relaxed a guard it was not asserting about, and reported that the gate held. `materialize()` checked presence but not **uniqueness**; it now rejects an ambiguous target. That is the same vacuity class the file exists to catch, caught by the file on itself.

The rest: the probes' control arms asserted only that compilation failed and not that it failed *for the fixture* (the arms are asymmetric, so an unrelated error would have made all four pass while measuring nothing); `schemas.test.ts` still called `promoteTree` with two arguments after the signature narrowed to four, passing only because the dry-run arm returns early; the replay witness's brand was probed but its **wiring** was not; and the module overclaimed the two evidence arms as equally strong — `replayedEvidence` takes two strings and consults nothing, while `emissionRecorder` forces a sink to be invoked and awaited. The asymmetry and its reason are now written down rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191kQ7YQZ8khTpiGUmDja2y
