### PR TITLE
feat(events): arm K2 primary-owner bijection gate (anchor 028, 4/4)

### DIFF
--- a/src/events/registration-validate.ts
+++ b/src/events/registration-validate.ts
@@ -167,8 +167,10 @@ import {
   type EffectProvider,
 } from '../contract/reachability/providers.js';
 import { EFFECT_OWNERSHIP, type EffectOwnershipRule } from '../architecture/effect-ledger.js';
-import type { AutoEmissionRole } from '../registry/gate-metadata.js';
 import { TOOL_REGISTRY, type CompositeTool } from '../registry.js';
+
+/** Same union as `registry/gate-metadata.ts` — local to avoid a forbidden events→registry import. */
+type AutoEmissionRole = 'primary' | 'recovery';
 import { EVENT_ANNOTATIONS } from './event-annotations.js';
 import { MODULE_EMISSIONS, type ModuleEmission } from './module-emissions.js';
 import {

--- a/src/events/registration-validate.ts
+++ b/src/events/registration-validate.ts
@@ -167,6 +167,7 @@ import {
   type EffectProvider,
 } from '../contract/reachability/providers.js';
 import { EFFECT_OWNERSHIP, type EffectOwnershipRule } from '../architecture/effect-ledger.js';
+import type { AutoEmissionRole } from '../registry/gate-metadata.js';
 import { TOOL_REGISTRY, type CompositeTool } from '../registry.js';
 import { EVENT_ANNOTATIONS } from './event-annotations.js';
 import { MODULE_EMISSIONS, type ModuleEmission } from './module-emissions.js';
@@ -196,6 +197,17 @@ export const EMISSION_PROVIDER_MISMATCH_CODE = 'EMISSION_PROVIDER_MISMATCH';
  * declared emission edge names — a weld claiming cover nothing in the tool registry backs.
  */
 export const STALE_CAPABILITY_COVER_CODE = 'STALE_CAPABILITY_COVER';
+/** No event type in the autoEmits population names a primary declaring tool. */
+export const ZERO_PRIMARY_OWNER_CODE = 'ZERO_PRIMARY_OWNER';
+/** Two or more distinct primary owners claim the same event type. */
+export const MULTI_PRIMARY_OWNER_CODE = 'MULTI_PRIMARY_OWNER';
+
+/**
+ * The measured size of the K2 primary-owner population: distinct event types that carry at least
+ * one `autoEmits` edge. A floor, not an expectation — same ratchet semantics as
+ * {@link EMISSION_DENOMINATOR_FLOOR}.
+ */
+export const PRIMARY_OWNER_POPULATION_FLOOR = 54;
 
 /**
  * The measured size of the set the provider comparison ranges over: declared emission edges whose
@@ -455,6 +467,38 @@ export type WeldResolutionDiagnostic =
       readonly excludedByLifecycle: number;
       readonly message: string;
       readonly severity: WeldDiagnosticSeverity;
+    }
+  | {
+      readonly code: 'EMPTY_PRIMARY_OWNER_DENOMINATOR';
+      readonly eventType: null;
+      readonly provider: null;
+      readonly message: string;
+      readonly severity: WeldDiagnosticSeverity;
+    }
+  | {
+      readonly code: 'NARROWED_PRIMARY_OWNER_DENOMINATOR';
+      readonly eventType: null;
+      readonly provider: null;
+      readonly compared: number;
+      readonly floor: number;
+      readonly message: string;
+      readonly severity: WeldDiagnosticSeverity;
+    }
+  | {
+      readonly code: typeof ZERO_PRIMARY_OWNER_CODE;
+      readonly eventType: string;
+      readonly provider: null;
+      readonly message: string;
+      readonly severity: WeldDiagnosticSeverity;
+    }
+  | {
+      readonly code: typeof MULTI_PRIMARY_OWNER_CODE;
+      readonly eventType: string;
+      readonly provider: null;
+      /** The distinct primary owners that collided — carried so the fault is readable in one line. */
+      readonly owners: readonly string[];
+      readonly message: string;
+      readonly severity: WeldDiagnosticSeverity;
     };
 
 /**
@@ -476,22 +520,20 @@ export type WeldDiagnosticCode = WeldResolutionDiagnostic['code'];
  * The four REFERENCE-INTEGRITY rows are `blocking`. That is not a placeholder: it is the
  * behaviour this gate shipped with, written down.
  *
- * The five EMISSION-COUPLING rows are `observe`, and that is the whole reason the axis exists.
- * The comparison they carry reports against the live tree BEFORE the tree is reconciled — there
- * are real, measured disagreements in the shipped catalog — so arming it as `blocking` would take
- * every entry point down over a break set nobody has dispositioned yet. Graduating them is a
- * deliberate edit of these rows once that set is disposed of, not a side effect of some other
- * change.
+ * The two EMISSION-COUPLING findings shipped `observe` and have since GRADUATED to `blocking`,
+ * once repair — not narrowing — emptied both break sets. The rows below carry that history
+ * inline; read them, not this paragraph, for which way a given code points.
  *
- * `NARROWED_EMISSION_DENOMINATOR` sits here for a second reason of its own: a floor that refused
- * startup would turn any legitimate re-tiering of a capability event into an unbootable tree for
- * every entry point at once, which is a far worse outcome than the narrowing it is watching for.
+ * The line the table now sits on is not reference-integrity versus emission-coupling. It is a
+ * CATALOG fault versus an INSTRUMENT one: a defect in what the tree declares refuses the process,
+ * and a collapse in this gate's own reach only reports, because a tree whose census stopped
+ * resolving must still boot so somebody can run the tooling that diagnoses it. That sentence is
+ * the whole rule for placing a NEW code.
  *
- * `STALE_CAPABILITY_COVER` sits here for the same reason its sibling comparison does — the shipped
- * catalog carries a measured break set of active capability registrations nothing declares it
- * emits, and refusing every entry point over a set nobody has dispositioned would be a worse gate
- * than none. Its vacuity guard rides at the same severity so the two cannot be read apart: a fault
- * and the reason its denominator vanished should not arrive with different weights.
+ * `NARROWED_EMISSION_DENOMINATOR` sits on the reporting side for a second reason of its own: a
+ * floor that refused startup would turn any legitimate re-tiering of a capability event into an
+ * unbootable tree for every entry point at once, which is a far worse outcome than the narrowing
+ * it is watching for.
  */
 export const DIAGNOSTIC_SEVERITY_POLICY: Readonly<Record<WeldDiagnosticCode, WeldDiagnosticSeverity>> =
   Object.freeze({
@@ -518,6 +560,8 @@ export const DIAGNOSTIC_SEVERITY_POLICY: Readonly<Record<WeldDiagnosticCode, Wel
     // disagreement refuses the process instead of printing a line nobody reads.
     [EMISSION_PROVIDER_MISMATCH_CODE]: 'blocking',
     [STALE_CAPABILITY_COVER_CODE]: 'blocking',
+    [ZERO_PRIMARY_OWNER_CODE]: 'blocking',
+    [MULTI_PRIMARY_OWNER_CODE]: 'blocking',
     // The three EMPTY_*/NARROWED_* denominator diagnostics stay `observe` DELIBERATELY. They fire
     // when a population this gate measures over has collapsed — which is a defect in the gate's
     // own reach, not in the catalog — and a tree whose emission census stopped resolving must
@@ -526,6 +570,8 @@ export const DIAGNOSTIC_SEVERITY_POLICY: Readonly<Record<WeldDiagnosticCode, Wel
     EMPTY_EMISSION_DENOMINATOR: 'observe',
     NARROWED_EMISSION_DENOMINATOR: 'observe',
     EMPTY_STALE_COVER_DENOMINATOR: 'observe',
+    EMPTY_PRIMARY_OWNER_DENOMINATOR: 'observe',
+    NARROWED_PRIMARY_OWNER_DENOMINATOR: 'observe',
   });
 
 /** The verdict, carrying EVERY denominator so no count can be read without its population. */
