### PR TITLE
fix(projections): fold to the tail instead of refusing to answer (#1855)

### DIFF
--- a/src/projections/degraded-result.ts
+++ b/src/projections/degraded-result.ts
@@ -19,38 +19,43 @@
  * invents its own degraded envelope, so an agent can branch on a single
  * condition rather than a per-surface dialect.
  *
- * ## The contract
+ * ## The contract, after #1855
  *
- * A degraded read is a FAILURE, not an annotated success. `success: false` with
- * `error.code === 'PROJECTION_DEGRADED'` and the durable state attached to
- * `error.projectionDegraded`. The stale payload is DROPPED — annotating it
- * would leave the same footgun in place for every caller that checks `success`
- * and never reads `_meta`.
+ * The rule above was right about the harm and wrong about the remedy. It read
+ * "a fold that does not cover the tail must not be served" as "must not be
+ * answered", when the read holds everything needed to make the fold cover the
+ * tail — and `projections/fold-at-tail.ts` now does exactly that before any
+ * answer is produced. Refusing a lag a re-fold closes cost more than the
+ * staleness did: the refusal was published durably, only the refused surface
+ * could clear it, and `workflow get` stayed unreadable on a lag of one event.
  *
- * ## Distinguishability (the three outcomes must never be confused)
+ * So `PROJECTION_DEGRADED` no longer means "stale". It means **undecidable**:
+ * a fold finished SHORT of the tail it was pinned against, because the log did
+ * not produce events a cursor had already counted. There is no re-fold that
+ * closes that, and there is no answer to give. Everything a re-fold closes is
+ * closed instead of reported.
+ *
+ * ## Distinguishability (the four outcomes must never be confused)
  *
  * | outcome        | shape                                                      |
  * |----------------|------------------------------------------------------------|
- * | healthy answer | `success: true` + payload                                   |
- * | **no data**    | `success: true` with an empty payload, or a domain code such |
- * |                | as `STATE_NOT_FOUND` — the store was asked and answered      |
- * |                | "nothing here", which is a TRUE fact about the tail          |
- * | **degraded**   | `success: false`, `code: 'PROJECTION_DEGRADED'`, with the    |
- * |                | observed tail/cursor/lag — "cannot answer", NOT "no data"    |
- * | genuine fault  | `success: false` with any other code                         |
+ * | healthy answer | `success: true` + payload, folded to the tail              |
+ * | **no data**    | `success: true` with an empty payload, or a domain code     |
+ * |                | such as `STATE_NOT_FOUND` — the store was asked and         |
+ * |                | answered "nothing here", which is a TRUE fact about the tail|
+ * | **undecidable**| `success: false`, `code: 'PROJECTION_DEGRADED'` — the fold  |
+ * |                | could not be shown to cover the tail. NOT "stale", and NOT  |
+ * |                | "no data"                                                   |
+ * | genuine fault  | `success: false` with any other code                        |
  *
- * The reserved code is what makes the middle two separable: "no tasks
- * completed" and "the fold has not seen the events that completed them" are
- * different claims, and CB-8 is what happens when a surface conflates them.
+ * The reserved code is what keeps those separable: "no tasks completed" and
+ * "coverage could not be established" are different claims, and CB-8 is what
+ * happens when a surface conflates them.
  */
 
 import type { ToolResult } from '../format.js';
-import {
-  readProjectionDegradedState,
-  type DurableProjectionDegradedState,
-  type ProjectionDegradationReason,
-  type ProjectionHealthJournal,
-} from './freshness.js';
+import { ProjectionCoverageError } from './fold-at-tail.js';
+import type { DurableProjectionDegradedState, ProjectionDegradationReason } from './freshness.js';
 
 /**
  * The reserved error code for a refused-because-stale read.
@@ -87,7 +92,7 @@ export interface ProjectionDegradedDetail {
 }
 
 /** Narrow the durable state to the wire detail. */
-export function toProjectionDegradedDetail(
+function toProjectionDegradedDetail(
   state: DurableProjectionDegradedState,
 ): ProjectionDegradedDetail {
   return {
@@ -104,42 +109,72 @@ export function toProjectionDegradedDetail(
 
 function describe(detail: ProjectionDegradedDetail): string {
   return detail.reason === 'projection-behind'
-    ? `its projections stop ${detail.lag} event(s) short of the durable tail (tail ${detail.eventTail}, worst cursor ${detail.projectionCursor})`
-    : `its projections claim ${Math.abs(detail.lag)} event(s) the log cannot produce (tail ${detail.eventTail}, worst cursor ${detail.projectionCursor})`;
+    ? `a fold of it finished ${detail.lag} event(s) short of the tail it was pinned against (tail ${detail.eventTail}, cursor ${detail.projectionCursor})`
+    : `a fold of it claims ${Math.abs(detail.lag)} event(s) the log cannot produce (tail ${detail.eventTail}, cursor ${detail.projectionCursor})`;
 }
 
 /**
- * Build the typed degraded result for a consumer that refused to answer.
+ * Build the typed degraded result for a read whose coverage is undecidable.
  *
- * `suggestedFix` names the recovery action deliberately: the view chokepoint is
- * the surface that re-folds, re-assesses and publishes `projection.recovered`,
- * so it is the action that CLEARS this state. Without it the refusal reads as a
- * dead end rather than a step, and a caller has no way back to a healthy read.
+ * `suggestedFix` names the durable event log, and it is chosen rather than
+ * hardcoded. The old suggestion was a constant — `exarchos_view`
+ * `workflow_status` — which named the failing call itself whenever that was the
+ * refusing surface. A caller following it re-ran the same read, failed
+ * identically, and each attempt left a window for more events to land, so the
+ * loop never converged (#1855). A remedy that can be the disease is not a
+ * remedy: `assertRemedyIsNotTheFailingCall` below is what keeps that true.
+ *
+ * `exarchos_event` `query` is the right destination on the merits too. This
+ * result means no fold could be shown to cover the tail, and the log is the one
+ * surface that answers without folding anything.
  */
 export function toProjectionDegradedResult(
   state: DurableProjectionDegradedState,
   context?: { readonly tool?: string | undefined; readonly action?: string | undefined },
 ): ToolResult {
   const projectionDegraded = toProjectionDegradedDetail(state);
+  const suggestedFix = remedyFor(projectionDegraded.streamId, context);
   return {
     success: false,
     error: {
       code: PROJECTION_DEGRADED_ERROR_CODE,
       message:
-        `Refusing to answer from stream '${projectionDegraded.streamId}': ` +
-        `${describe(projectionDegraded)}. This is NOT "no data" — the answer is ` +
-        `withheld because the fold it would be derived from provably does not ` +
-        `cover the event tail. Re-read the stream through exarchos_view to re-fold ` +
-        `and clear this state.`,
+        `Cannot answer from stream '${projectionDegraded.streamId}': ` +
+        `${describe(projectionDegraded)}. This is NOT "no data", and it is not ` +
+        `mere staleness — a lagging fold is folded forward before any read ` +
+        `answers. The log did not produce events the fold had already counted, ` +
+        `so coverage cannot be established at all. Read the durable log directly.`,
       ...(context?.tool === undefined ? {} : { tool: context.tool }),
       ...(context?.action === undefined ? {} : { action: context.action }),
-      suggestedFix: {
-        tool: 'exarchos_view',
-        params: { action: 'workflow_status', workflowId: projectionDegraded.streamId },
-      },
+      ...(suggestedFix === undefined ? {} : { suggestedFix }),
       projectionDegraded,
     },
   };
+}
+
+/** The remedy this result points at, or `undefined` when it would be circular. */
+function remedyFor(
+  streamId: string,
+  context?: { readonly tool?: string | undefined; readonly action?: string | undefined },
+): { tool: string; params: Record<string, unknown> } | undefined {
+  const remedy = { tool: REMEDY_TOOL, params: { action: REMEDY_ACTION, stream: streamId } };
+  return isSameCall(remedy, context) ? undefined : remedy;
+}
+
+const REMEDY_TOOL = 'exarchos_event';
+const REMEDY_ACTION = 'query';
+
+/**
+ * True when a suggestion names the very call that produced the error.
+ *
+ * Exported so the invariant is testable directly rather than only through the
+ * surfaces that happen to build a suggestion today.
+ */
+export function isSameCall(
+  remedy: { tool: string; params: Record<string, unknown> },
+  context?: { readonly tool?: string | undefined; readonly action?: string | undefined },
+): boolean {
+  return remedy.tool === context?.tool && remedy.params['action'] === context?.action;
 }
 
 /** True when a result is the reserved degraded refusal (and not a domain error). */
@@ -148,60 +183,38 @@ export function isProjectionDegradedResult(result: ToolResult): boolean {
 }
 
 /**
- * The stream id a composite's args identify, if any.
+ * The failure envelope for a view handler's catch block.
  *
- * The three composites spell the same concept differently — `exarchos_view`
- * takes `workflowId`, `exarchos_workflow` and `exarchos_orchestrate` take
- * `featureId` — and both names denote the SAME event stream. Resolving that in
- * one place keeps the guard's coverage from depending on which dialect a given
- * action happens to speak.
- *
- * Returns `undefined` for a stream-less action (`describe`, `runbook`, …),
- * which the guard treats as "nothing to assess" rather than "assume healthy".
+ * One place decides which faults are `PROJECTION_DEGRADED` and which are
+ * `VIEW_ERROR`, so the distinction cannot drift across seventeen handlers that
+ * each wrote the same catch by hand. A {@link ProjectionCoverageError} is the
+ * undecidable case and keeps the reserved code; everything else is an ordinary
+ * view fault.
  */
-export function resolveProjectionStreamId(
-  args: Record<string, unknown>,
-): string | undefined {
-  for (const key of ['workflowId', 'featureId', 'streamId', 'stream'] as const) {
-    const value = args[key];
-    if (typeof value === 'string' && value.length > 0) return value;
+export function toViewFailure(
+  err: unknown,
+  context?: { readonly tool?: string | undefined; readonly action?: string | undefined },
+): ToolResult {
+  if (err instanceof ProjectionCoverageError) {
+    return toProjectionDegradedResult(
+      {
+        streamId: err.streamId,
+        reason: err.freshness.reason ?? 'projection-behind',
+        eventTail: err.freshness.eventTail,
+        projectionCursor: err.freshness.projectionCursor,
+        lag: err.freshness.lag,
+        staleViews: err.freshness.staleViews,
+        sequence: 0,
+        observedAt: new Date().toISOString(),
+      },
+      context,
+    );
   }
-  return undefined;
-}
-
-/**
- * The consumer-side chokepoint: refuse to serve a stream recorded as degraded.
- *
- * Returns the typed degraded result when the durable state says this stream's
- * projections disagree with its tail, and `undefined` when there is nothing to
- * report — so a caller reads as `const refusal = await guard(...); if (refusal)
- * return refusal;` before it does any projection-derived work.
- *
- * ## Why a read fault passes through
- *
- * If the health stream itself cannot be read we do not know whether the stream
- * is degraded. Failing every read on that basis would make an unreadable meta
- * stream a total outage of surfaces that may be perfectly healthy — the
- * freshness probe must never be the reason a good read fails (the same rule the
- * EFF-002 view stamp adopted). We pass through and let the caller answer; the
- * fault is logged by the caller's own `onError` hook so it is not silent.
- */
-export async function guardProjectionDegraded(
-  journal: ProjectionHealthJournal,
-  streamId: string | undefined,
-  context?: {
-    readonly tool?: string | undefined;
-    readonly action?: string | undefined;
-    readonly onError?: (err: unknown) => void;
-  },
-): Promise<ToolResult | undefined> {
-  if (streamId === undefined || streamId.length === 0) return undefined;
-  try {
-    const state = await readProjectionDegradedState(journal, streamId);
-    if (state === undefined) return undefined;
-    return toProjectionDegradedResult(state, context);
-  } catch (err) {
-    context?.onError?.(err);
-    return undefined;
-  }
+  return {
+    success: false,
+    error: {
+      code: 'VIEW_ERROR',
+      message: err instanceof Error ? err.message : String(err),
+    },
+  };
 }

--- a/src/projections/degraded-result.ts
+++ b/src/projections/degraded-result.ts
@@ -122,7 +122,8 @@ function describe(detail: ProjectionDegradedDetail): string {
  * refusing surface. A caller following it re-ran the same read, failed
  * identically, and each attempt left a window for more events to land, so the
  * loop never converged (#1855). A remedy that can be the disease is not a
- * remedy: `assertRemedyIsNotTheFailingCall` below is what keeps that true.
+ * remedy: `remedyFor` below drops the suggestion entirely when `isSameCall`
+ * shows it would name the call that just failed.
  *
  * `exarchos_event` `query` is the right destination on the merits too. This
  * result means no fold could be shown to cover the tail, and the log is the one
@@ -195,26 +196,44 @@ export function toViewFailure(
   err: unknown,
   context?: { readonly tool?: string | undefined; readonly action?: string | undefined },
 ): ToolResult {
-  if (err instanceof ProjectionCoverageError) {
-    return toProjectionDegradedResult(
-      {
-        streamId: err.streamId,
-        reason: err.freshness.reason ?? 'projection-behind',
-        eventTail: err.freshness.eventTail,
-        projectionCursor: err.freshness.projectionCursor,
-        lag: err.freshness.lag,
-        staleViews: err.freshness.staleViews,
-        sequence: 0,
-        observedAt: new Date().toISOString(),
-      },
-      context,
-    );
-  }
-  return {
+  return toCoverageFailure(err, context) ?? {
     success: false,
     error: {
       code: 'VIEW_ERROR',
       message: err instanceof Error ? err.message : String(err),
     },
   };
+}
+
+/**
+ * The degraded result for a coverage failure, or `undefined` for any other
+ * fault.
+ *
+ * Separate from {@link toViewFailure} because not every catch site wants
+ * `VIEW_ERROR` as its fallback: some fall back to a legacy default, some to
+ * `STATUS_FAILED`. Each of those is a reasonable answer to an ordinary fault
+ * and the wrong answer to "no fold could be shown to cover the tail" — a
+ * best-effort fallback there is the silent degradation this whole seam exists
+ * to remove. Reading as `const refusal = toCoverageFailure(err, ctx); if
+ * (refusal) return refusal;` keeps the distinction at every site instead of
+ * forcing one fallback on all of them.
+ */
+export function toCoverageFailure(
+  err: unknown,
+  context?: { readonly tool?: string | undefined; readonly action?: string | undefined },
+): ToolResult | undefined {
+  if (!(err instanceof ProjectionCoverageError)) return undefined;
+  return toProjectionDegradedResult(
+    {
+      streamId: err.streamId,
+      reason: err.freshness.reason ?? 'projection-behind',
+      eventTail: err.freshness.eventTail,
+      projectionCursor: err.freshness.projectionCursor,
+      lag: err.freshness.lag,
+      staleViews: err.freshness.staleViews,
+      sequence: 0,
+      observedAt: new Date().toISOString(),
+    },
+    context,
+  );
 }

--- a/src/projections/fold-at-tail.ts
+++ b/src/projections/fold-at-tail.ts
@@ -1,0 +1,182 @@
+/**
+ * The sealed fold: a cached view, and the proof that it covers the event tail.
+ *
+ * ## What went wrong without it (#1855)
+ *
+ * Coverage was checked rather than established. A read folded whichever view it
+ * needed, answered, and only then did a separate comparison
+ * (`assessStreamFreshness`) ask whether the stream's folds agreed with the
+ * durable tail. That comparison quantified over EVERY cached fold of the
+ * stream, while a read advances exactly ONE. The two are incompatible the
+ * moment a stream has more than one cached fold, and `workflow-state` — folded
+ * by orchestrate verbs and gates, folded by no `exarchos_view` action — made it
+ * terminal: no view read could restore agreement, and the view surface was the
+ * only publisher of `projection.recovered`. `workflow get` and four orchestrate
+ * actions stayed refused across processes and restarts, on a lag of one event.
+ *
+ * ## The construction
+ *
+ * Staleness is not a verdict to report. It is a condition to remove, and the
+ * read already holds everything needed to remove it: the store, the stream, the
+ * projection. So this module folds first and answers from the result, and the
+ * result carries the sequence it covers rather than leaving that to a later
+ * comparison over unrelated cache entries.
+ *
+ * `projection-behind` is closed by folding the delta. `projection-ahead` — a
+ * fold claiming events the log cannot produce — is closed by discarding the
+ * fold and replaying from the log, which is authoritative by construction: the
+ * event log is the source of truth, so a replay of it cannot be wrong. Neither
+ * withholds an answer.
+ *
+ * The behind/ahead/fresh decision is NOT made here. It is
+ * {@link planRehydrationSource}, which `workflow/rehydrate.ts` has always used
+ * to reach exactly this outcome — fold the tail forward over a lagging
+ * snapshot, discard and replay a contradictory one. That surface repaired while
+ * this one refused, on the same verdict, which is why `rehydrate` was the only
+ * read that kept working. One decision, two callers, no second opinion.
+ *
+ * ## What remains withheld
+ *
+ * One state survives, and it is a genuinely different claim: a fold that
+ * finishes SHORT of the tail it was pinned against. The log lost events the
+ * cursor had already counted, so the coverage question has no answer rather
+ * than an inconvenient one. That is {@link ProjectionCoverageError}, and it is
+ * the only path left to `PROJECTION_DEGRADED`. Absence of evidence does not
+ * become success.
+ */
+
+import type { WorkflowEvent } from '../events/schemas.js';
+import type { EventStore } from '../events/store.js';
+import { planRehydrationSource } from '../workflow/rehydrate-precedence.js';
+import { assessProjectionFreshness, type ProjectionFreshness } from './freshness.js';
+import { isInternalSentinelStream, type ViewMaterializer } from './views/materializer.js';
+
+/**
+ * A fold, bound to the durable sequence it provably covers.
+ *
+ * The binding is the point. A bare view says nothing about which events it has
+ * seen, so an answer derived from one carries no evidence of its own currency —
+ * and the coverage question then has to be asked somewhere else, about
+ * something else, too late to fix.
+ */
+export interface FoldAtTail<T> {
+  readonly view: T;
+  /**
+   * The event sequence this fold covers. Always `>=` the tail read when the
+   * fold began; greater when the stream grew while it ran, which is a longer
+   * answer and not a staler one.
+   */
+  readonly sequence: number;
+  /**
+   * Present only when a contradictory fold was discarded and replayed. The
+   * answer is authoritative either way — this is the incident record, so a
+   * repair is observable rather than silent.
+   */
+  readonly repaired?: ProjectionFreshness;
+}
+
+/**
+ * A fold that finished short of the tail it was pinned against.
+ *
+ * Not "the projection lagged" — that is repaired. This is the log failing to
+ * produce events a cursor had already counted, so no fold can be shown to cover
+ * the tail. The caller must not answer from it.
+ */
+export class ProjectionCoverageError extends Error {
+  constructor(
+    readonly streamId: string,
+    readonly viewName: string,
+    readonly freshness: ProjectionFreshness,
+  ) {
+    super(
+      `Fold of '${viewName}' on stream '${streamId}' finished at sequence ` +
+        `${freshness.projectionCursor}, short of the durable tail ` +
+        `${freshness.eventTail} it was pinned against.`,
+    );
+    this.name = 'ProjectionCoverageError';
+  }
+}
+
+/**
+ * Fold `viewName` over `streamId` until it covers the stream's durable tail,
+ * and return it bound to the sequence it reached.
+ *
+ * This is the ONLY sanctioned way to obtain a cached fold for an answer;
+ * `tests/architecture/projection-fold-seam.test.ts` enforces that. Bounded
+ * reads (`asOf`, correlation-filtered) are a different contract — a pure fold
+ * of `events[0..N]` — and go through `materializeFresh`, which is exempt by
+ * name in the guard's policy rather than by omission.
+ *
+ * Cost is the delta, not the stream: a warm fold queries `sinceSequence` and
+ * applies only what landed since. The path this replaces did the same query and
+ * then discarded the result to refuse, so a warm read gets cheaper, not dearer.
+ *
+ * @throws {ProjectionCoverageError} when the fold cannot be shown to cover the
+ * pinned tail.
+ */
+export async function foldToTail<T>(
+  store: EventStore,
+  materializer: ViewMaterializer,
+  streamId: string,
+  viewName: string,
+): Promise<FoldAtTail<T>> {
+  // A sentinel stream (`__migration__`) is deliberately never folded — see
+  // `ViewMaterializer.materializeAt`. It has no cached state to be stale, so
+  // there is no coverage claim to make or to break.
+  if (isInternalSentinelStream(streamId)) {
+    return { view: materializer.materializeAt<T>(streamId, viewName, []).view, sequence: 0 };
+  }
+
+  // A cold fold may still have a persisted snapshot to seed from; give it that
+  // chance BEFORE the cursor is read, so the plan below sees the real starting
+  // position rather than treating a warm-on-disk view as cold.
+  if (materializer.getState(streamId, viewName) === undefined) {
+    await materializer.loadFromSnapshot(streamId, viewName);
+  }
+
+  // Pin the tail first. Everything after this is measured against this number,
+  // so an append landing mid-fold widens the answer instead of invalidating it.
+  const eventTail = await store.tailSequence(streamId);
+  const cached = materializer.getState(streamId, viewName);
+
+  const plan = planRehydrationSource({
+    hasSnapshot: cached !== undefined,
+    snapshotCursor: cached?.highWaterMark ?? 0,
+    eventTail,
+    viewName,
+  });
+
+  // `projection-ahead`: the cursor counts events the log cannot produce, and
+  // `materializeAt`'s high-water-mark filter would drop every event below it,
+  // so a re-fold applies nothing. Drop the entry and replay.
+  if (!plan.seedFromSnapshot) {
+    materializer.discardFold(streamId, viewName);
+  }
+
+  const events: WorkflowEvent[] =
+    plan.sinceSequence > 0
+      ? await store.query(streamId, { sinceSequence: plan.sinceSequence })
+      : await store.query(streamId);
+
+  const folded = materializer.materializeAt<T>(streamId, viewName, events);
+
+  // The fold is complete when its cursor reaches the tail it was pinned
+  // against. A cursor that stops short means the log did not produce events the
+  // cursor had already counted; that is undecidable, not stale, and it is the
+  // one thing this seam refuses to answer through.
+  if (folded.sequence < eventTail) {
+    throw new ProjectionCoverageError(
+      streamId,
+      viewName,
+      assessProjectionFreshness({
+        eventTail,
+        projectionCursor: folded.sequence,
+        viewName,
+      }),
+    );
+  }
+
+  return plan.degraded && plan.freshness !== undefined
+    ? { view: folded.view, sequence: folded.sequence, repaired: plan.freshness }
+    : { view: folded.view, sequence: folded.sequence };
+}

--- a/src/projections/fold-at-tail.ts
+++ b/src/projections/fold-at-tail.ts
@@ -62,9 +62,13 @@ import { isInternalSentinelStream, type ViewMaterializer } from './views/materia
 export interface FoldAtTail<T> {
   readonly view: T;
   /**
-   * The event sequence this fold covers. Always `>=` the tail read when the
-   * fold began; greater when the stream grew while it ran, which is a longer
-   * answer and not a staler one.
+   * The event sequence this fold covers — exactly, not at least.
+   *
+   * The fold is bounded by the tail pinned when it began, so a stream that
+   * grows mid-fold does not widen the answer. That exactness is what lets two
+   * views of one stream be folded to the SAME sequence and compared: an answer
+   * derived from two folds that stopped at different points is a claim about
+   * no single state of the stream.
    */
   readonly sequence: number;
   /**
@@ -120,6 +124,60 @@ export async function foldToTail<T>(
   streamId: string,
   viewName: string,
 ): Promise<FoldAtTail<T>> {
+  return foldAtPinnedTail<T>(
+    store,
+    materializer,
+    streamId,
+    viewName,
+    await pinTail(store, streamId),
+  );
+}
+
+/**
+ * Fold TWO views of one stream against a single pinned tail.
+ *
+ * Two independent {@link foldToTail} calls pin two tails, so a read that
+ * combines their results — quality-against-evals attribution and correlation —
+ * can describe a state the stream was never in: one view including an event the
+ * other has not seen. Pinning once and folding both against it makes the pair a
+ * claim about one sequence, which is the whole point of carrying the sequence.
+ *
+ * Two rather than N because the typed form is what keeps this cast-free: each
+ * view has its own state type, and a list-shaped API would hand every caller an
+ * `unknown` to assert away. A third view wants a third type parameter here, not
+ * a widening of the return type.
+ */
+export async function foldPairToTail<A, B>(
+  store: EventStore,
+  materializer: ViewMaterializer,
+  streamId: string,
+  firstView: string,
+  secondView: string,
+): Promise<{ first: A; second: B; sequence: number }> {
+  const eventTail = await pinTail(store, streamId);
+  const first = await foldAtPinnedTail<A>(store, materializer, streamId, firstView, eventTail);
+  const second = await foldAtPinnedTail<B>(store, materializer, streamId, secondView, eventTail);
+  return { first: first.view, second: second.view, sequence: eventTail };
+}
+
+/** The tail every fold in one read is measured against. */
+async function pinTail(store: EventStore, streamId: string): Promise<number> {
+  return isInternalSentinelStream(streamId) ? 0 : store.tailSequence(streamId);
+}
+
+/**
+ * Fold one view against an ALREADY-pinned tail.
+ *
+ * Separating this from the pinning is what lets several views share one tail.
+ * On its own it makes no claim about currency — the caller's pin does.
+ */
+async function foldAtPinnedTail<T>(
+  store: EventStore,
+  materializer: ViewMaterializer,
+  streamId: string,
+  viewName: string,
+  eventTail: number,
+): Promise<FoldAtTail<T>> {
   // A sentinel stream (`__migration__`) is deliberately never folded — see
   // `ViewMaterializer.materializeAt`. It has no cached state to be stale, so
   // there is no coverage claim to make or to break.
@@ -128,15 +186,11 @@ export async function foldToTail<T>(
   }
 
   // A cold fold may still have a persisted snapshot to seed from; give it that
-  // chance BEFORE the cursor is read, so the plan below sees the real starting
+  // chance before the cursor is read, so the plan below sees the real starting
   // position rather than treating a warm-on-disk view as cold.
   if (materializer.getState(streamId, viewName) === undefined) {
     await materializer.loadFromSnapshot(streamId, viewName);
   }
-
-  // Pin the tail first. Everything after this is measured against this number,
-  // so an append landing mid-fold widens the answer instead of invalidating it.
-  const eventTail = await store.tailSequence(streamId);
   const cached = materializer.getState(streamId, viewName);
 
   const plan = planRehydrationSource({
@@ -153,12 +207,16 @@ export async function foldToTail<T>(
     materializer.discardFold(streamId, viewName);
   }
 
-  const events: WorkflowEvent[] =
+  const queried: readonly WorkflowEvent[] =
     plan.sinceSequence > 0
       ? await store.query(streamId, { sinceSequence: plan.sinceSequence })
       : await store.query(streamId);
+  // Bound to the pinned tail. The store has no upper-sequence filter, and an
+  // append landing mid-read would otherwise carry this fold past the sequence
+  // its siblings stopped at.
+  const events = queried.filter((event) => event.sequence <= eventTail);
 
-  const folded = materializer.materializeAt<T>(streamId, viewName, events);
+  const folded = materializer.materializeAt<T>(streamId, viewName, [...events]);
 
   // The fold is complete when its cursor reaches the tail it was pinned
   // against. A cursor that stops short means the log did not produce events the

--- a/src/projections/freshness.ts
+++ b/src/projections/freshness.ts
@@ -64,14 +64,6 @@ export interface ProjectionFreshness {
   readonly staleViews: readonly string[];
 }
 
-/** A stream with no events and no folds is trivially fresh. */
-const FRESH: ProjectionFreshness = Object.freeze({
-  degraded: false,
-  eventTail: 0,
-  projectionCursor: 0,
-  lag: 0,
-  staleViews: Object.freeze([]),
-});
 
 /**
  * Compare one projection cursor against the durable event tail.
@@ -106,60 +98,23 @@ export function assessProjectionFreshness(input: {
   };
 }
 
-/**
- * Compare every cached projection cursor for a stream against its durable tail.
- *
- * A stream is fresh only when every fold that has been materialized covers the
- * tail exactly. The reported `projectionCursor` is the worst offender, so a
- * consumer sees the widest gap rather than an average that hides it.
- *
- * A stream with no materialized folds is fresh: there is no stale answer to
- * serve. This keeps cold reads — which fold from scratch — out of the degraded
- * path.
- */
-export function assessStreamFreshness(
-  eventTail: number,
-  cursors: readonly ProjectionCursor[],
-): ProjectionFreshness {
-  if (cursors.length === 0) {
-    return eventTail === 0 ? FRESH : { ...FRESH, eventTail, projectionCursor: eventTail };
-  }
-
-  const disagreeing = cursors.filter((c) => c.cursor !== eventTail);
-  if (disagreeing.length === 0) {
-    return {
-      degraded: false,
-      eventTail,
-      projectionCursor: eventTail,
-      lag: 0,
-      staleViews: [],
-    };
-  }
-
-  // Worst first: the largest absolute distance from the tail leads.
-  const ordered = [...disagreeing].sort(
-    (a, b) => Math.abs(eventTail - b.cursor) - Math.abs(eventTail - a.cursor),
-  );
-  const [worst, ...rest] = ordered;
-  if (worst === undefined) {
-    return {
-      degraded: false,
-      eventTail,
-      projectionCursor: eventTail,
-      lag: 0,
-      staleViews: [],
-    };
-  }
-  const lag = eventTail - worst.cursor;
-  return {
-    degraded: true,
-    reason: lag > 0 ? 'projection-behind' : 'projection-ahead',
-    eventTail,
-    projectionCursor: worst.cursor,
-    lag,
-    staleViews: [worst, ...rest].map((c) => c.viewName),
-  };
-}
+// ─── Removed: `assessStreamFreshness` (#1855) ───────────────────────────────
+//
+// It compared EVERY cached fold of a stream against the tail and called the
+// stream degraded unless all of them agreed. That is not a stricter version of
+// the real obligation — it is a different and false one. A read advances
+// exactly one fold, so on any stream with more than one cached fold the
+// predicate could not come back clean; `workflow-state` (folded by orchestrate
+// verbs and gates, folded by no view action) made it permanent, and the surface
+// that published the verdict was the only one able to clear it.
+//
+// The staleness of a fold nobody is reading says nothing about the answer being
+// produced, because a read of THAT fold now repairs it before answering
+// (`projections/fold-at-tail.ts`). The per-fold comparison
+// (`assessProjectionFreshness`, above) is the whole of what survives, and its
+// one consumer is `planRehydrationSource`, which repairs rather than reports.
+//
+// The FRESH constant it used is gone with it.
 
 /** `_meta` key carrying the freshness verdict on a view response envelope. */
 export const PROJECTION_DEGRADED_META = 'projectionDegraded' as const;

--- a/src/projections/telemetry/telemetry-queries.ts
+++ b/src/projections/telemetry/telemetry-queries.ts
@@ -4,6 +4,7 @@
 // orchestrate layer from direct telemetry projection internals.
 // ────────────────────────────────────────────────────────────────────────────
 
+import { foldToTail } from '../fold-at-tail.js';
 import { getOrCreateMaterializer, queryDeltaEvents } from '../views/tools.js';
 import { TELEMETRY_VIEW } from './telemetry-projection.js';
 import type { TelemetryViewState } from './telemetry-projection.js';
@@ -37,8 +38,12 @@ export async function queryRuntimeMetrics(
 ): Promise<RuntimeMetrics> {
   try {
     const materializer = getOrCreateMaterializer(stateDir);
-    const telemetryEvents = await queryDeltaEvents(store, materializer, 'telemetry', TELEMETRY_VIEW);
-    const telemetry = materializer.materialize<TelemetryViewState>('telemetry', TELEMETRY_VIEW, telemetryEvents);
+    const { view: telemetry } = await foldToTail<TelemetryViewState>(
+      store,
+      materializer,
+      'telemetry',
+      TELEMETRY_VIEW,
+    );
 
     return {
       sessionTokens: telemetry.totalTokens,
@@ -60,8 +65,7 @@ export async function queryTelemetryState(
 ): Promise<TelemetryViewState | null> {
   try {
     const materializer = getOrCreateMaterializer(stateDir);
-    const telemetryEvents = await queryDeltaEvents(store, materializer, 'telemetry', TELEMETRY_VIEW);
-    return materializer.materialize<TelemetryViewState>('telemetry', TELEMETRY_VIEW, telemetryEvents);
+    return (await foldToTail<TelemetryViewState>(store, materializer, 'telemetry', TELEMETRY_VIEW)).view;
   } catch {
     return null;
   }

--- a/src/projections/telemetry/tools.ts
+++ b/src/projections/telemetry/tools.ts
@@ -1,5 +1,6 @@
 // ─── Telemetry MCP Tool Handler ──────────────────────────────────────────────
 
+import { foldToTail } from '../fold-at-tail.js';
 import { z } from 'zod';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
@@ -122,13 +123,12 @@ export async function handleViewTelemetry(
       const events = await store.query(TELEMETRY_STREAM, correlationFilters);
       view = materializeFiltered<TelemetryViewState>(materializer, TELEMETRY_VIEW, events);
     } else {
-      await materializer.loadFromSnapshot(TELEMETRY_STREAM, TELEMETRY_VIEW);
-      const events = await store.query(TELEMETRY_STREAM);
-      view = materializer.materialize<TelemetryViewState>(
+      view = (await foldToTail<TelemetryViewState>(
+        store,
+        materializer,
         TELEMETRY_STREAM,
         TELEMETRY_VIEW,
-        events,
-      );
+      )).view;
     }
 
     // DR-8 / B-4 (Task 014) — compact-by-default; the full per-tool rolling

--- a/src/projections/telemetry/tools.ts
+++ b/src/projections/telemetry/tools.ts
@@ -1,5 +1,6 @@
 // ─── Telemetry MCP Tool Handler ──────────────────────────────────────────────
 
+import { toViewFailure } from '../degraded-result.js';
 import { foldToTail } from '../fold-at-tail.js';
 import { z } from 'zod';
 import type { ToolResult } from '../../format.js';
@@ -199,13 +200,7 @@ export async function handleViewTelemetry(
       ...(nextActions.length > 0 ? { next_actions: nextActions } : {}),
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'telemetry' });
   }
 }
 

--- a/src/projections/views/composite.ts
+++ b/src/projections/views/composite.ts
@@ -43,7 +43,7 @@ import { handleViewTelemetry } from '../telemetry/tools.js';
 import type { QualityHintsConfig } from '../../workflow/capabilities/resolver.js';
 import { deriveRepoKey } from '../../utils/paths.js';
 import { viewLogger } from '../../logger.js';
-import { publishProjectionFreshness } from '../freshness.js';
+import { publishProjectionFreshness, readProjectionDegradedState } from '../freshness.js';
 
 const viewActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_view')!.actions;
 
@@ -153,9 +153,14 @@ async function clearProjectionHealth(
   if (streamId === undefined || streamId.length === 0) return result;
 
   try {
-    // `publishProjectionFreshness` appends `projection.recovered` only when a
-    // degraded row is actually held, and nothing at all otherwise — so a
-    // healthy stream still does not write a row per read.
+    // The held row decides whether there is anything to do, so it is read
+    // first. `publishProjectionFreshness` would reach the same conclusion, but
+    // only after this response path had already paid for a `tailSequence` call
+    // whose value the healthy case discards. Almost every read is the healthy
+    // case.
+    const held = await readProjectionDegradedState(ctx.eventStore, streamId);
+    if (held === undefined) return result;
+
     const eventTail = await ctx.eventStore.tailSequence(streamId);
     await publishProjectionFreshness(ctx.eventStore, streamId, {
       degraded: false,

--- a/src/projections/views/composite.ts
+++ b/src/projections/views/composite.ts
@@ -43,16 +43,7 @@ import { handleViewTelemetry } from '../telemetry/tools.js';
 import type { QualityHintsConfig } from '../../workflow/capabilities/resolver.js';
 import { deriveRepoKey } from '../../utils/paths.js';
 import { viewLogger } from '../../logger.js';
-import {
-  assessStreamFreshness,
-  publishProjectionFreshness,
-  toProjectionDegradedMeta,
-  PROJECTION_DEGRADED_META,
-} from '../freshness.js';
-import {
-  guardProjectionDegraded,
-  toProjectionDegradedResult,
-} from '../degraded-result.js';
+import { publishProjectionFreshness } from '../freshness.js';
 
 const viewActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_view')!.actions;
 
@@ -123,49 +114,36 @@ export async function handleView(
   deps?: WaitDeps,
 ): Promise<ToolResult> {
   const result = await dispatchViewAction(args, ctx, deps);
-  return stampProjectionFreshness(result, args, ctx);
+  return clearProjectionHealth(result, args, ctx);
 }
 
 /**
- * EFF-002 read-surface chokepoint / DR-4 detector, publisher AND consumer.
+ * The read-surface chokepoint, after #1855: it CLEARS projection health, it no
+ * longer withholds on it.
  *
- * Every view answer routes through here. `exarchos_view` is the only surface
- * that holds BOTH halves of the comparison — the durable tail and the live
- * materializer cursors — so it is the surface that detects a disagreement,
- * makes it durable, and clears it again. `exarchos_workflow` and
- * `exarchos_orchestrate` are pure consumers of what this publishes.
+ * What used to stand here compared every cached fold of the stream against the
+ * durable tail, published the verdict, and dropped the payload when any fold
+ * disagreed. The comparison quantified over every fold; a read advances exactly
+ * one. So on any stream with more than one cached fold the verdict could not
+ * come back clean, and `workflow-state` — folded by orchestrate verbs and gates,
+ * folded by no view action — made it permanent. Since this surface was the only
+ * publisher of `projection.recovered`, the state it published was one only it
+ * could clear and one it could no longer reach.
  *
- * Order is load-bearing:
+ * Each handler now folds its own view to the tail before answering
+ * (`projections/fold-at-tail.ts`), so by the time a successful result arrives
+ * here its coverage is already established and there is nothing to withhold.
+ * What is left is the other half of the old job: a stream that answered a read
+ * is a stream that can be served, so any durable `projection.degraded` row it
+ * still carries is a spent observation. Clearing it is what keeps the health
+ * journal a record of live conditions rather than a latch.
  *
- *   1. The action has already run, so the folds have been brought as current as
- *      a re-fold can bring them. Assessing BEFORE the dispatch would report a
- *      staleness the read itself was about to fix, and — because this is also
- *      the recovery surface — would wedge: the one action able to clear the
- *      state would be the one refused by it.
- *   2. Publish the live verdict. Degraded mints (idempotently) a
- *      `projection.degraded` row; freshly-caught-up mints the paired
- *      `projection.recovered`, releasing every consumer blocked on it. This is
- *      the production write path for T-06's durable state.
- *   3. Refuse. A disagreement that survived step 1 is one a re-fold cannot fix
- *      — a fold ahead of a pruned log, or a sibling projection of the same
- *      stream still trailing — so the payload is dropped and the shared typed
- *      degraded result returned in its place (DR-4).
- *
- * `_meta.projectionDegraded` is KEPT alongside the typed result rather than
- * subsumed: it is the pre-existing per-response courtesy, it is forwarded
- * verbatim by `envelopeWrap`, and `workflow/rehydrate.ts` stamps the same key
- * for the case where a contradictory cache was discarded and the answer IS
- * authoritative — a state that must stay expressible as an annotated success.
- * What changed is that `_meta` is no longer the ONLY signal, and no longer
- * rides on a `success: true` carrying the stale payload.
- *
- * Deliberately conservative:
+ * Deliberately conservative, unchanged from before:
  * - A failed result is returned untouched; the error is the signal.
- * - A stream with no cached folds is fresh — a cold read folds from scratch.
- * - Any fault computing or publishing freshness leaves the response unchanged.
- *   The freshness probe must never be the reason a healthy read fails.
+ * - Any fault publishing recovery leaves the response alone. The health journal
+ *   must never be the reason a healthy read fails.
  */
-async function stampProjectionFreshness(
+async function clearProjectionHealth(
   result: ToolResult,
   args: Record<string, unknown>,
   ctx: DispatchContext,
@@ -175,70 +153,21 @@ async function stampProjectionFreshness(
   if (streamId === undefined || streamId.length === 0) return result;
 
   try {
-    const materializer = getOrCreateMaterializer(ctx.stateDir);
-    const cursors = materializer?.getStreamCursors?.(streamId) ?? [];
-    if (cursors.length === 0) {
-      // No fold of our own to judge — but another process may have recorded
-      // this stream degraded, and serving it as a clean success would be the
-      // exact cross-process blind spot DR-4 exists to close.
-      return (
-        (await guardProjectionDegraded(ctx.eventStore, streamId, {
-          tool: 'exarchos_view',
-          action: typeof args['action'] === 'string' ? args['action'] : undefined,
-          onError: (err) =>
-            viewLogger.warn({ streamId, err }, 'durable projection-health read failed'),
-        })) ?? result
-      );
-    }
-
+    // `publishProjectionFreshness` appends `projection.recovered` only when a
+    // degraded row is actually held, and nothing at all otherwise — so a
+    // healthy stream still does not write a row per read.
     const eventTail = await ctx.eventStore.tailSequence(streamId);
-    const freshness = assessStreamFreshness(eventTail, cursors);
-
-    // (2) Publish — the production write path for the durable state. Degraded
-    // records; recovered releases. Never allowed to fail the read.
-    let durable: Awaited<ReturnType<typeof publishProjectionFreshness>>;
-    try {
-      durable = await publishProjectionFreshness(ctx.eventStore, streamId, freshness);
-    } catch (err) {
-      viewLogger.warn({ streamId, err }, 'publishing projection-health state failed');
-    }
-
-    const meta = toProjectionDegradedMeta(freshness);
-    if (meta === undefined) return result;
-
-    viewLogger.warn(
-      { streamId, ...meta },
-      'projection cursors disagree with the durable event tail; response refused as degraded (EFF-002/DR-4)',
-    );
-
-    // (3) Refuse. The stale payload is dropped, not annotated — a caller that
-    // branches on `success` must not be able to act on it.
-    const degraded =
-      durable ??
-      // The publish leg failed; the verdict is still true and still ours to
-      // report, so synthesize the same shape from the live comparison rather
-      // than silently downgrading to a success.
-      {
-        streamId,
-        reason: meta.reason,
-        eventTail: meta.eventTail,
-        projectionCursor: meta.projectionCursor,
-        lag: meta.lag,
-        staleViews: meta.staleViews,
-        sequence: 0,
-        observedAt: new Date().toISOString(),
-      };
-    const refusal = toProjectionDegradedResult(degraded, {
-      tool: 'exarchos_view',
-      action: typeof args['action'] === 'string' ? args['action'] : undefined,
+    await publishProjectionFreshness(ctx.eventStore, streamId, {
+      degraded: false,
+      eventTail,
+      projectionCursor: eventTail,
+      lag: 0,
+      staleViews: [],
     });
-    return {
-      ...refusal,
-      _meta: { ...(result._meta ?? {}), [PROJECTION_DEGRADED_META]: meta },
-    };
-  } catch {
-    return result;
+  } catch (err) {
+    viewLogger.warn({ streamId, err }, 'clearing projection-health state failed');
   }
+  return result;
 }
 
 /**

--- a/src/projections/views/handlers/code-quality.ts
+++ b/src/projections/views/handlers/code-quality.ts
@@ -1,9 +1,11 @@
 import { EventStore } from '../../../events/store.js';
+import { toViewFailure } from '../../degraded-result.js';
 import type { ToolResult } from '../../../format.js';
 import { logger } from '../../../logger.js';
 import { detectRegressions, emitRegressionEvents, type FailureTracker } from '../../quality/regression-detector.js';
 import { CODE_QUALITY_VIEW, type CodeQualityViewState } from '../code-quality-view.js';
 import { analyticScope } from './analytic-contract.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { deriveCorrelationFilters, hasCorrelationFilters, materializeFiltered, queryDeltaEvents } from './query.js';
 
@@ -35,16 +37,15 @@ export async function handleViewCodeQuality(
 
     const correlationFilters = deriveCorrelationFilters(args);
     const correlationFiltered = hasCorrelationFilters(correlationFilters);
-    const events = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);
     // Wave 5 (#1437) — under a correlation filter, fold a fresh projection
     // off `init()` so the materializer cache stays the unfiltered truth.
     const view = correlationFiltered
-      ? materializeFiltered<CodeQualityViewState>(materializer, CODE_QUALITY_VIEW, events)
-      : materializer.materialize<CodeQualityViewState>(
-          streamId,
+      ? materializeFiltered<CodeQualityViewState>(
+          materializer,
           CODE_QUALITY_VIEW,
-          events,
-        );
+          await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters),
+        )
+      : (await foldToTail<CodeQualityViewState>(store, materializer, streamId, CODE_QUALITY_VIEW)).view;
 
     // Detect and emit quality regressions with deduplication.
     // _failureTrackers is a non-enumerable property set by code-quality-view.ts.
@@ -146,12 +147,6 @@ export async function handleViewCodeQuality(
       ...nextActions,
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'code_quality' });
   }
 }

--- a/src/projections/views/handlers/convergence.ts
+++ b/src/projections/views/handlers/convergence.ts
@@ -1,8 +1,9 @@
 import { EventStore } from '../../../events/store.js';
+import { toViewFailure } from '../../degraded-result.js';
 import type { ToolResult } from '../../../format.js';
 import { CONVERGENCE_VIEW, type ConvergenceViewState } from '../convergence-view.js';
 import { getOrCreateMaterializer } from './materializer.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { readWorkflowStateJson } from './streams.js';
 
 // ─── View Convergence Handler ──────────────────────────────────────────────
@@ -22,12 +23,7 @@ export async function handleViewConvergence(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, CONVERGENCE_VIEW);
-    const view = materializer.materialize<ConvergenceViewState>(
-      streamId,
-      CONVERGENCE_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<ConvergenceViewState>(store, materializer, streamId, CONVERGENCE_VIEW);
 
     // Fix 2 (#1184) — when `gate.executed` events don't cover all dimensions,
     // fall back to `state.reviews.findingsByDimension`. The reviewer stamps
@@ -69,12 +65,6 @@ export async function handleViewConvergence(
     }
     return { success: true, data: { ...effectiveView, dimensions } };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'convergence' });
   }
 }

--- a/src/projections/views/handlers/delegation-readiness.ts
+++ b/src/projections/views/handlers/delegation-readiness.ts
@@ -1,8 +1,9 @@
 import { EventStore } from '../../../events/store.js';
+import { toViewFailure } from '../../degraded-result.js';
 import type { ToolResult } from '../../../format.js';
 import { DELEGATION_READINESS_VIEW, type DelegationReadinessState, scopeReadinessToWave } from '../delegation-readiness-view.js';
 import { getOrCreateMaterializer } from './materializer.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 
 // ─── View Delegation Readiness Handler ──────────────────────────────────────
 
@@ -28,12 +29,7 @@ export async function handleViewDelegationReadiness(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, DELEGATION_READINESS_VIEW);
-    const materialized = materializer.materialize<DelegationReadinessState>(
-      streamId,
-      DELEGATION_READINESS_VIEW,
-      events,
-    );
+    const { view: materialized } = await foldToTail<DelegationReadinessState>(store, materializer, streamId, DELEGATION_READINESS_VIEW);
     const view = scopeReadinessToWave(
       materialized,
       args.tasks?.map((id) => ({ id })),
@@ -52,12 +48,6 @@ export async function handleViewDelegationReadiness(
     } = view.worktrees;
     return { success: true, data: { ...view, worktrees } };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'delegation_readiness' });
   }
 }

--- a/src/projections/views/handlers/delegation-timeline.ts
+++ b/src/projections/views/handlers/delegation-timeline.ts
@@ -1,9 +1,11 @@
 import { narrowAffordance } from '../../../dispatch/core/economy.js';
+import { toViewFailure } from '../../degraded-result.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
 import type { NextAction } from '../../../next-action.js';
 import { DELEGATION_TIMELINE_VIEW, type DelegationTimelineViewState, type TimelineTask } from '../delegation-timeline-view.js';
 import { CompactTimelineTask, compactTimelineTask, resolveInventoryWindow, scopeHiddenAffordance } from './inventory-contract.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { buildPage } from './pipeline.js';
 import { deriveCorrelationFilters, hasCorrelationFilters, materializeFiltered, queryDeltaEvents } from './query.js';
@@ -32,16 +34,15 @@ export async function handleViewDelegationTimeline(
 
     const correlationFilters = deriveCorrelationFilters(args);
     const filtered = hasCorrelationFilters(correlationFilters);
-    const events = await queryDeltaEvents(store, materializer, streamId, DELEGATION_TIMELINE_VIEW, correlationFilters);
     // Wave 5 (#1437) — under a correlation filter, fold a fresh projection
     // off `init()` so the materializer cache stays the unfiltered truth.
     const view = filtered
-      ? materializeFiltered<DelegationTimelineViewState>(materializer, DELEGATION_TIMELINE_VIEW, events)
-      : materializer.materialize<DelegationTimelineViewState>(
-          streamId,
+      ? materializeFiltered<DelegationTimelineViewState>(
+          materializer,
           DELEGATION_TIMELINE_VIEW,
-          events,
-        );
+          await queryDeltaEvents(store, materializer, streamId, DELEGATION_TIMELINE_VIEW, correlationFilters),
+        )
+      : (await foldToTail<DelegationTimelineViewState>(store, materializer, streamId, DELEGATION_TIMELINE_VIEW)).view;
 
     // DR-8 — the `tasks[]` list is the paged inventory; `total` is the scoped
     // (possibly correlation-filtered) task count.
@@ -58,13 +59,13 @@ export async function handleViewDelegationTimeline(
     let unscopedTotal = total;
     if (filtered) {
       scope = 'correlation';
-      const unfilteredEvents = await queryDeltaEvents(store, materializer, streamId, DELEGATION_TIMELINE_VIEW);
-      const unfilteredView = materializer.materialize<DelegationTimelineViewState>(
+      const unfiltered = await foldToTail<DelegationTimelineViewState>(
+        store,
+        materializer,
         streamId,
         DELEGATION_TIMELINE_VIEW,
-        unfilteredEvents,
       );
-      unscopedTotal = unfilteredView.tasks.length;
+      unscopedTotal = unfiltered.view.tasks.length;
     }
 
     // DR-8 — deterministic window (default item cap when `limit` omitted).
@@ -94,12 +95,6 @@ export async function handleViewDelegationTimeline(
       ...(nextActions.length > 0 ? { next_actions: nextActions } : {}),
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'delegation_timeline' });
   }
 }

--- a/src/projections/views/handlers/eval-results.ts
+++ b/src/projections/views/handlers/eval-results.ts
@@ -1,7 +1,9 @@
 import { EventStore } from '../../../events/store.js';
+import { toViewFailure } from '../../degraded-result.js';
 import type { ToolResult } from '../../../format.js';
 import { EVAL_RESULTS_VIEW, type EvalResultsViewState } from '../eval-results-view.js';
 import { analyticScope } from './analytic-contract.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { deriveCorrelationFilters, hasCorrelationFilters, materializeFiltered, queryDeltaEvents } from './query.js';
 
@@ -31,16 +33,15 @@ export async function handleViewEvalResults(
 
     const correlationFilters = deriveCorrelationFilters(args);
     const correlationFiltered = hasCorrelationFilters(correlationFilters);
-    const events = await queryDeltaEvents(store, materializer, streamId, EVAL_RESULTS_VIEW, correlationFilters);
     // Wave 5 (#1437) — under a correlation filter, fold a fresh projection
     // off `init()` so the materializer cache stays the unfiltered truth.
     const view = correlationFiltered
-      ? materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, events)
-      : materializer.materialize<EvalResultsViewState>(
-          streamId,
+      ? materializeFiltered<EvalResultsViewState>(
+          materializer,
           EVAL_RESULTS_VIEW,
-          events,
-        );
+          await queryDeltaEvents(store, materializer, streamId, EVAL_RESULTS_VIEW, correlationFilters),
+        )
+      : (await foldToTail<EvalResultsViewState>(store, materializer, streamId, EVAL_RESULTS_VIEW)).view;
 
     // Apply optional filters
     let filtered: EvalResultsViewState = { ...view };
@@ -86,12 +87,6 @@ export async function handleViewEvalResults(
       ...nextActions,
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'eval_results' });
   }
 }

--- a/src/projections/views/handlers/gate-reliability.ts
+++ b/src/projections/views/handlers/gate-reliability.ts
@@ -1,8 +1,9 @@
 import { EventStore } from '../../../events/store.js';
+import { toViewFailure } from '../../degraded-result.js';
 import type { ToolResult } from '../../../format.js';
 import { GATE_RELIABILITY_VIEW, type GateReliabilityViewState } from '../gate-reliability-view.js';
 import { getOrCreateMaterializer } from './materializer.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 
 // ─── View Gate Reliability Handler ─────────────────────────────────────────
 //
@@ -26,12 +27,7 @@ export async function handleViewGateReliability(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, GATE_RELIABILITY_VIEW);
-    const view = materializer.materialize<GateReliabilityViewState>(
-      streamId,
-      GATE_RELIABILITY_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<GateReliabilityViewState>(store, materializer, streamId, GATE_RELIABILITY_VIEW);
 
     if (args.detail) {
       return { success: true, data: view };
@@ -39,12 +35,6 @@ export async function handleViewGateReliability(
     const { _foldEvents: _ignoredFoldEvents, ...publicView } = view;
     return { success: true, data: publicView };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'gate_reliability' });
   }
 }

--- a/src/projections/views/handlers/pipeline.ts
+++ b/src/projections/views/handlers/pipeline.ts
@@ -1,4 +1,5 @@
 import { countBy, estimateOutputTokens, narrowAffordance, PIPELINE_DEFAULT_ITEM_CAP, resolveOutputTokenThreshold, SUMMARY_FIRST_PAGE_ITEMS } from '../../../dispatch/core/economy.js';
+import { toViewFailure } from '../../degraded-result.js';
 import { isFeatureStream } from '../../../dispatch/core/infra-streams.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
@@ -10,7 +11,7 @@ import { PROJECTION_LAG_THRESHOLD_MS } from '../../index.js';
 import { PIPELINE_VIEW, type PipelineViewState } from '../pipeline-view.js';
 import { isSnapshotSafeId } from '../snapshot-store.js';
 import { getOrCreateMaterializer } from './materializer.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { discoverStreams } from './streams.js';
 
 // ─── View Pipeline Handler ─────────────────────────────────────────────────
@@ -210,12 +211,7 @@ export async function handleViewPipeline(
     const allWorkflows: PipelineViewState[] = [];
 
     for (const streamId of streamIds) {
-      const events = await queryDeltaEvents(store, materializer, streamId, PIPELINE_VIEW);
-      const view = materializer.materialize<PipelineViewState>(
-        streamId,
-        PIPELINE_VIEW,
-        events,
-      );
+      const { view } = await foldToTail<PipelineViewState>(store, materializer, streamId, PIPELINE_VIEW);
       allWorkflows.push(view);
     }
 
@@ -415,12 +411,6 @@ export async function handleViewPipeline(
       ...(meta ? { _meta: meta } : {}),
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'pipeline' });
   }
 }

--- a/src/projections/views/handlers/provenance.ts
+++ b/src/projections/views/handlers/provenance.ts
@@ -1,4 +1,5 @@
 import { narrowAffordance } from '../../../dispatch/core/economy.js';
+import { toViewFailure } from '../../degraded-result.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
 import type { NextAction } from '../../../next-action.js';
@@ -6,7 +7,7 @@ import { PROVENANCE_VIEW, type ProvenanceViewState } from '../provenance-view.js
 import { resolveInventoryWindow } from './inventory-contract.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { buildPage } from './pipeline.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 
 // ─── View Provenance Handler ──────────────────────────────────────────────
 
@@ -28,12 +29,7 @@ export async function handleViewProvenance(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, PROVENANCE_VIEW);
-    const view = materializer.materialize<ProvenanceViewState>(
-      streamId,
-      PROVENANCE_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<ProvenanceViewState>(store, materializer, streamId, PROVENANCE_VIEW);
 
     // DR-8 (Task 024) — `requirements` is the dominant list, so page it. Strip
     // the internal `_completedTaskIds` mirror by default (mirrors
@@ -63,12 +59,6 @@ export async function handleViewProvenance(
       ...nextActionsWrap,
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'provenance' });
   }
 }

--- a/src/projections/views/handlers/quality-attribution.ts
+++ b/src/projections/views/handlers/quality-attribution.ts
@@ -8,7 +8,7 @@ import { CODE_QUALITY_VIEW, type CodeQualityViewState } from '../code-quality-vi
 import { EVAL_RESULTS_VIEW, type EvalResultsViewState } from '../eval-results-view.js';
 import { compactAttributionEntry } from './analytic-contract.js';
 import { resolveInventoryWindow } from './inventory-contract.js';
-import { foldToTail } from '../../fold-at-tail.js';
+import { foldPairToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { buildPage } from './pipeline.js';
 import { deriveCorrelationFilters, hasCorrelationFilters, materializeFiltered, queryDeltaEvents } from './query.js';
@@ -56,16 +56,35 @@ export async function handleViewQualityAttribution(
     const correlationFilters = deriveCorrelationFilters(args);
     const correlationFiltered = hasCorrelationFilters(correlationFilters);
 
-    // See handleViewQualityCorrelation above — under a correlation filter
-    // both projections fold from the same backend payload, so fetch once.
-    const cqEvents = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);
-    const cqView = correlationFiltered
-      ? materializeFiltered<CodeQualityViewState>(materializer, CODE_QUALITY_VIEW, cqEvents)
-      : (await foldToTail<CodeQualityViewState>(store, materializer, streamId, CODE_QUALITY_VIEW)).view;
-
-    const erView = correlationFiltered
-      ? materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, cqEvents)
-      : (await foldToTail<EvalResultsViewState>(store, materializer, streamId, EVAL_RESULTS_VIEW)).view;
+    // Both projections describe ONE state of the stream, so both must come from
+    // one sequence. Filtered, that is the single fetched event list they each
+    // fold; unfiltered, it is the single tail `foldPairToTail` pins for the
+    // pair. Folding them independently would let an append between the two
+    // produce a comparison of a state the stream was never in — and would also
+    // charge every unfiltered read for an event query it does not use.
+    let cqView: CodeQualityViewState;
+    let erView: EvalResultsViewState;
+    if (correlationFiltered) {
+      const cqEvents = await queryDeltaEvents(
+        store,
+        materializer,
+        streamId,
+        CODE_QUALITY_VIEW,
+        correlationFilters,
+      );
+      cqView = materializeFiltered<CodeQualityViewState>(materializer, CODE_QUALITY_VIEW, cqEvents);
+      erView = materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, cqEvents);
+    } else {
+      const pair = await foldPairToTail<CodeQualityViewState, EvalResultsViewState>(
+        store,
+        materializer,
+        streamId,
+        CODE_QUALITY_VIEW,
+        EVAL_RESULTS_VIEW,
+      );
+      cqView = pair.first;
+      erView = pair.second;
+    }
 
     // AttributionQuery.timeRange expects ISO 8601 duration string (e.g., 'P7D'),
     // but the MCP handler receives { start, end } — compute duration from the range

--- a/src/projections/views/handlers/quality-attribution.ts
+++ b/src/projections/views/handlers/quality-attribution.ts
@@ -1,4 +1,5 @@
 import { narrowAffordance } from '../../../dispatch/core/economy.js';
+import { toViewFailure } from '../../degraded-result.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
 import type { NextAction } from '../../../next-action.js';
@@ -7,6 +8,7 @@ import { CODE_QUALITY_VIEW, type CodeQualityViewState } from '../code-quality-vi
 import { EVAL_RESULTS_VIEW, type EvalResultsViewState } from '../eval-results-view.js';
 import { compactAttributionEntry } from './analytic-contract.js';
 import { resolveInventoryWindow } from './inventory-contract.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { buildPage } from './pipeline.js';
 import { deriveCorrelationFilters, hasCorrelationFilters, materializeFiltered, queryDeltaEvents } from './query.js';
@@ -59,22 +61,11 @@ export async function handleViewQualityAttribution(
     const cqEvents = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);
     const cqView = correlationFiltered
       ? materializeFiltered<CodeQualityViewState>(materializer, CODE_QUALITY_VIEW, cqEvents)
-      : materializer.materialize<CodeQualityViewState>(
-          streamId,
-          CODE_QUALITY_VIEW,
-          cqEvents,
-        );
+      : (await foldToTail<CodeQualityViewState>(store, materializer, streamId, CODE_QUALITY_VIEW)).view;
 
-    const erEvents = correlationFiltered
-      ? cqEvents
-      : await queryDeltaEvents(store, materializer, streamId, EVAL_RESULTS_VIEW);
     const erView = correlationFiltered
-      ? materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, erEvents)
-      : materializer.materialize<EvalResultsViewState>(
-          streamId,
-          EVAL_RESULTS_VIEW,
-          erEvents,
-        );
+      ? materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, cqEvents)
+      : (await foldToTail<EvalResultsViewState>(store, materializer, streamId, EVAL_RESULTS_VIEW)).view;
 
     // AttributionQuery.timeRange expects ISO 8601 duration string (e.g., 'P7D'),
     // but the MCP handler receives { start, end } — compute duration from the range
@@ -129,12 +120,6 @@ export async function handleViewQualityAttribution(
       ...nextActionsWrap,
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'quality_attribution' });
   }
 }

--- a/src/projections/views/handlers/quality-correlation.ts
+++ b/src/projections/views/handlers/quality-correlation.ts
@@ -5,7 +5,7 @@ import { correlateQualityAndEvals } from '../../quality/quality-correlation.js';
 import { CODE_QUALITY_VIEW, type CodeQualityViewState } from '../code-quality-view.js';
 import { EVAL_RESULTS_VIEW, type EvalResultsViewState } from '../eval-results-view.js';
 import { CompactSkillCorrelation, compactSkillCorrelation } from './analytic-contract.js';
-import { foldToTail } from '../../fold-at-tail.js';
+import { foldPairToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { deriveCorrelationFilters, hasCorrelationFilters, materializeFiltered, queryDeltaEvents } from './query.js';
 
@@ -37,17 +37,35 @@ export async function handleViewQualityCorrelation(
 
     // Under a correlation filter, `queryDeltaEvents` short-circuits the
     // cache and returns `store.query(streamId, filters)` regardless of
-    // `viewName` — so both calls would fetch an identical event list.
-    // Fetch once and fold the same list into both projections (each
-    // projection's `apply` ignores event types it doesn't care about).
-    const cqEvents = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);
-    const cqView = correlationFiltered
-      ? materializeFiltered<CodeQualityViewState>(materializer, CODE_QUALITY_VIEW, cqEvents)
-      : (await foldToTail<CodeQualityViewState>(store, materializer, streamId, CODE_QUALITY_VIEW)).view;
-
-    const erView = correlationFiltered
-      ? materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, cqEvents)
-      : (await foldToTail<EvalResultsViewState>(store, materializer, streamId, EVAL_RESULTS_VIEW)).view;
+    // Both projections describe ONE state of the stream, so both must come from
+    // one sequence. Filtered, that is the single fetched event list they each
+    // fold; unfiltered, it is the single tail `foldPairToTail` pins for the
+    // pair. Folding them independently would let an append between the two
+    // produce a comparison of a state the stream was never in — and would also
+    // charge every unfiltered read for an event query it does not use.
+    let cqView: CodeQualityViewState;
+    let erView: EvalResultsViewState;
+    if (correlationFiltered) {
+      const cqEvents = await queryDeltaEvents(
+        store,
+        materializer,
+        streamId,
+        CODE_QUALITY_VIEW,
+        correlationFilters,
+      );
+      cqView = materializeFiltered<CodeQualityViewState>(materializer, CODE_QUALITY_VIEW, cqEvents);
+      erView = materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, cqEvents);
+    } else {
+      const pair = await foldPairToTail<CodeQualityViewState, EvalResultsViewState>(
+        store,
+        materializer,
+        streamId,
+        CODE_QUALITY_VIEW,
+        EVAL_RESULTS_VIEW,
+      );
+      cqView = pair.first;
+      erView = pair.second;
+    }
 
     const correlation = correlateQualityAndEvals(cqView, erView);
     // DR-8 (Task 024) compact-by-default — keep each skill's headline (pass rate

--- a/src/projections/views/handlers/quality-correlation.ts
+++ b/src/projections/views/handlers/quality-correlation.ts
@@ -1,9 +1,11 @@
 import { EventStore } from '../../../events/store.js';
+import { toViewFailure } from '../../degraded-result.js';
 import type { ToolResult } from '../../../format.js';
 import { correlateQualityAndEvals } from '../../quality/quality-correlation.js';
 import { CODE_QUALITY_VIEW, type CodeQualityViewState } from '../code-quality-view.js';
 import { EVAL_RESULTS_VIEW, type EvalResultsViewState } from '../eval-results-view.js';
 import { CompactSkillCorrelation, compactSkillCorrelation } from './analytic-contract.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { deriveCorrelationFilters, hasCorrelationFilters, materializeFiltered, queryDeltaEvents } from './query.js';
 
@@ -41,22 +43,11 @@ export async function handleViewQualityCorrelation(
     const cqEvents = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);
     const cqView = correlationFiltered
       ? materializeFiltered<CodeQualityViewState>(materializer, CODE_QUALITY_VIEW, cqEvents)
-      : materializer.materialize<CodeQualityViewState>(
-          streamId,
-          CODE_QUALITY_VIEW,
-          cqEvents,
-        );
+      : (await foldToTail<CodeQualityViewState>(store, materializer, streamId, CODE_QUALITY_VIEW)).view;
 
-    const erEvents = correlationFiltered
-      ? cqEvents
-      : await queryDeltaEvents(store, materializer, streamId, EVAL_RESULTS_VIEW);
     const erView = correlationFiltered
-      ? materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, erEvents)
-      : materializer.materialize<EvalResultsViewState>(
-          streamId,
-          EVAL_RESULTS_VIEW,
-          erEvents,
-        );
+      ? materializeFiltered<EvalResultsViewState>(materializer, EVAL_RESULTS_VIEW, cqEvents)
+      : (await foldToTail<EvalResultsViewState>(store, materializer, streamId, EVAL_RESULTS_VIEW)).view;
 
     const correlation = correlateQualityAndEvals(cqView, erView);
     // DR-8 (Task 024) compact-by-default — keep each skill's headline (pass rate
@@ -70,12 +61,6 @@ export async function handleViewQualityCorrelation(
     }
     return { success: true, data: { skills } };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'quality_correlation' });
   }
 }

--- a/src/projections/views/handlers/quality-hints.ts
+++ b/src/projections/views/handlers/quality-hints.ts
@@ -1,4 +1,5 @@
 import { narrowAffordance } from '../../../dispatch/core/economy.js';
+import { toViewFailure } from '../../degraded-result.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
 import type { NextAction } from '../../../next-action.js';
@@ -8,7 +9,7 @@ import { CompactQualityHint, analyticScope, compactQualityHint } from './analyti
 import { resolveInventoryWindow } from './inventory-contract.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { buildPage } from './pipeline.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 
 // ─── View Quality Hints Handler ─────────────────────────────────────────────
 
@@ -30,12 +31,7 @@ export async function handleViewQualityHints(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW);
-    const view = materializer.materialize<CodeQualityViewState>(
-      streamId,
-      CODE_QUALITY_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<CodeQualityViewState>(store, materializer, streamId, CODE_QUALITY_VIEW);
 
     const { generateQualityHints } = await import('../../quality/hints.js');
     const hints = generateQualityHints(view, args.skill);
@@ -77,12 +73,6 @@ export async function handleViewQualityHints(
       ...(nextActions.length > 0 ? { next_actions: nextActions } : {}),
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'quality_hints' });
   }
 }

--- a/src/projections/views/handlers/session-provenance.ts
+++ b/src/projections/views/handlers/session-provenance.ts
@@ -1,3 +1,4 @@
+import { toViewFailure } from '../../degraded-result.js';
 import type { ToolResult } from '../../../format.js';
 
 // ─── View Session Provenance Handler ─────────────────────────────────────────
@@ -56,12 +57,6 @@ export async function handleViewSessionProvenance(
     const { fileAttribution: _fileAttribution, files: _files, ...compact } = result;
     return { success: true, data: compact };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'session_provenance' });
   }
 }

--- a/src/projections/views/handlers/shepherd-status.ts
+++ b/src/projections/views/handlers/shepherd-status.ts
@@ -1,3 +1,4 @@
+import { toViewFailure } from '../../degraded-result.js';
 import { narrowAffordance } from '../../../dispatch/core/economy.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
@@ -7,7 +8,7 @@ import { CompactPrStatus, compactPrStatus } from './analytic-contract.js';
 import { resolveInventoryWindow } from './inventory-contract.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { buildPage } from './pipeline.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 
 // ─── View Shepherd Status Handler ────────────────────────────────────────────
 
@@ -28,12 +29,7 @@ export async function handleViewShepherdStatus(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, SHEPHERD_STATUS_VIEW);
-    const view = materializer.materialize<ShepherdStatusState>(
-      streamId,
-      SHEPHERD_STATUS_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<ShepherdStatusState>(store, materializer, streamId, SHEPHERD_STATUS_VIEW);
 
     // DR-8 (Task 024) — `prs` is the dominant list, so page it. Compact-by-
     // default drops each PR's per-severity breakdown; `detail: true` restores it.
@@ -55,12 +51,6 @@ export async function handleViewShepherdStatus(
       ...(nextActions.length > 0 ? { next_actions: nextActions } : {}),
     };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'shepherd_status' });
   }
 }

--- a/src/projections/views/handlers/synthesis-readiness.ts
+++ b/src/projections/views/handlers/synthesis-readiness.ts
@@ -1,8 +1,9 @@
+import { toViewFailure } from '../../degraded-result.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
 import { SYNTHESIS_READINESS_VIEW, type SynthesisReadinessState } from '../synthesis-readiness-view.js';
 import { getOrCreateMaterializer } from './materializer.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { readWorkflowStateJson } from './streams.js';
 
 // ─── View Synthesis Readiness Handler ────────────────────────────────────────
@@ -22,12 +23,7 @@ export async function handleViewSynthesisReadiness(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, SYNTHESIS_READINESS_VIEW);
-    const view = materializer.materialize<SynthesisReadinessState>(
-      streamId,
-      SYNTHESIS_READINESS_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<SynthesisReadinessState>(store, materializer, streamId, SYNTHESIS_READINESS_VIEW);
 
     // Fix 2 (#1184) — review status is plan-state stamped via `workflow set`
     // (state.reviews); the synthesis-readiness projection only watches
@@ -112,12 +108,6 @@ export async function handleViewSynthesisReadiness(
     const { findingsBySeverity: _findingsBySeverity, ...compactReview } = data.review;
     return { success: true, data: { ...data, review: compactReview } };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'synthesis_readiness' });
   }
 }

--- a/src/projections/views/handlers/tasks.ts
+++ b/src/projections/views/handlers/tasks.ts
@@ -1,3 +1,4 @@
+import { toViewFailure } from '../../degraded-result.js';
 import { narrowAffordance } from '../../../dispatch/core/economy.js';
 import { EventStore } from '../../../events/store.js';
 import { pickFields, type ToolResult } from '../../../format.js';
@@ -6,7 +7,7 @@ import { TASK_DETAIL_VIEW, type TaskDetail, type TaskDetailViewState } from '../
 import { CompactTaskDetail, compactTaskDetail, resolveInventoryWindow, scopeHiddenAffordance } from './inventory-contract.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { buildPage } from './pipeline.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { readWorkflowStateJson } from './streams.js';
 
 // ─── View Tasks Handler ────────────────────────────────────────────────────
@@ -30,12 +31,7 @@ export async function handleViewTasks(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, TASK_DETAIL_VIEW);
-    const view = materializer.materialize<TaskDetailViewState>(
-      streamId,
-      TASK_DETAIL_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<TaskDetailViewState>(store, materializer, streamId, TASK_DETAIL_VIEW);
 
     // Fix 2 (#1184) — the task-detail projection is event-sourced and only
     // populates entries that have a `task.assigned` event. The planner often
@@ -143,12 +139,6 @@ export async function handleViewTasks(
       : windowed.map(compactTaskDetail);
     return { success: true, data: rows, ...envelopeExtras };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'tasks' });
   }
 }

--- a/src/projections/views/handlers/team-performance.ts
+++ b/src/projections/views/handlers/team-performance.ts
@@ -1,9 +1,10 @@
+import { toViewFailure } from '../../degraded-result.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
 import { TEAM_PERFORMANCE_VIEW, type TeamPerformanceViewState } from '../team-performance-view.js';
 import { CompactTeammateMetrics, compactTeammate } from './inventory-contract.js';
 import { getOrCreateMaterializer } from './materializer.js';
-import { queryDeltaEvents } from './query.js';
+import { foldToTail } from '../../fold-at-tail.js';
 
 // ─── View Team Performance Handler ──────────────────────────────────────────
 
@@ -17,12 +18,7 @@ export async function handleViewTeamPerformance(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const events = await queryDeltaEvents(store, materializer, streamId, TEAM_PERFORMANCE_VIEW);
-    const view = materializer.materialize<TeamPerformanceViewState>(
-      streamId,
-      TEAM_PERFORMANCE_VIEW,
-      events,
-    );
+    const { view } = await foldToTail<TeamPerformanceViewState>(store, materializer, streamId, TEAM_PERFORMANCE_VIEW);
 
     // DR-8 — `detail: true` returns the full projection (teammates + modules +
     // sizing). The compact default keeps the per-teammate CORE metrics (the
@@ -38,12 +34,6 @@ export async function handleViewTeamPerformance(
     }
     return { success: true, data: { teammates } };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'team_performance' });
   }
 }

--- a/src/projections/views/handlers/workflow-status.ts
+++ b/src/projections/views/handlers/workflow-status.ts
@@ -1,7 +1,9 @@
+import { toViewFailure } from '../../degraded-result.js';
 import { EventStore } from '../../../events/store.js';
 import type { ToolResult } from '../../../format.js';
 import { type AsOfParam, resolveAsOfEvents } from '../../cursor.js';
 import { WORKFLOW_STATUS_VIEW, type WorkflowStatusViewState } from '../workflow-status-view.js';
+import { foldToTail } from '../../fold-at-tail.js';
 import { getOrCreateMaterializer } from './materializer.js';
 import { queryDeltaEvents } from './query.js';
 import { readWorkflowStateJson } from './streams.js';
@@ -31,11 +33,12 @@ export async function handleViewWorkflowStatus(
           WORKFLOW_STATUS_VIEW,
           resolveAsOfEvents(await store.query(streamId), args.asOf),
         )
-      : materializer.materialize<WorkflowStatusViewState>(
+      : (await foldToTail<WorkflowStatusViewState>(
+          store,
+          materializer,
           streamId,
           WORKFLOW_STATUS_VIEW,
-          await queryDeltaEvents(store, materializer, streamId, WORKFLOW_STATUS_VIEW),
-        );
+        )).view;
 
     // Fix 2 (#1184) — `tasksTotal` is a plan-state fact: the planner stamps
     // the full task list via `workflow set` (state.patched events), and
@@ -78,12 +81,6 @@ export async function handleViewWorkflowStatus(
 
     return { success: true, data };
   } catch (err) {
-    return {
-      success: false,
-      error: {
-        code: 'VIEW_ERROR',
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
+    return toViewFailure(err, { tool: 'exarchos_view', action: 'workflow_status' });
   }
 }

--- a/src/projections/views/materializer.ts
+++ b/src/projections/views/materializer.ts
@@ -52,7 +52,7 @@ const DEFAULT_THRASHING_WINDOW_SIZE = 100;
 // (b) in #1434, explicitly rejected); the kebab-only constraint is the
 // right shape for user-facing featureIds and we don't want a future caller
 // to accidentally name a snapshot file `..` or `subdir/foo`.
-const isInternalSentinelStream = (id: string): boolean => id.startsWith('__');
+export const isInternalSentinelStream = (id: string): boolean => id.startsWith('__');
 
 /** Read EXARCHOS_MAX_CACHE_ENTRIES from env, falling back to default on invalid/missing. */
 function parseEnvMaxCacheEntries(): number {
@@ -139,6 +139,24 @@ export class ViewMaterializer {
    * Uses high-water mark tracking for incremental updates.
    */
   materialize<T>(streamId: string, viewName: string, events: WorkflowEvent[]): T {
+    return this.materializeAt<T>(streamId, viewName, events).view;
+  }
+
+  /**
+   * Materialize, and return the fold together with the sequence it covers.
+   *
+   * `materialize` above drops the cursor and hands back a bare view. That is
+   * the shape #1855 turned on: a fold and the evidence of what it covers were
+   * separable, so an answer could be derived from one without the other, and
+   * the coverage question moved to a separate comparison that ran too late to
+   * do anything but refuse. Returning the pair keeps the two together, and
+   * `projections/fold-at-tail.ts` is what turns the pair into a guarantee.
+   */
+  materializeAt<T>(
+    streamId: string,
+    viewName: string,
+    events: WorkflowEvent[],
+  ): { view: T; sequence: number } {
     const projection = this.projections.get(viewName);
     if (!projection) {
       throw new Error(`No projection registered for view: ${viewName}`);
@@ -154,7 +172,7 @@ export class ViewMaterializer {
         { streamId, viewName },
         'ViewMaterializer: skipping sentinel stream',
       );
-      return projection.init() as T;
+      return { view: projection.init() as T, sequence: 0 };
     }
 
     const stateKey = `${viewName}:${streamId}`;
@@ -238,7 +256,7 @@ export class ViewMaterializer {
       }
     }
 
-    return currentView;
+    return { view: currentView, sequence: maxSequence };
   }
 
   /**
@@ -359,6 +377,22 @@ export class ViewMaterializer {
    */
   recordBypass(): void {
     this.cacheBypasses++;
+  }
+
+  /**
+   * Drop one stream's cached fold for `viewName`.
+   *
+   * The repair half of the `projection-ahead` case: a fold whose cursor sits
+   * past the durable tail was built over events the log can no longer produce,
+   * and `materialize` cannot heal it — its high-water-mark filter discards
+   * every event below that cursor, so a re-fold applies nothing. Dropping the
+   * entry makes the next fold a full replay from the log, which is the source of
+   * truth and therefore authoritative by construction.
+   */
+  discardFold(streamId: string, viewName: string): void {
+    const stateKey = `${viewName}:${streamId}`;
+    this.states.delete(stateKey);
+    this.lastSnapshotHwm.delete(stateKey);
   }
 
   /**

--- a/src/verbs/composite.ts
+++ b/src/verbs/composite.ts
@@ -370,9 +370,19 @@ function adaptSetupWorktree(): ActionHandler {
         // #1509/#1501: project synthesis.integrationBranch so the handler can
         // base managed worktrees on the integration tip, not a stale `main`.
         workflowState = { tasks: view.tasks, synthesis: view.synthesis };
-      } catch {
-        // Best-effort: missing/unreadable state is not a setup_worktree
-        // failure — handler falls back to legacy default branch.
+      } catch (err) {
+        // A coverage failure is NOT best-effort material. Falling back to the
+        // legacy default branch here would base a managed worktree on `main`
+        // while the integration tip was merely unprovable — the silent
+        // degradation this seam exists to remove.
+        const { toCoverageFailure } = await import('../projections/degraded-result.js');
+        const refusal = toCoverageFailure(err, {
+          tool: 'exarchos_orchestrate',
+          action: 'setup_worktree',
+        });
+        if (refusal) return refusal;
+        // Anything else stays best-effort: missing or unreadable state is not a
+        // setup_worktree failure, and the handler falls back as before.
         workflowState = undefined;
       }
     }

--- a/src/verbs/composite.ts
+++ b/src/verbs/composite.ts
@@ -12,10 +12,6 @@ import { handleRunbook } from '../runbooks/handler.js';
 import { TOOL_REGISTRY } from '../registry.js';
 import { envelopeWrap } from '../envelope-wrap.js';
 import { orchestrateLogger } from '../logger.js';
-import {
-  guardProjectionDegraded,
-  resolveProjectionStreamId,
-} from '../projections/degraded-result.js';
 
 const orchestrateActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_orchestrate')!.actions;
 
@@ -363,19 +359,14 @@ function adaptSetupWorktree(): ActionHandler {
 
     if (featureId && ctx?.eventStore) {
       try {
-        const { getOrCreateMaterializer, queryDeltaEvents } = await import('../projections/views/tools.js');
+        const { getOrCreateMaterializer } = await import('../projections/views/tools.js');
+        const { foldToTail } = await import('../projections/fold-at-tail.js');
         const { WORKFLOW_STATE_VIEW } = await import('../projections/views/workflow-state-projection.js');
         const materializer = getOrCreateMaterializer(stateDir);
-        const events = await queryDeltaEvents(
-          ctx.eventStore,
-          materializer,
-          featureId,
-          WORKFLOW_STATE_VIEW,
-        );
-        const view = materializer.materialize<{
+        const { view } = await foldToTail<{
           tasks: Array<{ id: string; branch?: string }>;
           synthesis?: { integrationBranch?: string };
-        }>(featureId, WORKFLOW_STATE_VIEW, events);
+        }>(ctx.eventStore, materializer, featureId, WORKFLOW_STATE_VIEW);
         // #1509/#1501: project synthesis.integrationBranch so the handler can
         // base managed worktrees on the integration tip, not a stale `main`.
         workflowState = { tasks: view.tasks, synthesis: view.synthesis };
@@ -711,32 +702,21 @@ function validateInvariantsAmendArgs(
 // ─── Composite Handler ──────────────────────────────────────────────────────
 
 /**
- * DR-4 — orchestrate actions whose verdict is derived from a materialized fold.
+ * #1855 — the orchestrate degraded gate is gone, and its removal is the fix.
  *
- * Derived mechanically, not guessed: these are exactly the orchestrate handlers
- * that reach the materializer LRU (`git grep -l materializer -- src/orchestrate`
- * → check-convergence, check-event-emissions, prepare-delegation,
- * prepare-synthesis). Every OTHER orchestrate action either folds the event log
- * directly (authoritative by construction — a gate reading `eventStore.query`
- * cannot be stale) or touches no stream at all (worktree/git/scaffold/runbook
- * actions), so guarding them would refuse reads that are provably trustworthy.
+ * The four guarded actions — `prepare_delegation`, `prepare_synthesis`,
+ * `check_convergence`, `check_event_emissions` — were guarded because each
+ * decides whether to dispatch agents or whether a phase converged, and each
+ * read a materialized fold to do it. The reasoning was sound; the mechanism was
+ * not. The gate could only consult a durable verdict published by a different
+ * surface, so a stale marker refused a healthy stream and a fresh fold could
+ * not clear one.
  *
- * These four are precisely the readiness/reliability surfaces CB-8 burned:
- *
- * - `prepare_delegation` / `prepare_synthesis` decide whether to DISPATCH
- *   agents. Answering "ready" from a fold that has not seen the events that
- *   would say otherwise is how work gets dispatched against a cancelled
- *   workflow.
- * - `check_convergence` / `check_event_emissions` are reliability verdicts. A
- *   gate that passes because the fold has not caught up yet is worse than a
- *   gate that refuses to answer.
+ * Each of those handlers now folds to the stream's durable tail through
+ * `projections/fold-at-tail.ts` before it decides, which is what the gate was
+ * trying to approximate from outside. A readiness verdict derived from a fold
+ * that provably covers the tail needs no second opinion about the fold.
  */
-const PROJECTION_DERIVED_ORCHESTRATE_ACTIONS: ReadonlySet<string> = new Set([
-  'prepare_delegation',
-  'prepare_synthesis',
-  'check_convergence',
-  'check_event_emissions',
-]);
 
 /**
  * Routes the `action` field from args to the corresponding task handler.
@@ -760,24 +740,6 @@ export async function handleOrchestrate(
   const startedAt = Date.now();
   const { stateDir } = ctx;
   const { action, ...rest } = args;
-
-  // DR-4 consumer chokepoint — see PROJECTION_DERIVED_ORCHESTRATE_ACTIONS.
-  // Placed ahead of every dispatch branch below (including the `describe` /
-  // `doctor` / `onboard` special cases) so no arm can route around it; the set
-  // membership test, not the branch position, decides what is guarded.
-  if (typeof action === 'string' && PROJECTION_DERIVED_ORCHESTRATE_ACTIONS.has(action)) {
-    const refusal = await guardProjectionDegraded(
-      ctx.eventStore,
-      resolveProjectionStreamId(rest),
-      {
-        tool: 'exarchos_orchestrate',
-        action,
-        onError: (err) =>
-          orchestrateLogger.warn({ action, err }, 'durable projection-health read failed'),
-      },
-    );
-    if (refusal) return refusal;
-  }
 
   // Handle describe specially — it needs the action list, not stateDir
   if (action === 'describe') {

--- a/src/verbs/gates/check-convergence.ts
+++ b/src/verbs/gates/check-convergence.ts
@@ -7,10 +7,8 @@
 
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
-import {
-  getOrCreateMaterializer,
-  queryDeltaEvents,
-} from '../../projections/views/tools.js';
+import { foldToTail } from '../../projections/fold-at-tail.js';
+import { getOrCreateMaterializer } from '../../projections/views/tools.js';
 import { ALL_DIMENSIONS, CONVERGENCE_VIEW } from '../../projections/views/convergence-view.js';
 import type { ConvergenceViewState } from '../../projections/views/convergence-view.js';
 import { emitGateEvent } from './gate-utils.js';
@@ -65,12 +63,14 @@ export async function handleCheckConvergence(
   const materializer = getOrCreateMaterializer(stateDir);
   const streamId = args.workflowId ?? args.featureId;
 
-  // Materialize convergence view from gate.executed events
-  const events = await queryDeltaEvents(store, materializer, streamId, CONVERGENCE_VIEW);
-  const view = materializer.materialize<ConvergenceViewState>(
+  // Fold the convergence view over `gate.executed` up to the durable tail. A
+  // reliability verdict derived from a fold that has not seen the latest gate
+  // is worse than no verdict.
+  const { view } = await foldToTail<ConvergenceViewState>(
+    store,
+    materializer,
     streamId,
     CONVERGENCE_VIEW,
-    events,
   );
 
   // Apply phase filter if specified — filter gate results per dimension

--- a/src/verbs/gates/check-event-emissions.ts
+++ b/src/verbs/gates/check-event-emissions.ts
@@ -9,10 +9,8 @@ import type { EventType } from '../../events/schemas.js';
 import { EVENT_DATA_SCHEMAS, EVENT_EMISSION_REGISTRY } from '../../events/schemas.js';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
-import {
-  getOrCreateMaterializer,
-  queryDeltaEvents,
-} from '../../projections/views/tools.js';
+import { foldToTail } from '../../projections/fold-at-tail.js';
+import { getOrCreateMaterializer } from '../../projections/views/tools.js';
 import { WORKFLOW_STATE_VIEW } from '../../projections/views/workflow-state-projection.js';
 import type { WorkflowStateView } from '../../projections/views/workflow-state-projection.js';
 import { emitGateEvent } from './gate-utils.js';
@@ -164,12 +162,15 @@ export async function handleCheckEventEmissions(
   const materializer = getOrCreateMaterializer(stateDir);
   const streamId = args.workflowId ?? args.featureId;
 
-  // Materialize workflow state view to get the current phase
-  const stateEvents = await queryDeltaEvents(store, materializer, streamId, WORKFLOW_STATE_VIEW);
-  const view = materializer.materialize<WorkflowStateView>(
+  // Fold the workflow-state view to the durable tail to read the current
+  // phase. This is one of the folds #1855 was about: it lands in the shared
+  // view materializer and no `exarchos_view` action refreshes it, so before
+  // the seam it was the entry that went stale and stayed stale.
+  const { view } = await foldToTail<WorkflowStateView>(
+    store,
+    materializer,
     streamId,
     WORKFLOW_STATE_VIEW,
-    stateEvents,
   );
 
   const phase = view.phase;

--- a/src/verbs/gates/check-event-emissions.ts
+++ b/src/verbs/gates/check-event-emissions.ts
@@ -166,7 +166,7 @@ export async function handleCheckEventEmissions(
   // phase. This is one of the folds #1855 was about: it lands in the shared
   // view materializer and no `exarchos_view` action refreshes it, so before
   // the seam it was the entry that went stale and stayed stale.
-  const { view } = await foldToTail<WorkflowStateView>(
+  const { view, sequence } = await foldToTail<WorkflowStateView>(
     store,
     materializer,
     streamId,
@@ -190,8 +190,11 @@ export async function handleCheckEventEmissions(
     };
   }
 
-  // Query all events from the stream
-  const events = await store.query(streamId);
+  // The phase came from a fold covering `sequence`; the evidence for that
+  // phase must stop there too. An unbounded read would let events appended
+  // after the fold answer for a phase that predates them — reporting a phase
+  // complete on emissions belonging to the next one.
+  const events = (await store.query(streamId)).filter((e) => e.sequence <= sequence);
   const presentTypes = new Set(events.map((e) => e.type));
 
   // Check which expected events are missing

--- a/src/verbs/stack/tools.ts
+++ b/src/verbs/stack/tools.ts
@@ -1,5 +1,6 @@
 // ─── Stack MCP Tool Handlers ────────────────────────────────────────────────
 
+import { toCoverageFailure } from '../../projections/degraded-result.js';
 import { foldToTail } from '../../projections/fold-at-tail.js';
 import type { EventStore } from '../../events/store.js';
 import { toEventAck, type ToolResult } from '../../format.js';
@@ -42,6 +43,8 @@ export async function handleStackStatus(
 
     return { success: true, data: positions };
   } catch (err) {
+    const refusal = toCoverageFailure(err, { tool: 'exarchos_view', action: 'stack_status' });
+    if (refusal) return refusal;
     return {
       success: false,
       error: {

--- a/src/verbs/stack/tools.ts
+++ b/src/verbs/stack/tools.ts
@@ -1,5 +1,6 @@
 // ─── Stack MCP Tool Handlers ────────────────────────────────────────────────
 
+import { foldToTail } from '../../projections/fold-at-tail.js';
 import type { EventStore } from '../../events/store.js';
 import { toEventAck, type ToolResult } from '../../format.js';
 import { getOrCreateMaterializer } from '../../projections/views/tools.js';
@@ -25,9 +26,7 @@ export async function handleStackStatus(
     const store = eventStore;
     const materializer = getOrCreateMaterializer(stateDir);
 
-    await materializer.loadFromSnapshot(args.streamId, STACK_VIEW);
-    const events = await store.query(args.streamId);
-    const view = materializer.materialize<StackViewState>(args.streamId, STACK_VIEW, events);
+    const { view } = await foldToTail<StackViewState>(store, materializer, args.streamId, STACK_VIEW);
 
     let positions = view.positions;
 

--- a/src/verbs/tasks/tools.ts
+++ b/src/verbs/tasks/tools.ts
@@ -1,5 +1,6 @@
 // ─── Task MCP Tool Handlers ─────────────────────────────────────────────────
 
+import { foldToTail } from '../../projections/fold-at-tail.js';
 import * as path from 'node:path';
 import { EventStore, SequenceConflictError } from '../../events/store.js';
 import { validateAgentEvent } from '../../events/schemas.js';
@@ -191,16 +192,19 @@ async function attemptTaskClaim(
   const materializer = getOrCreateMaterializer(stateDir);
   const store = eventStore;
 
-  // Load snapshot (if any) and query all events for the stream
-  await materializer.loadFromSnapshot(streamId, TASK_DETAIL_VIEW);
-  const events = await store.query(streamId);
-  const currentSequence = events.length;
-
-  // Materialize the task-detail view to check claim status
-  const view = materializer.materialize<TaskDetailViewState>(
+  // Fold the task-detail view up to the stream's durable tail to check claim
+  // status. The CAS pin below MUST be the tail this decision was derived from,
+  // so it comes from the fold rather than being recomputed.
+  //
+  // A COUNT (`events.length`) is not a SEQUENCE. The two coincide only while
+  // the stream has no gaps, and the
+  // appender's OCC contract is stated in terms of the last event's sequence.
+  // A pruned or migrated stream would have silently pinned the wrong version.
+  const { view, sequence: currentSequence } = await foldToTail<TaskDetailViewState>(
+    store,
+    materializer,
     streamId,
     TASK_DETAIL_VIEW,
-    events,
   );
 
   // Check materialized view first (handles tasks with prior task.assigned event)
@@ -210,8 +214,11 @@ async function attemptTaskClaim(
   }
 
   // Fallback: check raw events for terminal task states without prior task.assigned
-  // (the view projection ignores claims for unassigned tasks)
+  // (the view projection ignores claims for unassigned tasks). Bounded by the
+  // same tail the fold covers, so the two checks cannot disagree about which
+  // events they have seen.
   if (!task) {
+    const events = await store.query(streamId);
     const isTerminal = events.some(
       (e) =>
         (e.type === 'task.claimed' || e.type === 'task.completed' || e.type === 'task.failed') &&

--- a/src/verbs/team/prepare-delegation.ts
+++ b/src/verbs/team/prepare-delegation.ts
@@ -13,10 +13,8 @@ import { DEFAULTS } from '../../config/resolve.js';
 import type { EventStore } from '../../events/store.js';
 import { orchestrateLogger } from '../../logger.js';
 import type { DispatchContext } from '../../dispatch/core/dispatch.js';
-import {
-  getOrCreateMaterializer,
-  queryDeltaEvents,
-} from '../../projections/views/tools.js';
+import { foldToTail } from '../../projections/fold-at-tail.js';
+import { getOrCreateMaterializer } from '../../projections/views/tools.js';
 import {
   validateBranchAncestry,
   assertMainWorktree,
@@ -1097,11 +1095,11 @@ export async function handlePrepareDelegation(
 
     // ─── DR-1: Branch Ancestry Preflight ────────────────────────────────
     // Materialize workflow state early to get integrationBranch
-    const wsEvents = await queryDeltaEvents(store, materializer, streamId, WORKFLOW_STATE_VIEW);
-    const workflowState = materializer.materialize<WorkflowStateView>(
+    const { view: workflowState } = await foldToTail<WorkflowStateView>(
+      store,
+      materializer,
       streamId,
       WORKFLOW_STATE_VIEW,
-      wsEvents,
     );
 
     const gitExec = createGitExec();
@@ -1391,11 +1389,11 @@ export async function handlePrepareDelegation(
     }
 
     // Materialize delegation readiness from event stream
-    const drEvents = await queryDeltaEvents(store, materializer, streamId, DELEGATION_READINESS_VIEW);
-    const readiness = materializer.materialize<DelegationReadinessState>(
+    const { view: readiness } = await foldToTail<DelegationReadinessState>(
+      store,
+      materializer,
       streamId,
       DELEGATION_READINESS_VIEW,
-      drEvents,
     );
 
     // DR-T-1 (#1205, T-03): plan-artifact presence is tracked by the
@@ -1484,12 +1482,12 @@ export async function handlePrepareDelegation(
     // Materialize code quality (best effort -- may have no events)
     let qualityState: CodeQualityViewState | null = null;
     try {
-      const cqEvents = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW);
-      qualityState = materializer.materialize<CodeQualityViewState>(
+      qualityState = (await foldToTail<CodeQualityViewState>(
+        store,
+        materializer,
         streamId,
         CODE_QUALITY_VIEW,
-        cqEvents,
-      );
+      )).view;
     } catch {
       // Quality view may not exist for this stream -- that's fine
     }

--- a/src/workflow/composite.ts
+++ b/src/workflow/composite.ts
@@ -10,39 +10,28 @@ import type { DispatchContext } from '../dispatch/core/dispatch.js';
 import { envelopeWrap } from '../envelope-wrap.js';
 import { deriveRepoKey } from '../utils/paths.js';
 import { workflowLogger } from '../logger.js';
-import {
-  guardProjectionDegraded,
-  resolveProjectionStreamId,
-} from '../projections/degraded-result.js';
+import { toViewFailure } from '../projections/degraded-result.js';
 
 const workflowActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!.actions;
 
 /**
- * DR-4 — workflow actions whose answer is derived from a materialized fold.
+ * #1855 — there is no consumer-side degraded gate here any more, and its
+ * removal is the fix rather than a relaxation.
  *
- * `get` resolves every query shape (scalar, dot-path, field projection) through
- * `moduleViewMaterializer.materialize` (workflow/tools.ts) — the same LRU CB-8
- * caught serving a cancelled workflow as `plan-review`. It is therefore the
- * workflow surface that can hand back a stale payload, and the one guarded.
+ * `exarchos_workflow` holds no materializer cursor of its own, so the gate
+ * could only read a verdict some other surface had published and refuse on it.
+ * That verdict was a point-in-time observation of one process's cache, treated
+ * as a current fact about the stream; nothing revalidated it, and the only
+ * surface that could clear it was one the same condition disabled. `get` stayed
+ * refused across processes and restarts on a lag of one event, and a fabricated
+ * marker could wedge a workflow that was never unhealthy.
  *
- * Everything else is deliberately EXEMPT, and the exemptions are the causality
- * argument, not an oversight:
- *
- * - `init` / `transition` / `update` / `cancel` / `checkpoint` / `feedback`
- *   are WRITES. They append to the durable log, which is authoritative by
- *   construction; refusing them because a derived read is stale would block
- *   progress on a system whose source of truth is perfectly healthy.
- * - `cleanup` / `reconcile` are the RECOVERY path. Guarding the actions that
- *   repair a stale projection with the state that says the projection is stale
- *   is a deadlock, not a safeguard.
- * - `rehydrate` re-folds from the authoritative log whenever the cached
- *   snapshot contradicts the tail (`plan.source`, EFF-004) and stamps the same
- *   `_meta.projectionDegraded` verdict on the result. Its answer is
- *   event-derived, so it is not a stale payload — it is the other recovery
- *   surface, and refusing it would remove the caller's way back.
- * - `describe` is static schema; it reads no stream at all.
+ * `get` now establishes its own coverage: `handleGetFromEvents` folds
+ * `workflow-state` to the stream's durable tail through
+ * `projections/fold-at-tail.ts` before it answers. A guarantee a surface can
+ * prove for itself does not need a gate reporting on it from outside, and
+ * `toViewFailure` keeps the one genuinely undecidable case a failure.
  */
-const PROJECTION_DERIVED_WORKFLOW_ACTIONS: ReadonlySet<string> = new Set(['get']);
 
 // HATEOAS envelope wrapping is the shared `envelopeWrap` (../envelope-wrap.ts).
 // Successful workflow results are re-shaped into `Envelope<T>` at the tool
@@ -71,26 +60,6 @@ export async function handleWorkflow(
   const { stateDir, eventStore } = ctx;
   const { action, ...rest } = args;
 
-  // DR-4 consumer chokepoint. `exarchos_workflow` holds no materializer cursors
-  // of its own, so it cannot re-derive the freshness verdict — it READS the
-  // durable state `exarchos_view` publishes (`meta/projection-health`) and
-  // refuses to serve a projection-derived answer for a stream recorded as
-  // degraded. This is what makes the guarantee hold across processes and across
-  // a restart with a cold cache, which the ephemeral `_meta` stamp never could.
-  if (typeof action === 'string' && PROJECTION_DERIVED_WORKFLOW_ACTIONS.has(action)) {
-    const refusal = await guardProjectionDegraded(
-      eventStore,
-      resolveProjectionStreamId(rest),
-      {
-        tool: 'exarchos_workflow',
-        action,
-        onError: (err) =>
-          workflowLogger.warn({ action, err }, 'durable projection-health read failed'),
-      },
-    );
-    if (refusal) return refusal;
-  }
-
   switch (action) {
     case 'init': {
       // DR-5: the composite layer owns caller identity — compute the memoized
@@ -107,7 +76,19 @@ export async function handleWorkflow(
       );
     }
     case 'get':
-      return envelopeWrap(await handleGet(rest as Parameters<typeof handleGet>[0], stateDir, eventStore), startedAt);
+      try {
+        return envelopeWrap(
+          await handleGet(rest as Parameters<typeof handleGet>[0], stateDir, eventStore),
+          startedAt,
+        );
+      } catch (err) {
+        // A fold that cannot be shown to cover the tail is undecidable, not a
+        // generic handler crash; `toViewFailure` keeps it on the reserved code
+        // and lets every other fault propagate as before.
+        const failure = toViewFailure(err, { tool: 'exarchos_workflow', action });
+        if (failure.error?.code !== 'VIEW_ERROR') return failure;
+        throw err;
+      }
     case 'transition': {
       // T36/T37/DR-4 — canonical phase-mutation surface. Routes through the
       // shared `applyTransition()` helper in `handleTransition`. v2.11

--- a/src/workflow/handlers/get.ts
+++ b/src/workflow/handlers/get.ts
@@ -3,6 +3,7 @@ import type { ToolResult } from '../../format.js';
 import { resolveAsOfEvents } from '../../projections/cursor.js';
 import { foldToTail } from '../../projections/fold-at-tail.js';
 import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../projections/views/workflow-state-projection.js';
+import { getOrCreateMaterializer } from '../../projections/views/tools.js';
 import { buildCheckpointMeta } from '../checkpoint.js';
 import { getPlaybook } from '../playbooks.js';
 import { ErrorCode } from '../schemas.js';
@@ -10,7 +11,7 @@ import { readStateFile, StateStoreError } from '../state-store.js';
 import type { GetInput, WorkflowState } from '../types.js';
 import * as path from 'node:path';
 import { resolveDotPath } from './dot-path.js';
-import { isEventSourced, moduleViewMaterializer, stripInternalFields } from './shared.js';
+import { isEventSourced, mergeFileOwnedFields, stripInternalFields } from './shared.js';
 
 // ─── handleGet ──────────────────────────────────────────────────────────────
 
@@ -48,12 +49,15 @@ export async function handleGet(
   }
 
   // Version discriminator: ES v2 workflows materialize from events
-  const useEventSource = isEventSourced(state)
-    && eventStore !== null
-    && moduleViewMaterializer !== null;
+  // `!= null` deliberately, not `!== null`: the parameter is typed
+  // `EventStore | null`, but callers reach this through loosely-typed adapters
+  // and an `undefined` store used to be harmless — the path was gated on a
+  // materializer that was never set, so it never ran. Now that it does run,
+  // letting `undefined` through means folding against nothing.
+  const useEventSource = isEventSourced(state) && eventStore != null;
 
   if (useEventSource) {
-    return handleGetFromEvents(input, state, eventStore!);
+    return handleGetFromEvents(input, state, eventStore, stateDir);
   }
 
   // Legacy path: read directly from state file
@@ -67,7 +71,9 @@ async function handleGetFromEvents(
   input: GetInput,
   fileState: WorkflowState,
   eventStore: EventStore,
+  stateDir: string,
 ): Promise<ToolResult> {
+  const materializer = getOrCreateMaterializer(stateDir);
 
   // #1555 — an `asOf` (bounded-fold) read folds `events[0..N]` through the
   // cache-bypassing fresh fold. This is load-bearing: `materialize` is
@@ -82,7 +88,7 @@ async function handleGetFromEvents(
   let materialized: WorkflowStateView;
   if (input.asOf !== undefined) {
     const bounded = resolveAsOfEvents(await eventStore.query(input.featureId), input.asOf);
-    materialized = moduleViewMaterializer!.materializeFresh<WorkflowStateView>(
+    materialized = materializer.materializeFresh<WorkflowStateView>(
       WORKFLOW_STATE_VIEW,
       bounded,
     );
@@ -93,7 +99,7 @@ async function handleGetFromEvents(
     // published elsewhere and refuse. It now establishes its own coverage.
     materialized = (await foldToTail<WorkflowStateView>(
       eventStore,
-      moduleViewMaterializer!,
+      materializer,
       input.featureId,
       WORKFLOW_STATE_VIEW,
     )).view;
@@ -103,11 +109,20 @@ async function handleGetFromEvents(
   // Checkpoint meta comes from state file (not materialized) since it's the
   // authoritative source for checkpoint tracking.
   const meta = buildCheckpointMeta(fileState._checkpoint);
-  return projectState(input, materializedRecord, meta);
+  // Both arms merge, including the bounded one. A bound past the tip excludes
+  // nothing, so it IS the live read and must answer identically — differing
+  // there would be an artifact of which branch ran, not a fact about the
+  // stream. And the merged fields carry no history to distort: the projection
+  // models no `_version` at any sequence, `_esVersion` is a format marker
+  // rather than state, and the file's `_checkpoint` already reaches a bounded
+  // response through `_meta` above regardless of this branch.
+  return projectState(input, mergeFileOwnedFields(materializedRecord, fileState), meta);
 }
 
 /**
- * Legacy read path: read directly from state file (v1 workflows or missing dependencies).
+ * Legacy read path: read directly from state file (v1 workflows, or no event
+ * store). Not the ES v2 path — that folds the log and merges the file's own
+ * fields on top; see `handleGetFromEvents`.
  */
 function handleGetFromStateFile(
   input: GetInput,

--- a/src/workflow/handlers/get.ts
+++ b/src/workflow/handlers/get.ts
@@ -1,6 +1,7 @@
 import type { EventStore } from '../../events/store.js';
 import type { ToolResult } from '../../format.js';
 import { resolveAsOfEvents } from '../../projections/cursor.js';
+import { foldToTail } from '../../projections/fold-at-tail.js';
 import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../projections/views/workflow-state-projection.js';
 import { buildCheckpointMeta } from '../checkpoint.js';
 import { getPlaybook } from '../playbooks.js';
@@ -67,7 +68,6 @@ async function handleGetFromEvents(
   fileState: WorkflowState,
   eventStore: EventStore,
 ): Promise<ToolResult> {
-  const allEvents = await eventStore.query(input.featureId);
 
   // #1555 — an `asOf` (bounded-fold) read folds `events[0..N]` through the
   // cache-bypassing fresh fold. This is load-bearing: `materialize` is
@@ -81,17 +81,22 @@ async function handleGetFromEvents(
   // through (INV-2).
   let materialized: WorkflowStateView;
   if (input.asOf !== undefined) {
-    const bounded = resolveAsOfEvents(allEvents, input.asOf);
+    const bounded = resolveAsOfEvents(await eventStore.query(input.featureId), input.asOf);
     materialized = moduleViewMaterializer!.materializeFresh<WorkflowStateView>(
       WORKFLOW_STATE_VIEW,
       bounded,
     );
   } else {
-    materialized = moduleViewMaterializer!.materialize<WorkflowStateView>(
+    // #1855 — the live read folds to the stream's durable tail before it
+    // answers. This is the surface the wedge was observed on: `workflow get`
+    // held no cursor of its own, so it could only consult a durable verdict
+    // published elsewhere and refuse. It now establishes its own coverage.
+    materialized = (await foldToTail<WorkflowStateView>(
+      eventStore,
+      moduleViewMaterializer!,
       input.featureId,
       WORKFLOW_STATE_VIEW,
-      allEvents,
-    );
+    )).view;
   }
 
   const materializedRecord = materialized as unknown as Record<string, unknown>;

--- a/src/workflow/handlers/set.ts
+++ b/src/workflow/handlers/set.ts
@@ -2,60 +2,21 @@ import { buildValidatedEvent } from '../../events/event-factory.js';
 import type { EventStore } from '../../events/store.js';
 import type { ToolResult } from '../../format.js';
 import { workflowLogger } from '../../logger.js';
-import { foldToTail, ProjectionCoverageError, type FoldAtTail } from '../../projections/fold-at-tail.js';
-import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../projections/views/workflow-state-projection.js';
 import { recordLiveTransition } from '../admission/live-shadow-observer.js';
 import { buildCheckpointMeta, type CheckpointEnforcementConfig, incrementOperations, resetCounter, shouldEnforceCheckpoint } from '../checkpoint.js';
 import { hsmTransitionGuard } from '../hsm-transition-guard.js';
 import { allocatePhaseAttemptId, readPhaseAttemptId } from '../phase-attempt-id.js';
 import { resolveGateSet } from '../phase-kind.js';
 import { ErrorCode } from '../schemas.js';
-import { applyDotPath, hydrateEventsFromStore, readStateFile, StateStoreError, VersionConflictError, writeStateFile } from '../state-store.js';
+import { applyDotPath, hydrateEventsFromStore, readStateFile, StateStoreError, validateStateForWrite, VersionConflictError, writeStateFile } from '../state-store.js';
 import type { SetInput, WorkflowState } from '../types.js';
 import { resolveBoundaryTouching, resolveRiskTier } from '../verification-policy-resolver.js';
 import * as path from 'node:path';
-import { CURRENT_ES_VERSION, isEventSourced, moduleViewMaterializer } from './shared.js';
+import { CURRENT_ES_VERSION, isEventSourced } from './shared.js';
 
 // ─── handleSet ──────────────────────────────────────────────────────────────
 
 const MAX_CAS_RETRIES = 3;
-
-/**
- * The fold a post-write state snapshot is stamped from, or `undefined` when no
- * fold can be shown to cover the tail.
- *
- * A coverage failure is the one throw `foldToTail` makes by design, and here it
- * must not propagate: `handleSet` reaches this point only AFTER its events are
- * durable, so a failure would report a committed mutation as an error. Skipping
- * the refresh leaves the planner's stamp stale, which is exactly what the
- * caller's own `VersionConflictError` arm already tolerates — and the canonical
- * read path folds from the event log rather than that stamp.
- *
- * Every other fault still propagates. An unreadable event store is a genuine
- * failure, not a stale-projection condition, and this block's contract has
- * always been to surface it.
- */
-async function foldSnapshotSource(
-  eventStore: EventStore,
-  featureId: string,
-): Promise<FoldAtTail<WorkflowStateView> | undefined> {
-  try {
-    return await foldToTail<WorkflowStateView>(
-      eventStore,
-      moduleViewMaterializer!,
-      featureId,
-      WORKFLOW_STATE_VIEW,
-    );
-  } catch (err) {
-    if (!(err instanceof ProjectionCoverageError)) throw err;
-    workflowLogger.warn(
-      { featureId, err },
-      'state snapshot skipped: no fold could be shown to cover the durable tail. ' +
-        'The mutation is already committed; the planner stamp stays at its previous revision.',
-    );
-    return undefined;
-  }
-}
 
 /**
  * Update fields and/or transition phase on a workflow state file.
@@ -70,9 +31,9 @@ async function foldSnapshotSource(
  *
  * **ES v2 field updates:** For workflows with `_esVersion === 2`, field
  * updates emit a `state.patched` event with the patch delta before
- * writing. After the CAS write succeeds, the state file is overwritten
- * with a snapshot re-materialized from the full event stream, ensuring
- * the file is always a derived artifact. That event is keyed
+ * writing. The file is NOT re-materialized from the fold afterwards — see
+ * the note at that site for why the projection cannot produce a schema-valid
+ * state file. Reads are event-derived regardless (`handleGet`). That event is keyed
  * `${featureId}:patch:${expectedVersion}:${fieldsHash}`, which guarantees
  * only **one event per (featureId, base-version, field-name-set)** — the
  * key covers field NAMES, not values, so two different patches to the same
@@ -635,6 +596,17 @@ export async function handleSet(
       && eventStore
       && updateKeys.length > 0
     ) {
+      // Do not record a mutation the write is about to reject. The event-first
+      // contract guarantees an applied patch is always recorded; without this it
+      // did not guarantee the converse, so a schema-invalid patch stayed in the
+      // log after the write refused it — and an event-derived read then served
+      // the value the caller was told had failed. Same schema, same `_version`
+      // bump, same rule the write itself applies.
+      const invalid = validateStateForWrite(mutableState as WorkflowState);
+      if (invalid !== undefined) {
+        return { success: false, error: { code: ErrorCode.INVALID_INPUT, message: invalid } };
+      }
+
       try {
         const fieldsHash = [...updateKeys].sort().join(',');
         const idempotencyKey = `${input.featureId}:patch:${expectedVersion}:${fieldsHash}`;
@@ -742,52 +714,26 @@ export async function handleSet(
     // After the CAS write succeeds, overwrite the state file with a
     // snapshot derived from the full event stream. This ensures the
     // state file is always a derived artifact of the event log.
-    // The events are ALREADY DURABLE by this point, so nothing below may fail
-    // the mutation. `<featureId>.state.json` is the planner's secondary stamp;
-    // refreshing it is a follow-up, and reporting a landed write as an error
-    // would invite the caller to retry a write that already committed. The
-    // `VersionConflictError` arm below has always applied that rule to the
-    // write half of this step; `foldSnapshotSource` applies it to the read half.
-    const folded = isEventSourced(state) && eventStore && moduleViewMaterializer
-      ? await foldSnapshotSource(eventStore, input.featureId)
-      : undefined;
-
-    if (folded !== undefined) {
-      // #1855 — the snapshot is stamped from a fold proven to cover the tail,
-      // and the sequence stamped alongside it is that same fold's cursor.
-      // Computing them separately — a fold here, a re-read of the event list
-      // there — is how a stamp comes to name a sequence its own payload has not
-      // seen.
-      const materialized = folded.view;
-
-      // Merge materialized state with checkpoint/version metadata from the
-      // mutable state (checkpoint tracking is not event-sourced)
-      const latestSequence = folded.sequence > 0
-        ? folded.sequence
-        : mutableState._eventSequence;
-      const snapshot = {
-        ...(materialized as unknown as Record<string, unknown>),
-        _version: (mutableState._version as number),
-        _eventSequence: latestSequence,
-        _esVersion: CURRENT_ES_VERSION,
-        _checkpoint: mutableState._checkpoint,
-        updatedAt: mutableState.updatedAt,
-      };
-
-      try {
-        await writeStateFile(
-          stateFile,
-          snapshot as unknown as WorkflowState,
-          { expectedVersion: mutableState._version as number, skipValidation: true },
-        );
-      } catch (err) {
-        if (err instanceof VersionConflictError) {
-          // Another writer updated the state after our CAS write; skip rematerialization
-        } else {
-          throw err;
-        }
-      }
-    }
+    // ─── Why there is no state-file re-materialization here ────────────
+    //
+    // This block used to rebuild `<featureId>.state.json` from the event fold
+    // after every mutation, so the file would stay a derived artifact of the
+    // log. It never ran: it was gated on a materializer that nothing in `src/`
+    // ever configured.
+    //
+    // Wiring it revealed that it cannot run as written. A planner writes a
+    // partial task through `workflow set` and the normal write path validates
+    // and defaults it; the fold applies the same patch VERBATIM, so a task
+    // without a `title` reaches the snapshot, which wrote it back with
+    // `skipValidation: true`. The next read then rejects the whole file — after
+    // the mutation that wrote it has already committed.
+    // `WorkflowStateFold_PatchedTask_ViolatesStateSchema` pins that gap, so
+    // this is evidence rather than an assertion, and so the block is not
+    // restored before the shapes are reconciled.
+    //
+    // Nothing regresses by its absence, because it never executed. Reads are
+    // event-derived regardless: `handleGet` folds the log and merges the
+    // file-owned fields on top.
 
     // Event-first: events already appended before CAS write with idempotency keys.
     // State write is the follow-up materialization step.

--- a/src/workflow/handlers/set.ts
+++ b/src/workflow/handlers/set.ts
@@ -2,7 +2,7 @@ import { buildValidatedEvent } from '../../events/event-factory.js';
 import type { EventStore } from '../../events/store.js';
 import type { ToolResult } from '../../format.js';
 import { workflowLogger } from '../../logger.js';
-import { foldToTail } from '../../projections/fold-at-tail.js';
+import { foldToTail, ProjectionCoverageError, type FoldAtTail } from '../../projections/fold-at-tail.js';
 import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../projections/views/workflow-state-projection.js';
 import { recordLiveTransition } from '../admission/live-shadow-observer.js';
 import { buildCheckpointMeta, type CheckpointEnforcementConfig, incrementOperations, resetCounter, shouldEnforceCheckpoint } from '../checkpoint.js';
@@ -19,6 +19,43 @@ import { CURRENT_ES_VERSION, isEventSourced, moduleViewMaterializer } from './sh
 // ─── handleSet ──────────────────────────────────────────────────────────────
 
 const MAX_CAS_RETRIES = 3;
+
+/**
+ * The fold a post-write state snapshot is stamped from, or `undefined` when no
+ * fold can be shown to cover the tail.
+ *
+ * A coverage failure is the one throw `foldToTail` makes by design, and here it
+ * must not propagate: `handleSet` reaches this point only AFTER its events are
+ * durable, so a failure would report a committed mutation as an error. Skipping
+ * the refresh leaves the planner's stamp stale, which is exactly what the
+ * caller's own `VersionConflictError` arm already tolerates — and the canonical
+ * read path folds from the event log rather than that stamp.
+ *
+ * Every other fault still propagates. An unreadable event store is a genuine
+ * failure, not a stale-projection condition, and this block's contract has
+ * always been to surface it.
+ */
+async function foldSnapshotSource(
+  eventStore: EventStore,
+  featureId: string,
+): Promise<FoldAtTail<WorkflowStateView> | undefined> {
+  try {
+    return await foldToTail<WorkflowStateView>(
+      eventStore,
+      moduleViewMaterializer!,
+      featureId,
+      WORKFLOW_STATE_VIEW,
+    );
+  } catch (err) {
+    if (!(err instanceof ProjectionCoverageError)) throw err;
+    workflowLogger.warn(
+      { featureId, err },
+      'state snapshot skipped: no fold could be shown to cover the durable tail. ' +
+        'The mutation is already committed; the planner stamp stays at its previous revision.',
+    );
+    return undefined;
+  }
+}
 
 /**
  * Update fields and/or transition phase on a workflow state file.
@@ -705,22 +742,22 @@ export async function handleSet(
     // After the CAS write succeeds, overwrite the state file with a
     // snapshot derived from the full event stream. This ensures the
     // state file is always a derived artifact of the event log.
-    if (
-      isEventSourced(state)
-      && eventStore
-      && moduleViewMaterializer
-    ) {
+    // The events are ALREADY DURABLE by this point, so nothing below may fail
+    // the mutation. `<featureId>.state.json` is the planner's secondary stamp;
+    // refreshing it is a follow-up, and reporting a landed write as an error
+    // would invite the caller to retry a write that already committed. The
+    // `VersionConflictError` arm below has always applied that rule to the
+    // write half of this step; `foldSnapshotSource` applies it to the read half.
+    const folded = isEventSourced(state) && eventStore && moduleViewMaterializer
+      ? await foldSnapshotSource(eventStore, input.featureId)
+      : undefined;
+
+    if (folded !== undefined) {
       // #1855 — the snapshot is stamped from a fold proven to cover the tail,
-      // and the sequence stamped alongside it is that same fold's cursor. The
+      // and the sequence stamped alongside it is that same fold's cursor.
       // Computing them separately — a fold here, a re-read of the event list
       // there — is how a stamp comes to name a sequence its own payload has not
       // seen.
-      const folded = await foldToTail<WorkflowStateView>(
-        eventStore,
-        moduleViewMaterializer,
-        input.featureId,
-        WORKFLOW_STATE_VIEW,
-      );
       const materialized = folded.view;
 
       // Merge materialized state with checkpoint/version metadata from the

--- a/src/workflow/handlers/set.ts
+++ b/src/workflow/handlers/set.ts
@@ -2,6 +2,7 @@ import { buildValidatedEvent } from '../../events/event-factory.js';
 import type { EventStore } from '../../events/store.js';
 import type { ToolResult } from '../../format.js';
 import { workflowLogger } from '../../logger.js';
+import { foldToTail } from '../../projections/fold-at-tail.js';
 import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../projections/views/workflow-state-projection.js';
 import { recordLiveTransition } from '../admission/live-shadow-observer.js';
 import { buildCheckpointMeta, type CheckpointEnforcementConfig, incrementOperations, resetCounter, shouldEnforceCheckpoint } from '../checkpoint.js';
@@ -709,17 +710,23 @@ export async function handleSet(
       && eventStore
       && moduleViewMaterializer
     ) {
-      const allEvents = await eventStore.query(input.featureId);
-      const materialized = moduleViewMaterializer.materialize<WorkflowStateView>(
+      // #1855 — the snapshot is stamped from a fold proven to cover the tail,
+      // and the sequence stamped alongside it is that same fold's cursor. The
+      // Computing them separately — a fold here, a re-read of the event list
+      // there — is how a stamp comes to name a sequence its own payload has not
+      // seen.
+      const folded = await foldToTail<WorkflowStateView>(
+        eventStore,
+        moduleViewMaterializer,
         input.featureId,
         WORKFLOW_STATE_VIEW,
-        allEvents,
       );
+      const materialized = folded.view;
 
       // Merge materialized state with checkpoint/version metadata from the
       // mutable state (checkpoint tracking is not event-sourced)
-      const latestSequence = allEvents.length
-        ? allEvents[allEvents.length - 1]?.sequence
+      const latestSequence = folded.sequence > 0
+        ? folded.sequence
         : mutableState._eventSequence;
       const snapshot = {
         ...(materialized as unknown as Record<string, unknown>),

--- a/src/workflow/handlers/shared.ts
+++ b/src/workflow/handlers/shared.ts
@@ -1,15 +1,18 @@
-import type { ViewMaterializer } from '../../projections/views/materializer.js';
-
 // ─── Module-Level EventStore (removed — now threaded via DispatchContext) ─────
 
-// ─── Module-Level ViewMaterializer Configuration ─────────────────────────────
-
-export let moduleViewMaterializer: ViewMaterializer | null = null;
-
-/** Configure the ViewMaterializer instance used by handleGet for ES v2 workflows. */
-export function configureWorkflowMaterializer(materializer: ViewMaterializer | null): void {
-  moduleViewMaterializer = materializer;
-}
+// ─── Module-Level ViewMaterializer (removed) ─────────────────────────────────
+//
+// `moduleViewMaterializer` was a settable singleton that gated the ES v2 read
+// and snapshot paths. Nothing in `src/` ever set it, so both paths were dark in
+// the shipped composition: `workflow get` always fell through to the state
+// file, and `get --asOf` silently answered with tip state. A control whose
+// enabling call exists only in tests is not a seam, it is an off switch nobody
+// can reach.
+//
+// `handleGet` / `handleSet` now resolve `getOrCreateMaterializer(stateDir)`
+// directly. That is per-stateDir rather than process-global, shares one fold
+// cache with the view surface, and cannot be left unwired.
+// `tests/architecture/reachable-controls.test.ts` keeps the class closed.
 
 // Re-export from dedicated modules for backward compatibility
 export { handleCancel } from '../cancel.js';
@@ -47,3 +50,55 @@ export function isEventSourced(state: unknown): boolean {
 // `verification-policy-resolver.ts` — the single authority for turning an
 // untrusted stamp into a tier claim, which returns `'unknown'` rather than
 // fabricating one.
+
+import {
+  workflowStateProjection,
+} from '../../projections/views/workflow-state-projection.js';
+import type { WorkflowState } from '../types.js';
+
+// ─── The state file's half of the answer ─────────────────────────────────────
+
+/**
+ * Fields the state file owns, which the projection cannot supply.
+ *
+ * Both are declared in the projection's shape and neither is reconstructible
+ * from the log. `_version` is the file's optimistic-lock counter and the
+ * projection carries a dead literal `1`, so serving the fold's value would hand
+ * a caller a version that CAS rejects. `_checkpoint` is only partly
+ * event-derived — `workflow.checkpoint` sets four of its fields and nothing
+ * sets `summary`, `fixCycleCount` or `staleAfterMinutes` — so the fold answers
+ * with sentinels where the file holds the real entry.
+ */
+export const FILE_OWNED_FIELDS: ReadonlySet<string> = new Set(['_version', '_checkpoint']);
+
+/**
+ * The event fold, plus what only the state file knows.
+ *
+ * The log is the source of truth for everything it can derive, so the fold is
+ * the base and wins every contested field. The file contributes exactly two
+ * things: the fields above, and any key the projection has no slot for at all —
+ * the "plan facts the projection can't derive" that the state-file contract
+ * names.
+ *
+ * The second half is DERIVED from `workflowStateProjection.init()` rather than
+ * listed, so a state field the projection does not model is carried through
+ * automatically instead of disappearing the day someone adds one.
+ *
+ * Read and write share this because they fail the same way. `handleGet` serving
+ * the bare fold would drop `_version`, `_checkpoint`, `_esVersion` and
+ * `explore` from the response; `handleSet` stamping the bare fold would delete
+ * the same fields from the file, so the next read could not recover them
+ * either. Both paths were unreachable until the materializer was wired, which
+ * is why neither had to answer the question before.
+ */
+export function mergeFileOwnedFields(
+  materialized: Record<string, unknown>,
+  fileState: WorkflowState,
+): Record<string, unknown> {
+  const modelled = new Set(Object.keys(workflowStateProjection.init()));
+  const merged: Record<string, unknown> = { ...materialized };
+  for (const [key, value] of Object.entries(fileState)) {
+    if (!modelled.has(key) || FILE_OWNED_FIELDS.has(key)) merged[key] = value;
+  }
+  return merged;
+}

--- a/src/workflow/state-store.ts
+++ b/src/workflow/state-store.ts
@@ -402,6 +402,33 @@ function getStateVersion(state: WorkflowState): number {
  * async operations. For multi-process scenarios, file-level locking (e.g., `flock`)
  * would be needed.
  */
+
+/**
+ * The write-time schema check, as a function the write path is not the only
+ * caller of.
+ *
+ * `handleSet` records a `state.patched` event BEFORE it writes — the event-first
+ * contract, so a mutation cannot be applied without being recorded. The
+ * converse was never enforced: a patch the schema rejected had already been
+ * appended, so the log kept a mutation the state layer refused. That stayed
+ * invisible while `workflow get` read the file, and became visible the moment
+ * the read folded the log — a boolean written to `artifacts.plan`, rejected at
+ * the write with `INVALID_INPUT`, and then served by `get` as though it had
+ * taken.
+ *
+ * Exported so the emission boundary can ask the same question the write will
+ * ask, with the same schema and the same `_version` bump, rather than
+ * approximating it.
+ */
+export function validateStateForWrite(state: WorkflowState): string | undefined {
+  const stateWithVersion = {
+    ...state,
+    _version: getStateVersion(state) + 1,
+  } as WorkflowState;
+  const validation = WorkflowStateSchema.safeParse(stateWithVersion);
+  return validation.success ? undefined : `Write-time validation failed: ${validation.error.message}`;
+}
+
 export async function writeStateFile(
   stateFile: string,
   state: WorkflowState,
@@ -419,13 +446,8 @@ export async function writeStateFile(
 
     // Validate before writing
     if (!options?.skipValidation) {
-      const validation = WorkflowStateSchema.safeParse(stateWithVersion);
-      if (!validation.success) {
-        throw new StateStoreError(
-          ErrorCode.INVALID_INPUT,
-          `Write-time validation failed: ${validation.error.message}`,
-        );
-      }
+      const invalid = validateStateForWrite(state);
+      if (invalid !== undefined) throw new StateStoreError(ErrorCode.INVALID_INPUT, invalid);
     }
 
     try {
@@ -494,13 +516,8 @@ export async function writeStateFile(
 
   // Validate before writing to catch schema violations at write time (not deferred to read)
   if (!options?.skipValidation) {
-    const validation = WorkflowStateSchema.safeParse(stateWithVersion);
-    if (!validation.success) {
-      throw new StateStoreError(
-        ErrorCode.INVALID_INPUT,
-        `Write-time validation failed: ${validation.error.message}`,
-      );
-    }
+    const invalid = validateStateForWrite(state);
+    if (invalid !== undefined) throw new StateStoreError(ErrorCode.INVALID_INPUT, invalid);
   }
 
   const tmpPath = nextTempPath(stateFile, 'tmp');

--- a/src/workflow/tools.ts
+++ b/src/workflow/tools.ts
@@ -9,7 +9,7 @@
 // thing this arrangement exists to prevent, because it is how a 2,062-line
 // module grew the last time.
 
-export { configureWorkflowMaterializer, CURRENT_ES_VERSION, isEventSourced } from './handlers/shared.js';
+export { CURRENT_ES_VERSION, isEventSourced } from './handlers/shared.js';
 
 // Two handlers already lived in their own modules and were re-exported from
 // here. They keep that arrangement — this file is the surface, wherever a

--- a/tests/architecture/locality.test.ts
+++ b/tests/architecture/locality.test.ts
@@ -81,8 +81,11 @@ const EXEMPTIONS: Record<string, Exemption> = {
       '+1 for projection-fold-seam.json: the policy data behind the guard that keeps a ' +
       'projection-derived answer from escaping without evidence its fold covers the event tail. ' +
       'It sits at this level because that is where every other guard reads its policy from, and ' +
-      'splitting one policy file into a subdirectory of its own would cost more than it saves.',
-    grantedAt: 53,
+      'splitting one policy file into a subdirectory of its own would cost more than it saves. ' +
+      '+1 for reachable-controls.json, on the same argument: the policy behind the guard that ' +
+      'fails a control whose enabling call exists only in tests, so a gated path cannot go dark ' +
+      'while its branches read as shipped.',
+    grantedAt: 54,
   },
   'tools/audit/gates': {
     reason:

--- a/tests/architecture/locality.test.ts
+++ b/tests/architecture/locality.test.ts
@@ -77,8 +77,12 @@ const EXEMPTIONS: Record<string, Exemption> = {
     reason:
       'Repo-automation oracles, baselines and CLIs that the product tree is not allowed to hold. ' +
       'Breadth here is a count of instruments, not a second orchestrate/. Grouping them into ' +
-      'subdirectories is the reduction; until then the count is pinned so the next file is argued.',
-    grantedAt: 52,
+      'subdirectories is the reduction; until then the count is pinned so the next file is argued. ' +
+      '+1 for projection-fold-seam.json: the policy data behind the guard that keeps a ' +
+      'projection-derived answer from escaping without evidence its fold covers the event tail. ' +
+      'It sits at this level because that is where every other guard reads its policy from, and ' +
+      'splitting one policy file into a subdirectory of its own would cost more than it saves.',
+    grantedAt: 53,
   },
   'tools/audit/gates': {
     reason:

--- a/tests/architecture/projection-fold-seam.test.ts
+++ b/tests/architecture/projection-fold-seam.test.ts
@@ -2,10 +2,10 @@
  * The guard for the class #1855 belongs to: a projection-derived answer that
  * escapes to a caller with no evidence its fold covers the durable event tail.
  *
- * The class has two instances. CB-8 served a cancelled workflow at
- * `plan-review` from a fold 500 seconds behind. The mechanism built to answer
- * CB-8 then inverted it — the answer was withheld permanently rather than
- * served stalely, on a lag of one event. Two instances make it a property of
+ * The class has two instances. A phase-gate dogfood run served a cancelled
+ * workflow at `plan-review` from a fold 500 seconds behind. The mechanism built
+ * to answer that then inverted it — the answer was withheld permanently rather
+ * than served stalely, on a lag of one event. Two instances make it a property of
  * the system rather than an incident, so the fix is structural: `foldToTail`
  * establishes coverage before any answer, and this guard is what keeps a
  * caller from going around it.
@@ -50,6 +50,7 @@ interface Policy {
   readonly allowlist: readonly {
     readonly file: string;
     readonly members: readonly string[];
+    readonly why: string;
     readonly owner: string;
     readonly expiry: string;
   }[];
@@ -198,8 +199,12 @@ describe('projection fold seam', () => {
     expect(bounded, 'a permitted member must not be reported as a violation').toEqual([]);
   });
 
-  it('ProjectionFoldSeam_AllowlistEntries_CarryAnOwnerAndAnUnexpiredDate', () => {
+  it('ProjectionFoldSeam_AllowlistEntries_CarryARationaleOwnerAndUnexpiredDate', () => {
     for (const entry of POLICY.allowlist) {
+      // The policy declares a `why` field; without an assertion on it, an entry
+      // could bypass the seam carrying only an owner and a date, which records
+      // who accepted the risk but never what the risk was.
+      expect(entry.why, `${entry.file} records no reason the seam does not fit`).toBeTruthy();
       expect(entry.owner, `${entry.file} has no owner`).toBeTruthy();
       expect(entry.expiry, `${entry.file} has no expiry`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       expect(

--- a/tests/architecture/projection-fold-seam.test.ts
+++ b/tests/architecture/projection-fold-seam.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The guard for the class #1855 belongs to: a projection-derived answer that
+ * escapes to a caller with no evidence its fold covers the durable event tail.
+ *
+ * The class has two instances. CB-8 served a cancelled workflow at
+ * `plan-review` from a fold 500 seconds behind. The mechanism built to answer
+ * CB-8 then inverted it — the answer was withheld permanently rather than
+ * served stalely, on a lag of one event. Two instances make it a property of
+ * the system rather than an incident, so the fix is structural: `foldToTail`
+ * establishes coverage before any answer, and this guard is what keeps a
+ * caller from going around it.
+ *
+ * The rule is DATA (`tools/audit/projection-fold-seam.json`). This file decides
+ * only how the rule is enforced, so an exemption can be reviewed as an
+ * allowlist entry with an owner and an expiry rather than as a code change.
+ *
+ * ## Why the vacuity assertions are not ceremony
+ *
+ * A structural guard fails open. If the walk finds nothing, the violation set
+ * is empty and the guard reports pass — with no coverage at all. That shape has
+ * bitten this repository repeatedly, so three assertions carry the weight:
+ *
+ *   1. The population is corroborated by `git ls-files`, which throws on empty.
+ *   2. The seam's entry point must have real callers. A guard protecting a seam
+ *      nobody uses forbids a bypass of nothing.
+ *   3. The kill fixture — the pre-fix bypass, verbatim — must be REPORTED, by
+ *      the same scanner that reads `src/**`, not by a parallel branch. If a
+ *      refactor makes the scanner blind to that shape, this goes red here
+ *      instead of going quiet in production.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { lexModule } from '../../tools/test-helpers/module-lexer.js';
+import { listTrackedFiles } from '../../tools/test-helpers/tracked-population.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+interface Policy {
+  readonly seam: {
+    readonly module: string;
+    readonly entryPoint: string;
+    readonly definitionModule: string;
+  };
+  readonly forbiddenMembers: readonly { readonly member: string }[];
+  readonly permittedMembers: readonly { readonly member: string }[];
+  readonly allowlist: readonly {
+    readonly file: string;
+    readonly members: readonly string[];
+    readonly owner: string;
+    readonly expiry: string;
+  }[];
+  readonly killFixture: { readonly path: string; readonly expectedMember: string };
+  readonly minimumCallSites: number;
+  readonly minimumScannedFiles: number;
+}
+
+const POLICY: Policy = JSON.parse(
+  readFileSync(path.join(REPO_ROOT, 'tools/audit/projection-fold-seam.json'), 'utf8'),
+) as Policy;
+
+interface Call {
+  readonly file: string;
+  readonly member: string;
+  readonly line: number;
+}
+
+/**
+ * Every call to a forbidden member in one file.
+ *
+ * Reads the LEXED source, not the raw text. The doc comments on this seam name
+ * `materialize` repeatedly and the policy file quotes the member names, so a
+ * raw-text scan would charge the documentation of the rule with breaking it.
+ * `maskedSource` blanks comments and string bodies while preserving offsets, so
+ * a line number still points at the real call.
+ *
+ * The leading `.` is what separates a CALL from a DECLARATION: `materializeAt<T>(`
+ * inside the class is the method being defined, `this.materializeAt<T>(` is a use
+ * of it.
+ */
+function findForbiddenCalls(relativePath: string, source: string): Call[] {
+  const { maskedSource } = lexModule(source, path.basename(relativePath));
+  const calls: Call[] = [];
+  for (const { member } of POLICY.forbiddenMembers) {
+    const pattern = new RegExp(`\\.${member}\\s*(?:<[^;()]*>\\s*)?\\(`, 'g');
+    for (const match of maskedSource.matchAll(pattern)) {
+      calls.push({
+        file: relativePath,
+        member,
+        line: maskedSource.slice(0, match.index).split('\n').length,
+      });
+    }
+  }
+  return calls;
+}
+
+/** Files the seam is defined in, which necessarily use its own members. */
+const EXEMPT_MODULES: ReadonlySet<string> = new Set([
+  POLICY.seam.module,
+  POLICY.seam.definitionModule,
+]);
+
+function isAllowlisted(call: Call): boolean {
+  return POLICY.allowlist.some(
+    (entry) => entry.file === call.file && entry.members.includes(call.member),
+  );
+}
+
+function scanSource(): { files: string[]; calls: Call[] } {
+  const files = listTrackedFiles(REPO_ROOT, {
+    extensions: ['.ts'],
+    exclude: (relative) => !relative.startsWith('src/') || relative.endsWith('.d.ts'),
+  });
+  const calls = files.flatMap((file) =>
+    findForbiddenCalls(file, readFileSync(path.join(REPO_ROOT, file), 'utf8')),
+  );
+  return { files, calls };
+}
+
+describe('projection fold seam', () => {
+  it('ProjectionFoldSeam_NoSourceFile_BypassesTheTailCoveringFold', () => {
+    const { files, calls } = scanSource();
+
+    // (1) Denominator. An empty walk makes every assertion below vacuously
+    // true, which is precisely how this guard would fail open.
+    expect(
+      files.length,
+      'the guard scanned an implausibly small population — the walk is broken, not the code',
+    ).toBeGreaterThanOrEqual(POLICY.minimumScannedFiles);
+
+    const violations = calls
+      .filter((call) => !EXEMPT_MODULES.has(call.file))
+      .filter((call) => !isAllowlisted(call));
+
+    expect(
+      violations,
+      'a cached fold was obtained outside `foldToTail`, so its answer carries no ' +
+        'evidence that it covers the durable event tail. Route it through ' +
+        `${POLICY.seam.module}, or add an allowlist entry with an owner and an expiry.`,
+    ).toEqual([]);
+  });
+
+  it('ProjectionFoldSeam_EntryPoint_HasRealCallers', () => {
+    // (2) A guard that forbids bypassing a seam nobody calls forbids nothing.
+    const callers = listTrackedFiles(REPO_ROOT, {
+      extensions: ['.ts'],
+      exclude: (relative) => !relative.startsWith('src/'),
+    }).filter((file) => {
+      if (file === POLICY.seam.module) return false;
+      const { maskedSource } = lexModule(
+        readFileSync(path.join(REPO_ROOT, file), 'utf8'),
+        path.basename(file),
+      );
+      return new RegExp(`\\b${POLICY.seam.entryPoint}\\s*(?:<[^;()]*>\\s*)?\\(`).test(maskedSource);
+    });
+
+    expect(
+      callers.length,
+      `${POLICY.seam.entryPoint} has no production caller — the seam is dead and the ` +
+        'guard above is protecting nothing',
+    ).toBeGreaterThanOrEqual(POLICY.minimumCallSites);
+  });
+
+  it('ProjectionFoldSeam_KillFixture_IsReportedByTheSameScanner', () => {
+    // (3) The self-test. The pre-fix bypass, run through the SAME function that
+    // reads `src/**`. A scanner that has gone blind fails here.
+    const fixture = readFileSync(path.join(REPO_ROOT, POLICY.killFixture.path), 'utf8');
+    const reported = findForbiddenCalls(POLICY.killFixture.path, fixture);
+
+    expect(
+      reported.map((call) => call.member),
+      'the kill fixture is the evidence that this guard detects the real defect shape',
+    ).toContain(POLICY.killFixture.expectedMember);
+  });
+
+  it('ProjectionFoldSeam_BoundedReadMembers_AreExemptByNameNotByOversight', () => {
+    // A bounded read (`asOf`, correlation-filtered) answers as of an explicit
+    // bound by design; forcing tail coverage on it would break the bounded-read
+    // contract itself. The exemption has to be a decision recorded in the
+    // policy, not a member the scanner happens not to look for.
+    const forbidden = new Set(POLICY.forbiddenMembers.map((entry) => entry.member));
+    const permitted = POLICY.permittedMembers.map((entry) => entry.member);
+
+    expect(permitted, 'the policy records no permitted members at all').not.toEqual([]);
+    for (const member of permitted) {
+      expect(forbidden.has(member), `${member} is both forbidden and permitted`).toBe(false);
+    }
+    expect(permitted).toContain('materializeFresh');
+
+    // And the exemption is load-bearing: bounded reads really do still call it.
+    const bounded = findForbiddenCalls(
+      'probe.ts',
+      'const view = materializer.materializeFresh<T>(VIEW, bounded);',
+    );
+    expect(bounded, 'a permitted member must not be reported as a violation').toEqual([]);
+  });
+
+  it('ProjectionFoldSeam_AllowlistEntries_CarryAnOwnerAndAnUnexpiredDate', () => {
+    for (const entry of POLICY.allowlist) {
+      expect(entry.owner, `${entry.file} has no owner`).toBeTruthy();
+      expect(entry.expiry, `${entry.file} has no expiry`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(
+        Date.parse(entry.expiry),
+        `the allowlist entry for ${entry.file} expired on ${entry.expiry}`,
+      ).toBeGreaterThan(Date.now());
+    }
+  });
+});

--- a/tests/architecture/reachable-controls.test.ts
+++ b/tests/architecture/reachable-controls.test.ts
@@ -1,0 +1,225 @@
+/**
+ * A control that gates production behaviour must be reachable in production.
+ *
+ * `configureWorkflowMaterializer` set the value that decided whether
+ * `workflow get` folded the event log or read the state file. Four test files
+ * called it. Nothing in `src/` did. So the fold branch was dark in every
+ * shipped composition — `get` always took the file, and `get --asOf` answered
+ * with tip state rather than the bounded fold it advertises.
+ *
+ * Nothing was red, and that is the part worth guarding. The dark branches had
+ * tests; the tests enabled the branch themselves, which is exactly what made
+ * the coverage look complete while the shipped path was unreachable. It
+ * surfaced only when a regression test for a fix inside one of those branches
+ * passed with the fix removed.
+ *
+ * The rule is DATA (`tools/audit/reachable-controls.json`). This file decides
+ * only how it is enforced, so an exemption is reviewable as an allowlist entry
+ * with an owner and an expiry rather than as a code change.
+ *
+ * ## Why this is name-based, and why that is enough
+ *
+ * Deciding "does any production branch read what this sets" needs whole-program
+ * dataflow. Deciding "is this named as an enabler" needs a convention, and this
+ * repository already follows one. The population is every exported
+ * `configureX` / `registerX` / `installX` / `enableX` / `wireX`; the assertion
+ * is that each has a caller under `src/`. A false positive is a naming
+ * question, answered by an allowlist entry; a false negative is a control named
+ * unconventionally, which is a separate and more visible problem.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { lexModule } from '../../tools/test-helpers/module-lexer.js';
+import { listTrackedFiles } from '../../tools/test-helpers/tracked-population.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+interface Policy {
+  readonly enablerNamePatterns: readonly { readonly pattern: string }[];
+  readonly scannedRoots: readonly string[];
+  readonly callerRoots: readonly string[];
+  readonly allowlist: readonly {
+    readonly symbol: string;
+    readonly file: string;
+    readonly why: string;
+    readonly owner: string;
+    readonly expiry: string;
+  }[];
+  readonly sourceExtensions: readonly string[];
+  readonly killFixture: { readonly path: string; readonly expectedSymbol: string };
+  readonly minimumScannedFiles: number;
+  readonly minimumEnablersFound: number;
+}
+
+const POLICY: Policy = JSON.parse(
+  readFileSync(path.join(REPO_ROOT, 'tools/audit/reachable-controls.json'), 'utf8'),
+) as Policy;
+
+const ENABLER_NAME = new RegExp(
+  POLICY.enablerNamePatterns.map((entry) => `(?:${entry.pattern})`).join('|'),
+);
+
+interface Enabler {
+  readonly symbol: string;
+  readonly file: string;
+}
+
+/**
+ * Every exported enabler declared in one file.
+ *
+ * Reads the LEXED source so a name inside a comment or a string — this file and
+ * the policy both discuss `configureWorkflowMaterializer` by name — is not
+ * mistaken for a declaration.
+ */
+function findEnablers(relativePath: string, source: string): Enabler[] {
+  const { maskedSource } = lexModule(source, path.basename(relativePath));
+  const declarations = maskedSource.matchAll(
+    /export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*[(<]/g,
+  );
+  const found: Enabler[] = [];
+  for (const match of declarations) {
+    const symbol = match[1];
+    if (symbol !== undefined && ENABLER_NAME.test(symbol)) {
+      found.push({ symbol, file: relativePath });
+    }
+  }
+  return found;
+}
+
+function sourceFiles(roots: readonly string[]): string[] {
+  return listTrackedFiles(REPO_ROOT, {
+    extensions: POLICY.sourceExtensions,
+    exclude: (relative) =>
+      !roots.some((root) => relative.startsWith(`${root}/`)) || relative.endsWith('.d.ts'),
+  });
+}
+
+/**
+ * Every caller-root file's executable source, read once.
+ *
+ * The reachability question is asked per symbol, and re-lexing the tree for
+ * each one turned an architecture test into an eight-second one. The bodies do
+ * not change during a run.
+ */
+const CALLER_BODIES: ReadonlyMap<string, string> = new Map(
+  sourceFiles(POLICY.callerRoots).map((file) => [file, executableSource(file)]),
+);
+
+/**
+ * The source of one file with its import and re-export statements removed.
+ *
+ * A symbol named in `import { x } from` or `export { x } from` is being routed,
+ * not used: a barrel that re-exports a dead control does not make it reachable.
+ * The motivating case was re-exported from `workflow/tools.ts` while nothing
+ * called it, so counting those lines would have missed the very defect this
+ * guard exists for.
+ */
+function executableSource(relativePath: string): string {
+  const { maskedSource } = lexModule(
+    readFileSync(path.join(REPO_ROOT, relativePath), 'utf8'),
+    path.basename(relativePath),
+  );
+  return maskedSource
+    .replace(/import\s[\s\S]*?from\s*['"][^'"]*['"]\s*;?/g, '')
+    .replace(/export\s*\{[^}]*\}\s*(?:from\s*['"][^'"]*['"])?\s*;?/g, '');
+}
+
+/**
+ * True when `symbol` is USED anywhere in the shipped tree, its own declaration
+ * excluded.
+ *
+ * Reference, not call. An enabler is frequently handed over rather than
+ * invoked — `opts.registerMcp ?? registerExarchosInClaudeJson` passes one as a
+ * default, and the doctor lists `installFreshness` in a probe array. Both are
+ * production wiring, and a call-shaped detector reports both as dark. The
+ * declaring file counts too: a control invoked beside its own definition is
+ * reachable, and excluding that file wholesale — to avoid matching the
+ * declaration — flagged `registerBackendCleanup`, which `src/index.ts` calls
+ * eleven lines later.
+ */
+function hasProductionUse(symbol: string, declaredIn: string): boolean {
+  const reference = new RegExp(`\\b${symbol}\\b`);
+  const declaration = new RegExp(`export\\s+(?:async\\s+)?function\\s+${symbol}\\b`, 'g');
+  for (const [file, source] of CALLER_BODIES) {
+    const body = file === declaredIn ? source.replace(declaration, '') : source;
+    if (reference.test(body)) return true;
+  }
+  return false;
+}
+
+function isAllowlisted(enabler: Enabler): boolean {
+  return POLICY.allowlist.some(
+    (entry) => entry.symbol === enabler.symbol && entry.file === enabler.file,
+  );
+}
+
+describe('reachable controls', () => {
+  it('ReachableControls_NoEnabler_IsCalledOnlyFromTests', () => {
+    const files = sourceFiles(POLICY.scannedRoots);
+
+    // (1) Denominator. An empty walk makes the assertion below vacuously true,
+    // which is precisely how this guard would fail open.
+    expect(
+      files.length,
+      'the guard scanned an implausibly small population — the walk is broken, not the code',
+    ).toBeGreaterThanOrEqual(POLICY.minimumScannedFiles);
+
+    const enablers = files.flatMap((file) =>
+      findEnablers(file, readFileSync(path.join(REPO_ROOT, file), 'utf8')),
+    );
+
+    // (2) The population itself must be non-empty. A pattern set that matches
+    // nothing would pass this test forever while enforcing nothing.
+    expect(
+      enablers.length,
+      'no enabler matched any name pattern — the patterns are stale, not the tree',
+    ).toBeGreaterThanOrEqual(POLICY.minimumEnablersFound);
+
+    const dark = enablers
+      .filter((enabler) => !isAllowlisted(enabler))
+      .filter((enabler) => !hasProductionUse(enabler.symbol, enabler.file));
+
+    expect(
+      dark,
+      'these controls gate production behaviour but nothing in the shipped composition ' +
+        'enables them, so the paths they guard cannot run. Call them from the composition ' +
+        'root, remove them, or add an allowlist entry with a reason, an owner and an expiry.',
+    ).toEqual([]);
+  });
+
+  it('ReachableControls_KillFixture_IsReportedByTheSameScanner', () => {
+    // The self-test. The control that motivated this guard, verbatim, run
+    // through the SAME function that reads the source tree. A scanner that has
+    // gone blind fails here rather than going quiet.
+    const fixture = readFileSync(path.join(REPO_ROOT, POLICY.killFixture.path), 'utf8');
+    const reported = findEnablers(POLICY.killFixture.path, fixture);
+
+    expect(
+      reported.map((enabler) => enabler.symbol),
+      'the kill fixture is the evidence that this guard detects the real defect shape',
+    ).toContain(POLICY.killFixture.expectedSymbol);
+
+    // …and it must be reported as DARK, not merely found: nothing in `src/`
+    // calls it, which is the condition the guard exists to catch.
+    expect(
+      hasProductionUse(POLICY.killFixture.expectedSymbol, POLICY.killFixture.path),
+      'the fixture symbol is used in the shipped tree, so it no longer demonstrates the defect',
+    ).toBe(false);
+  });
+
+  it('ReachableControls_AllowlistEntries_CarryAReasonOwnerAndUnexpiredDate', () => {
+    for (const entry of POLICY.allowlist) {
+      expect(entry.why, `${entry.symbol} records no reason`).toBeTruthy();
+      expect(entry.owner, `${entry.symbol} has no owner`).toBeTruthy();
+      expect(entry.expiry, `${entry.symbol} has no expiry`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(
+        Date.parse(entry.expiry),
+        `the allowlist entry for ${entry.symbol} expired on ${entry.expiry}`,
+      ).toBeGreaterThan(Date.now());
+    }
+  });
+});

--- a/tests/core/integration/governance/evidence-provenance.test.ts
+++ b/tests/core/integration/governance/evidence-provenance.test.ts
@@ -401,8 +401,8 @@ describe('T2 governance — evidence provenance (DR-2, DR-3, DR-4, DR-10)', () =
    *
    * BLOCKING arm: with the marker in place, `get` answers, and it answers with
    * the phase at the tail — a fold that had not seen the transition could not
-   * produce it, so this is the CB-8 guarantee stated about the answer instead
-   * of about the presence of an error.
+   * produce it, so the guarantee is stated about the answer instead of about
+   * the presence of an error.
    * NEGATIVE TWIN: `exarchos_event query` reports the same phase from the
    * durable log with no fold involved. If the read above were serving a
    * remembered value rather than folding the tail, the two would disagree.

--- a/tests/core/integration/governance/evidence-provenance.test.ts
+++ b/tests/core/integration/governance/evidence-provenance.test.ts
@@ -388,16 +388,26 @@ describe('T2 governance — evidence provenance (DR-2, DR-3, DR-4, DR-10)', () =
   }, 300_000);
 
   /**
-   * DR-4: a degraded projection is never served as success.
+   * A projection-derived read answers from the durable tail, and a spent
+   * health marker does not withhold it (#1855).
    *
-   * BLOCKING arm: with a durable `projection.degraded` marker, a projection-
-   * derived read REFUSES with `PROJECTION_DEGRADED` and a message that carries
-   * the INJECTED lag numbers — an answer synthesised from a stale fold, or a
-   * generic well-formed envelope, could not contain them.
-   * NEGATIVE TWIN: append `projection.recovered` and the identical read
-   * succeeds and returns the real state.
+   * The arms below inverted. This case used to assert that a
+   * `projection.degraded` marker made `workflow get` REFUSE, and the marker it
+   * injected — tail 42, cursor 13 — bore no relation to a store whose real tail
+   * was two events. That a fabricated observation could wedge a workflow which
+   * was never unhealthy is the defect, not the guarantee: nothing revalidated
+   * the marker, and the only surface able to clear it was one the same marker
+   * disabled.
+   *
+   * BLOCKING arm: with the marker in place, `get` answers, and it answers with
+   * the phase at the tail — a fold that had not seen the transition could not
+   * produce it, so this is the CB-8 guarantee stated about the answer instead
+   * of about the presence of an error.
+   * NEGATIVE TWIN: `exarchos_event query` reports the same phase from the
+   * durable log with no fold involved. If the read above were serving a
+   * remembered value rather than folding the tail, the two would disagree.
    */
-  it('Governance_Dr4_DegradedProjection_IsNeverServedAsSuccess', async () => {
+  it('Governance_ProjectionDerivedRead_AnswersFromTheDurableTail', async () => {
     const featureId = 'gov-t2-degraded';
     await withHarness({}, async (h) => {
       await h.runAction('exarchos_workflow', 'init', { featureId, workflowType: 'feature' });
@@ -405,6 +415,19 @@ describe('T2 governance — evidence provenance (DR-2, DR-3, DR-4, DR-10)', () =
       const healthy = await h.runAction('exarchos_workflow', 'get', { featureId });
       expect(healthy.result?.success).toBe(true);
       expect(data(healthy).phase).toBe('plan');
+
+      // Move the workflow, so "the phase at the tail" and "the phase a stale
+      // fold remembers" are different answers.
+      const stamped = await h.runAction('exarchos_workflow', 'update', {
+        featureId,
+        updates: { artifacts: { plan: 'a plan the transition guard accepts' } },
+      });
+      expect(stamped.result?.success).toBe(true);
+      const moved = await h.runAction('exarchos_workflow', 'transition', {
+        featureId,
+        target: 'plan-review',
+      });
+      expect(moved.result?.success, JSON.stringify(moved.result?.error)).toBe(true);
 
       // ── BLOCKING ARM ──────────────────────────────────────────────────
       const inject = await h.runAction('exarchos_event', 'append', {
@@ -423,31 +446,26 @@ describe('T2 governance — evidence provenance (DR-2, DR-3, DR-4, DR-10)', () =
       });
       expect(inject.result?.success).toBe(true);
 
-      const refused = await h.runAction('exarchos_workflow', 'get', { featureId });
-      expect(refused.result?.success).toBe(false);
-      expect(refused.errorCode).toBe('PROJECTION_DEGRADED');
-      const message = String(refused.result?.error?.message);
-      expect(message).toContain('29 event(s) short');
-      expect(message).toContain('tail 42');
-      expect(message).toContain('worst cursor 13');
-      expect(message).toContain(featureId);
-      // Emphatically not a "no data" answer served as success.
-      expect(refused.result?.data).toBeUndefined();
+      const answered = await h.runAction('exarchos_workflow', 'get', { featureId });
+      expect(answered.errorCode).toBeUndefined();
+      expect(answered.result?.success).toBe(true);
+      expect(
+        data(answered).phase,
+        'the read served a remembered fold rather than folding the durable tail',
+      ).toBe('plan-review');
 
       // ── NEGATIVE TWIN ─────────────────────────────────────────────────
-      const recover = await h.runAction('exarchos_event', 'append', {
-        stream: 'meta/projection-health',
-        event: {
-          type: 'projection.recovered',
-          data: { streamId: featureId, eventTail: 42, projectionCursor: 42 },
-        },
-      });
-      expect(recover.result?.success).toBe(true);
-
-      const restored = await h.runAction('exarchos_workflow', 'get', { featureId });
-      expect(restored.errorCode).toBeUndefined();
-      expect(restored.result?.success).toBe(true);
-      expect(data(restored).phase).toBe('plan');
+      // The durable log, with no fold in the path at all.
+      const queried = await h.runAction('exarchos_event', 'query', { stream: featureId });
+      expect(queried.result?.success).toBe(true);
+      const events = (queried.result?.data as { events?: { type: string; data?: Record<string, unknown> }[] })
+        ?.events ?? [];
+      const transitions = events.filter((event) => typeof event.type === 'string'
+        && event.type.startsWith('workflow.') && event.data?.['phase'] !== undefined);
+      expect(
+        transitions.at(-1)?.data?.['phase'] ?? data(answered).phase,
+        'the fold and the durable log disagree about the tip phase',
+      ).toBe('plan-review');
     });
   }, 180_000);
 

--- a/tests/unit/mcp-tools.integration.test.ts
+++ b/tests/unit/mcp-tools.integration.test.ts
@@ -14,7 +14,7 @@ import { handleEvent } from '../../src/events/composite.js';
 import { handleView } from '../../src/projections/views/composite.js';
 import { handleOrchestrate } from '../../src/verbs/composite.js';
 import { handleSync } from '../../src/sync/composite.js';
-import { configureWorkflowMaterializer, handleSet } from '../../src/workflow/tools.js';
+import { handleSet } from '../../src/workflow/tools.js';
 import { EventStore } from '../../src/events/store.js';
 import { resetMaterializerCache } from '../../src/projections/views/tools.js';
 import type { DispatchContext } from '../../src/dispatch/core/dispatch.js';
@@ -36,12 +36,10 @@ function ctx(): DispatchContext {
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-integration-'));
   // Reset all module-level caches to prevent cross-test contamination
-  configureWorkflowMaterializer(null);
   resetMaterializerCache();
 });
 
 afterEach(async () => {
-  configureWorkflowMaterializer(null);
   resetMaterializerCache();
   await rmrfAsync(tmpDir);
 });

--- a/tests/unit/projections/degraded-consumers.test.ts
+++ b/tests/unit/projections/degraded-consumers.test.ts
@@ -1,41 +1,43 @@
-// ─── DR-4 (T-07): every consumer returns a typed degraded result ────────────
+// ─── Every projection-derived consumer answers from a tail-covering fold ────
 //
-// ## Characterization — what these consumers did BEFORE this task
+// ## What this file used to assert, and why it moved
 //
-// T-06 made ONE durable degraded state publishable (`projection.degraded` on
-// `meta/projection-health`, read back through `readProjectionDegradedState`).
-// Nothing consumed it. Every read surface below folded through the SAME
-// in-memory materializer LRU that CB-8 caught lying, and answered
-// `success: true` with the stale payload:
+// CB-8 caught workflow views serving a silently stale fold: a cancelled
+// workflow reported at `plan-review`, 7 of 10 completed tasks visible, lag past
+// 500s. The answer shipped for it made the verdict durable
+// (`projection.degraded` on `meta/projection-health`) and had every
+// readiness / workflow / reliability consumer REFUSE on it. This file was the
+// enumeration of those consumers, and every case asserted the refusal.
 //
-//   - `exarchos_view`      → `success: true`, degradation only whispered on the
-//                            ephemeral `_meta.projectionDegraded` courtesy key.
-//   - `exarchos_workflow`  → `success: true` off `moduleViewMaterializer`;
-//                            no freshness signal at all, not even `_meta`.
-//   - `exarchos_orchestrate` readiness/reliability actions
-//                          → `success: true` off `getOrCreateMaterializer`;
-//                            no freshness signal at all.
+// The refusal was the wrong remedy for the right harm (#1855). It was published
+// durably from a point-in-time observation of one process's cache and never
+// revalidated, only the refused surface could clear it, and the freshness
+// predicate quantified over every cached fold of a stream while a read advances
+// exactly one — so on a live stream it could not be cleared at all. `workflow
+// get` stayed unreadable on a lag of ONE event, and a fabricated marker wedged
+// workflows that were never unhealthy.
 //
-// A caller could therefore dispatch agents, gate a phase, or report a workflow
-// complete from a fold that provably did not cover the durable tail.
+// ## What it asserts now
 //
-// ## The change
+// The same enumeration, against the claim that replaced the refusal: each
+// consumer folds its own view to the stream's durable tail before answering
+// (`projections/fold-at-tail.ts`), so it ANSWERS, it answers from the tail, and
+// no durable marker can wedge it. The enumeration is worth keeping — it is the
+// list of surfaces that can serve a projection-derived answer, and that list is
+// what a future change to the seam has to keep covered.
 //
-// One shared typed degraded result (`projections/degraded-result.ts`) is now
-// returned by every one of those consumers when `readProjectionDegradedState`
-// reports the stream degraded: `success: false` with the reserved
-// `PROJECTION_DEGRADED` error code and the durable state attached as
-// `error.projectionDegraded`. The stale payload is DROPPED, not annotated.
+// CB-8's guarantee is stronger here than it was under the refusal, because the
+// assertion is about the ANSWER rather than about the presence of an error:
+// `Consumer_RewoundFold_AnswersFromTheTail` reads the phase back and requires
+// it to be the phase at the tail, which a stale fold cannot produce.
 //
 // ## Fault injection (no mocked readers anywhere in this file)
 //
-// Every test drives a REAL stale cursor: seed real events on a real
-// `EventStore`, warm a REAL fold through the REAL view chokepoint, then rewind
-// that fold's high-water mark via `materializer.loadState(...)`. The durable
-// `projection.degraded` row is then produced by the production publish path
-// (the view chokepoint) or by `publishProjectionFreshness` fed from the REAL
-// live cursor/tail comparison — never by stubbing `readProjectionDegradedState`.
-// ─────────────────────────────────────────────────────────────────────────────
+// Every test drives a REAL stale cursor on a REAL `EventStore`: warm a REAL
+// fold through the REAL view chokepoint, then rewind that fold's high-water
+// mark via `materializer.loadState(...)`. Durable rows are produced by
+// `publishProjectionFreshness` fed from the REAL live cursor/tail comparison,
+// never by stubbing `readProjectionDegradedState`.
 
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -49,25 +51,29 @@ import { EventStore } from '../../../src/events/store.js';
 import { handleView } from '../../../src/projections/views/composite.js';
 import { handleWorkflow } from '../../../src/workflow/composite.js';
 import { handleOrchestrate } from '../../../src/verbs/composite.js';
-import { getOrCreateMaterializer } from '../../../src/projections/views/tools.js';
+import { getOrCreateMaterializer, resetMaterializerCache } from '../../../src/projections/views/tools.js';
 import { rmrfAsync } from '../../../tools/test-helpers/temp-dir.js';
 import {
-  assessStreamFreshness,
+  assessProjectionFreshness,
   publishProjectionFreshness,
   readProjectionDegradedState,
 } from '../../../src/projections/freshness.js';
 import {
   isProjectionDegradedResult,
+  isSameCall,
   PROJECTION_DEGRADED_ERROR_CODE,
 } from '../../../src/projections/degraded-result.js';
 
 const STREAM = 'dr4-consumers-feature';
+/** The fold `workflow get` and the workflow-shaped verbs read. */
+const JUDGED_VIEW = 'workflow-state';
 
 let stateDir: string;
 let store: EventStore;
 let ctx: DispatchContext;
 
 beforeEach(async () => {
+  resetMaterializerCache();
   stateDir = await mkdtemp(nodePath.join(tmpdir(), 'dr4-consumers-'));
   store = new EventStore(stateDir);
   await store.initialize();
@@ -77,6 +83,7 @@ beforeEach(async () => {
 afterEach(async () => {
   store.close();
   await rmrfAsync(stateDir);
+  resetMaterializerCache();
 });
 
 /** Seed a REAL workflow stream through the REAL init path, then real activity. */
@@ -93,27 +100,26 @@ async function seedWorkflow(): Promise<void> {
 
 /**
  * The CB-8 fault, injected for real: warm a genuine fold through the genuine
- * view chokepoint, then rewind its high-water mark so the materialized cursor
- * provably stops short of the durable tail.
+ * view chokepoint, then rewind ONE named fold's high-water mark so the
+ * materialized cursor provably stops short of the durable tail.
  */
 async function injectStaleFold(cursor: number): Promise<void> {
   await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
   const materializer = getOrCreateMaterializer(stateDir);
-  const cursors = materializer.getStreamCursors(STREAM);
-  expect(cursors.length, 'fault injection needs a real materialized fold').toBeGreaterThan(0);
-  for (const { viewName } of cursors) {
-    const state = materializer.getState(STREAM, viewName);
-    if (state) materializer.loadState(STREAM, viewName, state.view, cursor);
-  }
+  const state = materializer.getState(STREAM, JUDGED_VIEW)
+    ?? materializer.getState(STREAM, 'workflow-status');
+  expect(state, 'fault injection needs a real materialized fold').toBeDefined();
+  if (state) materializer.loadState(STREAM, JUDGED_VIEW, state.view, cursor);
 }
 
 /** Publish the durable row from the REAL live cursor/tail disagreement. */
 async function publishLiveDegradation(): Promise<void> {
   const materializer = getOrCreateMaterializer(stateDir);
-  const freshness = assessStreamFreshness(
-    await store.tailSequence(STREAM),
-    materializer.getStreamCursors(STREAM),
-  );
+  const freshness = assessProjectionFreshness({
+    eventTail: await store.tailSequence(STREAM),
+    projectionCursor: materializer.getState(STREAM, JUDGED_VIEW)?.highWaterMark ?? 0,
+    viewName: JUDGED_VIEW,
+  });
   expect(freshness.degraded, 'fault injection must produce a real disagreement').toBe(true);
   await publishProjectionFreshness(store, STREAM, freshness);
   expect(await readProjectionDegradedState(store, STREAM)).toBeDefined();
@@ -123,84 +129,14 @@ function errorCode(result: ToolResult): string | undefined {
   return result.error?.code;
 }
 
-describe('CHARACTERIZATION (superseded) — consumers served stale folds as success:true', () => {
-  // These three cases are the RECORD of the pre-T-07 contract, rewritten to the
-  // contract that replaced it. Each `expect` below inverts exactly one
-  // assertion that used to read `expect(result.success).toBe(true)` with no
-  // error code — the change is the deliverable, so the tests move with it
-  // rather than being weakened to stay green.
+// ─── Every consumer, one claim ──────────────────────────────────────────────
 
-  it('ViewComposite_DegradedProjection_ReturnsTypedDegradedResult', async () => {
-    await seedWorkflow();
-    // `projection-ahead`: a fold claiming events the log cannot produce. A
-    // re-fold cannot heal it, so the disagreement survives the read that
-    // observes it — exactly the snapshot-over-pruned-log case.
-    await injectStaleFold(25);
-
-    const result = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
-
-    // WAS: success:true with the stale payload; degradation only on `_meta`.
-    expect(result.success).toBe(false);
-    expect(errorCode(result)).toBe(PROJECTION_DEGRADED_ERROR_CODE);
-    expect(isProjectionDegradedResult(result)).toBe(true);
-    expect(result.error?.projectionDegraded).toMatchObject({
-      streamId: STREAM,
-      reason: 'projection-ahead',
-      eventTail: 4,
-      projectionCursor: 25,
-      lag: -21,
-    });
-    // The stale payload is DROPPED, not annotated — a caller branching on
-    // `success` must not be able to reach it.
-    expect(result.data).toBeUndefined();
-  });
-
-  it('WorkflowComposite_DegradedProjection_DoesNotReturnStalePayload', async () => {
-    await seedWorkflow();
-    await injectStaleFold(1);
-    await publishLiveDegradation();
-
-    const result = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
-
-    // WAS: success:true off the materializer LRU, with no freshness signal.
-    expect(result.success).toBe(false);
-    expect(errorCode(result)).toBe(PROJECTION_DEGRADED_ERROR_CODE);
-    expect(result.data).toBeUndefined();
-    expect(result.error?.projectionDegraded).toMatchObject({
-      streamId: STREAM,
-      reason: 'projection-behind',
-      eventTail: 4,
-      projectionCursor: 1,
-      lag: 3,
-    });
-  });
-
-  it('OrchestrateComposite_DegradedProjection_ReturnsTypedDegradedResult', async () => {
-    await seedWorkflow();
-    await injectStaleFold(1);
-    await publishLiveDegradation();
-
-    const result = await handleOrchestrate(
-      { action: 'check_convergence', featureId: STREAM },
-      ctx,
-    );
-
-    // WAS: success:true carrying a convergence verdict computed off a fold
-    // that provably did not cover the tail.
-    expect(result.success).toBe(false);
-    expect(errorCode(result)).toBe(PROJECTION_DEGRADED_ERROR_CODE);
-    expect(result.data).toBeUndefined();
-  });
-});
-
-// ─── Every consumer, one shape ──────────────────────────────────────────────
-
-describe('DR-4 — every readiness/workflow/reliability consumer refuses', () => {
+describe('#1855 — every readiness/workflow/reliability consumer answers', () => {
   /**
    * The full enumeration, derived mechanically rather than assumed: these are
-   * the composite actions whose answer flows through the materializer LRU
-   * (`git grep -l materializer -- src/{views,workflow,orchestrate}`). Each is
-   * driven here against a REAL durable `projection.degraded` row.
+   * the composite actions whose answer flows through a cached fold. Each is
+   * driven here against a REAL stale cursor AND a REAL durable degraded row —
+   * the exact state that used to refuse all ten.
    */
   const CONSUMERS: ReadonlyArray<{
     readonly label: string;
@@ -250,51 +186,67 @@ describe('DR-4 — every readiness/workflow/reliability consumer refuses', () =>
   ];
 
   for (const { label, run } of CONSUMERS) {
-    it(`Consumer_DegradedProjection_ReturnsTypedDegradedResult [${label}]`, async () => {
+    it(`Consumer_StaleFoldAndDurableMarker_IsNotWedged [${label}]`, async () => {
       await seedWorkflow();
-      // A fold ahead of the log: the disagreement is real, is published by the
-      // production view chokepoint, and cannot be healed by a re-fold — so the
-      // durable row still stands when each consumer below is driven.
-      await injectStaleFold(25);
+      await injectStaleFold(1);
       await publishLiveDegradation();
 
       const result = await run();
 
-      expect(result.success, `${label} must not answer from a stale fold`).toBe(false);
-      expect(errorCode(result)).toBe(PROJECTION_DEGRADED_ERROR_CODE);
-      // ONE shape, reused verbatim — not a per-consumer dialect.
-      expect(result.error?.projectionDegraded).toMatchObject({
-        streamId: STREAM,
-        reason: 'projection-ahead',
-        eventTail: 4,
-        projectionCursor: 25,
-      });
-      expect(result.error?.suggestedFix?.tool).toBe('exarchos_view');
-      expect(result.data, 'the stale payload must be dropped, not annotated').toBeUndefined();
+      // Each of these ten returned `PROJECTION_DEGRADED` before, and stayed
+      // returning it: the marker could only be cleared by a surface the same
+      // marker disabled. A readiness verdict may still legitimately be
+      // negative — what it may not be is withheld because a cache lagged.
+      expect(
+        errorCode(result),
+        `${label} refused a read it could have folded: ${JSON.stringify(result.error)}`,
+      ).not.toBe(PROJECTION_DEGRADED_ERROR_CODE);
+      expect(isProjectionDegradedResult(result)).toBe(false);
     });
   }
+
+  it('Consumer_RewoundFold_AnswersFromTheTail', async () => {
+    // The CB-8 guarantee itself, stated as a claim about the ANSWER rather than
+    // about the presence of an error. A fold rewound to sequence 1 has not seen
+    // the transition; if the answer still carries the tip phase, it was not
+    // served from the stale fold.
+    await seedWorkflow();
+    const stamped = await handleWorkflow(
+      {
+        action: 'update',
+        featureId: STREAM,
+        updates: { artifacts: { plan: 'a plan the transition guard accepts' } },
+      },
+      ctx,
+    );
+    expect(stamped.success, JSON.stringify(stamped.error)).toBe(true);
+    const moved = await handleWorkflow(
+      { action: 'transition', featureId: STREAM, target: 'plan-review' },
+      ctx,
+    );
+    expect(moved.success, JSON.stringify(moved.error)).toBe(true);
+
+    await injectStaleFold(1);
+
+    const result = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
+    expect(result.success, JSON.stringify(result.error)).toBe(true);
+    const data = result.data as { data?: { phase?: string }; phase?: string } | undefined;
+    expect(
+      data?.phase ?? data?.data?.phase,
+      'the answer came from the rewound fold, not from the durable tail',
+    ).toBe('plan-review');
+  });
 });
 
-// ─── Causality: degraded ≠ no data ≠ genuine failure ────────────────────────
+// ─── Causality: undecidable ≠ no data ≠ genuine failure ─────────────────────
 
-describe('DR-4 — a degraded result is distinguishable from its neighbours', () => {
+describe('#1855 — the reserved code still separates its neighbours', () => {
   it('DegradedResult_IsNotConfusableWithNoData', async () => {
     // "No data": a stream that was never written. The store WAS asked and
-    // answered truthfully — that is a fact about the tail, not a failure to
-    // read it, so it must NOT carry the reserved code.
+    // answered truthfully — a fact about the tail, not a failure to read it.
     const empty = await handleWorkflow({ action: 'get', featureId: 'never-written' }, ctx);
     expect(errorCode(empty)).not.toBe(PROJECTION_DEGRADED_ERROR_CODE);
     expect(isProjectionDegradedResult(empty)).toBe(false);
-
-    // Degraded: the same surface, same success:false, DIFFERENT code — and
-    // unlike the above it reports how far the fold missed by.
-    await seedWorkflow();
-    await injectStaleFold(1);
-    await publishLiveDegradation();
-    const degraded = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
-    expect(isProjectionDegradedResult(degraded)).toBe(true);
-    expect(degraded.error?.projectionDegraded?.lag).toBe(3);
-    expect(errorCode(degraded)).not.toBe(errorCode(empty));
   });
 
   it('DegradedResult_IsNotConfusableWithGenuineFailure', async () => {
@@ -302,9 +254,9 @@ describe('DR-4 — a degraded result is distinguishable from its neighbours', ()
     await injectStaleFold(1);
     await publishLiveDegradation();
 
-    // A real input fault on a degraded stream still reports the input fault:
-    // an unknown action is not a projection problem and must not be laundered
-    // into one (nor the reverse).
+    // An input fault on a stream carrying a degraded marker still reports the
+    // input fault. An unknown action is not a projection problem and must not
+    // be laundered into one, nor the reverse.
     const bogus = await handleWorkflow({ action: 'no_such_action', featureId: STREAM }, ctx);
     expect(bogus.success).toBe(false);
     expect(errorCode(bogus)).toBe('UNKNOWN_ACTION');
@@ -312,58 +264,49 @@ describe('DR-4 — a degraded result is distinguishable from its neighbours', ()
     expect(bogus.error?.projectionDegraded).toBeUndefined();
   });
 
-  it('HealthyStream_NoDurableRow_ConsumersAnswerNormally', async () => {
-    // The negative control. Without fault injection every consumer answers as
-    // before — the guard must not degrade a healthy stream.
-    await seedWorkflow();
-    expect(await readProjectionDegradedState(store, STREAM)).toBeUndefined();
-
-    const view = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
-    expect(view.success).toBe(true);
-    expect(isProjectionDegradedResult(view)).toBe(false);
-
-    const wf = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
-    expect(wf.success).toBe(true);
-    expect(isProjectionDegradedResult(wf)).toBe(false);
-
-    const orch = await handleOrchestrate(
-      { action: 'check_convergence', featureId: STREAM },
-      ctx,
-    );
-    expect(isProjectionDegradedResult(orch)).toBe(false);
+  it('SuggestedFix_NeverNamesTheCallThatFailed', () => {
+    // The loop #1855 reported: the remedy was a constant naming
+    // `exarchos_view workflow_status`, so when that was the refusing surface
+    // the caller retried the identical read, failed identically, and each
+    // attempt left a window for more events to land.
+    expect(
+      isSameCall(
+        { tool: 'exarchos_event', params: { action: 'query', stream: STREAM } },
+        { tool: 'exarchos_event', action: 'query' },
+      ),
+      'a remedy identical to the failing call must be recognised as circular',
+    ).toBe(true);
+    expect(
+      isSameCall(
+        { tool: 'exarchos_event', params: { action: 'query', stream: STREAM } },
+        { tool: 'exarchos_view', action: 'workflow_status' },
+      ),
+    ).toBe(false);
   });
 });
 
-// ─── Recovery: the refusal is a step, not a dead end ────────────────────────
+// ─── The journal records live conditions, it does not latch ─────────────────
 
-describe('DR-4 — recovery clears the refusal', () => {
-  it('DegradedStream_RefoldViaViewChokepoint_PublishesRecoveryAndUnblocksConsumers', async () => {
+describe('#1855 — a spent observation clears', () => {
+  it('DegradedRow_SurvivingRead_IsClearedByTheViewChokepoint', async () => {
     await seedWorkflow();
-    // A fold merely BEHIND the tail — the case a re-fold genuinely repairs.
     await injectStaleFold(1);
     await publishLiveDegradation();
-    expect(
-      isProjectionDegradedResult(await handleWorkflow({ action: 'get', featureId: STREAM }, ctx)),
-    ).toBe(true);
+    expect(await readProjectionDegradedState(store, STREAM)).toBeDefined();
 
-    // The view chokepoint is the publisher: reading through it re-folds to the
-    // tail, observes agreement, and emits the paired `projection.recovered`.
+    // A read that answers is proof the stream is servable, so the row it still
+    // carries is a spent observation. Before #1855 this was the ONLY way to
+    // clear the row and it was unreachable on a live stream; now it is a
+    // bookkeeping step on a read that was never blocked.
     const reread = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
     expect(reread.success).toBe(true);
     expect(await readProjectionDegradedState(store, STREAM)).toBeUndefined();
-
-    // …which releases the pure consumers. A refusal that could not be cleared
-    // would be a wedge, not a safeguard.
-    const wf = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
-    expect(wf.success).toBe(true);
-    expect(isProjectionDegradedResult(wf)).toBe(false);
   });
 
   it('WorkflowMutationsAndRecoveryActions_StayUnguarded', async () => {
-    // Causality: writes land on the authoritative log and `reconcile` REPAIRS
-    // the projection. Refusing either because a derived read is stale would
-    // block progress on a healthy source of truth, and deadlock the one action
-    // able to clear the state.
+    // Causality, unchanged: writes land on the authoritative log and
+    // `reconcile` REPAIRS the projection. Neither may be refused because a
+    // derived read lagged.
     await seedWorkflow();
     await injectStaleFold(1);
     await publishLiveDegradation();

--- a/tests/unit/projections/degraded-consumers.test.ts
+++ b/tests/unit/projections/degraded-consumers.test.ts
@@ -2,7 +2,7 @@
 //
 // ## What this file used to assert, and why it moved
 //
-// CB-8 caught workflow views serving a silently stale fold: a cancelled
+// A dogfood run caught workflow views serving a silently stale fold: a cancelled
 // workflow reported at `plan-review`, 7 of 10 completed tasks visible, lag past
 // 500s. The answer shipped for it made the verdict durable
 // (`projection.degraded` on `meta/projection-health`) and had every
@@ -26,7 +26,7 @@
 // list of surfaces that can serve a projection-derived answer, and that list is
 // what a future change to the seam has to keep covered.
 //
-// CB-8's guarantee is stronger here than it was under the refusal, because the
+// The guarantee is stronger here than it was under the refusal, because the
 // assertion is about the ANSWER rather than about the presence of an error:
 // `Consumer_RewoundFold_AnswersFromTheTail` reads the phase back and requires
 // it to be the phase at the tail, which a stale fold cannot produce.
@@ -99,7 +99,7 @@ async function seedWorkflow(): Promise<void> {
 }
 
 /**
- * The CB-8 fault, injected for real: warm a genuine fold through the genuine
+ * The stale-fold fault, injected for real: warm a genuine fold through the genuine
  * view chokepoint, then rewind ONE named fold's high-water mark so the
  * materialized cursor provably stops short of the durable tail.
  */
@@ -206,8 +206,9 @@ describe('#1855 — every readiness/workflow/reliability consumer answers', () =
   }
 
   it('Consumer_RewoundFold_AnswersFromTheTail', async () => {
-    // The CB-8 guarantee itself, stated as a claim about the ANSWER rather than
-    // about the presence of an error. A fold rewound to sequence 1 has not seen
+    // The guarantee itself — a read never answers from a fold that has not seen
+    // events already durable when it was asked — stated as a claim about the
+    // ANSWER rather than about the presence of an error. A fold rewound to sequence 1 has not seen
     // the transition; if the answer still carries the tip phase, it was not
     // served from the stale fold.
     await seedWorkflow();

--- a/tests/unit/projections/fold-at-tail.test.ts
+++ b/tests/unit/projections/fold-at-tail.test.ts
@@ -34,7 +34,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { DispatchContext } from '../../../src/dispatch/core/dispatch.js';
 import { EventStore } from '../../../src/events/store.js';
-import { foldToTail } from '../../../src/projections/fold-at-tail.js';
+import { foldPairToTail, foldToTail } from '../../../src/projections/fold-at-tail.js';
 import {
   PROJECTION_HEALTH_STREAM_ID,
   PROJECTION_DEGRADED_EVENT_TYPE,
@@ -45,6 +45,42 @@ import { getOrCreateMaterializer, resetMaterializerCache } from '../../../src/pr
 import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../../src/projections/views/workflow-state-projection.js';
 import { handleWorkflow } from '../../../src/workflow/composite.js';
 import { rmrfAsync } from '../../../tools/test-helpers/temp-dir.js';
+
+/** Only the cursor matters for the pair test, so the shape is deliberately loose. */
+type WorkflowStatusLike = Record<string, unknown>;
+
+/**
+ * A store that lets one event land in the window between the tail pin and the
+ * fold's query — the window a concurrent writer actually occupies.
+ *
+ * Without it these guarantees cannot be tested at all: a single-threaded fold
+ * queries microseconds after it pins, so the bound never has anything to
+ * exclude and the assertions hold for the wrong reason. Removing the bound from
+ * the seam leaves such a test green, which is the definition of a test that
+ * cannot fail.
+ */
+class RacingEventStore extends EventStore {
+  private queries = 0;
+
+  constructor(
+    stateDir: string,
+    private readonly raceOnQuery: number,
+    private readonly raceStream: string,
+  ) {
+    super(stateDir);
+  }
+
+  override async query(
+    streamId: string,
+    filters?: Parameters<EventStore['query']>[1],
+  ): Promise<Awaited<ReturnType<EventStore['query']>>> {
+    this.queries += 1;
+    if (this.queries === this.raceOnQuery) {
+      await super.append(this.raceStream, { type: 'task.progressed', data: { raced: true } });
+    }
+    return super.query(streamId, filters);
+  }
+}
 
 const STREAM = 'fold-at-tail-feature';
 
@@ -156,13 +192,14 @@ describe('#1855 — the wedge', () => {
   });
 });
 
-describe('#1855 — the guarantee CB-8 bought, kept', () => {
+describe('#1855 — a read never answers from a fold behind the tail', () => {
   it('FoldAtTail_RewoundFold_AnswersFromTheTailNotFromTheStaleFold', async () => {
     await seedWorkflow();
     const materializer = getOrCreateMaterializer(stateDir);
 
-    // Warm a real fold, then rewind its cursor and let the stream move — the
-    // CB-8 fault injected for real. The old contract detected this and refused.
+    // Warm a real fold, then rewind its cursor and let the stream move — a
+    // genuinely stale fold, injected for real. The old contract detected this
+    // and refused.
     // The stronger claim is that the ANSWER is right, so assert the answer.
     const warm = await foldToTail<WorkflowStateView>(store, materializer, STREAM, WORKFLOW_STATE_VIEW);
     const rewound = materializer.getState<WorkflowStateView>(STREAM, WORKFLOW_STATE_VIEW);
@@ -229,6 +266,63 @@ describe('#1855 — the guarantee CB-8 bought, kept', () => {
 
     expect(folded.sequence).toBe(await store.tailSequence(STREAM));
     expect(folded.repaired).toBeUndefined();
+  });
+
+  it('FoldAtTail_AppendLandsMidFold_SequenceStaysOnThePinnedTail', async () => {
+    // The reported sequence is what callers bound their own evidence to — the
+    // emissions gate reads the phase from the fold and then filters raw events
+    // to that sequence. A fold that ran past its own pin would make those two
+    // halves describe different states of the stream.
+    await seedWorkflow();
+    const racing = new RacingEventStore(stateDir, 1, STREAM);
+    await racing.initialize();
+    try {
+      const materializer = getOrCreateMaterializer(stateDir);
+      const pinned = await racing.tailSequence(STREAM);
+
+      const folded = await foldToTail<WorkflowStateView>(
+        racing,
+        materializer,
+        STREAM,
+        WORKFLOW_STATE_VIEW,
+      );
+
+      // The raced event is real and the tail really did move…
+      expect(await racing.tailSequence(STREAM)).toBeGreaterThan(pinned);
+      // …and the fold still answers for the sequence it pinned.
+      expect(folded.sequence).toBe(pinned);
+    } finally {
+      racing.close();
+    }
+  });
+
+  it('FoldPairToTail_TwoViews_ShareOneSequence', async () => {
+    // Two independent folds pin two tails, so a read that COMBINES them can
+    // describe a state the stream was never in: one view holding an event the
+    // other has not seen. The attribution and correlation views do exactly that
+    // combining.
+    await seedWorkflow();
+    const materializer = getOrCreateMaterializer(stateDir);
+
+    // Race an append into the window BETWEEN the two folds. Two independent
+    // pins would put the second view a sequence ahead of the first.
+    const racing = new RacingEventStore(stateDir, 2, STREAM);
+    await racing.initialize();
+    try {
+      const pair = await foldPairToTail<WorkflowStateView, WorkflowStatusLike>(
+        racing,
+        materializer,
+        STREAM,
+        WORKFLOW_STATE_VIEW,
+        'workflow-status',
+      );
+
+      expect(await racing.tailSequence(STREAM)).toBeGreaterThan(pair.sequence);
+      expect(materializer.getState(STREAM, WORKFLOW_STATE_VIEW)?.highWaterMark).toBe(pair.sequence);
+      expect(materializer.getState(STREAM, 'workflow-status')?.highWaterMark).toBe(pair.sequence);
+    } finally {
+      racing.close();
+    }
   });
 
   it('FoldAtTail_EmptyStream_IsCoveredAtSequenceZero', async () => {

--- a/tests/unit/projections/fold-at-tail.test.ts
+++ b/tests/unit/projections/fold-at-tail.test.ts
@@ -48,7 +48,6 @@ import {
   type WorkflowStateView,
 } from '../../../src/projections/views/workflow-state-projection.js';
 import { ViewMaterializer } from '../../../src/projections/views/materializer.js';
-import { configureWorkflowMaterializer } from '../../../src/workflow/tools.js';
 import { handleWorkflow } from '../../../src/workflow/composite.js';
 import { rmrfAsync } from '../../../tools/test-helpers/temp-dir.js';
 
@@ -370,7 +369,6 @@ describe('#1855 — a committed mutation is never reported as a failure', () => 
     // reachability gap itself is a separate finding.
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     await seedWorkflow();
 
@@ -386,7 +384,6 @@ describe('#1855 — a committed mutation is never reported as a failure', () => 
       expect(update.error?.code).not.toBe('INTERNAL_ERROR');
     } finally {
       lying.close();
-      configureWorkflowMaterializer(null);
     }
 
     // …and the write really did land: a healthy read sees it.

--- a/tests/unit/projections/fold-at-tail.test.ts
+++ b/tests/unit/projections/fold-at-tail.test.ts
@@ -1,0 +1,244 @@
+// ─── #1855: a read establishes its own tail coverage ────────────────────────
+//
+// ## The defect these tests pin
+//
+// `assessStreamFreshness` required EVERY cached fold of a stream to sit exactly
+// on the durable tail. A read advances exactly ONE. The two are incompatible
+// the moment a stream has more than one cached fold, and `workflow-state` made
+// it terminal: orchestrate verbs and gates fold it into the shared view
+// materializer, and no `exarchos_view` action folds it, so no view read could
+// restore agreement — while the view surface was the only publisher of
+// `projection.recovered`. `workflow get` and four orchestrate actions stayed
+// refused across processes and restarts on a lag of ONE event, and the
+// `suggestedFix` named the call that had just failed.
+//
+// ## What replaced it
+//
+// Every projection-derived read folds its own view to the stream's durable tail
+// before answering (`projections/fold-at-tail.ts`). Behind is folded forward;
+// ahead is discarded and replayed from the log. `PROJECTION_DEGRADED` now means
+// undecidable — a fold that finished short of the tail it was pinned against —
+// and nothing else.
+//
+// ## No mocked readers
+//
+// Every case drives a REAL `EventStore` on a real temp dir, through the REAL
+// composite handlers. Faults are injected by rewinding an actual materialized
+// cursor (`loadState`), never by stubbing a freshness reader.
+
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { DispatchContext } from '../../../src/dispatch/core/dispatch.js';
+import { EventStore } from '../../../src/events/store.js';
+import { foldToTail } from '../../../src/projections/fold-at-tail.js';
+import {
+  PROJECTION_HEALTH_STREAM_ID,
+  PROJECTION_DEGRADED_EVENT_TYPE,
+  readProjectionDegradedState,
+} from '../../../src/projections/freshness.js';
+import { handleView } from '../../../src/projections/views/composite.js';
+import { getOrCreateMaterializer, resetMaterializerCache } from '../../../src/projections/views/tools.js';
+import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../../src/projections/views/workflow-state-projection.js';
+import { handleWorkflow } from '../../../src/workflow/composite.js';
+import { rmrfAsync } from '../../../tools/test-helpers/temp-dir.js';
+
+const STREAM = 'fold-at-tail-feature';
+
+let stateDir: string;
+let store: EventStore;
+let ctx: DispatchContext;
+
+beforeEach(async () => {
+  resetMaterializerCache();
+  stateDir = await mkdtemp(nodePath.join(tmpdir(), 'fold-at-tail-'));
+  store = new EventStore(stateDir);
+  await store.initialize();
+  ctx = { stateDir, eventStore: store, enableTelemetry: false };
+});
+
+afterEach(async () => {
+  store.close();
+  await rmrfAsync(stateDir);
+  resetMaterializerCache();
+});
+
+async function seedWorkflow(): Promise<void> {
+  const init = await handleWorkflow(
+    { action: 'init', featureId: STREAM, workflowType: 'feature' },
+    ctx,
+  );
+  expect(init.success, `seed init failed: ${JSON.stringify(init.error)}`).toBe(true);
+}
+
+/**
+ * The exact shape of #1855: a verb folds `workflow-state` into the SHARED view
+ * materializer, then the stream keeps appending. Before the fix this made every
+ * subsequent read of the stream refuse, on any view, forever.
+ */
+async function foldWorkflowStateThenAppend(appends: number): Promise<void> {
+  const materializer = getOrCreateMaterializer(stateDir);
+  await foldToTail<WorkflowStateView>(store, materializer, STREAM, WORKFLOW_STATE_VIEW);
+  for (let i = 0; i < appends; i++) {
+    await store.append(STREAM, { type: 'task.progressed', data: { i } });
+  }
+}
+
+describe('#1855 — the wedge', () => {
+  it('FoldAtTail_StaleSiblingFold_DoesNotRefuseAnUnrelatedViewRead', async () => {
+    await seedWorkflow();
+    await foldWorkflowStateThenAppend(1);
+
+    // A single event behind a fold NOTHING in this read touches. This is the
+    // reported case verbatim: `convergence` refused with
+    // `staleViews: ["workflow-state"]` at lag 1.
+    const result = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
+
+    expect(result.error?.code, JSON.stringify(result.error)).not.toBe('PROJECTION_DEGRADED');
+    expect(result.success).toBe(true);
+  });
+
+  it('FoldAtTail_RepeatedReadsOnAnAppendingStream_AllSucceed', async () => {
+    await seedWorkflow();
+    await foldWorkflowStateThenAppend(1);
+
+    // The reported loop: each refusal window was long enough for more events to
+    // land, so retrying the refusing read never drained the lag. Append between
+    // every attempt and every attempt must still answer.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await store.append(STREAM, { type: 'task.progressed', data: { attempt } });
+      const result = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
+      expect(result.success, `attempt ${attempt}: ${JSON.stringify(result.error)}`).toBe(true);
+    }
+  });
+
+  it('FoldAtTail_WorkflowGet_IsNotWedgedByASiblingFold', async () => {
+    await seedWorkflow();
+    await foldWorkflowStateThenAppend(1);
+
+    const result = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
+
+    expect(result.error?.code, JSON.stringify(result.error)).not.toBe('PROJECTION_DEGRADED');
+    expect(result.success).toBe(true);
+  });
+
+  it('FoldAtTail_FabricatedDegradedMarker_DoesNotWedgeAHealthyStream', async () => {
+    await seedWorkflow();
+
+    // A durable marker whose numbers bear no relation to this store — the
+    // sticky-latch shape. It is a point-in-time observation, not a current fact
+    // about the stream, and a read that can prove its own coverage must not
+    // defer to it.
+    await store.append(PROJECTION_HEALTH_STREAM_ID, {
+      type: PROJECTION_DEGRADED_EVENT_TYPE,
+      data: {
+        streamId: STREAM,
+        reason: 'projection-behind',
+        eventTail: 42,
+        projectionCursor: 13,
+        lag: 29,
+        staleViews: ['workflow-state'],
+      },
+    });
+    expect(await readProjectionDegradedState(store, STREAM)).toBeDefined();
+
+    const get = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
+    expect(get.success, JSON.stringify(get.error)).toBe(true);
+
+    // …and a view read clears the spent observation, so the journal records live
+    // conditions rather than latching.
+    const view = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
+    expect(view.success).toBe(true);
+    expect(await readProjectionDegradedState(store, STREAM)).toBeUndefined();
+  });
+});
+
+describe('#1855 — the guarantee CB-8 bought, kept', () => {
+  it('FoldAtTail_RewoundFold_AnswersFromTheTailNotFromTheStaleFold', async () => {
+    await seedWorkflow();
+    const materializer = getOrCreateMaterializer(stateDir);
+
+    // Warm a real fold, then rewind its cursor and let the stream move — the
+    // CB-8 fault injected for real. The old contract detected this and refused.
+    // The stronger claim is that the ANSWER is right, so assert the answer.
+    const warm = await foldToTail<WorkflowStateView>(store, materializer, STREAM, WORKFLOW_STATE_VIEW);
+    const rewound = materializer.getState<WorkflowStateView>(STREAM, WORKFLOW_STATE_VIEW);
+    expect(rewound, 'the fault needs a real materialized fold').toBeDefined();
+    materializer.loadState(STREAM, WORKFLOW_STATE_VIEW, rewound!.view, 1);
+
+    const stamped = await handleWorkflow(
+      {
+        action: 'update',
+        featureId: STREAM,
+        updates: { artifacts: { plan: 'a plan the transition guard accepts' } },
+      },
+      ctx,
+    );
+    expect(stamped.success, JSON.stringify(stamped.error)).toBe(true);
+    const transition = await handleWorkflow(
+      { action: 'transition', featureId: STREAM, target: 'plan-review' },
+      ctx,
+    );
+    expect(transition.success, JSON.stringify(transition.error)).toBe(true);
+
+    const refolded = await foldToTail<WorkflowStateView>(store, materializer, STREAM, WORKFLOW_STATE_VIEW);
+    expect(refolded.sequence).toBe(await store.tailSequence(STREAM));
+    expect(refolded.sequence).toBeGreaterThan(warm.sequence);
+    expect(refolded.view.phase, 'the answer came from the stale fold, not the tail').toBe(
+      'plan-review',
+    );
+  });
+
+  it('FoldAtTail_ContradictoryFold_IsDiscardedAndReplayedFromTheLog', async () => {
+    await seedWorkflow();
+    const materializer = getOrCreateMaterializer(stateDir);
+
+    const warm = await foldToTail<WorkflowStateView>(store, materializer, STREAM, WORKFLOW_STATE_VIEW);
+    const tail = await store.tailSequence(STREAM);
+
+    // `projection-ahead`: a cursor past the tail, with a corrupted payload. A
+    // hwm-filtered re-fold cannot heal this — every event sits below the cursor
+    // — so the fold must be DISCARDED and replayed from the log.
+    materializer.loadState(
+      STREAM,
+      WORKFLOW_STATE_VIEW,
+      { ...warm.view, phase: 'synthesize' } as WorkflowStateView,
+      tail + 50,
+    );
+
+    const repaired = await foldToTail<WorkflowStateView>(store, materializer, STREAM, WORKFLOW_STATE_VIEW);
+
+    expect(repaired.sequence).toBe(tail);
+    expect(repaired.view.phase, 'the contradictory payload survived the repair').toBe('plan');
+    expect(repaired.repaired?.reason, 'the repair must stay observable').toBe('projection-ahead');
+  });
+
+  it('FoldAtTail_ColdStream_CoversTheTailWithNoWarmFold', async () => {
+    await seedWorkflow();
+    await store.append(STREAM, { type: 'task.progressed', data: {} });
+
+    const folded = await foldToTail<WorkflowStateView>(
+      store,
+      getOrCreateMaterializer(stateDir),
+      STREAM,
+      WORKFLOW_STATE_VIEW,
+    );
+
+    expect(folded.sequence).toBe(await store.tailSequence(STREAM));
+    expect(folded.repaired).toBeUndefined();
+  });
+
+  it('FoldAtTail_EmptyStream_IsCoveredAtSequenceZero', async () => {
+    const folded = await foldToTail<WorkflowStateView>(
+      store,
+      getOrCreateMaterializer(stateDir),
+      'never-written',
+      WORKFLOW_STATE_VIEW,
+    );
+
+    expect(folded.sequence).toBe(0);
+  });
+});

--- a/tests/unit/projections/fold-at-tail.test.ts
+++ b/tests/unit/projections/fold-at-tail.test.ts
@@ -42,7 +42,13 @@ import {
 } from '../../../src/projections/freshness.js';
 import { handleView } from '../../../src/projections/views/composite.js';
 import { getOrCreateMaterializer, resetMaterializerCache } from '../../../src/projections/views/tools.js';
-import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../../../src/projections/views/workflow-state-projection.js';
+import {
+  WORKFLOW_STATE_VIEW,
+  workflowStateProjection,
+  type WorkflowStateView,
+} from '../../../src/projections/views/workflow-state-projection.js';
+import { ViewMaterializer } from '../../../src/projections/views/materializer.js';
+import { configureWorkflowMaterializer } from '../../../src/workflow/tools.js';
 import { handleWorkflow } from '../../../src/workflow/composite.js';
 import { rmrfAsync } from '../../../tools/test-helpers/temp-dir.js';
 
@@ -79,6 +85,18 @@ class RacingEventStore extends EventStore {
       await super.append(this.raceStream, { type: 'task.progressed', data: { raced: true } });
     }
     return super.query(streamId, filters);
+  }
+}
+
+
+/**
+ * A store whose tail outruns what it can produce — the one condition
+ * `foldToTail` refuses to answer through. `tailSequence` claims events the log
+ * cannot return, so no fold can be shown to cover it.
+ */
+class UnprovableTailEventStore extends EventStore {
+  override async tailSequence(streamId: string): Promise<number> {
+    return (await super.tailSequence(streamId)) + 10;
   }
 }
 
@@ -334,5 +352,70 @@ describe('#1855 — a read never answers from a fold behind the tail', () => {
     );
 
     expect(folded.sequence).toBe(0);
+  });
+});
+
+describe('#1855 — a committed mutation is never reported as a failure', () => {
+  it('WorkflowUpdate_CoverageUnprovable_StillReportsTheCommittedWrite', async () => {
+    // `handleSet` refreshes `<featureId>.state.json` AFTER its events are
+    // durable. A coverage failure in that refresh used to reject the whole
+    // call, so a caller saw `INTERNAL_ERROR` for a write that had landed — and
+    // would reasonably retry it.
+    //
+    // The snapshot path is gated on a CONFIGURED workflow materializer, and
+    // nothing in `src/` calls `configureWorkflowMaterializer`, so the path is
+    // dark in the shipped composition today. Without this wiring the test
+    // passes whether or not the fix is present — it never reaches the fold.
+    // Configuring it here is what makes the assertion mean something, and the
+    // reachability gap itself is a separate finding.
+    const materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowMaterializer(materializer);
+
+    await seedWorkflow();
+
+    const lying = new UnprovableTailEventStore(stateDir);
+    await lying.initialize();
+    try {
+      const update = await handleWorkflow(
+        { action: 'update', featureId: STREAM, updates: { riskTier: 'low' } },
+        { stateDir, eventStore: lying, enableTelemetry: false },
+      );
+
+      expect(update.success, JSON.stringify(update.error)).toBe(true);
+      expect(update.error?.code).not.toBe('INTERNAL_ERROR');
+    } finally {
+      lying.close();
+      configureWorkflowMaterializer(null);
+    }
+
+    // …and the write really did land: a healthy read sees it.
+    const get = await handleWorkflow({ action: 'get', featureId: STREAM }, ctx);
+    expect(get.success, JSON.stringify(get.error)).toBe(true);
+    const data = get.data as { riskTier?: string; data?: { riskTier?: string } } | undefined;
+    expect(data?.riskTier ?? data?.data?.riskTier).toBe('low');
+  });
+
+  it('FoldAtTail_UnprovableCoverage_ThrowsRatherThanAnswering', async () => {
+    // The negative twin. A READ in the same condition must not answer at all —
+    // that is the one meaning `PROJECTION_DEGRADED` still carries, and it is
+    // what makes the tolerance above a deliberate write-side rule rather than a
+    // blanket swallow.
+    await seedWorkflow();
+
+    const lying = new UnprovableTailEventStore(stateDir);
+    await lying.initialize();
+    try {
+      await expect(
+        foldToTail<WorkflowStateView>(
+          lying,
+          getOrCreateMaterializer(stateDir),
+          STREAM,
+          WORKFLOW_STATE_VIEW,
+        ),
+      ).rejects.toThrow(/short of the durable tail/);
+    } finally {
+      lying.close();
+    }
   });
 });

--- a/tests/unit/projections/freshness.test.ts
+++ b/tests/unit/projections/freshness.test.ts
@@ -5,9 +5,17 @@
 // visible, lag past 500s — with nothing on the response saying the answer did
 // not derive from the current event tail.
 //
-// The comparison is pure (`assessStreamFreshness`); the chokepoint is
-// `handleView`, so EVERY view action inherits it rather than each handler
-// re-implementing a freshness check.
+// The comparison is pure (`assessProjectionFreshness`). Its consumer is
+// `planRehydrationSource`, which REPAIRS what it reports — folds a lagging fold
+// forward, discards and replays a contradictory one — and
+// `projections/fold-at-tail.ts` runs that decision ahead of every
+// projection-derived read.
+//
+// #1855 removed the stream-wide sibling `assessStreamFreshness`, which required
+// every cached fold of a stream to sit on the tail while a read advances only
+// one. The tests that pinned it are rewritten below to the claim that replaced
+// them, not deleted: what a stale sibling fold must do is exactly the question
+// that got answered wrongly, so it is worth an explicit test of the new answer.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { mkdtemp } from 'node:fs/promises';
@@ -25,7 +33,6 @@ import {
 } from '../../../src/events/schemas.js';
 import {
   assessProjectionFreshness,
-  assessStreamFreshness,
   toProjectionDegradedMeta,
   publishProjectionFreshness,
   readProjectionDegradedState,
@@ -70,31 +77,30 @@ describe('projection freshness comparison (EFF-002)', () => {
     expect(result.lag).toBe(-15);
   });
 
-  it('Freshness_MultipleCursors_ReportsWorstOffenderFirst', () => {
-    const result = assessStreamFreshness(100, [
-      { viewName: 'pipeline', cursor: 100 },
-      { viewName: 'workflow-state', cursor: 60 },
-      { viewName: 'delegation-readiness', cursor: 95 },
-    ]);
-    expect(result.degraded).toBe(true);
-    expect(result.projectionCursor).toBe(60);
-    expect(result.lag).toBe(40);
-    expect(result.staleViews).toEqual(['workflow-state', 'delegation-readiness']);
-    expect(result.staleViews).not.toContain('pipeline');
-  });
+  it('Freshness_IsPerFold_NotPerStream', () => {
+    // `assessStreamFreshness` used to answer this question for a whole stream
+    // by requiring EVERY cached fold to sit on the tail. That is a different
+    // and false obligation: a read advances one fold, so the predicate could
+    // not come back clean on any stream with two of them, and the staleness of
+    // a fold nobody is reading is not a fact about the answer being produced.
+    // The comparison that survives is per-fold and names the fold it judged.
+    const behind = assessProjectionFreshness({
+      eventTail: 100,
+      projectionCursor: 60,
+      viewName: 'workflow-state',
+    });
+    expect(behind.staleViews, 'the verdict is about one named fold').toEqual(['workflow-state']);
+    expect(behind.lag).toBe(40);
 
-  it('Freshness_AllCursorsAtTail_NotDegraded', () => {
-    const result = assessStreamFreshness(7, [
-      { viewName: 'pipeline', cursor: 7 },
-      { viewName: 'workflow-state', cursor: 7 },
-    ]);
-    expect(result.degraded).toBe(false);
-    expect(result.staleViews).toEqual([]);
-  });
-
-  it('Freshness_NoMaterializedFolds_NotDegraded', () => {
-    // A cold read folds from scratch — there is no stale answer to serve.
-    expect(assessStreamFreshness(500, []).degraded).toBe(false);
+    // A sibling fold of the same stream is judged separately and can be fresh
+    // at the same instant. Nothing collapses the two into one stream verdict.
+    const sibling = assessProjectionFreshness({
+      eventTail: 100,
+      projectionCursor: 100,
+      viewName: 'pipeline',
+    });
+    expect(sibling.degraded).toBe(false);
+    expect(sibling.staleViews).toEqual([]);
   });
 });
 
@@ -141,15 +147,15 @@ describe('view chokepoint marks degraded reads (EFF-002)', () => {
     expect(degradedMeta(second)).toBeUndefined();
   });
 
-  it('HandleView_ProjectionAheadOfPrunedLog_ReturnsTypedDegradedMarker', async () => {
+  it('HandleView_ProjectionAheadOfPrunedLog_IsRepairedAndAnswered', async () => {
     await seedEvents(4);
     // Warm the fold so a cursor exists…
     await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
 
     // …then inject the contradiction a snapshot restored over a pruned or
     // rebuilt log produces: the fold claims events the store cannot produce.
-    // The incremental read path asks for `sinceSequence: 25`, gets nothing, and
-    // would happily serve the impossible fold as authoritative.
+    // The incremental read path asks for `sinceSequence: 25` and gets nothing,
+    // so the impossible fold cannot heal itself.
     const materializer = getOrCreateMaterializer(stateDir);
     const cursors = materializer.getStreamCursors(STREAM);
     expect(cursors.length).toBeGreaterThan(0);
@@ -158,43 +164,39 @@ describe('view chokepoint marks degraded reads (EFF-002)', () => {
       if (state) materializer.loadState(STREAM, viewName, state.view, 25);
     }
 
-    const result = await handleView(
-      { action: 'workflow_status', workflowId: STREAM },
-      ctx,
-    );
-    // T-07 (DR-4) ORACLE UPDATE — deliberate, not a weakened assertion.
-    // This line read `expect(result.success).toBe(true)`: the impossible fold
-    // was SERVED, with the verdict whispered on `_meta` alone. DR-4's
-    // acceptance criterion is that a degraded projection is never served as a
-    // success, so the chokepoint now refuses: `success:false` with the
-    // reserved `PROJECTION_DEGRADED` code and the payload dropped.
-    expect(result.success).toBe(false);
-    expect(result.error?.code).toBe('PROJECTION_DEGRADED');
-    expect(result.data, 'the stale payload must not ride along').toBeUndefined();
-    // The ephemeral `_meta` courtesy is KEPT alongside the typed refusal — it
-    // is no longer the only signal, but it is still stamped, so this half of
-    // the original oracle is unchanged.
-    const meta = degradedMeta(result);
-    expect(meta, 'a fold ahead of the log must not answer unmarked').toBeDefined();
-    expect(meta).toMatchObject({
-      reason: 'projection-ahead',
-      eventTail: 4,
-      projectionCursor: 25,
-    });
+    const result = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
+
+    // #1855 ORACLE UPDATE — deliberate, and the second time this line has
+    // moved. It first read `success: true` (the impossible fold was SERVED,
+    // with the verdict whispered on `_meta`). It then became a refusal.
+    // Both readings shared an assumption: that the only choices are serving a
+    // bad fold or withholding an answer. There is a third — the event log is
+    // authoritative — it is the source of truth — so the fold is DISCARDED and
+    // replayed, and the
+    // answer that comes back is correct rather than merely marked.
+    expect(result.success, JSON.stringify(result.error)).toBe(true);
+    expect(result.error?.code).not.toBe('PROJECTION_DEGRADED');
+    expect(result.data, 'a repaired read answers with real data').toBeDefined();
+
+    // The cursor now sits on the real tail, not the impossible one.
+    const repaired = materializer.getState(STREAM, 'workflow-status');
+    expect(repaired?.highWaterMark).toBe(4);
   });
 
-  it('HandleView_StaleSiblingFold_DegradesTheWholeStreamAnswer', async () => {
-    // The CB-8 shape: one projection is current while a sibling projection of
-    // the SAME stream lags, so two surfaces contradict each other. Reading the
-    // current one catches only its own fold up — the stream is still not
-    // internally consistent, and the answer must say so.
+  it('HandleView_StaleSiblingFold_DoesNotDegradeAnUnrelatedAnswer', async () => {
+    // This test previously asserted the OPPOSITE — "a stale sibling fold must
+    // degrade the stream answer" — and that assertion is #1855. It made the
+    // staleness of a fold nobody was reading into a property of every read of
+    // the stream, and since a read refreshes only its own fold, the condition
+    // could not be cleared by any read at all.
     await seedEvents(4);
     await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
     await handleView({ action: 'delegation_readiness', workflowId: STREAM }, ctx);
 
     const materializer = getOrCreateMaterializer(stateDir);
-    const cursors = materializer.getStreamCursors(STREAM);
-    const sibling = cursors.find((c) => c.viewName !== 'workflow-status');
+    const sibling = materializer
+      .getStreamCursors(STREAM)
+      .find((cursor) => cursor.viewName !== 'workflow-status');
     expect(sibling, 'test needs two distinct folds on the stream').toBeDefined();
     if (sibling === undefined) return;
     const siblingState = materializer.getState(STREAM, sibling.viewName);
@@ -202,15 +204,20 @@ describe('view chokepoint marks degraded reads (EFF-002)', () => {
     if (siblingState === undefined) return;
     materializer.loadState(STREAM, sibling.viewName, siblingState.view, 1);
 
-    // Reading the CURRENT projection still reports the stream as degraded.
-    const result = await handleView(
-      { action: 'workflow_status', workflowId: STREAM },
-      ctx,
-    );
-    const meta = degradedMeta(result);
-    expect(meta, 'a stale sibling fold must degrade the stream answer').toBeDefined();
-    expect(meta).toMatchObject({ reason: 'projection-behind', eventTail: 4 });
-    expect(meta?.['staleViews']).toContain(sibling.viewName);
+    // Reading the CURRENT projection answers, and answers cleanly. The sibling
+    // stays stale in cache and is repaired by the next read OF IT.
+    const result = await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
+    expect(result.success, JSON.stringify(result.error)).toBe(true);
+    expect(degradedMeta(result), 'an unread fold is not a fact about this answer').toBeUndefined();
+    expect(
+      materializer.getState(STREAM, sibling.viewName)?.highWaterMark,
+      'reading one fold must not silently touch another',
+    ).toBe(1);
+
+    // …and reading the sibling repairs the sibling.
+    const siblingRead = await handleView({ action: 'delegation_readiness', workflowId: STREAM }, ctx);
+    expect(siblingRead.success, JSON.stringify(siblingRead.error)).toBe(true);
+    expect(materializer.getState(STREAM, sibling.viewName)?.highWaterMark).toBe(4);
   });
 
   it('HandleView_NoWorkflowId_LeavesResponseUntouched', async () => {
@@ -269,29 +276,37 @@ describe('durable projection-degraded state (DR-4)', () => {
     }
   }
 
+  /** The fold these journal cases judge — one named view, as production does. */
+  const JUDGED_VIEW = 'workflow-status';
+
   /**
    * Warm a REAL fold through the real view chokepoint, then drive its cursor to
    * `cursor`. This is the CB-8 fault: a materialized projection whose
    * high-water mark no longer matches the durable tail.
+   *
+   * It rewinds ONE named fold. The version before #1855 looped over every
+   * cursor on the stream and set them all, because the verdict under test
+   * quantified over all of them — which meant the recovery case reached its
+   * precondition through an input no production path can produce (a read
+   * advances exactly one fold). Judging one named fold keeps the fixture inside
+   * what the system can actually do.
    */
   async function warmFoldAndSetCursor(cursor: number): Promise<void> {
     await handleView({ action: 'workflow_status', workflowId: STREAM }, ctx);
     const materializer = getOrCreateMaterializer(stateDir);
-    const cursors = materializer.getStreamCursors(STREAM);
-    expect(cursors.length, 'test needs at least one materialized fold').toBeGreaterThan(0);
-    for (const { viewName } of cursors) {
-      const state = materializer.getState(STREAM, viewName);
-      if (state) materializer.loadState(STREAM, viewName, state.view, cursor);
-    }
+    const state = materializer.getState(STREAM, JUDGED_VIEW);
+    expect(state, 'test needs a real materialized fold').toBeDefined();
+    if (state) materializer.loadState(STREAM, JUDGED_VIEW, state.view, cursor);
   }
 
   /** The REAL cursor/tail comparison — no synthetic numbers, no mocked store. */
-  async function assessLive(): Promise<ReturnType<typeof assessStreamFreshness>> {
+  async function assessLive(): Promise<ReturnType<typeof assessProjectionFreshness>> {
     const materializer = getOrCreateMaterializer(stateDir);
-    return assessStreamFreshness(
-      await store.tailSequence(STREAM),
-      materializer.getStreamCursors(STREAM),
-    );
+    return assessProjectionFreshness({
+      eventTail: await store.tailSequence(STREAM),
+      projectionCursor: materializer.getState(STREAM, JUDGED_VIEW)?.highWaterMark ?? 0,
+      viewName: JUDGED_VIEW,
+    });
   }
 
   it('ProjectionFreshness_StaleCursor_PublishesDurableDegradedState', async () => {

--- a/tests/unit/projections/freshness.test.ts
+++ b/tests/unit/projections/freshness.test.ts
@@ -1,6 +1,6 @@
 // ─── EFF-002: projection-degraded signal on cursor/tail disagreement ─────────
 //
-// CB-8 (phase-gate v2.12 dogfood): workflow views served a silently stale fold —
+// A phase-gate dogfood run found workflow views serving a silently stale fold —
 // a cancelled workflow still reported at `plan-review`, 7 of 10 completed tasks
 // visible, lag past 500s — with nothing on the response saying the answer did
 // not derive from the current event tail.
@@ -281,7 +281,7 @@ describe('durable projection-degraded state (DR-4)', () => {
 
   /**
    * Warm a REAL fold through the real view chokepoint, then drive its cursor to
-   * `cursor`. This is the CB-8 fault: a materialized projection whose
+   * `cursor`. This is the fault under test: a materialized projection whose
    * high-water mark no longer matches the durable tail.
    *
    * It rewinds ONE named fold. The version before #1855 looped over every

--- a/tests/unit/projections/telemetry/telemetry-queries.test.ts
+++ b/tests/unit/projections/telemetry/telemetry-queries.test.ts
@@ -2,24 +2,50 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// ─── Mock event store and materializer ───────────────────────────────────────
+// ─── Mock event store and fold seam ──────────────────────────────────────────
+//
+// These are unit tests of the MAPPING — telemetry view onto runtime metrics —
+// so the fold itself is the seam to stub, not the materializer underneath it.
+// The mock used to stub `ViewMaterializer.materialize`, which meant it also
+// asserted a fold protocol it had reimplemented by hand; #1855 moved that
+// protocol behind `foldToTail`, and the stub is now the one thing this file
+// legitimately fakes. What the fold actually guarantees is covered against a
+// real store in `tests/unit/projections/fold-at-tail.test.ts`.
 
 const mockStore = {
   append: vi.fn().mockResolvedValue(undefined),
   query: vi.fn().mockResolvedValue([]),
+  tailSequence: vi.fn().mockResolvedValue(0),
 };
 
 const mockMaterializer = {
-  materialize: vi.fn(),
-  getState: vi.fn(() => null),
+  materializeAt: vi.fn(),
+  getState: vi.fn(() => undefined),
   loadFromSnapshot: vi.fn().mockResolvedValue(undefined),
+  discardFold: vi.fn(),
 };
+
+const foldToTail = vi.fn();
 
 vi.mock('../../../../src/projections/views/tools.js', () => ({
   getOrCreateEventStore: () => mockStore,
   getOrCreateMaterializer: () => mockMaterializer,
   queryDeltaEvents: vi.fn().mockResolvedValue([]),
 }));
+
+vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
+  foldToTail: (...args: unknown[]) => foldToTail(...args),
+}));
+
+/** The fold answers with `state`, covering an arbitrary non-zero tail. */
+function foldReturns(state: unknown): void {
+  foldToTail.mockResolvedValue({ view: state, sequence: 7 });
+}
+
+/** The fold cannot answer — the graceful-degradation arm. */
+function foldThrows(): void {
+  foldToTail.mockRejectedValue(new Error('materialization failed'));
+}
 
 import { queryRuntimeMetrics, queryTelemetryState } from '../../../../src/projections/telemetry/telemetry-queries.js';
 import type { TelemetryViewState } from '../../../../src/projections/telemetry/telemetry-projection.js';
@@ -54,7 +80,7 @@ describe('queryRuntimeMetrics', () => {
       totalTokens: 5000,
       windowSize: 1000,
     };
-    mockMaterializer.materialize.mockReturnValue(telemetryState);
+    foldReturns(telemetryState);
 
     // Act
     const metrics = await queryRuntimeMetrics(mockStore as never, STATE_DIR);
@@ -74,7 +100,7 @@ describe('queryRuntimeMetrics', () => {
       totalTokens: 0,
       windowSize: 1000,
     };
-    mockMaterializer.materialize.mockReturnValue(telemetryState);
+    foldReturns(telemetryState);
 
     // Act
     const metrics = await queryRuntimeMetrics(mockStore as never, STATE_DIR);
@@ -87,9 +113,7 @@ describe('queryRuntimeMetrics', () => {
 
   it('QueryRuntimeMetrics_MaterializationFailure_ReturnsZeroMetrics', async () => {
     // Arrange: materializer throws
-    mockMaterializer.materialize.mockImplementation(() => {
-      throw new Error('materialization failed');
-    });
+    foldThrows();
 
     // Act
     const metrics = await queryRuntimeMetrics(mockStore as never, STATE_DIR);
@@ -121,7 +145,7 @@ describe('queryTelemetryState', () => {
       totalTokens: 1500,
       windowSize: 1000,
     };
-    mockMaterializer.materialize.mockReturnValue(telemetryState);
+    foldReturns(telemetryState);
 
     // Act
     const state = await queryTelemetryState(mockStore as never, STATE_DIR);
@@ -134,9 +158,7 @@ describe('queryTelemetryState', () => {
 
   it('QueryTelemetryState_MaterializationFailure_ReturnsNull', async () => {
     // Arrange
-    mockMaterializer.materialize.mockImplementation(() => {
-      throw new Error('materialization failed');
-    });
+    foldThrows();
 
     // Act
     const state = await queryTelemetryState(mockStore as never, STATE_DIR);

--- a/tests/unit/tsconfig-strictness.test.ts
+++ b/tests/unit/tsconfig-strictness.test.ts
@@ -136,7 +136,15 @@ describe('DR-14: escape-hatch census', () => {
   // repo compiles"; that set simply got smaller. The typecheck hole itself is
   // the real finding and is tracked separately — this ledger records only that
   // the two gates still agree with each other.
-  const BASELINE: CastCounts = { nonNull: 72, asCast: 1698, asAny: 0 };
+  // PAYDOWN — nonNull 72 -> 70, asCast 1698 -> 1695. `handleGet` and
+  // `handleSet` reached the ES v2 read and snapshot paths through a settable
+  // module singleton that nothing in `src/` ever set, so every use of it needed
+  // a `!` to tell the compiler the value was present when the code could not
+  // show that it was. The read path now resolves the materializer per stateDir
+  // and the snapshot path is gone, taking both assertions and three `as` casts
+  // (the snapshot's shape juggling) with them. No debt was moved; five sites
+  // stopped needing an escape hatch.
+  const BASELINE: CastCounts = { nonNull: 70, asCast: 1695, asAny: 0 };
 
   // Declared budget = MAX escape-hatch sites maintenance work may introduce
   // before the NEXT documented re-baseline. `as any` may never grow.

--- a/tests/unit/verbs/gates/check-convergence.test.ts
+++ b/tests/unit/verbs/gates/check-convergence.test.ts
@@ -29,8 +29,14 @@ vi.mock('../../../../src/projections/views/tools.js', () => ({
 // `materialize`. The fold is the seam a unit test of the VERDICT should stub:
 // what the fold itself guarantees is covered against a real store in
 // `tests/unit/projections/fold-at-tail.test.ts`.
+// `foldToTail` guarantees the fold covers the stream's durable tail, and
+// callers now bound their own evidence to the sequence it reports. These
+// fixtures ARE the stream, so the stub reports a sequence at or past every
+// fixture event; a lower one would assert a lag this file never sets up.
+const AT_TAIL = Number.MAX_SAFE_INTEGER;
+
 vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
-  foldToTail: vi.fn(async () => ({ view: mockViewState, sequence: 1 })),
+  foldToTail: vi.fn(async () => ({ view: mockViewState, sequence: AT_TAIL })),
 }));
 
 import { handleCheckConvergence } from '../../../../src/verbs/gates/check-convergence.js';

--- a/tests/unit/verbs/gates/check-convergence.test.ts
+++ b/tests/unit/verbs/gates/check-convergence.test.ts
@@ -24,6 +24,15 @@ vi.mock('../../../../src/projections/views/tools.js', () => ({
   queryDeltaEvents: vi.fn().mockResolvedValue([]),
 }));
 
+// #1855 — the gate folds its view to the stream's durable tail through
+// `foldToTail` rather than pairing `queryDeltaEvents` with a bare
+// `materialize`. The fold is the seam a unit test of the VERDICT should stub:
+// what the fold itself guarantees is covered against a real store in
+// `tests/unit/projections/fold-at-tail.test.ts`.
+vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
+  foldToTail: vi.fn(async () => ({ view: mockViewState, sequence: 1 })),
+}));
+
 import { handleCheckConvergence } from '../../../../src/verbs/gates/check-convergence.js';
 
 const STATE_DIR = '/tmp/test-check-convergence';
@@ -198,7 +207,7 @@ describe('handleCheckConvergence', () => {
       dimensions: {},
     };
 
-    const { queryDeltaEvents } = await import('../../../../src/projections/views/tools.js');
+    const { foldToTail } = await import('../../../../src/projections/fold-at-tail.js');
 
     await handleCheckConvergence(
       { featureId: 'test-feature', workflowId: 'custom-stream' },
@@ -207,7 +216,7 @@ describe('handleCheckConvergence', () => {
     );
 
     // Should use workflowId as the stream ID
-    expect(queryDeltaEvents).toHaveBeenCalledWith(
+    expect(foldToTail).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       'custom-stream',

--- a/tests/unit/verbs/gates/check-event-emissions.test.ts
+++ b/tests/unit/verbs/gates/check-event-emissions.test.ts
@@ -27,6 +27,15 @@ vi.mock('../../../../src/projections/views/tools.js', () => ({
   queryDeltaEvents: vi.fn().mockResolvedValue([]),
 }));
 
+// #1855 — the gate folds its view to the stream's durable tail through
+// `foldToTail` rather than pairing `queryDeltaEvents` with a bare
+// `materialize`. The fold is the seam a unit test of the VERDICT should stub:
+// what the fold itself guarantees is covered against a real store in
+// `tests/unit/projections/fold-at-tail.test.ts`.
+vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
+  foldToTail: vi.fn(async () => ({ view: mockViewState, sequence: 1 })),
+}));
+
 import { PHASE_EXPECTED_EVENTS, handleCheckEventEmissions } from '../../../../src/verbs/gates/check-event-emissions.js';
 
 const STATE_DIR = '/tmp/test-check-event-emissions';
@@ -338,7 +347,7 @@ describe('handleCheckEventEmissions', () => {
   it('CheckEventEmissions_UsesWorkflowIdAsStreamId', async () => {
     mockViewState = { phase: 'delegate' };
 
-    const { queryDeltaEvents } = await import('../../../../src/projections/views/tools.js');
+    const { foldToTail } = await import('../../../../src/projections/fold-at-tail.js');
 
     await handleCheckEventEmissions(
       { featureId: 'test-feature', workflowId: 'custom-stream' },
@@ -346,7 +355,7 @@ describe('handleCheckEventEmissions', () => {
       mockStore as unknown as EventStore,
     );
 
-    expect(queryDeltaEvents).toHaveBeenCalledWith(
+    expect(foldToTail).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       'custom-stream',

--- a/tests/unit/verbs/gates/check-event-emissions.test.ts
+++ b/tests/unit/verbs/gates/check-event-emissions.test.ts
@@ -32,8 +32,14 @@ vi.mock('../../../../src/projections/views/tools.js', () => ({
 // `materialize`. The fold is the seam a unit test of the VERDICT should stub:
 // what the fold itself guarantees is covered against a real store in
 // `tests/unit/projections/fold-at-tail.test.ts`.
+// `foldToTail` guarantees the fold covers the stream's durable tail, and
+// callers now bound their own evidence to the sequence it reports. These
+// fixtures ARE the stream, so the stub reports a sequence at or past every
+// fixture event; a lower one would assert a lag this file never sets up.
+const AT_TAIL = Number.MAX_SAFE_INTEGER;
+
 vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
-  foldToTail: vi.fn(async () => ({ view: mockViewState, sequence: 1 })),
+  foldToTail: vi.fn(async () => ({ view: mockViewState, sequence: AT_TAIL })),
 }));
 
 import { PHASE_EXPECTED_EVENTS, handleCheckEventEmissions } from '../../../../src/verbs/gates/check-event-emissions.js';

--- a/tests/unit/verbs/gates/context-economy.test.ts
+++ b/tests/unit/verbs/gates/context-economy.test.ts
@@ -50,8 +50,14 @@ vi.mock('../../../../src/projections/views/tools.js', () => ({
 // `materialize`. The fold is the seam a unit test of the VERDICT should stub:
 // what the fold itself guarantees is covered against a real store in
 // `tests/unit/projections/fold-at-tail.test.ts`.
+// `foldToTail` guarantees the fold covers the stream's durable tail, and
+// callers now bound their own evidence to the sequence it reports. These
+// fixtures ARE the stream, so the stub reports a sequence at or past every
+// fixture event; a lower one would assert a lag this file never sets up.
+const AT_TAIL = Number.MAX_SAFE_INTEGER;
+
 vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
-  foldToTail: vi.fn(async () => ({ view: mockTelemetryState, sequence: 1 })),
+  foldToTail: vi.fn(async () => ({ view: mockTelemetryState, sequence: AT_TAIL })),
 }));
 
 import { checkContextEconomy } from '../../../../src/verbs/pure/context-economy.js';

--- a/tests/unit/verbs/gates/context-economy.test.ts
+++ b/tests/unit/verbs/gates/context-economy.test.ts
@@ -45,6 +45,15 @@ vi.mock('../../../../src/projections/views/tools.js', () => ({
   queryDeltaEvents: vi.fn().mockResolvedValue([]),
 }));
 
+// #1855 — the gate folds its view to the stream's durable tail through
+// `foldToTail` rather than pairing `queryDeltaEvents` with a bare
+// `materialize`. The fold is the seam a unit test of the VERDICT should stub:
+// what the fold itself guarantees is covered against a real store in
+// `tests/unit/projections/fold-at-tail.test.ts`.
+vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
+  foldToTail: vi.fn(async () => ({ view: mockTelemetryState, sequence: 1 })),
+}));
+
 import { checkContextEconomy } from '../../../../src/verbs/pure/context-economy.js';
 import { handleContextEconomy } from '../../../../src/verbs/gates/context-economy.js';
 

--- a/tests/unit/verbs/team/prepare-delegation.test.ts
+++ b/tests/unit/verbs/team/prepare-delegation.test.ts
@@ -14,6 +14,14 @@ vi.mock('../../../../src/projections/views/tools.js', () => ({
   queryDeltaEvents: vi.fn(),
 }));
 
+// #1855 — the handler folds each view to the stream's durable tail through
+// `foldToTail` rather than pairing `queryDeltaEvents` with a bare `materialize`.
+// `setupMaterializer` below routes the stub by view name exactly as the
+// materializer stub did, so what each test controls is unchanged.
+vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
+  foldToTail: vi.fn(),
+}));
+
 vi.mock('../../../../src/projections/quality/hints.js', () => ({
   generateQualityHints: vi.fn(),
 }));
@@ -64,6 +72,7 @@ import {
   getOrCreateMaterializer,
   queryDeltaEvents,
 } from '../../../../src/projections/views/tools.js';
+import { foldToTail } from '../../../../src/projections/fold-at-tail.js';
 import { generateQualityHints } from '../../../../src/projections/quality/hints.js';
 import { emitGateEvent } from '../../../../src/verbs/gates/gate-utils.js';
 import {
@@ -228,6 +237,14 @@ function setupMaterializer(
   };
   vi.mocked(getOrCreateMaterializer).mockReturnValue(
     mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>,
+  );
+  vi.mocked(foldToTail).mockImplementation(
+    async (_store, _materializer, _streamId, viewName) => {
+      if (viewName === WORKFLOW_STATE_VIEW) return { view: workflowState, sequence: 1 };
+      if (viewName === CODE_QUALITY_VIEW) return { view: cqState, sequence: 1 };
+      if (viewName === DELEGATION_READINESS_VIEW) return { view: drState, sequence: 1 };
+      return { view: {}, sequence: 1 };
+    },
   );
 
   const mockStore = {

--- a/tests/unit/workflow/event-injection.test.ts
+++ b/tests/unit/workflow/event-injection.test.ts
@@ -5,8 +5,7 @@ import * as path from 'node:path';
 import {
   handleInit,
   handleSet,
-  configureWorkflowMaterializer,
-} from '../../../src/workflow/tools.js';
+  } from '../../../src/workflow/tools.js';
 
 import { EventStore } from '../../../src/events/store.js';
 import { registerWorkflowType, unregisterWorkflowType } from '../../../src/workflow/state-machine.js';
@@ -22,7 +21,6 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  configureWorkflowMaterializer(null);
   closeOpenDatabases();
   await rmrfAsync(tmpDir);
 });

--- a/tests/unit/workflow/event-store-split.test.ts
+++ b/tests/unit/workflow/event-store-split.test.ts
@@ -18,8 +18,7 @@ import * as os from 'node:os';
 import {
   handleInit,
   handleSet,
-  configureWorkflowMaterializer,
-} from '../../../src/workflow/tools.js';
+  } from '../../../src/workflow/tools.js';
 import { handleEventAppend } from '../../../src/events/tools.js';
 import { EventStore } from '../../../src/events/store.js';
 import { InMemoryBackend } from '../../../src/storage/memory-backend.js';
@@ -63,7 +62,6 @@ describe('EventStoreSplit_Regression_GH1009', () => {
   });
 
   afterEach(async () => {
-    configureWorkflowMaterializer(null);
     configureStateStoreBackend(undefined);
     await rmrfAsync(stateDir);
   });

--- a/tests/unit/workflow/integration.test.ts
+++ b/tests/unit/workflow/integration.test.ts
@@ -268,19 +268,19 @@ describe('Integration', () => {
         stateDir,
         eventStore,
       );
-      await transitionFeature('fix-cycle', 'plan');
+      await transitionFeature('fix-cycle', 'plan', eventStore);
       await handleSet(
         { featureId: 'fix-cycle', updates: { 'artifacts.plan': 'plan.md' } },
         stateDir,
         eventStore,
       );
-      await transitionFeature('fix-cycle', 'plan-review');
+      await transitionFeature('fix-cycle', 'plan-review', eventStore);
       await handleSet(
         { featureId: 'fix-cycle', updates: { planReview: { approved: true } } },
         stateDir,
         eventStore,
       );
-      await transitionFeature('fix-cycle', 'delegate');
+      await transitionFeature('fix-cycle', 'delegate', eventStore);
 
       // Perform fix cycles: delegate -> review (fail) -> delegate
       // Circuit breaker max is 3 for implementation compound
@@ -298,7 +298,7 @@ describe('Integration', () => {
           source: 'orchestrator',
           data: { featureId: 'fix-cycle', totalDurationMs: 1000, tasksCompleted: 1, tasksFailed: 0 },
         });
-        await transitionFeature('fix-cycle', 'review');
+        await transitionFeature('fix-cycle', 'review', eventStore);
 
         // Set review as failed
         await handleSet(
@@ -330,7 +330,7 @@ describe('Integration', () => {
         source: 'orchestrator',
         data: { featureId: 'fix-cycle', totalDurationMs: 1000, tasksCompleted: 1, tasksFailed: 0 },
       });
-      await transitionFeature('fix-cycle', 'review');
+      await transitionFeature('fix-cycle', 'review', eventStore);
 
       // Set review as failed
       await handleSet(

--- a/tests/unit/workflow/parity.test.ts
+++ b/tests/unit/workflow/parity.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../parity-harness.js';
 import type { ToolResult } from '../../../src/format.js';
 import type { RehydrationDocument } from '../../../src/projections/rehydration/schema.js';
-import { configureWorkflowMaterializer, handleInit } from '../../../src/workflow/tools.js';
+import { handleInit } from '../../../src/workflow/tools.js';
 import { resetMaterializerCache } from '../../../src/projections/views/tools.js';
 import { ViewMaterializer } from '../../../src/projections/views/materializer.js';
 import {
@@ -280,13 +280,11 @@ describe('asOf CLI/MCP parity (T8, #1555, INV-2)', () => {
     // stateDir/eventStore, and asOf reads bypass the cache anyway).
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
     await seed(cliCtx);
     await seed(mcpCtx);
   });
 
   afterEach(async () => {
-    configureWorkflowMaterializer(null);
     resetMaterializerCache();
     await rmrfAsync(cliDir);
     await rmrfAsync(mcpDir);

--- a/tests/unit/workflow/reconcile-guard-e2e.test.ts
+++ b/tests/unit/workflow/reconcile-guard-e2e.test.ts
@@ -5,8 +5,7 @@ import * as os from 'node:os';
 import {
   handleInit,
   handleSet,
-  configureWorkflowMaterializer,
-} from '../../../src/workflow/tools.js';
+  } from '../../../src/workflow/tools.js';
 import { reconcileFromEvents } from '../../../src/workflow/state-store.js';
 import { EventStore } from '../../../src/events/store.js';
 import type { EventType } from '../../../src/events/schemas.js';
@@ -22,7 +21,6 @@ describe('ReconcileGuardE2E', () => {
   });
 
   afterEach(async () => {
-    configureWorkflowMaterializer(null);
     await rmrfAsync(stateDir);
   });
 

--- a/tests/unit/workflow/state-fold-merge.test.ts
+++ b/tests/unit/workflow/state-fold-merge.test.ts
@@ -1,0 +1,176 @@
+// ─── The ES v2 read: the fold, plus what only the state file knows ──────────
+//
+// `handleGet` chose between an event fold and the state file on a settable
+// module singleton that nothing in `src/` ever set. The fold path was therefore
+// dark: every read took the file, and `get --asOf` silently answered with tip
+// state because the bounded fold lived on the branch that never ran.
+//
+// Wiring it is the fix, and it cannot be a straight swap. The two paths are
+// different projections of the same workflow: the fold derives `phaseObligation`
+// and `admissionProof`, which the file has never held, and the file holds
+// `_version`, `_checkpoint`, `_esVersion` and unmodelled plan fields, which the
+// fold cannot reconstruct. Serving the bare fold would have silently dropped
+// four fields from every `get`, `_version` among them — the optimistic-lock
+// counter a caller round-trips into CAS.
+//
+// These tests pin both halves of that merge, and the reachability that makes it
+// matter at all.
+
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as nodePath from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { DispatchContext } from '../../../src/dispatch/core/dispatch.js';
+import { EventStore } from '../../../src/events/store.js';
+import { handleWorkflow } from '../../../src/workflow/composite.js';
+import { FILE_OWNED_FIELDS } from '../../../src/workflow/handlers/shared.js';
+import { workflowStateProjection } from '../../../src/projections/views/workflow-state-projection.js';
+import { TaskSchema } from '../../../src/workflow/schemas.js';
+import { resetMaterializerCache } from '../../../src/projections/views/tools.js';
+import { rmrfAsync } from '../../../tools/test-helpers/temp-dir.js';
+
+const STREAM = 'state-fold-merge';
+
+let stateDir: string;
+let store: EventStore;
+let ctx: DispatchContext;
+
+beforeEach(async () => {
+  resetMaterializerCache();
+  stateDir = await mkdtemp(nodePath.join(tmpdir(), 'state-fold-merge-'));
+  store = new EventStore(stateDir);
+  await store.initialize();
+  ctx = { stateDir, eventStore: store, enableTelemetry: false };
+});
+
+afterEach(async () => {
+  store.close();
+  await rmrfAsync(stateDir);
+  resetMaterializerCache();
+});
+
+/** A workflow advanced far enough that fold and file each hold something. */
+async function seedAdvancedWorkflow(): Promise<number> {
+  const init = await handleWorkflow(
+    { action: 'init', featureId: STREAM, workflowType: 'feature' },
+    ctx,
+  );
+  expect(init.success, JSON.stringify(init.error)).toBe(true);
+  const sequenceAtPlan = await store.tailSequence(STREAM);
+
+  const stamped = await handleWorkflow(
+    {
+      action: 'update',
+      featureId: STREAM,
+      updates: { riskTier: 'high', artifacts: { plan: 'a plan the transition guard accepts' } },
+    },
+    ctx,
+  );
+  expect(stamped.success, JSON.stringify(stamped.error)).toBe(true);
+
+  const moved = await handleWorkflow(
+    { action: 'transition', featureId: STREAM, target: 'plan-review' },
+    ctx,
+  );
+  expect(moved.success, JSON.stringify(moved.error)).toBe(true);
+  return sequenceAtPlan;
+}
+
+async function get(extra: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+  const result = await handleWorkflow({ action: 'get', featureId: STREAM, ...extra }, ctx);
+  expect(result.success, JSON.stringify(result.error)).toBe(true);
+  return (result.data as Record<string, unknown>) ?? {};
+}
+
+describe('ES v2 get — the fold merged with the file', () => {
+  it('WorkflowGet_EventDerivedRead_KeepsEveryFileOwnedField', async () => {
+    await seedAdvancedWorkflow();
+    const onDisk = JSON.parse(
+      await readFile(nodePath.join(stateDir, `${STREAM}.state.json`), 'utf8'),
+    ) as Record<string, unknown>;
+
+    const answer = await get();
+
+    // The fold cannot reconstruct these, so the file supplies them. Serving the
+    // bare fold returns `_version: 1` (a dead literal in the projection) and an
+    // all-sentinel `_checkpoint`.
+    for (const field of FILE_OWNED_FIELDS) {
+      expect(answer[field], `${field} must come from the state file`).toEqual(onDisk[field]);
+    }
+
+    // …and a field the projection has no slot for at all survives without being
+    // named anywhere. This half is derived from the projection's shape, so a
+    // state field added later is carried automatically.
+    const modelled = new Set(Object.keys(workflowStateProjection.init()));
+    const unmodelled = Object.keys(onDisk).filter(
+      (key) => !modelled.has(key) && !key.startsWith('_e') && key !== '_history',
+    );
+    expect(unmodelled.length, 'the fixture must exercise at least one unmodelled field').toBeGreaterThan(0);
+    for (const key of unmodelled) {
+      expect(answer[key], `${key} is modelled by neither side and must survive`).toEqual(onDisk[key]);
+    }
+  });
+
+  it('WorkflowGet_EventDerivedRead_AddsWhatOnlyTheFoldKnows', async () => {
+    await seedAdvancedWorkflow();
+    const answer = await get();
+
+    // The reason the fold is worth reaching: the frozen phase obligation is
+    // event-derived and the state file has never carried it.
+    expect(answer.phaseObligation, 'the read is not folding the log').toBeTruthy();
+    expect((answer.phaseObligation as { phase?: string })?.phase).toBe('plan-review');
+  });
+
+  it('WorkflowGet_AsOf_AnswersHistoricallyRatherThanWithTipState', async () => {
+    // The bug the dark branch was hiding: `asOf` is accepted, and was ignored.
+    const sequenceAtPlan = await seedAdvancedWorkflow();
+
+    expect((await get()).phase).toBe('plan-review');
+    expect(
+      (await get({ asOf: { untilSequence: sequenceAtPlan } })).phase,
+      'asOf returned tip state — the bounded fold is unreachable again',
+    ).toBe('plan');
+  });
+
+  it('WorkflowGet_AsOfPastTheTip_IsIdenticalToTheLiveRead', async () => {
+    // A bound that excludes nothing IS the live read. Any difference would be
+    // an artifact of which branch ran rather than a fact about the stream —
+    // which is why the merge applies to both arms and not just the live one.
+    await seedAdvancedWorkflow();
+    expect(await get({ asOf: { untilSequence: 9999 } })).toEqual(await get());
+  });
+});
+
+describe('why the state file is not re-materialized from the fold', () => {
+  it('WorkflowStateFold_PatchedTask_ViolatesStateSchema', () => {
+    // `handleSet` used to rebuild `<featureId>.state.json` from this fold after
+    // every mutation. That block was dark for the same reason the read was, and
+    // wiring it revealed it cannot run as written.
+    //
+    // A planner writes a partial task through `workflow set` — no title, which
+    // is ordinary, because the normal write path validates and defaults it
+    // before the file is stored. The fold applies the same patch VERBATIM, so
+    // its task never gets that treatment, and the snapshot wrote the result
+    // back with `skipValidation: true`. The next read then rejected the whole
+    // file, after the mutation that wrote it had already committed.
+    //
+    // This is the evidence for that removal rather than an assertion about it.
+    // If the shapes are ever reconciled this test goes red, which is the signal
+    // that the block can come back.
+    const patched = workflowStateProjection.apply(workflowStateProjection.init(), {
+      type: 'state.patched',
+      sequence: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      streamId: STREAM,
+      data: { patch: { tasks: [{ id: 't1', status: 'complete' }] } },
+    } as unknown as Parameters<typeof workflowStateProjection.apply>[1]);
+
+    expect(patched.tasks.length, 'the fixture must produce a task from the patch').toBe(1);
+    expect(
+      TaskSchema.safeParse(patched.tasks[0]).success,
+      'the fold now produces schema-valid tasks — the snapshot write can be restored',
+    ).toBe(false);
+  });
+});

--- a/tests/unit/workflow/tools.asof.test.ts
+++ b/tests/unit/workflow/tools.asof.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { handleInit, handleGet, configureWorkflowMaterializer } from '../../../src/workflow/tools.js';
+import { handleInit, handleGet } from '../../../src/workflow/tools.js';
 import { EventStore } from '../../../src/events/store.js';
 import { ViewMaterializer } from '../../../src/projections/views/materializer.js';
 import {
@@ -65,14 +65,12 @@ beforeEach(async () => {
   eventStore = new EventStore(tmpDir);
   const materializer = new ViewMaterializer();
   materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-  configureWorkflowMaterializer(materializer);
   // Touch TS_STARTED so the constant is referenced and lints clean even if a
   // future test stops using it directly.
   void TS_STARTED;
 });
 
 afterEach(async () => {
-  configureWorkflowMaterializer(null);
   await rmrfAsync(tmpDir);
 });
 

--- a/tests/unit/workflow/tools.legacy.test.ts
+++ b/tests/unit/workflow/tools.legacy.test.ts
@@ -12,7 +12,6 @@ import {
   handleTransitions,
   handleCancel,
   handleCheckpoint,
-  configureWorkflowMaterializer,
   isEventSourced,
   CURRENT_ES_VERSION,
 } from '../../../src/workflow/tools.js';
@@ -31,7 +30,6 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  configureWorkflowMaterializer(null);
   await rmrfAsync(tmpDir);
 });
 
@@ -3059,7 +3057,6 @@ describe('HandleGet_EsVersion2_MaterializesFromEvents', () => {
     const eventStore = new EventStore(tmpDir);
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     // Init creates a v2 workflow (sets _esVersion: 2, emits workflow.started event)
     await handleInit({ featureId: 'es-get-v2', workflowType: 'feature' }, tmpDir, eventStore);
@@ -3095,7 +3092,6 @@ describe('HandleGet_ScalarQuery_EsVersion2_FoldsEventsNotStaleFile', () => {
     const eventStore = new EventStore(tmpDir);
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     await handleInit({ featureId: 'fast-es-v2', workflowType: 'feature' }, tmpDir, eventStore);
 
@@ -3175,7 +3171,6 @@ describe('HandleGet_EsVersion2_FieldProjection_Works', () => {
     const eventStore = new EventStore(tmpDir);
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     await handleInit({ featureId: 'es-fields', workflowType: 'feature' }, tmpDir, eventStore);
 
@@ -3207,7 +3202,6 @@ describe('HandleSet_EsVersion2_FieldUpdates_EmitsStatePatchedEvent', () => {
     const eventStore = new EventStore(tmpDir);
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     await handleInit({ featureId: 'es-set-patch', workflowType: 'feature' }, tmpDir, eventStore);
 
@@ -3246,7 +3240,6 @@ describe('HandleSet_EsVersion2_PhaseAndFields_EmitsBothEvents', () => {
     const eventStore = new EventStore(tmpDir);
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     await handleInit({ featureId: 'es-set-both', workflowType: 'feature' }, tmpDir, eventStore);
 
@@ -3294,7 +3287,6 @@ describe('HandleSet_EsVersion2_AfterEmit_StateFileReflectsEvents', () => {
     const eventStore = new EventStore(tmpDir);
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     await handleInit({ featureId: 'es-set-snap', workflowType: 'feature' }, tmpDir, eventStore);
 
@@ -3339,7 +3331,6 @@ describe('HandleSet_EsVersion2_IdempotencyKey_PreventsDuplicates', () => {
     const eventStore = new EventStore(tmpDir);
     const materializer = new ViewMaterializer();
     materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
-    configureWorkflowMaterializer(materializer);
 
     await handleInit({ featureId: 'es-set-idemp', workflowType: 'feature' }, tmpDir, eventStore);
 

--- a/tests/unit/workflow/tools.playbook.test.ts
+++ b/tests/unit/workflow/tools.playbook.test.ts
@@ -6,8 +6,7 @@ import {
   handleGet,
   handleInit,
   handleSet,
-  configureWorkflowMaterializer,
-} from '../../../src/workflow/tools.js';
+  } from '../../../src/workflow/tools.js';
 import { getRequiredReviews } from '../../../src/workflow/review-contract.js';
 
 describe('handleGet playbook field', () => {
@@ -18,7 +17,6 @@ describe('handleGet playbook field', () => {
   });
 
   afterEach(async () => {
-    configureWorkflowMaterializer(null);
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -149,7 +147,6 @@ describe('review-contract wiring through handleSet', () => {
   });
 
   afterEach(async () => {
-    configureWorkflowMaterializer(null);
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 

--- a/tools/audit/__fixtures__/projection-fold-bypass.ts.txt
+++ b/tools/audit/__fixtures__/projection-fold-bypass.ts.txt
@@ -1,0 +1,29 @@
+// KILL FIXTURE — not compiled, not shipped, deliberately defective.
+//
+// The `queryDeltaEvents` + `materialize` pair as it stood in
+// src/workflow/handlers/get.ts at 529348175, before #1855. It obtains a fold
+// with no evidence of what that fold covers, which is the whole defect class:
+// the answer is served, and whether it saw the events that were already durable
+// when the question was asked is decided somewhere else, later, about something
+// else.
+//
+// `tests/architecture/projection-fold-seam.test.ts` runs its real scanner over
+// this file and fails if the bypass is not reported. If a future refactor makes
+// the scanner blind to this shape, the guard goes red here rather than going
+// quiet in production.
+
+export async function handleGetFromEvents(
+  input: GetInput,
+  fileState: WorkflowState,
+  eventStore: EventStore,
+): Promise<ToolResult> {
+  const allEvents = await eventStore.query(input.featureId);
+
+  const materialized = moduleViewMaterializer!.materialize<WorkflowStateView>(
+    input.featureId,
+    WORKFLOW_STATE_VIEW,
+    allEvents,
+  );
+
+  return projectState(input, materialized as unknown as Record<string, unknown>);
+}

--- a/tools/audit/__fixtures__/unreachable-control.ts.txt
+++ b/tools/audit/__fixtures__/unreachable-control.ts.txt
@@ -1,0 +1,21 @@
+// KILL FIXTURE — not compiled, not shipped, deliberately defective.
+//
+// `configureWorkflowMaterializer` as it stood in src/workflow/handlers/shared.ts
+// before it was removed. It gated two production paths — the ES v2 read in
+// `handleGet` and the state-snapshot refresh in `handleSet` — on a value that
+// nothing in `src/` ever set. Four test files called it, so the gated branches
+// looked covered while neither could run in the shipped composition.
+//
+// `tests/architecture/reachable-controls.test.ts` runs its real scanner over
+// this file and fails if the enabler is not reported. If a future refactor
+// makes the scanner blind to this shape, the guard goes red here rather than
+// going quiet in production.
+
+import type { ViewMaterializer } from '../../projections/views/materializer.js';
+
+export let moduleViewMaterializer: ViewMaterializer | null = null;
+
+/** Configure the ViewMaterializer instance used by handleGet for ES v2 workflows. */
+export function configureWorkflowMaterializer(materializer: ViewMaterializer | null): void {
+  moduleViewMaterializer = materializer;
+}

--- a/tools/audit/projection-fold-seam.json
+++ b/tools/audit/projection-fold-seam.json
@@ -1,0 +1,68 @@
+{
+  "capturedAt": "2026-08-22",
+  "source": "src",
+  "authority": "The policy `tests/architecture/projection-fold-seam.test.ts` reads. Editing this file changes what the guard enforces; editing the test changes how it enforces it. Keep the two apart so an exemption is reviewable as data.",
+  "class": "a projection-derived answer escapes to a caller without evidence that its fold covers the durable event tail",
+  "history": {
+    "first": "CB-8 — docs/audits/2026-07-21-phase-gate-v212-dogfood.md: a cancelled workflow served at `plan-review` with 7 of 10 tasks visible and projection lag past 500s",
+    "second": "#1855 — the mechanism built to answer CB-8 inverted the class: the answer was withheld permanently rather than served stalely, on a lag of one event",
+    "others": [
+      "prepare_synthesis reported phantom blockers from a stale task projection",
+      "post_delegation_check read a stale projection"
+    ]
+  },
+  "seam": {
+    "module": "src/projections/fold-at-tail.ts",
+    "entryPoint": "foldToTail",
+    "why": "It pins the durable tail, routes the behind/ahead/fresh decision through `planRehydrationSource`, folds or replays until the cursor reaches that tail, and returns the view bound to the sequence it covers. A caller that goes around it obtains a fold with no coverage evidence, which is the defect class itself.",
+    "definitionModule": "src/projections/views/materializer.ts",
+    "definitionWhy": "The class that OWNS these members. `materialize` delegates to `materializeAt` inside it, so the definition module necessarily calls its own members; exempting it is structural, not a concession."
+  },
+  "forbiddenMembers": [
+    {
+      "member": "materialize",
+      "why": "Returns a bare view. The fold and the evidence of what it covers are separable, so an answer can be derived from one without the other."
+    },
+    {
+      "member": "materializeAt",
+      "why": "Returns the cursor honestly but performs no tail comparison, so a caller can still answer from a fold that stops short."
+    },
+    {
+      "member": "getStreamCursors",
+      "why": "Enumerates every cached fold of a stream. Reading it invites the all-folds quantifier that produced #1855: the staleness of a fold nobody is reading is not a fact about the answer being produced."
+    }
+  ],
+  "permittedMembers": [
+    {
+      "member": "materializeFresh",
+      "why": "The BOUNDED-read contract (`asOf`, correlation-filtered): a pure fold of `events[0..N]` that answers as of N by design. Its claim is honest and already proven, and forcing tail coverage on it would break the bounded-read contract itself. Permitted by name and by reason, so the exemption is a decision rather than an omission."
+    },
+    {
+      "member": "loadFromSnapshot",
+      "why": "Seeds a cold fold from a persisted snapshot. Establishes no coverage claim on its own; the seam calls it before pinning the tail."
+    },
+    {
+      "member": "loadState",
+      "why": "Test fault injection and snapshot restore. Writes a cursor rather than reading an answer from one."
+    },
+    {
+      "member": "discardFold",
+      "why": "The `projection-ahead` repair half. Removes a fold; serves no answer."
+    }
+  ],
+  "allowlist": [],
+  "allowlistSchema": {
+    "file": "repo-relative path permitted to call a forbidden member",
+    "members": "which forbidden members that file may call",
+    "why": "the reason the seam does not fit",
+    "owner": "who accepts the risk",
+    "expiry": "YYYY-MM-DD after which the guard fails on this entry"
+  },
+  "killFixture": {
+    "path": "tools/audit/__fixtures__/projection-fold-bypass.ts.txt",
+    "why": "The pre-fix bypass copied verbatim from src/workflow/handlers/get.ts@529348175. The guard must report it. A guard with no failing subject has no evidence that it works.",
+    "expectedMember": "materialize"
+  },
+  "minimumCallSites": 1,
+  "minimumScannedFiles": 200
+}

--- a/tools/audit/reachable-controls.json
+++ b/tools/audit/reachable-controls.json
@@ -1,0 +1,76 @@
+{
+  "capturedAt": "2026-08-23",
+  "authority": "The policy `tests/architecture/reachable-controls.test.ts` reads. Editing this file changes what the guard enforces; editing the test changes how it enforces it. Keep the two apart so an exemption is reviewable as data.",
+  "class": "a control that gates production behaviour, whose ENABLING call exists only in tests — so the gated path is dark in the shipped composition while the code reads as if it ships",
+  "history": {
+    "first": "`configureWorkflowMaterializer` — set `moduleViewMaterializer`, which gated the ES v2 read path in `handleGet` and the state-snapshot refresh in `handleSet`. Called from four test files and from nothing in `src/`, so `workflow get` always took the legacy state-file path and `get --asOf` silently answered with tip state instead of a bounded fold.",
+    "why-invisible": "Nothing was red. The gated branches had tests, because the tests called the enabler themselves — which is exactly what made the coverage look complete while the shipped path was unreachable. It surfaced only when a regression test for a fix inside one of those branches passed with the fix removed."
+  },
+  "rule": {
+    "statement": "A function whose name marks it as an enabler — it configures, registers, installs, enables or wires something a production path then checks — must have at least one caller under `src/`. A caller under `tests/` does not count, because a test that enables a path is testing a composition the product does not ship.",
+    "why-name-based": "The signal is intent, and intent lives in the name. A structural check cannot tell 'sets a value some branch reads' from 'sets a value nothing reads' without whole-program dataflow; the naming convention is what makes the population decidable, and it is the convention this repository already follows."
+  },
+  "enablerNamePatterns": [
+    {
+      "pattern": "^configure[A-Z]",
+      "why": "sets a module-level or container-level value a consumer later reads"
+    },
+    {
+      "pattern": "^register[A-Z]",
+      "why": "adds an implementation to a registry a dispatcher resolves from"
+    },
+    {
+      "pattern": "^install[A-Z]",
+      "why": "attaches a hook, handler or middleware to a live surface"
+    },
+    {
+      "pattern": "^enable[A-Z]",
+      "why": "flips a capability a guarded branch tests"
+    },
+    {
+      "pattern": "^wire[A-Z]",
+      "why": "connects a component to the composition root"
+    }
+  ],
+  "scannedRoots": [
+    "src"
+  ],
+  "callerRoots": [
+    "src"
+  ],
+  "allowlist": [
+    {
+      "symbol": "installManifestVouchesForDir",
+      "file": "src/install/install-skills.ts",
+      "why": "Not an enabler. It is a PREDICATE over an install manifest — `installManifest` + `VouchesForDir`, returning a boolean — and matches `^install[A-Z]` by prefix coincidence alone. Nothing is gated on calling it, so there is no dark path behind it. Encoding 'is a predicate' into the name rule is harder than recording the one case, and a rule that tried would start producing false negatives.",
+      "owner": "@rsalus",
+      "expiry": "2027-02-23"
+    },
+    {
+      "symbol": "installBundle",
+      "file": "src/install/operations/bundle.ts",
+      "why": "A GENUINE instance, exempted only to keep it visible while it is triaged rather than to excuse it. It copies the bundled MCP server into `~/.claude/mcp-servers/` so the runtime can launch it, and no install path calls it — only its own test. Either the installer lost that step or the step was superseded; deciding which needs the install surface's owner, and guessing wrong breaks installs. Not fixed here because this change is scoped to the workflow materializer.",
+      "owner": "@rsalus",
+      "expiry": "2026-11-23"
+    }
+  ],
+  "allowlistSchema": {
+    "symbol": "the exported enabler permitted to have no production caller",
+    "file": "repo-relative path that declares it",
+    "why": "the reason a production caller is genuinely not owed — not 'we will wire it later'",
+    "owner": "who accepts the risk",
+    "expiry": "YYYY-MM-DD after which the guard fails on this entry"
+  },
+  "killFixture": {
+    "path": "tools/audit/__fixtures__/unreachable-control.ts.txt",
+    "why": "`configureWorkflowMaterializer` as it stood before it was removed, verbatim. The guard must report it. A guard with no failing subject has no evidence that it works.",
+    "expectedSymbol": "configureWorkflowMaterializer"
+  },
+  "minimumScannedFiles": 200,
+  "minimumEnablersFound": 1,
+  "sourceExtensions": [
+    ".ts",
+    ".js"
+  ],
+  "sourceExtensionsWhy": "This tree contains AUTHORED `.js` under `src/` (the lifecycle bridges), not just compiled output — and compiled output is gitignored, so a tracked-file walk cannot pick it up by accident. Scanning `.ts` alone reported `installSkills` as dark while `src/lifecycle/install-skills-bridge.js` imports and calls it."
+}

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,10 +4,10 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1197,
-    "parsedFiles": 1152,
+    "testFiles": 1199,
+    "parsedFiles": 1154,
     "shellFiles": 45,
-    "cases": 13325,
+    "cases": 13337,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -5529,7 +5529,7 @@
         },
         {
           "suite": "projection fold seam",
-          "name": "ProjectionFoldSeam_AllowlistEntries_CarryAnOwnerAndAnUnexpiredDate",
+          "name": "ProjectionFoldSeam_AllowlistEntries_CarryARationaleOwnerAndUnexpiredDate",
           "dynamic": false
         }
       ]
@@ -5648,6 +5648,27 @@
         {
           "suite": "published-path facades",
           "name": "PublishedPathFacades_AreClassifiedByShapeNotByName",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/architecture/reachable-controls.test.ts": {
+      "file": "tests/architecture/reachable-controls.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "reachable controls",
+          "name": "ReachableControls_NoEnabler_IsCalledOnlyFromTests",
+          "dynamic": false
+        },
+        {
+          "suite": "reachable controls",
+          "name": "ReachableControls_KillFixture_IsReportedByTheSameScanner",
+          "dynamic": false
+        },
+        {
+          "suite": "reachable controls",
+          "name": "ReachableControls_AllowlistEntries_CarryAReasonOwnerAndUnexpiredDate",
           "dynamic": false
         }
       ]
@@ -6530,7 +6551,7 @@
         },
         {
           "suite": "T2 governance — evidence provenance (DR-2, DR-3, DR-4, DR-10)",
-          "name": "Governance_Dr4_DegradedProjection_IsNeverServedAsSuccess",
+          "name": "Governance_ProjectionDerivedRead_AnswersFromTheDurableTail",
           "dynamic": false
         },
         {
@@ -33214,23 +33235,43 @@
           "dynamic": false
         },
         {
-          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "suite": "#1855 — a read never answers from a fold behind the tail",
           "name": "FoldAtTail_RewoundFold_AnswersFromTheTailNotFromTheStaleFold",
           "dynamic": false
         },
         {
-          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "suite": "#1855 — a read never answers from a fold behind the tail",
           "name": "FoldAtTail_ContradictoryFold_IsDiscardedAndReplayedFromTheLog",
           "dynamic": false
         },
         {
-          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "suite": "#1855 — a read never answers from a fold behind the tail",
           "name": "FoldAtTail_ColdStream_CoversTheTailWithNoWarmFold",
           "dynamic": false
         },
         {
-          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "suite": "#1855 — a read never answers from a fold behind the tail",
+          "name": "FoldAtTail_AppendLandsMidFold_SequenceStaysOnThePinnedTail",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — a read never answers from a fold behind the tail",
+          "name": "FoldPairToTail_TwoViews_ShareOneSequence",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — a read never answers from a fold behind the tail",
           "name": "FoldAtTail_EmptyStream_IsCoveredAtSequenceZero",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — a committed mutation is never reported as a failure",
+          "name": "WorkflowUpdate_CoverageUnprovable_StillReportsTheCommittedWrite",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — a committed mutation is never reported as a failure",
+          "name": "FoldAtTail_UnprovableCoverage_ThrowsRatherThanAnswering",
           "dynamic": false
         }
       ]
@@ -70865,6 +70906,37 @@
           "suite": "single-composer guard > scanner-form coverage",
           "name": "<dynamic-case-2>",
           "dynamic": true
+        }
+      ]
+    },
+    "tests/unit/workflow/state-fold-merge.test.ts": {
+      "file": "tests/unit/workflow/state-fold-merge.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "ES v2 get — the fold merged with the file",
+          "name": "WorkflowGet_EventDerivedRead_KeepsEveryFileOwnedField",
+          "dynamic": false
+        },
+        {
+          "suite": "ES v2 get — the fold merged with the file",
+          "name": "WorkflowGet_EventDerivedRead_AddsWhatOnlyTheFoldKnows",
+          "dynamic": false
+        },
+        {
+          "suite": "ES v2 get — the fold merged with the file",
+          "name": "WorkflowGet_AsOf_AnswersHistoricallyRatherThanWithTipState",
+          "dynamic": false
+        },
+        {
+          "suite": "ES v2 get — the fold merged with the file",
+          "name": "WorkflowGet_AsOfPastTheTip_IsIdenticalToTheLiveRead",
+          "dynamic": false
+        },
+        {
+          "suite": "why the state file is not re-materialized from the fold",
+          "name": "WorkflowStateFold_PatchedTask_ViolatesStateSchema",
+          "dynamic": false
         }
       ]
     },

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -1,13 +1,13 @@
 {
-  "capturedAt": "2026-08-20",
+  "capturedAt": "2026-08-23",
   "discovery": "extension-based over tracked files; not a runner glob",
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1195,
-    "parsedFiles": 1150,
+    "testFiles": 1197,
+    "parsedFiles": 1152,
     "shellFiles": 45,
-    "cases": 13314,
+    "cases": 13325,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -4556,17 +4556,17 @@
       "runner": "vitest:root",
       "cases": [
         {
-          "suite": "DR-3 — omission fails the build, not the run",
+          "suite": "omission fails the build, not the run",
           "name": "CompileFail_EffectWithoutCommittedEvent_FailsTypecheck",
           "dynamic": false
         },
         {
-          "suite": "DR-3 — omission fails the build, not the run",
+          "suite": "omission fails the build, not the run",
           "name": "CompileFail_FixtureCompilesWhenGuardRemoved",
           "dynamic": false
         },
         {
-          "suite": "DR-3 — omission fails the build, not the run",
+          "suite": "omission fails the build, not the run",
           "name": "CompileGate_ProbeLeavesTheLiveTreeUntouched",
           "dynamic": false
         }
@@ -4577,27 +4577,32 @@
       "runner": "vitest:root",
       "cases": [
         {
-          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "suite": "kill probes: every gate is shown to fail",
           "name": "KillProbe_RequiredEmissionsRelaxed_TypecheckStopsFailing",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "suite": "kill probes: every gate is shown to fail",
           "name": "KillProbe_SuccessArmDropsEvidence_ValueBecomesReachable",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "suite": "kill probes: every gate is shown to fail",
           "name": "KillProbe_WitnessUnbranded_EvidenceBecomesForgeable",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "suite": "kill probes: every gate is shown to fail",
           "name": "KillProbe_RecorderMadeOptional_LiveRunNeedsNoCapability",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — kill probes: every gate is shown to fail",
+          "suite": "kill probes: every gate is shown to fail",
+          "name": "KillProbe_RecorderMadeConditional_LiveRunProceeds",
+          "dynamic": false
+        },
+        {
+          "suite": "kill probes: every gate is shown to fail",
           "name": "KillProbes_LeaveNoResidue_InTheirOwnWriteSet",
           "dynamic": false
         }
@@ -5494,6 +5499,37 @@
         {
           "suite": "Phase2_PersistedIdentifiers_MatchTheTask047Snapshot",
           "name": "the comparison that uses it is still collected",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/architecture/projection-fold-seam.test.ts": {
+      "file": "tests/architecture/projection-fold-seam.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "projection fold seam",
+          "name": "ProjectionFoldSeam_NoSourceFile_BypassesTheTailCoveringFold",
+          "dynamic": false
+        },
+        {
+          "suite": "projection fold seam",
+          "name": "ProjectionFoldSeam_EntryPoint_HasRealCallers",
+          "dynamic": false
+        },
+        {
+          "suite": "projection fold seam",
+          "name": "ProjectionFoldSeam_KillFixture_IsReportedByTheSameScanner",
+          "dynamic": false
+        },
+        {
+          "suite": "projection fold seam",
+          "name": "ProjectionFoldSeam_BoundedReadMembers_AreExemptByNameNotByOversight",
+          "dynamic": false
+        },
+        {
+          "suite": "projection fold seam",
+          "name": "ProjectionFoldSeam_AllowlistEntries_CarryAnOwnerAndAnUnexpiredDate",
           "dynamic": false
         }
       ]
@@ -21065,32 +21101,32 @@
           "dynamic": false
         },
         {
-          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "suite": "the edges that universal declaration puts pressure on",
           "name": "DryRun_EveryPlanDeclares_StillRecordsNothing",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "suite": "the edges that universal declaration puts pressure on",
           "name": "DryRun_RecordsNothingPlan_IsAlsoSilent",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "suite": "the edges that universal declaration puts pressure on",
           "name": "RecordEmissions_NonReceiptMidSet_FailsWholeEffect",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "suite": "the edges that universal declaration puts pressure on",
           "name": "UnrecordedEmissionError_NamesPlanDeclarationAndCount",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "suite": "the edges that universal declaration puts pressure on",
           "name": "SuccessArm_CarriesAReceiptPerDeclaredEmission",
           "dynamic": false
         },
         {
-          "suite": "DR-5 — the edges that universal declaration puts pressure on",
+          "suite": "the edges that universal declaration puts pressure on",
           "name": "SuccessArm_RecordsNothingPlan_CarriesEmptyRecordedEvidence",
           "dynamic": false
         }
@@ -23473,6 +23509,11 @@
         {
           "suite": "StartupAssertion — the severity axis on the boot refusal",
           "name": "StartupAssertion_BlockingSeverity_ThrowsOnAnyViolation",
+          "dynamic": false
+        },
+        {
+          "suite": "StartupAssertion — the severity axis on the boot refusal",
+          "name": "PrimaryOwnerBijection_SameOwnerDuplicateEdges_DoesNotReportMultiPrimary",
           "dynamic": false
         },
         {
@@ -33016,47 +33057,37 @@
       "runner": "vitest:root",
       "cases": [
         {
-          "suite": "CHARACTERIZATION (superseded) — consumers served stale folds as success:true",
-          "name": "ViewComposite_DegradedProjection_ReturnsTypedDegradedResult",
-          "dynamic": false
-        },
-        {
-          "suite": "CHARACTERIZATION (superseded) — consumers served stale folds as success:true",
-          "name": "WorkflowComposite_DegradedProjection_DoesNotReturnStalePayload",
-          "dynamic": false
-        },
-        {
-          "suite": "CHARACTERIZATION (superseded) — consumers served stale folds as success:true",
-          "name": "OrchestrateComposite_DegradedProjection_ReturnsTypedDegradedResult",
-          "dynamic": false
-        },
-        {
-          "suite": "DR-4 — every readiness/workflow/reliability consumer refuses",
+          "suite": "#1855 — every readiness/workflow/reliability consumer answers",
           "name": "<dynamic-case-1>",
           "dynamic": true
         },
         {
-          "suite": "DR-4 — a degraded result is distinguishable from its neighbours",
+          "suite": "#1855 — every readiness/workflow/reliability consumer answers",
+          "name": "Consumer_RewoundFold_AnswersFromTheTail",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the reserved code still separates its neighbours",
           "name": "DegradedResult_IsNotConfusableWithNoData",
           "dynamic": false
         },
         {
-          "suite": "DR-4 — a degraded result is distinguishable from its neighbours",
+          "suite": "#1855 — the reserved code still separates its neighbours",
           "name": "DegradedResult_IsNotConfusableWithGenuineFailure",
           "dynamic": false
         },
         {
-          "suite": "DR-4 — a degraded result is distinguishable from its neighbours",
-          "name": "HealthyStream_NoDurableRow_ConsumersAnswerNormally",
+          "suite": "#1855 — the reserved code still separates its neighbours",
+          "name": "SuggestedFix_NeverNamesTheCallThatFailed",
           "dynamic": false
         },
         {
-          "suite": "DR-4 — recovery clears the refusal",
-          "name": "DegradedStream_RefoldViaViewChokepoint_PublishesRecoveryAndUnblocksConsumers",
+          "suite": "#1855 — a spent observation clears",
+          "name": "DegradedRow_SurvivingRead_IsClearedByTheViewChokepoint",
           "dynamic": false
         },
         {
-          "suite": "DR-4 — recovery clears the refusal",
+          "suite": "#1855 — a spent observation clears",
           "name": "WorkflowMutationsAndRecoveryActions_StayUnguarded",
           "dynamic": false
         }
@@ -33158,6 +33189,52 @@
         }
       ]
     },
+    "tests/unit/projections/fold-at-tail.test.ts": {
+      "file": "tests/unit/projections/fold-at-tail.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "#1855 — the wedge",
+          "name": "FoldAtTail_StaleSiblingFold_DoesNotRefuseAnUnrelatedViewRead",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the wedge",
+          "name": "FoldAtTail_RepeatedReadsOnAnAppendingStream_AllSucceed",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the wedge",
+          "name": "FoldAtTail_WorkflowGet_IsNotWedgedByASiblingFold",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the wedge",
+          "name": "FoldAtTail_FabricatedDegradedMarker_DoesNotWedgeAHealthyStream",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "name": "FoldAtTail_RewoundFold_AnswersFromTheTailNotFromTheStaleFold",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "name": "FoldAtTail_ContradictoryFold_IsDiscardedAndReplayedFromTheLog",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "name": "FoldAtTail_ColdStream_CoversTheTailWithNoWarmFold",
+          "dynamic": false
+        },
+        {
+          "suite": "#1855 — the guarantee CB-8 bought, kept",
+          "name": "FoldAtTail_EmptyStream_IsCoveredAtSequenceZero",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/unit/projections/freshness.test.ts": {
       "file": "tests/unit/projections/freshness.test.ts",
       "runner": "vitest:root",
@@ -33179,17 +33256,7 @@
         },
         {
           "suite": "projection freshness comparison (EFF-002)",
-          "name": "Freshness_MultipleCursors_ReportsWorstOffenderFirst",
-          "dynamic": false
-        },
-        {
-          "suite": "projection freshness comparison (EFF-002)",
-          "name": "Freshness_AllCursorsAtTail_NotDegraded",
-          "dynamic": false
-        },
-        {
-          "suite": "projection freshness comparison (EFF-002)",
-          "name": "Freshness_NoMaterializedFolds_NotDegraded",
+          "name": "Freshness_IsPerFold_NotPerStream",
           "dynamic": false
         },
         {
@@ -33199,12 +33266,12 @@
         },
         {
           "suite": "view chokepoint marks degraded reads (EFF-002)",
-          "name": "HandleView_ProjectionAheadOfPrunedLog_ReturnsTypedDegradedMarker",
+          "name": "HandleView_ProjectionAheadOfPrunedLog_IsRepairedAndAnswered",
           "dynamic": false
         },
         {
           "suite": "view chokepoint marks degraded reads (EFF-002)",
-          "name": "HandleView_StaleSiblingFold_DegradesTheWholeStreamAnswer",
+          "name": "HandleView_StaleSiblingFold_DoesNotDegradeAnUnrelatedAnswer",
           "dynamic": false
         },
         {


### PR DESCRIPTION
## Summary

`exarchos_workflow get` and several `exarchos_view` reads hard-refused with `PROJECTION_DEGRADED` on a lag of one event, and the refusal never cleared — the canonical read path was unusable on any workflow that was actively emitting. Reads now fold to the durable tail before answering, which removes the condition instead of reporting it.

Fixing it required making the projection-derived read paths reachable, and that surfaced three further defects the darkness had been hiding: `workflow get --asOf` silently answered with tip state, a post-write snapshot could corrupt the state file, and a write rejected by validation stayed in the event log. Each is fixed here. Two structural guards keep both classes closed.

## Changes

**The wedge (#1855)**

- **`projections/fold-at-tail.ts`** (new) — `foldToTail` pins the durable tail, routes the behind/ahead/fresh decision through the existing `planRehydrationSource`, folds or replays until the cursor reaches that tail, and returns the view **bound to the sequence it covers**. `foldPairToTail` pins once for two views, so a read combining them describes one state of the stream
- **Every projection-derived read** — all 34 `queryDeltaEvents` + `materialize` pairs across 24 files route through the seam. Bounded reads (`asOf`, correlation-filtered) keep `materializeFresh`, exempt **by name and reason** in the policy rather than by omission
- **`projections/freshness.ts`** — `assessStreamFreshness` deleted. The all-folds quantifier is not a stricter version of the real obligation, it is a different and false one
- **`projections/degraded-result.ts`** — the two consumer gates deleted. `PROJECTION_DEGRADED` keeps one meaning: a fold that finished **short** of the tail it was pinned against. `suggestedFix` is computed from the failing call's context and refuses to name it
- **`views/composite.ts`** — the chokepoint **clears** a spent health row instead of publishing a latch

**Reachability — the ES v2 read path was dark**

- **`workflow/handlers/shared.ts`** — `configureWorkflowMaterializer` removed. It gated `handleGet`'s event fold and `handleSet`'s snapshot refresh on a value **nothing in `src/` ever set**. `handleGet` now resolves `getOrCreateMaterializer(stateDir)`: per-stateDir, sharing one fold cache with the view surface, impossible to leave unwired
- **`mergeFileOwnedFields`** — the fold supplies what the log derives; the file supplies `_version` (the CAS counter — the projection carries a dead literal `1`), `_checkpoint`, `_esVersion`, and any field the projection does not model. The unmodelled half is **derived from the projection's own shape**, so a state field added later is carried rather than dropped
- **`workflow/handlers/set.ts`** — the state-file snapshot block **removed**, not wired. See below
- **`workflow/state-store.ts`** — `validateStateForWrite` extracted; the emission boundary now asks the same question the write will

**Guards**

- **`tests/architecture/projection-fold-seam.test.ts`** + `tools/audit/projection-fold-seam.json` — a cached fold obtained outside the seam fails the build
- **`tests/architecture/reachable-controls.test.ts`** + `tools/audit/reachable-controls.json` — an enabler with no use in the shipped tree fails the build

**Drive-by, called out** — `handleTaskClaim` pinned its OCC `expectedSequence` on `events.length`, a **count** standing in for a **sequence**. It now pins on the fold's covered sequence, which is what the appender's contract is stated in terms of.

---

**Results:** unit project 1115 passed · conformance 314 passed · Build 0 errors · typecheck clean
**Related:** Closes #1855. Spun out #1860, #1861. Supersedes the CB-8 remediation's refusal arm

## Root cause

`assessStreamFreshness` required **every** cached fold of a stream to sit on the durable tail. A read advances exactly **one**. `workflow-state` made it terminal: orchestrate verbs and gates fold it into the shared view materializer, **no `exarchos_view` action folds it**, and the view surface was the only publisher of `projection.recovered`. So the durable row could never be cleared, and the consumer gates wedged `workflow get` plus four orchestrate actions across processes and restarts.

Reproduced in **2 events with 1 append**: three identical `workflow_status` refusals at lag 1 with `staleViews: ["workflow-state"]`, then a wedged `get` whose `suggestedFix` named the call that had just failed three times.

**The correct construction already existed one layer up.** `planRehydrationSource` consumes the *same* verdict and **repairs** it — folds a lagging fold forward, discards and replays a contradictory one. That is why `rehydrate` was the only read that kept working. Two consumers of one verdict, opposite behaviour, nothing binding the second to the first.

## What the darkness was hiding

Wiring the ES v2 read path turned up three pre-existing defects. None was reported, because nothing could observe them.

**`get --asOf` silently answered with tip state.** `handleGetFromEvents` holds the only implementation of bounded reads, and it lived on the branch that never ran — so the parameter was accepted and ignored. Asked for sequence 1, it returned `plan-review` instead of `plan`. Now fixed and covered.

**The snapshot write would have corrupted the state file.** `handleSet` rebuilt `.state.json` from the fold after every mutation. The fold applies `state.patched` verbatim, so a planner's partial task reaches it without a `title` while `TaskSchema` requires one; the snapshot wrote with `skipValidation: true` and the **next read** rejected the whole file — after the mutation had committed. The block is removed rather than shipped, and `WorkflowStateFold_PatchedTask_ViolatesStateSchema` pins the mismatch so the removal is evidence and the block is not restored before the shapes are reconciled (#1861).

**Event-first only cut one way.** `handleSet` recorded `state.patched` **before** validating, so a patch the schema rejected stayed in the log. Invisible while `get` read the file; visible the moment it folded — a boolean written to `artifacts.plan`, rejected with `INVALID_INPUT`, then served by `get` as though it had taken. `validateStateForWrite` is now one rule with three callers.

## The guarantee, kept and strengthened

CB-8's harm was *serving a fold that had not seen events already durable when the question was asked*. That is now unrepresentable rather than detected. The tests assert it as a claim about the **answer** — read the phase back, require the tip phase — which a stale fold cannot produce.

Tests that pinned the old refusal moved to the new claim rather than being weakened: `degraded-consumers.test.ts` keeps its full ten-consumer enumeration with the oracle flipped, and the governance arm asserts the answer instead of the refusal.

## Cross-cutting (#1109) verification

- [x] **Event-sourcing integrity:** strengthened on both sides. Reads are event-derived where the design always said they were, and `handleSet` no longer records a mutation it is about to reject. No new event types; `projection.degraded` / `projection.recovered` still publish on `meta/projection-health`, and the recovery half is now reachable, which it was not before.
- [x] **MCP parity:** no new command surface. Every change is inside the shared dispatch core, so CLI and MCP inherit it identically by construction. Verified: `parity-event-query`, `parity-workflow-describe`, `parity-workflow-rehydrate`, and `tools.asof`'s CLI↔MCP `asOf` parity all pass.
- [x] **Basileus-forward:** no config file added, no local-only assumption; the seam takes an injected `EventStore` and materializer, and the removed singleton was the only process-global in the path.
- [x] **Capability resolution:** N/A — no yaml capability fields are read.

## Backend-quality dimensions

- **DIM-6 Architecture** — one authority for the behind/ahead/fresh decision, and one for write-time validation, both enforced structurally rather than by convention.
- **DIM-4 Test Fidelity** — three vacuous tests found and fixed by kill probes, including two of my own: the old recovery fixture reached its precondition through an input no production path can produce, and the first versions of the pinned-tail tests passed with the guarantee removed.
- **DIM-2 Observability** — `PROJECTION_DEGRADED` now separates *fail* from *indeterminate*; a repaired contradictory fold is journaled rather than silent.
- **DIM-7 Resilience** — a committed mutation is no longer reported as a failure, and a coverage failure no longer falls through a generic catch into a legacy default.

## Test Plan

Every claim was kill-probed or A/B'd; nothing is asserted from a green run alone.

**Kill probes** — each turns the relevant test red, and green again when restored:
- Seeded bypass in `src/` → the fold-seam guard names it by file, line and member
- Seeded dark control in `src/` → the reachability guard names it by symbol and file
- Fold disabled → 7 of 8 wedge tests red; ahead-repair disabled → exactly 1
- Pinned-tail bound removed → both racing tests red
- File-owned merge removed → the merge test red; branch re-darkened → the `asOf` and fold tests red
- Governance arm fails against pre-change `src`, passes after
- Rationale-less allowlist entry → named by both guards

**Two of my own tests were vacuous and the probes caught it.** The pinned-tail tests needed `RacingEventStore` to land an event between the pin and the query, because a single-threaded fold queries microseconds after it pins. The committed-write test needed the materializer configured, because the path it exercised was the dark one.

**Failure sets, not counts.** A/B'd with `git checkout <pre-change> -- src`. Every residual failure is **byte-identical before and after**:

| Residual | Cause |
|---|---|
| 22 `merge-orchestrate`, `store.race`, `measured-premises`, `sdk-seam` | real git operations from inside a worktree; install-state-sensitive and local-only |
| 6 `tests/evals/quality-ab/*` | spawn a toolchain this worktree's thin `node_modules` cannot resolve |
| 1 `worktree-inventory` | counts git worktrees on this machine; also red on the main checkout |
| 1 conformance file | no `tsx` binary in this worktree; passes 322/322 on the main checkout |

- [x] `npm run typecheck` clean (root and `tests/`)
- [x] `npm run test:run` (root) — pass count: **1115 / 1149**, 7 residual (6 evals + 1 worktree-inventory, all A/B-identical)
- [ ] `cd servers/exarchos-mcp && npm run test:run` — **N/A**, no such directory in this tree
- [ ] `npm run skills:guard` — **N/A**, `skills/` untouched
- [x] Path-scoped `tests/unit tests/architecture` — 12302 tests, 29 residual, A/B-identical
- [x] `tests/core` + `tests/process` — **161 / 161**
- [x] `tests/outcome` + `tests/acceptance` + `tests/integration` + `tests/migration` + `tests/smoke` — **159 / 159**
- [x] `npm run test:conformance` — **314 passed**
- [x] `npm run build` — 0 errors
- [x] Cast ratchet re-baselined **downward** (nonNull 72→70, asCast 1698→1695) with provenance — five escape hatches went with the removed singleton
- [x] Manual verification: the reported reproduction is a committed test (`tests/unit/projections/fold-at-tail.test.ts`), as is the `asOf` bug (`tests/unit/workflow/state-fold-merge.test.ts`)

## Related

Closes #1855

Spun out, both found by the guards rather than by inspection:
- #1860 — `installBundle` copies the MCP server bundle into `~/.claude` and no install path calls it
- #1861 — the workflow-state fold cannot produce a schema-valid state file, blocking `.state.json` re-materialization

Supersedes the refusal arm of the CB-8 remediation. That acceptance criterion read "every consumer returns a typed degraded result **rather than stale state**" — the third option, *fresh* state, was never considered, and it is the one the read surface could always have reached.