@@ -693,6 +739,10 @@ export interface EmissionEdge {
   readonly action: string;
   /** The composite tool that action is registered under. */
   readonly declaringTool: string;
+  /** Which edge this declaration is, when the registry carries it. */
+  readonly role?: AutoEmissionRole;
+  /** The accountable owner string from the declaration, when present. */
+  readonly owner?: string;
 }
 
 /**
@@ -711,7 +761,13 @@ export function declaredEmissionEdges(
   for (const tool of registry) {
     for (const action of tool.actions) {
       for (const emission of action.autoEmits ?? []) {
-        edges.push({ event: emission.event, action: action.name, declaringTool: tool.name });
+        edges.push({
+          event: emission.event,
+          action: action.name,
+          declaringTool: tool.name,
+          ...(emission.role !== undefined ? { role: emission.role } : {}),
+          ...(emission.owner !== undefined ? { owner: emission.owner } : {}),
+        });
       }
     }
   }
@@ -746,6 +802,7 @@ export function validateRegistrationWelds(
     Record<EventLifecycle, StaleCoverEligibility>
   > = STALE_COVER_LIFECYCLE_POLICY,
   moduleEmissions: readonly ModuleEmission[] = MODULE_EMISSIONS,
+  primaryOwnerEmissions: readonly EmissionEdge[] = declaredEmissionEdges(),
 ): WeldResolutionVerdict {
   const diagnostics: WeldResolutionDiagnostic[] = [];
   // One lookup, so severity is stamped from the table at every emission site and never decided
@@ -956,6 +1013,83 @@ export function validateRegistrationWelds(
         "entry that would name it, or nothing emits the event and the registration's lifecycle " +
         'should say so.',
     });
+  }
+
+  // ── Primary-owner bijection (K2): per event type, distinct primary owners ──
+  //
+  // Counts distinct primary `owner` strings per event type over the autoEmits population — not
+  // primary edges. A boot-time check over declarations has no access to occurrences; the message
+  // names what is checked (one declaring tool claims primary) rather than an over-broad "owner".
+  const eventsWithEdges = new Set(primaryOwnerEmissions.map((edge) => edge.event));
+  const populationSize = eventsWithEdges.size;
+
+  if (populationSize === 0) {
+    diagnostics.push({
+      code: 'EMPTY_PRIMARY_OWNER_DENOMINATOR',
+      eventType: null,
+      provider: null,
+      severity: severityOf('EMPTY_PRIMARY_OWNER_DENOMINATOR'),
+      message:
+        'no event type is named by any declared autoEmits edge — the primary-owner comparison ' +
+        'ranged over an empty population and cannot have found anything, which must not read as ' +
+        'clean.',
+    });
+  } else if (populationSize < PRIMARY_OWNER_POPULATION_FLOOR) {
+    diagnostics.push({
+      code: 'NARROWED_PRIMARY_OWNER_DENOMINATOR',
+      eventType: null,
+      provider: null,
+      compared: populationSize,
+      floor: PRIMARY_OWNER_POPULATION_FLOOR,
+      severity: severityOf('NARROWED_PRIMARY_OWNER_DENOMINATOR'),
+      message:
+        `the primary-owner comparison ranged over ${populationSize} event type(s), below the ` +
+        `measured floor of ${PRIMARY_OWNER_POPULATION_FLOOR}, out of ${primaryOwnerEmissions.length} declared ` +
+        'edge(s). The population is not empty, so vacuity guards pass and a narrowing still hides. ' +
+        'If the shrink is intended, lower PRIMARY_OWNER_POPULATION_FLOOR in the same change and say why.',
+    });
+  }
+
+  if (populationSize > 0) {
+    const primaryOwnersByEvent = new Map<string, Set<string>>();
+    for (const edge of primaryOwnerEmissions) {
+      if (edge.role !== 'primary' || edge.owner === undefined) continue;
+      let owners = primaryOwnersByEvent.get(edge.event);
+      if (owners === undefined) {
+        owners = new Set();
+        primaryOwnersByEvent.set(edge.event, owners);
+      }
+      owners.add(edge.owner);
+    }
+
+    for (const eventType of [...eventsWithEdges].sort(byString)) {
+      const owners = primaryOwnersByEvent.get(eventType) ?? new Set<string>();
+      if (owners.size === 0) {
+        diagnostics.push({
+          code: ZERO_PRIMARY_OWNER_CODE,
+          eventType,
+          provider: null,
+          severity: severityOf(ZERO_PRIMARY_OWNER_CODE),
+          message:
+            `event '${eventType}' is named by declared autoEmits edge(s) but no edge declares ` +
+            'itself primary with an owner — no declaring tool claims primary for this event type.',
+        });
+        continue;
+      }
+      if (owners.size > 1) {
+        const ownerList = [...owners].sort(byString);
+        diagnostics.push({
+          code: MULTI_PRIMARY_OWNER_CODE,
+          eventType,
+          provider: null,
+          owners: ownerList,
+          severity: severityOf(MULTI_PRIMARY_OWNER_CODE),
+          message:
+            `event '${eventType}' has ${owners.size} distinct primary owners [${ownerList.join(', ')}] ` +
+            '— two or more declaring tools both claim primary for the same event type.',
+        });
+      }
+    }
   }
 
   const sorted = [...diagnostics].sort((a, b) =>
@@ -1689,6 +1823,7 @@ export function assertRegistrationWeldsAtStartup(
     Record<EventLifecycle, StaleCoverEligibility>
   > = STALE_COVER_LIFECYCLE_POLICY,
   moduleEmissions: readonly ModuleEmission[] = MODULE_EMISSIONS,
+  primaryOwnerEmissions: readonly EmissionEdge[] = declaredEmissionEdges(),
 ): WeldResolutionVerdict {
   const verdict = validateRegistrationWelds(
     annotations,
@@ -1699,6 +1834,7 @@ export function assertRegistrationWeldsAtStartup(
     emissions,
     lifecyclePolicy,
     moduleEmissions,
+    primaryOwnerEmissions,
   );
   if (!verdict.bootable) throw new RegistrationWeldError(verdict);
   // Survivable, but not silent. An observation nobody is told about is indistinguishable from a

--- a/src/registry/actions/orchestrate/merge.ts
+++ b/src/registry/actions/orchestrate/merge.ts
@@ -42,10 +42,9 @@ export const mergeActions: readonly BuiltinToolAction[] = [
       // The legacy `merge.rollback` write path is retired (read-tolerant, not
       // emittable) so it is NO LONGER declared here — a `retired` event must not
       // appear in any `autoEmits` (RegistryDrift enforces `autoEmits ⊆ auto`).
-      // Fires only once the execute arm has already failed — the compensating
-      // path, not the normal one. No expiry: the recovery ladder is a permanent
-      // part of the merge contract rather than a stopgap awaiting removal.
-      { event: 'merge.recovered', condition: 'conditional', description: 'When execute fails and the INV-14 recovery ladder runs', role: 'recovery', owner: 'orchestrate' },
+      // Compensation terminal for the merge saga — the only emitter of this
+      // event, not a backstop for another primary edge.
+      { event: 'merge.recovered', condition: 'conditional', description: 'When execute fails and the INV-14 recovery ladder runs', role: 'primary', owner: 'orchestrate' },
       // The terminal marker, appended by `execute-merge.ts` in the same dispatch that already
       // declares `merge.executed`. A losing concurrent invocation returns STATE_CONFLICT and
       // defers completion to the winner, so this is conditional rather than always.

--- a/tests/unit/events/registration-validate.test.ts
+++ b/tests/unit/events/registration-validate.test.ts
@@ -812,6 +812,38 @@ describe('StartupAssertion — the severity axis on the boot refusal', () => {
     }
   });
 
+  it('PrimaryOwnerBijection_SameOwnerDuplicateEdges_DoesNotReportMultiPrimary', () => {
+    const verdict = validateRegistrationWelds(
+      EVENT_ANNOTATIONS,
+      EFFECT_PROVIDERS,
+      EFFECT_OWNERSHIP,
+      WELD_RESOLUTION_POLICY,
+      DIAGNOSTIC_SEVERITY_POLICY,
+      CONFORMING_EMISSIONS,
+      STALE_COVER_LIFECYCLE_POLICY,
+      [],
+      [
+        ...declaredEmissionEdges(),
+        {
+          event: 'seeded.same-owner-dup',
+          action: 'first-claim',
+          declaringTool: 'exarchos_orchestrate',
+          role: 'primary',
+          owner: 'orchestrate',
+        },
+        {
+          event: 'seeded.same-owner-dup',
+          action: 'second-claim',
+          declaringTool: 'exarchos_workflow',
+          role: 'primary',
+          owner: 'orchestrate',
+        },
+      ],
+    );
+
+    expect(verdict.diagnostics.filter((d) => d.code === MULTI_PRIMARY_OWNER_CODE)).toEqual([]);
+  });
+
   it('StartupAssertion_ObserveSeverity_ReportsWithoutThrowing', () => {
     // THE OTHER ARM, over the same six inputs — including the two whose shipped severity is
     // already `observe`, so this loop covers every code the gate can emit rather than only the

--- a/tests/unit/events/registration-validate.test.ts
+++ b/tests/unit/events/registration-validate.test.ts
@@ -53,6 +53,7 @@ import {
   DIAGNOSTIC_SEVERITY_POLICY,
   EMISSION_DENOMINATOR_FLOOR,
   EMISSION_PROVIDER_MISMATCH_CODE,
+  MULTI_PRIMARY_OWNER_CODE,
   PROVIDER_DISAGREEMENT_DISPOSITIONS,
   PROVIDER_REGISTRY_DRIFT_CODE,
   RegistrationWeldError,
@@ -61,6 +62,7 @@ import {
   STALE_COVER_LIFECYCLE_POLICY,
   UNRESOLVABLE_PROVIDER_CODE,
   WELD_RESOLUTION_POLICY,
+  ZERO_PRIMARY_OWNER_CODE,
   assertRegistrationWeldsAtStartup,
   auditDisagreementDispositions,
   auditStaleCoverDispositions,
@@ -188,6 +190,8 @@ function conformingEmissionEdgesFor(
     event: eventType,
     action: `${eventType}-emitter`,
     declaringTool: provider,
+    role: 'primary' as const,
+    owner: provider.startsWith('exarchos_') ? provider.slice('exarchos_'.length) : provider,
   }));
 }
 
@@ -235,6 +239,7 @@ interface DiagnosticSeed {
   readonly providers: readonly EffectProvider[];
   readonly rules: readonly EffectOwnershipRule[];
   readonly emissions: readonly EmissionEdge[];
+  readonly primaryOwnerEmissions?: readonly EmissionEdge[];
 }
 
 /**
@@ -368,6 +373,63 @@ const DIAGNOSTIC_SEEDS: readonly DiagnosticSeed[] = [
     providers: EFFECT_PROVIDERS,
     rules: EFFECT_OWNERSHIP,
     emissions: CONFORMING_EMISSIONS,
+  },
+  {
+    code: 'EMPTY_PRIMARY_OWNER_DENOMINATOR',
+    annotations: EVENT_ANNOTATIONS,
+    providers: EFFECT_PROVIDERS,
+    rules: EFFECT_OWNERSHIP,
+    emissions: CONFORMING_EMISSIONS,
+    primaryOwnerEmissions: [],
+  },
+  {
+    code: 'NARROWED_PRIMARY_OWNER_DENOMINATOR',
+    annotations: EVENT_ANNOTATIONS,
+    providers: EFFECT_PROVIDERS,
+    rules: EFFECT_OWNERSHIP,
+    emissions: CONFORMING_EMISSIONS,
+    primaryOwnerEmissions: declaredEmissionEdges().slice(0, 1),
+  },
+  {
+    code: ZERO_PRIMARY_OWNER_CODE,
+    annotations: EVENT_ANNOTATIONS,
+    providers: EFFECT_PROVIDERS,
+    rules: EFFECT_OWNERSHIP,
+    emissions: CONFORMING_EMISSIONS,
+    primaryOwnerEmissions: [
+      ...declaredEmissionEdges(),
+      {
+        event: 'seeded.zero-primary',
+        action: 'recovery-only',
+        declaringTool: 'exarchos_orchestrate',
+        role: 'recovery',
+        owner: 'orchestrate',
+      },
+    ],
+  },
+  {
+    code: MULTI_PRIMARY_OWNER_CODE,
+    annotations: EVENT_ANNOTATIONS,
+    providers: EFFECT_PROVIDERS,
+    rules: EFFECT_OWNERSHIP,
+    emissions: CONFORMING_EMISSIONS,
+    primaryOwnerEmissions: [
+      ...declaredEmissionEdges(),
+      {
+        event: 'seeded.multi-primary',
+        action: 'orchestrate-claims',
+        declaringTool: 'exarchos_orchestrate',
+        role: 'primary',
+        owner: 'orchestrate',
+      },
+      {
+        event: 'seeded.multi-primary',
+        action: 'workflow-claims',
+        declaringTool: 'exarchos_workflow',
+        role: 'primary',
+        owner: 'workflow',
+      },
+    ],
   },
 ];
 
@@ -677,6 +739,8 @@ describe('StartupAssertion — the severity axis on the boot refusal', () => {
         'EMPTY_PROVIDER_REGISTRY',
         EMISSION_PROVIDER_MISMATCH_CODE,
         STALE_CAPABILITY_COVER_CODE,
+        ZERO_PRIMARY_OWNER_CODE,
+        MULTI_PRIMARY_OWNER_CODE,
       ].sort(),
     );
     expect(codesAt('observe')).toEqual(
@@ -684,6 +748,8 @@ describe('StartupAssertion — the severity axis on the boot refusal', () => {
         'EMPTY_EMISSION_DENOMINATOR',
         'NARROWED_EMISSION_DENOMINATOR',
         'EMPTY_STALE_COVER_DENOMINATOR',
+        'EMPTY_PRIMARY_OWNER_DENOMINATOR',
+        'NARROWED_PRIMARY_OWNER_DENOMINATOR',
       ].sort(),
     );
 
@@ -711,6 +777,7 @@ describe('StartupAssertion — the severity axis on the boot refusal', () => {
         // shipped table would let an unrelated `MODULE_EMISSIONS` row cover the stale-cover seed,
         // which is exactly how this loop would silently stop exercising the code it names.
         [],
+        seed.primaryOwnerEmissions ?? declaredEmissionEdges(),
       );
       const matching = verdict.diagnostics.filter((d) => d.code === seed.code);
       expect(matching.length).toBeGreaterThan(0);
@@ -738,6 +805,7 @@ describe('StartupAssertion — the severity axis on the boot refusal', () => {
           seed.emissions,
           STALE_COVER_LIFECYCLE_POLICY,
           [],
+          seed.primaryOwnerEmissions ?? declaredEmissionEdges(),
         ),
       ).toThrow(RegistrationWeldError);
       expect(reported).toEqual([]);
@@ -767,6 +835,7 @@ describe('StartupAssertion — the severity axis on the boot refusal', () => {
         // Seeded world: no non-action emitters. Inheriting the shipped table
         // would let an unrelated row cover a seed and silently empty this arm.
         [],
+        seed.primaryOwnerEmissions ?? declaredEmissionEdges(),
       );
 
       // Found something, and said so — but did not stop the process.
@@ -1024,6 +1093,7 @@ describe('ProviderComparison — the declaring tool against the declared provide
       // surface is emptied too — otherwise the premise the assertion rests on
       // is false and the counts below measure a different scenario.
       [],
+      [],
     );
     expect(verdict.comparedEmissionEdgeCount).toBe(0);
     expect(verdict.ok).toBe(false);
@@ -1038,9 +1108,13 @@ describe('ProviderComparison — the declaring tool against the declared provide
     const emptyCodes = verdict.diagnostics
       .map((d) => d.code)
       .filter((code) => code.startsWith('EMPTY_') || code === 'NARROWED_EMISSION_DENOMINATOR');
-    expect(emptyCodes).toEqual(['EMPTY_EMISSION_DENOMINATOR']);
+    expect(emptyCodes).toEqual(['EMPTY_EMISSION_DENOMINATOR', 'EMPTY_PRIMARY_OWNER_DENOMINATOR']);
     expect(new Set(verdict.diagnostics.map((d) => d.code))).toEqual(
-      new Set(['EMPTY_EMISSION_DENOMINATOR', STALE_CAPABILITY_COVER_CODE]),
+      new Set([
+        'EMPTY_EMISSION_DENOMINATOR',
+        'EMPTY_PRIMARY_OWNER_DENOMINATOR',
+        STALE_CAPABILITY_COVER_CODE,
+      ]),
     );
     expect(
       verdict.diagnostics.filter((d) => d.code === STALE_CAPABILITY_COVER_CODE),

--- a/tools/audit/core/measure-primary-owner-population.mjs
+++ b/tools/audit/core/measure-primary-owner-population.mjs
@@ -1,0 +1,397 @@
+// What does "exactly one primary owner" quantify over? Enumerate each candidate.
+//
+// ── Why this is a census and not a gate ─────────────────────────────────────
+//
+// The one-primary-owner criterion has been specified three times and refuted
+// three times, always for the same reason: the check was designed before anyone
+// decided which population it ranged over. Two populations are obvious and both
+// are wrong. Over the events an `EffectPlan` names, the slice arming the check
+// would author its own input, so drift is unreachable and the gate cannot fail.
+// Over the live emission edges the check is red on arrival — and the largest
+// red row is `gate.executed`, where many gates each emit it, each the primary
+// emitter of its own occurrence. That is not a catalog defect; it is evidence
+// the criterion keys on event TYPE while the catalog keys on something else.
+//
+// So this file counts rather than judges. It enumerates the population under
+// every candidate key, keeps zero-primary and multi-primary apart (they are
+// different defects and must not share a disposition), and writes the numbers
+// down. The decision is made against the output, not against a description of
+// it.
+//
+// ── The two counts the criterion conflates ─────────────────────────────────
+//
+// "Exactly one primary owner" can be read two ways over the same catalog, and
+// they disagree. Counting primary EDGES asks how many declarations claim the
+// primary role. Counting distinct primary OWNERS asks how many accountable
+// parties those declarations name. Twenty-four gate actions all declaring
+// `owner: 'orchestrate'` are twenty-four edges and one owner. The criterion
+// says "owner", so both are measured and reported separately; picking one
+// silently is how the previous attempts smuggled the modelling decision into
+// an implementation detail.
+//
+// ── Determinism is the point ────────────────────────────────────────────────
+//
+// The output carries no timestamp and no commit sha, so re-running on an
+// unchanged tree reproduces it byte for byte and `--check` can tell "the
+// catalog moved" from "the script ran again". A census whose output churns on
+// every run cannot be evidence of anything.
+//
+// Usage:
+//   node tools/audit/core/measure-primary-owner-population.mjs           # write
+//   node tools/audit/core/measure-primary-owner-population.mjs --check   # verify
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const OUT = path.join(ROOT, 'tools/audit/core/primary-owner-population.json');
+
+// ─── Raw facts, read from the live registry as VALUES ────────────────────────
+//
+// Read by importing, never by parsing: a regex over `src/registry/actions/**`
+// would be a second authority on what the registry contains, and the whole
+// point of the measurement is that it agrees with what boots. The registry
+// pulls the SQLite substrate, so it runs through the workspace's own `tsx`
+// rather than this process.
+const EXTRACT = `
+import { TOOL_REGISTRY } from './src/registry.js';
+import { EVENT_ANNOTATIONS } from './src/events/event-annotations.js';
+import { MODULE_EMISSIONS } from './src/events/module-emissions.js';
+import { VCS_LEDGER_EMISSIONS } from './src/vcs/mutation-owner.js';
+import { PROMOTION_EXECUTED } from './src/install/atomic-promotion.js';
+
+const edges = [];
+for (const tool of TOOL_REGISTRY) {
+  for (const action of tool.actions) {
+    for (const emission of action.autoEmits ?? []) {
+      edges.push({
+        event: emission.event,
+        action: action.name,
+        declaringTool: tool.name,
+        condition: emission.condition,
+        role: emission.role ?? null,
+        owner: emission.owner ?? null,
+      });
+    }
+  }
+}
+
+const annotations = {};
+for (const [event, registration] of Object.entries(EVENT_ANNOTATIONS)) {
+  annotations[event] = { tier: registration.tier, lifecycle: registration.lifecycle };
+}
+
+// The events an EffectPlan names. Derived from the two live plan sites rather
+// than transcribed, so a third sink appearing shows up here instead of going
+// unnoticed.
+const planDeclared = [
+  ...VCS_LEDGER_EMISSIONS.emissions.map((e) => e.event),
+  PROMOTION_EXECUTED,
+];
+
+process.stdout.write(
+  '<<<CENSUS>>>' +
+    JSON.stringify({
+      edges,
+      annotations,
+      moduleEmissions: MODULE_EMISSIONS.map((m) => ({
+        event: m.event,
+        module: m.module,
+        trigger: m.trigger,
+      })),
+      planDeclared,
+    }),
+);
+`;
+
+function readRawFacts() {
+  const tmp = path.join(ROOT, '.tmp-primary-owner-census.mts');
+  fs.writeFileSync(tmp, EXTRACT, 'utf8');
+  try {
+    const out = execFileSync('npx', ['tsx', tmp], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const marker = out.indexOf('<<<CENSUS>>>');
+    if (marker === -1) throw new Error(`census extractor produced no payload:\n${out}`);
+    return JSON.parse(out.slice(marker + '<<<CENSUS>>>'.length));
+  } finally {
+    fs.rmSync(tmp, { force: true });
+  }
+}
+
+// ─── Candidate keys ─────────────────────────────────────────────────────────
+
+const byName = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+
+/**
+ * Group the edges by a key, then count primaries within each group two ways.
+ *
+ * `countOwners` is what separates the two readings of the criterion: counting
+ * distinct owner strings asks how many parties are accountable, counting edges
+ * asks how many declarations exist. A group whose edges all name one owner has
+ * one owner and many edges.
+ */
+function tally(edges, keyOf) {
+  const groups = new Map();
+  for (const edge of edges) {
+    const key = keyOf(edge);
+    let group = groups.get(key);
+    if (group === undefined) {
+      group = { key, edges: [], primaryEdges: [], primaryOwners: new Set() };
+      groups.set(key, group);
+    }
+    group.edges.push(edge);
+    if (edge.role === 'primary') {
+      group.primaryEdges.push(edge);
+      if (edge.owner !== null) group.primaryOwners.add(edge.owner);
+    }
+  }
+  return [...groups.values()].sort((a, b) => byName(a.key, b.key));
+}
+
+/**
+ * Split a tallied population into satisfying, zero-primary and multi-primary.
+ *
+ * The two violation arms stay separate all the way to the output. Zero primary
+ * owners means nothing claims the event; more than one means two things claim
+ * it. Merging them into a single "violations" count is how a disposition ends
+ * up applying the wrong repair to half its subjects.
+ */
+function verdict(groups, count) {
+  const satisfied = [];
+  const zeroPrimary = [];
+  const multiPrimary = [];
+  for (const group of groups) {
+    const n = count(group);
+    const row = {
+      key: group.key,
+      primaryEdges: group.primaryEdges.length,
+      primaryOwners: [...group.primaryOwners].sort(byName),
+      declaringEdges: group.edges.length,
+      declaredBy: group.edges
+        .map((e) => `${e.declaringTool}.${e.action}`)
+        .sort(byName)
+        .filter((id, i, all) => all.indexOf(id) === i),
+    };
+    if (n === 1) satisfied.push(row);
+    else if (n === 0) zeroPrimary.push(row);
+    else multiPrimary.push(row);
+  }
+  return {
+    populationSize: groups.length,
+    satisfyingCount: satisfied.length,
+    zeroPrimaryCount: zeroPrimary.length,
+    multiPrimaryCount: multiPrimary.length,
+    zeroPrimary,
+    multiPrimary,
+    // The satisfying rows are the population a gate would range over without
+    // failing. Their key names alone are enough; the detail is on the
+    // violations, which are the rows a disposition has to act on.
+    satisfyingKeys: satisfied.map((row) => row.key),
+  };
+}
+
+/**
+ * Can this key's two failure arms ever fire?
+ *
+ * A key with no live violations is not the same as a key that can never have
+ * one, and the difference is the whole reason this census exists — the
+ * per-emission-site key looks clean for the same reason a deleted guard looks
+ * clean. So each key is probed with the SAME two drifts, over a COPY of the
+ * measured edges, and reported on whether it notices.
+ *
+ * The two recipes are the realistic drifts, not arbitrary mutations:
+ *
+ *   • MULTI — a second action, in a different tool, starts declaring itself the
+ *     primary emitter of an already-owned event. That is two parties claiming
+ *     one event, which is exactly what a bijection exists to catch.
+ *   • ZERO — an event's only primary edge is relabelled `recovery`. That is not
+ *     hypothetical: it is what `merge.recovered` looks like today.
+ *
+ * This is a reachability probe over data, NOT the seeded kill-probe a shipped
+ * gate owes. It says an arm is expressible; it does not say a check was
+ * observed to reject it.
+ */
+function probeArms(edges, keyOf, count) {
+  const subject = edges.find((e) => e.role === 'primary');
+  if (subject === undefined) return { multiArmReachable: false, zeroArmReachable: false };
+
+  const groupCount = (population, key) => {
+    const group = tally(population, keyOf).find((g) => g.key === key);
+    return group === undefined ? null : count(group);
+  };
+
+  // MULTI: clone the subject onto a foreign tool, still claiming primary.
+  const foreign = {
+    ...subject,
+    action: `${subject.action}__seeded`,
+    declaringTool: '__seeded_tool',
+    owner: '__seeded_owner',
+  };
+  const withForeign = [...edges, foreign];
+  const multiArmReachable = tally(withForeign, keyOf).some((g) => count(g) > 1);
+
+  // ZERO: relabel every primary edge of one event as recovery. Pick an event
+  // with a single primary so the relabel is total for that event.
+  const primariesPerEvent = new Map();
+  for (const edge of edges) {
+    if (edge.role !== 'primary') continue;
+    primariesPerEvent.set(edge.event, (primariesPerEvent.get(edge.event) ?? 0) + 1);
+  }
+  const soleOwned = [...primariesPerEvent.entries()].find(([, n]) => n === 1);
+  let zeroArmReachable = false;
+  if (soleOwned !== undefined) {
+    const [event] = soleOwned;
+    const relabelled = edges.map((e) =>
+      e.event === event && e.role === 'primary' ? { ...e, role: 'recovery' } : e,
+    );
+    zeroArmReachable = tally(relabelled, keyOf).some(
+      (g) => g.edges.some((e) => e.event === event) && count(g) === 0,
+    );
+  }
+
+  return { multiArmReachable, zeroArmReachable, probedWith: { multi: foreign.event, zero: soleOwned?.[0] ?? null } };
+}
+
+function measure(raw) {
+  const edges = [...raw.edges].sort(
+    (a, b) =>
+      byName(a.event, b.event) || byName(a.declaringTool, b.declaringTool) || byName(a.action, b.action),
+  );
+
+  const byEventType = tally(edges, (e) => e.event);
+  const byEmissionSite = tally(edges, (e) => `${e.event}@${e.declaringTool}.${e.action}`);
+  const byEventAndTool = tally(edges, (e) => `${e.event}@${e.declaringTool}`);
+
+  /** One key's live verdict, plus whether either of its arms could ever fire. */
+  const keyed = (groups, keyOf, count) => ({
+    ...verdict(groups, count),
+    arms: probeArms(edges, keyOf, count),
+  });
+
+  // The per-tier key is not a fourth grouping of edges — it is the per-type key
+  // restricted to a subset of tiers. So it is reported as the tier breakdown of
+  // the per-type population, which is what a tier-scoped rule would have to
+  // choose from.
+  const tierRows = new Map();
+  for (const group of byEventType) {
+    const annotation = raw.annotations[group.key];
+    const tier = annotation === undefined ? '<unregistered>' : annotation.tier;
+    let row = tierRows.get(tier);
+    if (row === undefined) {
+      row = { tier, events: [], zeroPrimaryEvents: [], multiPrimaryEventsByOwner: [] };
+      tierRows.set(tier, row);
+    }
+    row.events.push(group.key);
+    if (group.primaryOwners.size === 0) row.zeroPrimaryEvents.push(group.key);
+    else if (group.primaryOwners.size > 1) row.multiPrimaryEventsByOwner.push(group.key);
+  }
+  const perTier = [...tierRows.values()]
+    .map((row) => ({
+      tier: row.tier,
+      eventCount: row.events.length,
+      events: row.events.sort(byName),
+      zeroPrimaryEvents: row.zeroPrimaryEvents.sort(byName),
+      multiPrimaryEventsByOwner: row.multiPrimaryEventsByOwner.sort(byName),
+    }))
+    .sort((a, b) => byName(a.tier, b.tier));
+
+  const declaredEvents = new Set(edges.map((e) => e.event));
+  const planDeclared = [...new Set(raw.planDeclared)].sort(byName);
+
+  return {
+    // What the numbers below are a function of. A reader who re-runs this and
+    // sees different totals is looking at a moved catalog, not a flaky script.
+    totals: {
+      emissionEdges: edges.length,
+      edgesCarryingRole: edges.filter((e) => e.role !== null).length,
+      edgesCarryingOwner: edges.filter((e) => e.owner !== null).length,
+      distinctEventsWithEdges: declaredEvents.size,
+      distinctOwners: [...new Set(edges.map((e) => e.owner).filter((o) => o !== null))].sort(byName)
+        .length,
+      registeredEvents: Object.keys(raw.annotations).length,
+      moduleEmitterRows: raw.moduleEmissions.length,
+    },
+
+    keys: {
+      // K1 — the reading the criterion is written in, counting declarations.
+      'per-event-type/primary-edges': keyed(byEventType, (e) => e.event, (g) => g.primaryEdges.length),
+      // K2 — the same key, counting the accountable parties the criterion
+      // actually names. This is the reading the word "owner" supports.
+      'per-event-type/primary-owners': keyed(byEventType, (e) => e.event, (g) => g.primaryOwners.size),
+      // K3 — one emission site is one occurrence's declared emitter. A site is
+      // a single declaration, so this can only fail on a literally duplicated
+      // one; whether that is expressible at all is the finding.
+      'per-emission-site/primary-edges': keyed(
+        byEmissionSite,
+        (e) => `${e.event}@${e.declaringTool}.${e.action}`,
+        (g) => g.primaryEdges.length,
+      ),
+      // K4 — the middle reading: one primary owner per event per declaring
+      // tool. Collapses sibling actions of one tool without collapsing tools.
+      'per-event-and-tool/primary-owners': keyed(
+        byEventAndTool,
+        (e) => `${e.event}@${e.declaringTool}`,
+        (g) => g.primaryOwners.size,
+      ),
+    },
+
+    // K5 — the tier-scoped rule, as the tier breakdown of the per-type
+    // population. A tier-scoped gate has to pick its tiers from this table.
+    perTier,
+
+    // The other candidate population, and why it is empty. Zero overlap means a
+    // gate keyed here would range over events no edge declares.
+    planDeclaredPopulation: {
+      events: planDeclared,
+      coveredByAutoEmits: planDeclared.filter((e) => declaredEvents.has(e)).sort(byName),
+      uncoveredByAutoEmits: planDeclared.filter((e) => !declaredEvents.has(e)).sort(byName),
+      registeredInCatalog: planDeclared.filter((e) => raw.annotations[e] !== undefined).sort(byName),
+    },
+
+    // Emitters that are not actions carry no role and no owner. They are
+    // reported because an event whose only emitter is a module has zero primary
+    // owners for a structural reason, not a missing declaration — and the two
+    // must not receive the same disposition.
+    moduleEmitters: [...raw.moduleEmissions]
+      .map((m) => ({
+        ...m,
+        alsoDeclaredByAnAction: declaredEvents.has(m.event),
+      }))
+      .sort((a, b) => byName(a.event, b.event) || byName(a.module, b.module)),
+
+    // Events with an emission edge but no catalog registration. Empty is the
+    // expected answer; a non-empty list would mean the per-type key ranges over
+    // events the catalog does not know.
+    unregisteredEmittedEvents: [...declaredEvents]
+      .filter((e) => raw.annotations[e] === undefined)
+      .sort(byName),
+  };
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────────
+
+const rendered = `${JSON.stringify(measure(readRawFacts()), null, 2)}\n`;
+
+if (process.argv.includes('--check')) {
+  const existing = fs.existsSync(OUT) ? fs.readFileSync(OUT, 'utf8') : null;
+  if (existing === rendered) {
+    console.log(`primary-owner population census matches ${path.relative(ROOT, OUT)}`);
+    process.exit(0);
+  }
+  console.error(
+    existing === null
+      ? `MISSING: ${path.relative(ROOT, OUT)} — run this script without --check to write it.`
+      : `DRIFT: the catalog no longer matches ${path.relative(ROOT, OUT)}.\n` +
+          'Re-run without --check, then re-read the decision this census supports: the\n' +
+          'population under the chosen key has moved, so the disposition may be stale.',
+  );
+  process.exit(1);
+}
+
+fs.writeFileSync(OUT, rendered, 'utf8');
+console.log(`wrote ${path.relative(ROOT, OUT)}`);

--- a/tools/audit/core/measure-primary-owner-population.mjs
+++ b/tools/audit/core/measure-primary-owner-population.mjs
@@ -44,9 +44,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const OUT = path.join(ROOT, 'tools/audit/core/primary-owner-population.json');
+/** Must match {@link PRIMARY_OWNER_POPULATION_FLOOR} in `src/events/registration-validate.ts`. */
+const PRIMARY_OWNER_POPULATION_FLOOR = 54;
+const CENSUS_MARKER = '<<<CENSUS>>>';
 
 // ─── Raw facts, read from the live registry as VALUES ────────────────────────
 //
@@ -92,7 +96,7 @@ const planDeclared = [
 ];
 
 process.stdout.write(
-  '<<<CENSUS>>>' +
+  '${CENSUS_MARKER}' +
     JSON.stringify({
       edges,
       annotations,
@@ -102,22 +106,26 @@ process.stdout.write(
         trigger: m.trigger,
       })),
       planDeclared,
-    }),
+    }) +
+    '${CENSUS_MARKER}',
 );
 `;
 
 function readRawFacts() {
-  const tmp = path.join(ROOT, '.tmp-primary-owner-census.mts');
+  const tmp = path.join(ROOT, `.tmp-primary-owner-census-${randomUUID()}.mts`);
+  const tsxCli = path.join(ROOT, 'node_modules/tsx/dist/cli.mjs');
   fs.writeFileSync(tmp, EXTRACT, 'utf8');
   try {
-    const out = execFileSync('npx', ['tsx', tmp], {
+    const out = execFileSync(process.execPath, [tsxCli, tmp], {
       cwd: ROOT,
       encoding: 'utf8',
       maxBuffer: 32 * 1024 * 1024,
     });
-    const marker = out.indexOf('<<<CENSUS>>>');
+    const marker = out.indexOf(CENSUS_MARKER);
     if (marker === -1) throw new Error(`census extractor produced no payload:\n${out}`);
-    return JSON.parse(out.slice(marker + '<<<CENSUS>>>'.length));
+    const end = out.indexOf(CENSUS_MARKER, marker + CENSUS_MARKER.length);
+    if (end === -1) throw new Error(`census extractor payload was truncated:\n${out}`);
+    return JSON.parse(out.slice(marker + CENSUS_MARKER.length, end));
   } finally {
     fs.rmSync(tmp, { force: true });
   }
@@ -141,13 +149,20 @@ function tally(edges, keyOf) {
     const key = keyOf(edge);
     let group = groups.get(key);
     if (group === undefined) {
-      group = { key, edges: [], primaryEdges: [], primaryOwners: new Set() };
+      group = {
+        key,
+        edges: [],
+        primaryEdges: [],
+        primaryOwners: new Set(),
+        unattributedPrimaryEdges: [],
+      };
       groups.set(key, group);
     }
     group.edges.push(edge);
     if (edge.role === 'primary') {
       group.primaryEdges.push(edge);
-      if (edge.owner !== null) group.primaryOwners.add(edge.owner);
+      if (edge.owner === null) group.unattributedPrimaryEdges.push(edge);
+      else group.primaryOwners.add(edge.owner);
     }
   }
   return [...groups.values()].sort((a, b) => byName(a.key, b.key));
@@ -164,6 +179,7 @@ function tally(edges, keyOf) {
 function verdict(groups, count) {
   const satisfied = [];
   const zeroPrimary = [];
+  const unownedPrimary = [];
   const multiPrimary = [];
   for (const group of groups) {
     const n = count(group);
@@ -171,6 +187,7 @@ function verdict(groups, count) {
       key: group.key,
       primaryEdges: group.primaryEdges.length,
       primaryOwners: [...group.primaryOwners].sort(byName),
+      unattributedPrimaryEdges: group.unattributedPrimaryEdges.length,
       declaringEdges: group.edges.length,
       declaredBy: group.edges
         .map((e) => `${e.declaringTool}.${e.action}`)
@@ -178,6 +195,7 @@ function verdict(groups, count) {
         .filter((id, i, all) => all.indexOf(id) === i),
     };
     if (n === 1) satisfied.push(row);
+    else if (n === 0 && group.unattributedPrimaryEdges.length > 0) unownedPrimary.push(row);
     else if (n === 0) zeroPrimary.push(row);
     else multiPrimary.push(row);
   }
@@ -185,8 +203,10 @@ function verdict(groups, count) {
     populationSize: groups.length,
     satisfyingCount: satisfied.length,
     zeroPrimaryCount: zeroPrimary.length,
+    unownedPrimaryCount: unownedPrimary.length,
     multiPrimaryCount: multiPrimary.length,
     zeroPrimary,
+    unownedPrimary,
     multiPrimary,
     // The satisfying rows are the population a gate would range over without
     // failing. Their key names alone are enough; the detail is on the
@@ -218,7 +238,13 @@ function verdict(groups, count) {
  */
 function probeArms(edges, keyOf, count) {
   const subject = edges.find((e) => e.role === 'primary');
-  if (subject === undefined) return { multiArmReachable: false, zeroArmReachable: false };
+  if (subject === undefined) {
+    return {
+      multiArmReachable: false,
+      zeroArmReachable: false,
+      probedWith: { multi: null, zero: null },
+    };
+  }
 
   const groupCount = (population, key) => {
     const group = tally(population, keyOf).find((g) => g.key === key);
@@ -232,8 +258,12 @@ function probeArms(edges, keyOf, count) {
     declaringTool: '__seeded_tool',
     owner: '__seeded_owner',
   };
-  const withForeign = [...edges, foreign];
-  const multiArmReachable = tally(withForeign, keyOf).some((g) => count(g) > 1);
+  // Only the seeded group's own count may answer this. A population-wide scan
+  // would report the arm reachable on the strength of a pre-existing row.
+  const seededKey = keyOf(foreign);
+  const before = groupCount(edges, seededKey) ?? 0;
+  const after = groupCount([...edges, foreign], seededKey) ?? 0;
+  const multiArmReachable = after > 1 && after > before;
 
   // ZERO: relabel every primary edge of one event as recovery. Pick an event
   // with a single primary so the relabel is total for that event.
@@ -375,7 +405,20 @@ function measure(raw) {
 
 // ─── Entry point ────────────────────────────────────────────────────────────
 
-const rendered = `${JSON.stringify(measure(readRawFacts()), null, 2)}\n`;
+function assertPopulationFloor(measured) {
+  const population = measured.keys['per-event-type/primary-owners'].populationSize;
+  if (population !== PRIMARY_OWNER_POPULATION_FLOOR) {
+    throw new Error(
+      `PRIMARY_OWNER_POPULATION_FLOOR drift: census reports ${population}, ` +
+        `script constant is ${PRIMARY_OWNER_POPULATION_FLOOR}; reconcile with ` +
+        'src/events/registration-validate.ts PRIMARY_OWNER_POPULATION_FLOOR.',
+    );
+  }
+}
+
+const measured = measure(readRawFacts());
+assertPopulationFloor(measured);
+const rendered = `${JSON.stringify(measured, null, 2)}\n`;
 
 if (process.argv.includes('--check')) {
   const existing = fs.existsSync(OUT) ? fs.readFileSync(OUT, 'utf8') : null;

--- a/tools/audit/core/primary-owner-population.json
+++ b/tools/audit/core/primary-owner-population.json
@@ -1,0 +1,600 @@
+{
+  "totals": {
+    "emissionEdges": 86,
+    "edgesCarryingRole": 86,
+    "edgesCarryingOwner": 86,
+    "distinctEventsWithEdges": 54,
+    "distinctOwners": 2,
+    "registeredEvents": 176,
+    "moduleEmitterRows": 11
+  },
+  "keys": {
+    "per-event-type/primary-edges": {
+      "populationSize": 54,
+      "satisfyingCount": 50,
+      "zeroPrimaryCount": 0,
+      "multiPrimaryCount": 4,
+      "zeroPrimary": [],
+      "multiPrimary": [
+        {
+          "key": "admission.evidence-recorded",
+          "primaryEdges": 5,
+          "primaryOwners": [
+            "orchestrate"
+          ],
+          "declaringEdges": 5,
+          "declaredBy": [
+            "exarchos_orchestrate.check_contract_drift",
+            "exarchos_orchestrate.check_integration_suite",
+            "exarchos_orchestrate.check_mock_boundary",
+            "exarchos_orchestrate.check_static_analysis",
+            "exarchos_orchestrate.check_test_adequacy"
+          ]
+        },
+        {
+          "key": "gate.executed",
+          "primaryEdges": 24,
+          "primaryOwners": [
+            "orchestrate"
+          ],
+          "declaringEdges": 24,
+          "declaredBy": [
+            "exarchos_orchestrate.assess_stack",
+            "exarchos_orchestrate.check_context_economy",
+            "exarchos_orchestrate.check_contract_drift",
+            "exarchos_orchestrate.check_convergence",
+            "exarchos_orchestrate.check_design_completeness",
+            "exarchos_orchestrate.check_event_emissions",
+            "exarchos_orchestrate.check_exploration_depth",
+            "exarchos_orchestrate.check_integration_suite",
+            "exarchos_orchestrate.check_invariant_conformance",
+            "exarchos_orchestrate.check_mock_boundary",
+            "exarchos_orchestrate.check_operational_resilience",
+            "exarchos_orchestrate.check_plan_coverage",
+            "exarchos_orchestrate.check_post_merge",
+            "exarchos_orchestrate.check_provenance_chain",
+            "exarchos_orchestrate.check_review_verdict",
+            "exarchos_orchestrate.check_security_scan",
+            "exarchos_orchestrate.check_static_analysis",
+            "exarchos_orchestrate.check_task_decomposition",
+            "exarchos_orchestrate.check_test_adequacy",
+            "exarchos_orchestrate.check_workflow_determinism",
+            "exarchos_orchestrate.mutation-adequacy",
+            "exarchos_orchestrate.post_delegation_check",
+            "exarchos_orchestrate.pre_synthesis_check",
+            "exarchos_orchestrate.prepare_synthesis"
+          ]
+        },
+        {
+          "key": "worktree.merge_executed",
+          "primaryEdges": 2,
+          "primaryOwners": [
+            "orchestrate"
+          ],
+          "declaringEdges": 2,
+          "declaredBy": [
+            "exarchos_orchestrate.reconcile_worktrees",
+            "exarchos_orchestrate.serialize_merge"
+          ]
+        },
+        {
+          "key": "worktree.released",
+          "primaryEdges": 2,
+          "primaryOwners": [
+            "orchestrate"
+          ],
+          "declaringEdges": 2,
+          "declaredBy": [
+            "exarchos_orchestrate.reconcile_worktrees",
+            "exarchos_orchestrate.release_worktree"
+          ]
+        }
+      ],
+      "satisfyingKeys": [
+        "admission.enforcement-enabled",
+        "admission.rollout-decision",
+        "catalog.registered",
+        "ci.status",
+        "diagnostic.executed",
+        "feedback.recorded",
+        "invariant.amended",
+        "invariant.authored",
+        "issue.created",
+        "launch.executed",
+        "merge.completed",
+        "merge.executed",
+        "merge.preflight",
+        "merge.recovered",
+        "mutation.executed",
+        "mutation.executing_started",
+        "onboard.executed",
+        "onboard.requested",
+        "pr.commented",
+        "pr.created",
+        "pr.merged",
+        "prune.executed",
+        "prune.executing_started",
+        "quality.hint.generated",
+        "review.routed",
+        "shepherd.approval_requested",
+        "shepherd.completed",
+        "shepherd.escalated",
+        "shepherd.started",
+        "stack.position-filled",
+        "state.patched",
+        "synthesize.requested",
+        "task.claimed",
+        "task.completed",
+        "task.failed",
+        "workflow.cancel",
+        "workflow.checkpoint",
+        "workflow.cleanup",
+        "workflow.compensation",
+        "workflow.fix-cycle",
+        "workflow.pruned",
+        "workflow.rehydrated",
+        "workflow.started",
+        "workflow.transition",
+        "worktree.adopted",
+        "worktree.merge_requested",
+        "worktree.orphan_detected",
+        "worktree.remove.executed",
+        "worktree.remove.requested",
+        "worktree.reserved"
+      ],
+      "arms": {
+        "multiArmReachable": true,
+        "zeroArmReachable": true,
+        "probedWith": {
+          "multi": "admission.enforcement-enabled",
+          "zero": "admission.enforcement-enabled"
+        }
+      }
+    },
+    "per-event-type/primary-owners": {
+      "populationSize": 54,
+      "satisfyingCount": 54,
+      "zeroPrimaryCount": 0,
+      "multiPrimaryCount": 0,
+      "zeroPrimary": [],
+      "multiPrimary": [],
+      "satisfyingKeys": [
+        "admission.enforcement-enabled",
+        "admission.evidence-recorded",
+        "admission.rollout-decision",
+        "catalog.registered",
+        "ci.status",
+        "diagnostic.executed",
+        "feedback.recorded",
+        "gate.executed",
+        "invariant.amended",
+        "invariant.authored",
+        "issue.created",
+        "launch.executed",
+        "merge.completed",
+        "merge.executed",
+        "merge.preflight",
+        "merge.recovered",
+        "mutation.executed",
+        "mutation.executing_started",
+        "onboard.executed",
+        "onboard.requested",
+        "pr.commented",
+        "pr.created",
+        "pr.merged",
+        "prune.executed",
+        "prune.executing_started",
+        "quality.hint.generated",
+        "review.routed",
+        "shepherd.approval_requested",
+        "shepherd.completed",
+        "shepherd.escalated",
+        "shepherd.started",
+        "stack.position-filled",
+        "state.patched",
+        "synthesize.requested",
+        "task.claimed",
+        "task.completed",
+        "task.failed",
+        "workflow.cancel",
+        "workflow.checkpoint",
+        "workflow.cleanup",
+        "workflow.compensation",
+        "workflow.fix-cycle",
+        "workflow.pruned",
+        "workflow.rehydrated",
+        "workflow.started",
+        "workflow.transition",
+        "worktree.adopted",
+        "worktree.merge_executed",
+        "worktree.merge_requested",
+        "worktree.orphan_detected",
+        "worktree.released",
+        "worktree.remove.executed",
+        "worktree.remove.requested",
+        "worktree.reserved"
+      ],
+      "arms": {
+        "multiArmReachable": true,
+        "zeroArmReachable": true,
+        "probedWith": {
+          "multi": "admission.enforcement-enabled",
+          "zero": "admission.enforcement-enabled"
+        }
+      }
+    },
+    "per-emission-site/primary-edges": {
+      "populationSize": 86,
+      "satisfyingCount": 83,
+      "zeroPrimaryCount": 3,
+      "multiPrimaryCount": 0,
+      "zeroPrimary": [
+        {
+          "key": "onboard.executed@exarchos_orchestrate.doctor",
+          "primaryEdges": 0,
+          "primaryOwners": [],
+          "declaringEdges": 1,
+          "declaredBy": [
+            "exarchos_orchestrate.doctor"
+          ]
+        },
+        {
+          "key": "onboard.requested@exarchos_orchestrate.doctor",
+          "primaryEdges": 0,
+          "primaryOwners": [],
+          "declaringEdges": 1,
+          "declaredBy": [
+            "exarchos_orchestrate.doctor"
+          ]
+        },
+        {
+          "key": "state.patched@exarchos_orchestrate.discover_bridge",
+          "primaryEdges": 0,
+          "primaryOwners": [],
+          "declaringEdges": 1,
+          "declaredBy": [
+            "exarchos_orchestrate.discover_bridge"
+          ]
+        }
+      ],
+      "multiPrimary": [],
+      "satisfyingKeys": [
+        "admission.enforcement-enabled@exarchos_orchestrate.cutover_decide",
+        "admission.evidence-recorded@exarchos_orchestrate.check_contract_drift",
+        "admission.evidence-recorded@exarchos_orchestrate.check_integration_suite",
+        "admission.evidence-recorded@exarchos_orchestrate.check_mock_boundary",
+        "admission.evidence-recorded@exarchos_orchestrate.check_static_analysis",
+        "admission.evidence-recorded@exarchos_orchestrate.check_test_adequacy",
+        "admission.rollout-decision@exarchos_orchestrate.cutover_decide",
+        "catalog.registered@exarchos_orchestrate.invariants_add",
+        "ci.status@exarchos_orchestrate.assess_stack",
+        "diagnostic.executed@exarchos_orchestrate.doctor",
+        "feedback.recorded@exarchos_workflow.feedback",
+        "gate.executed@exarchos_orchestrate.assess_stack",
+        "gate.executed@exarchos_orchestrate.check_context_economy",
+        "gate.executed@exarchos_orchestrate.check_contract_drift",
+        "gate.executed@exarchos_orchestrate.check_convergence",
+        "gate.executed@exarchos_orchestrate.check_design_completeness",
+        "gate.executed@exarchos_orchestrate.check_event_emissions",
+        "gate.executed@exarchos_orchestrate.check_exploration_depth",
+        "gate.executed@exarchos_orchestrate.check_integration_suite",
+        "gate.executed@exarchos_orchestrate.check_invariant_conformance",
+        "gate.executed@exarchos_orchestrate.check_mock_boundary",
+        "gate.executed@exarchos_orchestrate.check_operational_resilience",
+        "gate.executed@exarchos_orchestrate.check_plan_coverage",
+        "gate.executed@exarchos_orchestrate.check_post_merge",
+        "gate.executed@exarchos_orchestrate.check_provenance_chain",
+        "gate.executed@exarchos_orchestrate.check_review_verdict",
+        "gate.executed@exarchos_orchestrate.check_security_scan",
+        "gate.executed@exarchos_orchestrate.check_static_analysis",
+        "gate.executed@exarchos_orchestrate.check_task_decomposition",
+        "gate.executed@exarchos_orchestrate.check_test_adequacy",
+        "gate.executed@exarchos_orchestrate.check_workflow_determinism",
+        "gate.executed@exarchos_orchestrate.mutation-adequacy",
+        "gate.executed@exarchos_orchestrate.post_delegation_check",
+        "gate.executed@exarchos_orchestrate.pre_synthesis_check",
+        "gate.executed@exarchos_orchestrate.prepare_synthesis",
+        "invariant.amended@exarchos_orchestrate.invariants_amend",
+        "invariant.authored@exarchos_orchestrate.invariants_add",
+        "issue.created@exarchos_orchestrate.create_issue",
+        "launch.executed@exarchos_orchestrate.reconcile_worktrees",
+        "merge.completed@exarchos_orchestrate.merge_orchestrate",
+        "merge.executed@exarchos_orchestrate.merge_orchestrate",
+        "merge.preflight@exarchos_orchestrate.merge_orchestrate",
+        "merge.recovered@exarchos_orchestrate.merge_orchestrate",
+        "mutation.executed@exarchos_orchestrate.mutation-adequacy",
+        "mutation.executing_started@exarchos_orchestrate.mutation-adequacy",
+        "onboard.executed@exarchos_orchestrate.onboard",
+        "onboard.requested@exarchos_orchestrate.onboard",
+        "pr.commented@exarchos_orchestrate.add_pr_comment",
+        "pr.created@exarchos_orchestrate.create_pr",
+        "pr.merged@exarchos_orchestrate.merge_pr",
+        "prune.executed@exarchos_orchestrate.prune_worktrees",
+        "prune.executing_started@exarchos_orchestrate.prune_worktrees",
+        "quality.hint.generated@exarchos_orchestrate.prepare_delegation",
+        "review.routed@exarchos_orchestrate.review_triage",
+        "shepherd.approval_requested@exarchos_orchestrate.assess_stack",
+        "shepherd.completed@exarchos_orchestrate.assess_stack",
+        "shepherd.escalated@exarchos_orchestrate.assess_stack",
+        "shepherd.started@exarchos_orchestrate.assess_stack",
+        "stack.position-filled@exarchos_orchestrate.stack_place",
+        "state.patched@exarchos_workflow.update",
+        "synthesize.requested@exarchos_orchestrate.request_synthesize",
+        "task.claimed@exarchos_orchestrate.task_claim",
+        "task.completed@exarchos_orchestrate.task_complete",
+        "task.failed@exarchos_orchestrate.task_fail",
+        "workflow.cancel@exarchos_workflow.cancel",
+        "workflow.checkpoint@exarchos_workflow.checkpoint",
+        "workflow.cleanup@exarchos_workflow.cleanup",
+        "workflow.compensation@exarchos_workflow.cancel",
+        "workflow.fix-cycle@exarchos_workflow.transition",
+        "workflow.pruned@exarchos_orchestrate.prune_stale_workflows",
+        "workflow.rehydrated@exarchos_workflow.rehydrate",
+        "workflow.started@exarchos_workflow.init",
+        "workflow.transition@exarchos_workflow.transition",
+        "worktree.adopted@exarchos_orchestrate.acquire_worktree",
+        "worktree.merge_executed@exarchos_orchestrate.reconcile_worktrees",
+        "worktree.merge_executed@exarchos_orchestrate.serialize_merge",
+        "worktree.merge_requested@exarchos_orchestrate.serialize_merge",
+        "worktree.orphan_detected@exarchos_orchestrate.reconcile_worktrees",
+        "worktree.released@exarchos_orchestrate.reconcile_worktrees",
+        "worktree.released@exarchos_orchestrate.release_worktree",
+        "worktree.remove.executed@exarchos_orchestrate.prune_worktrees",
+        "worktree.remove.requested@exarchos_orchestrate.prune_worktrees",
+        "worktree.reserved@exarchos_orchestrate.acquire_worktree"
+      ],
+      "arms": {
+        "multiArmReachable": false,
+        "zeroArmReachable": true,
+        "probedWith": {
+          "multi": "admission.enforcement-enabled",
+          "zero": "admission.enforcement-enabled"
+        }
+      }
+    },
+    "per-event-and-tool/primary-owners": {
+      "populationSize": 55,
+      "satisfyingCount": 54,
+      "zeroPrimaryCount": 1,
+      "multiPrimaryCount": 0,
+      "zeroPrimary": [
+        {
+          "key": "state.patched@exarchos_orchestrate",
+          "primaryEdges": 0,
+          "primaryOwners": [],
+          "declaringEdges": 1,
+          "declaredBy": [
+            "exarchos_orchestrate.discover_bridge"
+          ]
+        }
+      ],
+      "multiPrimary": [],
+      "satisfyingKeys": [
+        "admission.enforcement-enabled@exarchos_orchestrate",
+        "admission.evidence-recorded@exarchos_orchestrate",
+        "admission.rollout-decision@exarchos_orchestrate",
+        "catalog.registered@exarchos_orchestrate",
+        "ci.status@exarchos_orchestrate",
+        "diagnostic.executed@exarchos_orchestrate",
+        "feedback.recorded@exarchos_workflow",
+        "gate.executed@exarchos_orchestrate",
+        "invariant.amended@exarchos_orchestrate",
+        "invariant.authored@exarchos_orchestrate",
+        "issue.created@exarchos_orchestrate",
+        "launch.executed@exarchos_orchestrate",
+        "merge.completed@exarchos_orchestrate",
+        "merge.executed@exarchos_orchestrate",
+        "merge.preflight@exarchos_orchestrate",
+        "merge.recovered@exarchos_orchestrate",
+        "mutation.executed@exarchos_orchestrate",
+        "mutation.executing_started@exarchos_orchestrate",
+        "onboard.executed@exarchos_orchestrate",
+        "onboard.requested@exarchos_orchestrate",
+        "pr.commented@exarchos_orchestrate",
+        "pr.created@exarchos_orchestrate",
+        "pr.merged@exarchos_orchestrate",
+        "prune.executed@exarchos_orchestrate",
+        "prune.executing_started@exarchos_orchestrate",
+        "quality.hint.generated@exarchos_orchestrate",
+        "review.routed@exarchos_orchestrate",
+        "shepherd.approval_requested@exarchos_orchestrate",
+        "shepherd.completed@exarchos_orchestrate",
+        "shepherd.escalated@exarchos_orchestrate",
+        "shepherd.started@exarchos_orchestrate",
+        "stack.position-filled@exarchos_orchestrate",
+        "state.patched@exarchos_workflow",
+        "synthesize.requested@exarchos_orchestrate",
+        "task.claimed@exarchos_orchestrate",
+        "task.completed@exarchos_orchestrate",
+        "task.failed@exarchos_orchestrate",
+        "workflow.cancel@exarchos_workflow",
+        "workflow.checkpoint@exarchos_workflow",
+        "workflow.cleanup@exarchos_workflow",
+        "workflow.compensation@exarchos_workflow",
+        "workflow.fix-cycle@exarchos_workflow",
+        "workflow.pruned@exarchos_orchestrate",
+        "workflow.rehydrated@exarchos_workflow",
+        "workflow.started@exarchos_workflow",
+        "workflow.transition@exarchos_workflow",
+        "worktree.adopted@exarchos_orchestrate",
+        "worktree.merge_executed@exarchos_orchestrate",
+        "worktree.merge_requested@exarchos_orchestrate",
+        "worktree.orphan_detected@exarchos_orchestrate",
+        "worktree.released@exarchos_orchestrate",
+        "worktree.remove.executed@exarchos_orchestrate",
+        "worktree.remove.requested@exarchos_orchestrate",
+        "worktree.reserved@exarchos_orchestrate"
+      ],
+      "arms": {
+        "multiArmReachable": false,
+        "zeroArmReachable": true,
+        "probedWith": {
+          "multi": "admission.enforcement-enabled",
+          "zero": "admission.enforcement-enabled"
+        }
+      }
+    }
+  },
+  "perTier": [
+    {
+      "tier": "capability",
+      "eventCount": 29,
+      "events": [
+        "admission.enforcement-enabled",
+        "admission.evidence-recorded",
+        "admission.rollout-decision",
+        "ci.status",
+        "gate.executed",
+        "launch.executed",
+        "merge.completed",
+        "merge.executed",
+        "merge.preflight",
+        "merge.recovered",
+        "prune.executed",
+        "prune.executing_started",
+        "review.routed",
+        "shepherd.approval_requested",
+        "shepherd.completed",
+        "shepherd.escalated",
+        "shepherd.started",
+        "stack.position-filled",
+        "task.claimed",
+        "task.completed",
+        "task.failed",
+        "workflow.fix-cycle",
+        "worktree.adopted",
+        "worktree.merge_executed",
+        "worktree.merge_requested",
+        "worktree.orphan_detected",
+        "worktree.released",
+        "worktree.remove.executed",
+        "worktree.reserved"
+      ],
+      "zeroPrimaryEvents": [],
+      "multiPrimaryEventsByOwner": []
+    },
+    {
+      "tier": "substrate",
+      "eventCount": 25,
+      "events": [
+        "catalog.registered",
+        "diagnostic.executed",
+        "feedback.recorded",
+        "invariant.amended",
+        "invariant.authored",
+        "issue.created",
+        "mutation.executed",
+        "mutation.executing_started",
+        "onboard.executed",
+        "onboard.requested",
+        "pr.commented",
+        "pr.created",
+        "pr.merged",
+        "quality.hint.generated",
+        "state.patched",
+        "synthesize.requested",
+        "workflow.cancel",
+        "workflow.checkpoint",
+        "workflow.cleanup",
+        "workflow.compensation",
+        "workflow.pruned",
+        "workflow.rehydrated",
+        "workflow.started",
+        "workflow.transition",
+        "worktree.remove.requested"
+      ],
+      "zeroPrimaryEvents": [],
+      "multiPrimaryEventsByOwner": []
+    }
+  ],
+  "planDeclaredPopulation": {
+    "events": [
+      "promotion.executed",
+      "vcs.compensated",
+      "vcs.executed",
+      "vcs.requested"
+    ],
+    "coveredByAutoEmits": [],
+    "uncoveredByAutoEmits": [
+      "promotion.executed",
+      "vcs.compensated",
+      "vcs.executed",
+      "vcs.requested"
+    ],
+    "registeredInCatalog": [
+      "promotion.executed",
+      "vcs.compensated",
+      "vcs.executed",
+      "vcs.requested"
+    ]
+  },
+  "moduleEmitters": [
+    {
+      "event": "admission.cutover-ready",
+      "module": "workflow/admission/cutover-auto-export.ts",
+      "trigger": "success-hook",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "admission.disagreement-disposition",
+      "module": "workflow/admission/live-shadow-observer.ts",
+      "trigger": "observer-drain",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "admission.shadow-attempt",
+      "module": "workflow/admission/live-shadow-observer.ts",
+      "trigger": "observer-drain",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "emission.violated",
+      "module": "dispatch/core/interceptors/emission-verifier.ts",
+      "trigger": "dispatch-interceptor",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "launch.executing_started",
+      "module": "runtime/launcher/liveness.ts",
+      "trigger": "process-hook",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "session.machinery_consumed",
+      "module": "dispatch/core/interceptors/session-machinery.ts",
+      "trigger": "dispatch-interceptor",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "subagent.tokens_used",
+      "module": "lifecycle/subagent-stop.ts",
+      "trigger": "process-hook",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "tool.action_errored",
+      "module": "projections/telemetry/middleware.ts",
+      "trigger": "dispatch-wrapper",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "tool.completed",
+      "module": "projections/telemetry/middleware.ts",
+      "trigger": "dispatch-wrapper",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "tool.errored",
+      "module": "projections/telemetry/middleware.ts",
+      "trigger": "dispatch-wrapper",
+      "alsoDeclaredByAnAction": false
+    },
+    {
+      "event": "tool.invoked",
+      "module": "projections/telemetry/middleware.ts",
+      "trigger": "dispatch-wrapper",
+      "alsoDeclaredByAnAction": false
+    }
+  ],
+  "unregisteredEmittedEvents": []
+}

--- a/tools/audit/core/primary-owner-population.json
+++ b/tools/audit/core/primary-owner-population.json
@@ -13,8 +13,10 @@
       "populationSize": 54,
       "satisfyingCount": 50,
       "zeroPrimaryCount": 0,
+      "unownedPrimaryCount": 0,
       "multiPrimaryCount": 4,
       "zeroPrimary": [],
+      "unownedPrimary": [],
       "multiPrimary": [
         {
           "key": "admission.evidence-recorded",
@@ -22,6 +24,7 @@
           "primaryOwners": [
             "orchestrate"
           ],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 5,
           "declaredBy": [
             "exarchos_orchestrate.check_contract_drift",
@@ -37,6 +40,7 @@
           "primaryOwners": [
             "orchestrate"
           ],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 24,
           "declaredBy": [
             "exarchos_orchestrate.assess_stack",
@@ -71,6 +75,7 @@
           "primaryOwners": [
             "orchestrate"
           ],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 2,
           "declaredBy": [
             "exarchos_orchestrate.reconcile_worktrees",
@@ -83,6 +88,7 @@
           "primaryOwners": [
             "orchestrate"
           ],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 2,
           "declaredBy": [
             "exarchos_orchestrate.reconcile_worktrees",
@@ -155,8 +161,10 @@
       "populationSize": 54,
       "satisfyingCount": 54,
       "zeroPrimaryCount": 0,
+      "unownedPrimaryCount": 0,
       "multiPrimaryCount": 0,
       "zeroPrimary": [],
+      "unownedPrimary": [],
       "multiPrimary": [],
       "satisfyingKeys": [
         "admission.enforcement-enabled",
@@ -227,12 +235,14 @@
       "populationSize": 86,
       "satisfyingCount": 83,
       "zeroPrimaryCount": 3,
+      "unownedPrimaryCount": 0,
       "multiPrimaryCount": 0,
       "zeroPrimary": [
         {
           "key": "onboard.executed@exarchos_orchestrate.doctor",
           "primaryEdges": 0,
           "primaryOwners": [],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 1,
           "declaredBy": [
             "exarchos_orchestrate.doctor"
@@ -242,6 +252,7 @@
           "key": "onboard.requested@exarchos_orchestrate.doctor",
           "primaryEdges": 0,
           "primaryOwners": [],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 1,
           "declaredBy": [
             "exarchos_orchestrate.doctor"
@@ -251,12 +262,14 @@
           "key": "state.patched@exarchos_orchestrate.discover_bridge",
           "primaryEdges": 0,
           "primaryOwners": [],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 1,
           "declaredBy": [
             "exarchos_orchestrate.discover_bridge"
           ]
         }
       ],
+      "unownedPrimary": [],
       "multiPrimary": [],
       "satisfyingKeys": [
         "admission.enforcement-enabled@exarchos_orchestrate.cutover_decide",
@@ -356,18 +369,21 @@
       "populationSize": 55,
       "satisfyingCount": 54,
       "zeroPrimaryCount": 1,
+      "unownedPrimaryCount": 0,
       "multiPrimaryCount": 0,
       "zeroPrimary": [
         {
           "key": "state.patched@exarchos_orchestrate",
           "primaryEdges": 0,
           "primaryOwners": [],
+          "unattributedPrimaryEdges": 0,
           "declaringEdges": 1,
           "declaredBy": [
             "exarchos_orchestrate.discover_bridge"
           ]
         }
       ],
+      "unownedPrimary": [],
       "multiPrimary": [],
       "satisfyingKeys": [
         "admission.enforcement-enabled@exarchos_orchestrate",


### PR DESCRIPTION
## Summary

- Closes the remaining anchor-028 criterion: **one primary owner per event type** on the K2 key (distinct primary `owner` strings, not edge count).
- Fixes `merge.recovered` — sole emitter of the merge saga's compensation terminal was mislabelled `recovery`.
- Adds boot-time `ZERO_PRIMARY_OWNER` and `MULTI_PRIMARY_OWNER` diagnostics (blocking) with vacuity guards at `observe`, plus `PRIMARY_OWNER_POPULATION_FLOOR = 54`.
- Lands the population census (`measure-primary-owner-population.mjs` + frozen JSON) as design evidence.

## Changes

- `src/events/registration-validate.ts` — K2 primary-owner bijection check, vacuity guards, local `AutoEmissionRole` alias (avoids forbidden events→registry import)
- `src/registry/actions/orchestrate/merge.ts` — `merge.recovered` emission role corrected to `primary`
- `tools/audit/core/measure-primary-owner-population.mjs` + `primary-owner-population.json` — population census instrument and frozen baseline
- `tests/unit/events/registration-validate.test.ts` — coverage for new diagnostics

## Test Plan

- [x] `npx vitest run tests/unit/events/registration-validate.test.ts` (31/31)
- [x] `npm run typecheck`
- [x] `node tools/audit/core/measure-primary-owner-population.mjs --check`
- [ ] CI green on PR

Closes #1765 (anchor 028, criterion 4/4).