### PR TITLE
feat(gates): resolve a gate's result carrier and base branch, not just its command

### DIFF
--- a/content/delivery/skills/delegate/references/fixer-prompt.md
+++ b/content/delivery/skills/delegate/references/fixer-prompt.md
@@ -23,7 +23,10 @@ This posture exists because subagent self-assessment is an unreliable signal. Im
 
 Before making ANY changes:
 1. Run: `pwd`
-2. Verify path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   `[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]`
+   (the main checkout names the same directory twice). Where a repository keeps
+   its worktrees is its own choice, so the path's spelling settles nothing.
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory
@@ -114,7 +117,8 @@ Task({
 
 Before making ANY changes:
 1. Run: \`pwd\`
-2. Verify path contains \`.worktrees/\`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   \`[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]\`
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory

--- a/content/delivery/skills/delegate/references/implementer-prompt.md
+++ b/content/delivery/skills/delegate/references/implementer-prompt.md
@@ -39,7 +39,10 @@ correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree. Ask git, not the path:
+   where a repository keeps its worktrees is its own choice (`.worktrees/`,
+   `.claude/worktrees/`, or a directory outside the repo), so no substring of
+   the path settles it either way.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -47,7 +50,17 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+# A linked worktree keeps its own git dir beneath the shared one; the main
+# checkout names the same directory twice.
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
+```
+
+Or ask the gate, which reads the same fact from git:
+
+```typescript
+exarchos_orchestrate({ action: "verify_worktree" })
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
@@ -370,7 +383,7 @@ After that, the verification block below confirms you landed correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -378,7 +391,9 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.

--- a/content/delivery/skills/delegate/references/worktree-enforcement.md
+++ b/content/delivery/skills/delegate/references/worktree-enforcement.md
@@ -36,7 +36,7 @@ is the one way to silently land on `main` — so pass `featureId`, or set
 integration tip across all six runtimes.
 
 **Validates:**
-- `.worktrees/` is gitignored (adds to `.gitignore` if missing)
+- `.worktrees/` is listed in the repo's own `.gitignore` — reported, never written: a missing entry is a SKIP naming the file and the line to add, for you to add yourself
 - Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree

--- a/content/synthesis/skills/synthesize/references/synthesis-steps.md
+++ b/content/synthesis/skills/synthesize/references/synthesis-steps.md
@@ -67,8 +67,13 @@ mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
 
 The script queries GitHub's PR reviews API for each PR, filters for CodeRabbit reviews, and classifies the latest review state.
 
-**On `passed: true`:** All PRs are APPROVED or have no CodeRabbit review -- proceed to Step 5.
-**On `passed: false`:** At least one PR has CHANGES_REQUESTED or PENDING. The output identifies which PRs need attention. Route to fix cycle:
+Read `skipped` BEFORE `passed`. The check reports three outcomes, and two of them share `passed: false`:
+
+**`passed: true`** -- every PR carries a CodeRabbit APPROVED review. Proceed to Step 5.
+
+**`passed: false` with `skipped: true`** (`discriminant: "coderabbit-reviewer-absent"`) -- INDETERMINATE, not a failure. No CodeRabbit review exists on the PRs named in `reason`, which is what a repository this reviewer does not watch looks like. There is nothing to fix and nothing to re-check: shepherding a PR cannot summon a review from a bot that is not installed. Record the outcome and proceed to Step 5. An absent reviewer is not an approval either -- if this repository is supposed to have CodeRabbit, install it or remove this step, but do not read the absence as coverage.
+
+**`passed: false` with no `skipped`** -- a real disproof: at least one PR has CHANGES_REQUESTED or PENDING. The output identifies which PRs need attention. Route to fix cycle:
 ```typescript
 Skill({ skill: "exarchos:shepherd", args: "[PR_URL]" })
 ```

--- a/rendered/skills/claude/delegate/references/fixer-prompt.md
+++ b/rendered/skills/claude/delegate/references/fixer-prompt.md
@@ -23,7 +23,10 @@ This posture exists because subagent self-assessment is an unreliable signal. Im
 
 Before making ANY changes:
 1. Run: `pwd`
-2. Verify path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   `[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]`
+   (the main checkout names the same directory twice). Where a repository keeps
+   its worktrees is its own choice, so the path's spelling settles nothing.
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory
@@ -114,7 +117,8 @@ Task({
 
 Before making ANY changes:
 1. Run: \`pwd\`
-2. Verify path contains \`.worktrees/\`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   \`[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]\`
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory

--- a/rendered/skills/claude/delegate/references/implementer-prompt.md
+++ b/rendered/skills/claude/delegate/references/implementer-prompt.md
@@ -39,7 +39,10 @@ correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree. Ask git, not the path:
+   where a repository keeps its worktrees is its own choice (`.worktrees/`,
+   `.claude/worktrees/`, or a directory outside the repo), so no substring of
+   the path settles it either way.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -47,7 +50,17 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+# A linked worktree keeps its own git dir beneath the shared one; the main
+# checkout names the same directory twice.
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
+```
+
+Or ask the gate, which reads the same fact from git:
+
+```typescript
+exarchos_orchestrate({ action: "verify_worktree" })
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
@@ -375,7 +388,7 @@ After that, the verification block below confirms you landed correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -383,7 +396,9 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.

--- a/rendered/skills/claude/delegate/references/worktree-enforcement.md
+++ b/rendered/skills/claude/delegate/references/worktree-enforcement.md
@@ -36,7 +36,7 @@ is the one way to silently land on `main` — so pass `featureId`, or set
 integration tip across all six runtimes.
 
 **Validates:**
-- `.worktrees/` is gitignored (adds to `.gitignore` if missing)
+- `.worktrees/` is listed in the repo's own `.gitignore` — reported, never written: a missing entry is a SKIP naming the file and the line to add, for you to add yourself
 - Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree

--- a/rendered/skills/codex/delegate/references/fixer-prompt.md
+++ b/rendered/skills/codex/delegate/references/fixer-prompt.md
@@ -23,7 +23,10 @@ This posture exists because subagent self-assessment is an unreliable signal. Im
 
 Before making ANY changes:
 1. Run: `pwd`
-2. Verify path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   `[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]`
+   (the main checkout names the same directory twice). Where a repository keeps
+   its worktrees is its own choice, so the path's spelling settles nothing.
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory
@@ -114,7 +117,8 @@ Task({
 
 Before making ANY changes:
 1. Run: \`pwd\`
-2. Verify path contains \`.worktrees/\`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   \`[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]\`
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory

--- a/rendered/skills/codex/delegate/references/implementer-prompt.md
+++ b/rendered/skills/codex/delegate/references/implementer-prompt.md
@@ -39,7 +39,10 @@ correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree. Ask git, not the path:
+   where a repository keeps its worktrees is its own choice (`.worktrees/`,
+   `.claude/worktrees/`, or a directory outside the repo), so no substring of
+   the path settles it either way.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -47,7 +50,17 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+# A linked worktree keeps its own git dir beneath the shared one; the main
+# checkout names the same directory twice.
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
+```
+
+Or ask the gate, which reads the same fact from git:
+
+```typescript
+exarchos_orchestrate({ action: "verify_worktree" })
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
@@ -347,7 +360,7 @@ After that, the verification block below confirms you landed correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -355,7 +368,9 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.

--- a/rendered/skills/codex/delegate/references/worktree-enforcement.md
+++ b/rendered/skills/codex/delegate/references/worktree-enforcement.md
@@ -36,7 +36,7 @@ is the one way to silently land on `main` — so pass `featureId`, or set
 integration tip across all six runtimes.
 
 **Validates:**
-- `.worktrees/` is gitignored (adds to `.gitignore` if missing)
+- `.worktrees/` is listed in the repo's own `.gitignore` — reported, never written: a missing entry is a SKIP naming the file and the line to add, for you to add yourself
 - Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree

--- a/rendered/skills/copilot/delegate/references/fixer-prompt.md
+++ b/rendered/skills/copilot/delegate/references/fixer-prompt.md
@@ -23,7 +23,10 @@ This posture exists because subagent self-assessment is an unreliable signal. Im
 
 Before making ANY changes:
 1. Run: `pwd`
-2. Verify path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   `[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]`
+   (the main checkout names the same directory twice). Where a repository keeps
+   its worktrees is its own choice, so the path's spelling settles nothing.
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory
@@ -114,7 +117,8 @@ Task({
 
 Before making ANY changes:
 1. Run: \`pwd\`
-2. Verify path contains \`.worktrees/\`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   \`[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]\`
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory

--- a/rendered/skills/copilot/delegate/references/implementer-prompt.md
+++ b/rendered/skills/copilot/delegate/references/implementer-prompt.md
@@ -39,7 +39,10 @@ correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree. Ask git, not the path:
+   where a repository keeps its worktrees is its own choice (`.worktrees/`,
+   `.claude/worktrees/`, or a directory outside the repo), so no substring of
+   the path settles it either way.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -47,7 +50,17 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+# A linked worktree keeps its own git dir beneath the shared one; the main
+# checkout names the same directory twice.
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
+```
+
+Or ask the gate, which reads the same fact from git:
+
+```typescript
+exarchos_orchestrate({ action: "verify_worktree" })
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
@@ -343,7 +356,7 @@ After that, the verification block below confirms you landed correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -351,7 +364,9 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.

--- a/rendered/skills/copilot/delegate/references/worktree-enforcement.md
+++ b/rendered/skills/copilot/delegate/references/worktree-enforcement.md
@@ -36,7 +36,7 @@ is the one way to silently land on `main` — so pass `featureId`, or set
 integration tip across all six runtimes.
 
 **Validates:**
-- `.worktrees/` is gitignored (adds to `.gitignore` if missing)
+- `.worktrees/` is listed in the repo's own `.gitignore` — reported, never written: a missing entry is a SKIP naming the file and the line to add, for you to add yourself
 - Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree

--- a/rendered/skills/cursor/delegate/references/fixer-prompt.md
+++ b/rendered/skills/cursor/delegate/references/fixer-prompt.md
@@ -23,7 +23,10 @@ This posture exists because subagent self-assessment is an unreliable signal. Im
 
 Before making ANY changes:
 1. Run: `pwd`
-2. Verify path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   `[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]`
+   (the main checkout names the same directory twice). Where a repository keeps
+   its worktrees is its own choice, so the path's spelling settles nothing.
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory
@@ -114,7 +117,8 @@ Task({
 
 Before making ANY changes:
 1. Run: \`pwd\`
-2. Verify path contains \`.worktrees/\`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   \`[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]\`
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory

--- a/rendered/skills/cursor/delegate/references/implementer-prompt.md
+++ b/rendered/skills/cursor/delegate/references/implementer-prompt.md
@@ -39,7 +39,10 @@ correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree. Ask git, not the path:
+   where a repository keeps its worktrees is its own choice (`.worktrees/`,
+   `.claude/worktrees/`, or a directory outside the repo), so no substring of
+   the path settles it either way.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -47,7 +50,17 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+# A linked worktree keeps its own git dir beneath the shared one; the main
+# checkout names the same directory twice.
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
+```
+
+Or ask the gate, which reads the same fact from git:
+
+```typescript
+exarchos_orchestrate({ action: "verify_worktree" })
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
@@ -348,7 +361,7 @@ After that, the verification block below confirms you landed correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -356,7 +369,9 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.

--- a/rendered/skills/cursor/delegate/references/worktree-enforcement.md
+++ b/rendered/skills/cursor/delegate/references/worktree-enforcement.md
@@ -36,7 +36,7 @@ is the one way to silently land on `main` — so pass `featureId`, or set
 integration tip across all six runtimes.
 
 **Validates:**
-- `.worktrees/` is gitignored (adds to `.gitignore` if missing)
+- `.worktrees/` is listed in the repo's own `.gitignore` — reported, never written: a missing entry is a SKIP naming the file and the line to add, for you to add yourself
 - Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree

--- a/rendered/skills/generic/delegate/references/fixer-prompt.md
+++ b/rendered/skills/generic/delegate/references/fixer-prompt.md
@@ -23,7 +23,10 @@ This posture exists because subagent self-assessment is an unreliable signal. Im
 
 Before making ANY changes:
 1. Run: `pwd`
-2. Verify path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   `[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]`
+   (the main checkout names the same directory twice). Where a repository keeps
+   its worktrees is its own choice, so the path's spelling settles nothing.
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory
@@ -114,7 +117,8 @@ Task({
 
 Before making ANY changes:
 1. Run: \`pwd\`
-2. Verify path contains \`.worktrees/\`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   \`[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]\`
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory

--- a/rendered/skills/generic/delegate/references/implementer-prompt.md
+++ b/rendered/skills/generic/delegate/references/implementer-prompt.md
@@ -39,7 +39,10 @@ correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree. Ask git, not the path:
+   where a repository keeps its worktrees is its own choice (`.worktrees/`,
+   `.claude/worktrees/`, or a directory outside the repo), so no substring of
+   the path settles it either way.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -47,7 +50,17 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+# A linked worktree keeps its own git dir beneath the shared one; the main
+# checkout names the same directory twice.
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
+```
+
+Or ask the gate, which reads the same fact from git:
+
+```typescript
+exarchos_orchestrate({ action: "verify_worktree" })
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
@@ -343,7 +356,7 @@ After that, the verification block below confirms you landed correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -351,7 +364,9 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.

--- a/rendered/skills/generic/delegate/references/worktree-enforcement.md
+++ b/rendered/skills/generic/delegate/references/worktree-enforcement.md
@@ -36,7 +36,7 @@ is the one way to silently land on `main` — so pass `featureId`, or set
 integration tip across all six runtimes.
 
 **Validates:**
-- `.worktrees/` is gitignored (adds to `.gitignore` if missing)
+- `.worktrees/` is listed in the repo's own `.gitignore` — reported, never written: a missing entry is a SKIP naming the file and the line to add, for you to add yourself
 - Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree

--- a/rendered/skills/opencode/delegate/references/fixer-prompt.md
+++ b/rendered/skills/opencode/delegate/references/fixer-prompt.md
@@ -23,7 +23,10 @@ This posture exists because subagent self-assessment is an unreliable signal. Im
 
 Before making ANY changes:
 1. Run: `pwd`
-2. Verify path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   `[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]`
+   (the main checkout names the same directory twice). Where a repository keeps
+   its worktrees is its own choice, so the path's spelling settles nothing.
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory
@@ -114,7 +117,8 @@ Task({
 
 Before making ANY changes:
 1. Run: \`pwd\`
-2. Verify path contains \`.worktrees/\`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path:
+   \`[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]\`
 3. If NOT in worktree: STOP and report error
 
 ## Working Directory

--- a/rendered/skills/opencode/delegate/references/implementer-prompt.md
+++ b/rendered/skills/opencode/delegate/references/implementer-prompt.md
@@ -39,7 +39,10 @@ correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree. Ask git, not the path:
+   where a repository keeps its worktrees is its own choice (`.worktrees/`,
+   `.claude/worktrees/`, or a directory outside the repo), so no substring of
+   the path settles it either way.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -47,7 +50,17 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+# A linked worktree keeps its own git dir beneath the shared one; the main
+# checkout names the same directory twice.
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
+```
+
+Or ask the gate, which reads the same fact from git:
+
+```typescript
+exarchos_orchestrate({ action: "verify_worktree" })
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
@@ -347,7 +360,7 @@ After that, the verification block below confirms you landed correctly.
 Before making ANY file changes, you MUST verify you are in a worktree:
 
 1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+2. Confirm that directory is a **linked** git worktree — ask git, not the path.
 3. If NOT in a worktree directory:
    - STOP immediately
    - Report: "ERROR: Working directory is not a worktree. Aborting task."
@@ -355,7 +368,9 @@ Before making ANY file changes, you MUST verify you are in a worktree:
 
 **Example verification:**
 ```bash
-pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
+pwd
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] \
+  || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.

--- a/rendered/skills/opencode/delegate/references/worktree-enforcement.md
+++ b/rendered/skills/opencode/delegate/references/worktree-enforcement.md
@@ -36,7 +36,7 @@ is the one way to silently land on `main` — so pass `featureId`, or set
 integration tip across all six runtimes.
 
 **Validates:**
-- `.worktrees/` is gitignored (adds to `.gitignore` if missing)
+- `.worktrees/` is listed in the repo's own `.gitignore` — reported, never written: a missing entry is a SKIP naming the file and the line to add, for you to add yourself
 - Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree

--- a/rendered/skills/standard/synthesize/references/synthesis-steps.md
+++ b/rendered/skills/standard/synthesize/references/synthesis-steps.md
@@ -67,8 +67,13 @@ mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
 
 The script queries GitHub's PR reviews API for each PR, filters for CodeRabbit reviews, and classifies the latest review state.
 
-**On `passed: true`:** All PRs are APPROVED or have no CodeRabbit review -- proceed to Step 5.
-**On `passed: false`:** At least one PR has CHANGES_REQUESTED or PENDING. The output identifies which PRs need attention. Route to fix cycle:
+Read `skipped` BEFORE `passed`. The check reports three outcomes, and two of them share `passed: false`:
+
+**`passed: true`** -- every PR carries a CodeRabbit APPROVED review. Proceed to Step 5.
+
+**`passed: false` with `skipped: true`** (`discriminant: "coderabbit-reviewer-absent"`) -- INDETERMINATE, not a failure. No CodeRabbit review exists on the PRs named in `reason`, which is what a repository this reviewer does not watch looks like. There is nothing to fix and nothing to re-check: shepherding a PR cannot summon a review from a bot that is not installed. Record the outcome and proceed to Step 5. An absent reviewer is not an approval either -- if this repository is supposed to have CodeRabbit, install it or remove this step, but do not read the absence as coverage.
+
+**`passed: false` with no `skipped`** -- a real disproof: at least one PR has CHANGES_REQUESTED or PENDING. The output identifies which PRs need attention. Route to fix cycle:
 ```typescript
 Skill({ skill: "exarchos:shepherd", args: "[PR_URL]" })
 ```

--- a/src/config/toolchains.ts
+++ b/src/config/toolchains.ts
@@ -75,7 +75,7 @@ export interface Toolchain {
 // (package.json wins). Entries below the original five (node, dotnet, rust, go,
 // python) are additive: repos that previously resolved to "no toolchain" now
 // detect — never overriding an existing match.
-export const BUILTIN_TOOLCHAINS: readonly Toolchain[] = [
+export const BUILTIN_TOOLCHAINS = [
   {
     id: 'node',
     projectType: 'Node.js',
@@ -235,7 +235,14 @@ export const BUILTIN_TOOLCHAINS: readonly Toolchain[] = [
       contract: null,
     },
   },
-];
+] as const satisfies readonly Toolchain[];
+
+/**
+ * The closed set of built-in toolchain ids, derived from the registry array
+ * rather than hand-listed — so a table keyed by this type cannot fall behind
+ * the registry. See {@link TestReportFormat}.
+ */
+export type ToolchainId = (typeof BUILTIN_TOOLCHAINS)[number]['id'];
 
 /** Shape of a `.exarchos.yml` `toolchains:` entry (see exarchos-config-schema). */
 export interface ConfigToolchain {
@@ -467,6 +474,132 @@ export function resolveMutationDiffScope(toolchainId: string, base: string): Mut
     : `toolchain '${toolchainId}' has no resolved mutation runner to diff-scope; the mutation run is unscoped`;
   return { kind: 'unscoped-warning', warning: reason };
 }
+
+// ─── Test report carrier (the result side of the command SoT) ───────────────
+//
+// The runner COMMAND has a per-toolchain source of truth above; its RESULT
+// CARRIER had none, so the integration-suite gate appended vitest's
+// `--reporter=json` to every resolved command and parsed vitest JSON only —
+// `cargo test --reporter=json`, `pytest --reporter=json`. Which carrier a
+// runner produces is per-runner knowledge, so it belongs here beside the
+// commands: consumers branch on the descriptor's `kind` and never on an id.
+//
+// Three arms, because three is what a gate reads. A `junit-xml` or `tap` arm
+// would be a guess about a format nothing parses; a new arm arrives with the
+// gate that needs it.
+
+/**
+ * How a toolchain's test runner reports its result.
+ *
+ * - `vitest-json`    — the runner emits vitest's JSON summary. `reporterFlag`
+ *                      is what asks for it, carried ON the descriptor so no
+ *                      consumer spells a runner's flag itself.
+ * - `exit-code-only` — the exit code is the whole verdict. Not a degradation:
+ *                      a pass/fail gate over an exit code is fully generic and
+ *                      fully trustworthy (`check_test_adequacy` is the model).
+ * - `unknown`        — the carrier is not known; the gate reports indeterminate
+ *                      rather than guess a flag or a parse.
+ */
+export type TestReportFormat =
+  | { readonly kind: 'vitest-json'; readonly reporterFlag: '--reporter=json' }
+  | { readonly kind: 'exit-code-only' }
+  | { readonly kind: 'unknown'; readonly reason: string };
+
+/**
+ * Result carrier per built-in toolchain.
+ *
+ * `satisfies Record<ToolchainId, …>` is load-bearing: a toolchain added to
+ * {@link BUILTIN_TOOLCHAINS} with no row here is a COMPILE error, never a
+ * silent `unknown`.
+ */
+const TEST_REPORT_FORMAT = {
+  // `node` is the arm that owes a justification, because its command does not
+  // name its runner: `npm run test:run` is a SCRIPT INDIRECTION, the script
+  // could be jest or node:test, and the resolver does not even always land on
+  // that command — it resolves node package-manager-aware and may produce
+  // `pnpm test`, `yarn test`, `bun run test:run`, or Bun's own native
+  // `bun test`. Indirection alone is not what singles node out, either:
+  // `composer test` and `bundle exec rake test` are the same shape.
+  //
+  // The mapping stands on two facts rather than on a guarantee. Vitest is what
+  // the node script conventionally resolves to — the resolver's missing-script
+  // hint offers `"test:run": "vitest run"` as its example — and being wrong
+  // here is SAFE, because a runner that emits no vitest JSON lands on the
+  // integration gate's existing fail-closed unparseable-output path. A false
+  // red, never a false green. A project that genuinely runs something else
+  // declares its own toolchain in `.exarchos.yml`; that id is not a built-in
+  // and resolves to `unknown`, which is what serves it — not a new union arm.
+  node: { kind: 'vitest-json', reporterFlag: '--reporter=json' },
+  // No other entry's runner — whether the command names it outright
+  // (`cargo test`, `pytest`) or reaches it through a task indirection
+  // (`composer test`, `./gradlew test`) — accepts `--reporter=json` or writes a
+  // machine-readable summary to stdout by default. The exit code is their
+  // honest carrier, and a complete one for a pass/fail gate, which is why this
+  // is the majority answer rather than a fallback.
+  dotnet: { kind: 'exit-code-only' },
+  rust: { kind: 'exit-code-only' },
+  go: { kind: 'exit-code-only' },
+  python: { kind: 'exit-code-only' },
+  'java-gradle': { kind: 'exit-code-only' },
+  'java-maven': { kind: 'exit-code-only' },
+  ruby: { kind: 'exit-code-only' },
+  php: { kind: 'exit-code-only' },
+  elixir: { kind: 'exit-code-only' },
+  swift: { kind: 'exit-code-only' },
+  cmake: { kind: 'exit-code-only' },
+} as const satisfies Record<ToolchainId, TestReportFormat>;
+
+/**
+ * Resolve how a toolchain's test runner reports its result.
+ *
+ * Total over the built-in ids by construction. Any other id — a `.exarchos.yml`
+ * toolchain, or a caller naming a runner this registry does not know — returns
+ * the `unknown` arm with its reason, so the gate degrades to indeterminate
+ * instead of handing one runner another runner's flag.
+ */
+export function resolveTestReportFormat(toolchainId: string): TestReportFormat {
+  const known: Readonly<Record<string, TestReportFormat>> = TEST_REPORT_FORMAT;
+  const format = known[toolchainId];
+  if (format) return format;
+  return {
+    kind: 'unknown',
+    reason: `toolchain '${toolchainId}' is not a built-in toolchain, so how its test runner reports a result is unknown`,
+  };
+}
+
+// ─── Compile-time proof (verified by `npm run typecheck`) ───────────────────
+//
+// The claim "a registry entry with no carrier row is a COMPILE error" cannot be
+// pinned from the test tier: the tests tsconfig excludes `unit/**`, so a
+// `@ts-expect-error` sited beside the runtime tests would be read by no
+// compiler. The proof lives here in the subject module, where `tsc` does read
+// it — the same placement, and the same `Expect<T extends true>` device, as the
+// event-grammar proofs. Its runtime twin is `MissingEntry_IsACompileError`.
+
+type Expect<T extends true> = T;
+/** Set equality for unions of literals: mutual assignability, neither side split. */
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+/**
+ * The carrier table's rows cover exactly the registry's ids — no id without a
+ * row, no row naming an id the registry dropped.
+ *
+ * `satisfies Record<ToolchainId, …>` is the device, but it is only as strong as
+ * its key type: widen that key to `string` and every row becomes optional again
+ * with nothing at runtime to notice, because a missing row simply resolves to
+ * `unknown`. This alias fails on that weakening.
+ *
+ * The `extends [never]` guard is the non-empty-denominator rule at the type
+ * level: an emptied registry collapses `ToolchainId` to `never`, and `never` is
+ * mutually assignable with `never`, so the equality would otherwise read as a
+ * clean proof over nothing.
+ * @proof
+ */
+export type _Toolchains_CarrierRows_CoverExactlyTheRegistry = Expect<
+  [ToolchainId] extends [never]
+    ? false
+    : MutuallyAssignable<ToolchainId, keyof typeof TEST_REPORT_FORMAT>
+>;
 
 // ─── Hermetic-double resolution (SIV-5 / #1531) ──────────────────────────────
 //

--- a/src/registry/actions/orchestrate/coordination.ts
+++ b/src/registry/actions/orchestrate/coordination.ts
@@ -178,8 +178,8 @@ export const coordinationActions: readonly BuiltinToolAction[] = [
     phases: SYNTHESIS_REVIEW_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: true, gateClass: 'prepare-synthesis' },
-    // DR-5: invokes `npm run test:run` + typecheck under the hood; seconds
-    // to minutes on non-trivial repos.  CLI adapter emits heartbeats.
+    // Invokes the repository's own resolved test and typecheck commands;
+    // seconds to minutes on non-trivial repos. CLI adapter emits heartbeats.
     longRunning: true,
     autoEmits: [
       { event: 'gate.executed', condition: 'always', role: 'primary', owner: 'orchestrate' },

--- a/src/registry/actions/orchestrate/verification.ts
+++ b/src/registry/actions/orchestrate/verification.ts
@@ -321,8 +321,8 @@ export const verificationActions: readonly BuiltinToolAction[] = [
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: true },
-    // DR-5: chains `npm run test:run` across every task worktree with a
-    // 120s per-worktree timeout; scales with the number of tasks.
+    // Chains each worktree's own resolved test command, with a 120s
+    // per-worktree timeout; scales with the number of tasks.
     longRunning: true,
     autoEmits: [
       { event: 'gate.executed', condition: 'always', role: 'primary', owner: 'orchestrate' },

--- a/src/runbooks/definitions.ts
+++ b/src/runbooks/definitions.ts
@@ -184,22 +184,32 @@ export const SYNTHESIS_FLOW: RunbookDefinition = {
       note: 'Fill <repoRoot> with the absolute path of the repo under synthesis; all four legs (tests, typecheck, stack, changed files) run there' },
     { tool: 'exarchos_orchestrate', action: 'validate_pr_stack', onFail: 'stop' },
     { tool: 'exarchos_orchestrate', action: 'validate_pr_body', onFail: 'stop' },
-    { tool: 'native:bash', action: 'gh_pr_create', onFail: 'stop',
-      note: 'Create PR via gh CLI' },
+    // The registered action goes through the VcsProvider seam, which all three
+    // providers implement — a `native:bash` `gh` step made this canonical flow
+    // executable on GitHub alone, and silently so: the runbook surface never
+    // resolves a native step against the registry, so nothing could report that
+    // the recipe did not apply. It also auto-emits `pr.created`, which the bash
+    // step could not, so the agent no longer has to append that record by hand.
+    { tool: 'exarchos_orchestrate', action: 'create_pr', onFail: 'stop',
+      params: { title: '<title>', body: '<body>', base: '<baseBranch>', head: '<head>' },
+      note: 'Create the PR through the provider seam (GitHub / GitLab / Azure DevOps)' },
     { tool: 'exarchos_event', action: 'append', onFail: 'stop',
       params: { type: 'state.patched' },
       note: 'Record PR URL in artifacts.prUrl — emit state.patched directly (DR-4: `set` MCP surface removed in v2.11)' },
   ],
   // T5a.1/DR-4 (v2.11): added `stream` and `event` template vars to cover
-  // the new `event.append` step's required schema fields.
-  templateVars: ['featureId', 'baseBranch', 'repoRoot', 'stream', 'event'],
+  // the new `event.append` step's required schema fields. `title`, `body` and
+  // `head` cover `create_pr`'s remaining required fields; its `base` binds to
+  // the `baseBranch` var the flow already declared.
+  templateVars: ['featureId', 'baseBranch', 'repoRoot', 'stream', 'event', 'title', 'body', 'head'],
   // T5a.1/DR-4 (v2.11): `set` removed. The `hsm.deprecated_action_invoked`
   // emission disappeared with it; remaining auto-emits are the canonical
   // event types this synthesis flow still produces. `state.patched` is
   // emitted via `event.append({type: 'state.patched'})` — that's a
   // `params.type` value rather than an action-level `autoEmits` entry,
-  // so it does not appear in the computed-from-registry view.
-  autoEmits: ['gate.executed'],
+  // so it does not appear in the computed-from-registry view. `pr.created`
+  // arrives with the seam-backed create step, which declares it unconditionally.
+  autoEmits: ['gate.executed', 'pr.created'],
 };
 
 export const SHEPHERD_ITERATION: RunbookDefinition = {

--- a/src/vcs/resolve-base-branch.ts
+++ b/src/vcs/resolve-base-branch.ts
@@ -20,13 +20,18 @@ export type BaseBranchResolution =
   | { readonly kind: 'unresolved'; readonly reason: string };
 
 /**
- * Reads a git ref from `repoRoot`, or `null` when git cannot answer. Injected so
- * the fallback and rejected-ref arms are exercisable without a fixture repo.
+ * Runs a read-only git command in `repoRoot` and hands back its stdout, or
+ * `null` when git cannot answer (non-zero exit, missing repository, timeout).
+ * Injected so every rung of the ladder below — including the one that talks to
+ * the network — is exercisable without a fixture repo.
  */
 export type GitRefReader = (repoRoot: string, args: readonly string[]) => string | null;
 
 const ORIGIN_HEAD_REF = 'refs/remotes/origin/HEAD';
 const ORIGIN_PREFIX = 'refs/remotes/origin/';
+
+/** `git remote show origin` prints the remote's own HEAD on this line. */
+const REMOTE_SHOW_HEAD = /^\s*HEAD branch:\s*(\S+)\s*$/m;
 
 // The two arms answer from different trust classes, so they need different
 // rules; holding both to one rule is what silently discards a real branch.
@@ -69,12 +74,19 @@ function safeHostedBranchName(candidate: string | undefined): string | null {
   return UNSAFE_IN_BRANCH_NAME.test(name) ? null : name;
 }
 
+/**
+ * Bounds every rung, including the one that reaches the network. A remote that
+ * hangs must cost a gate a few seconds and then fall to the next signal, not
+ * stall the run it was asked to scope.
+ */
+const GIT_READ_TIMEOUT_MS = 5_000;
+
 const readGitRef: GitRefReader = (repoRoot, args) => {
   try {
     const stdout = runCommandSync('git', args, {
       cwd: repoRoot,
       encoding: 'utf-8',
-      timeout: 5_000,
+      timeout: GIT_READ_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     return typeof stdout === 'string' ? stdout : stdout.toString('utf-8');
@@ -96,10 +108,103 @@ async function providerDefaultBranch(provider: VcsProvider): Promise<string | un
   }
 }
 
+// ─── The git ladder ─────────────────────────────────────────────────────────
+//
+// `symbolic-ref refs/remotes/origin/HEAD` is the cheapest local answer, and it
+// is also the one that is MISSING most often: `git clone` writes it, but
+// `git init` + `git remote add` never does, and neither do the shallow or
+// detached checkouts most CI providers hand a job. One rung meant that whole
+// population resolved `unresolved`, which — now that no literal stands behind
+// it — takes a working gate offline on a repository that has a perfectly
+// ordinary default branch.
+//
+// So the ladder is explicit about WHAT KIND of statement each rung makes:
+//
+//   authoritative — someone who knows the answer said it. The host's API
+//                   record, the local ref git wrote from the remote's HEAD, and
+//                   the remote's own reply to `git remote show`. Accepting one
+//                   of these is reporting a fact.
+//
+//   inferred      — nobody stated this repository's default; the name is a
+//                   guess assembled from a setting that describes something
+//                   ELSE (`init.defaultBranch` says what name NEW repositories
+//                   get). A guess is only ever accepted after the branch it
+//                   names is confirmed to exist here, which is what keeps this
+//                   from being the invented literal in a new costume: an
+//                   inferred rung can be wrong about which branch is the
+//                   default, but it can never name a branch the repository does
+//                   not have.
+//
+// Deliberately NOT a rung: "there is exactly one remote-tracking branch, so
+// that must be it". A `fetch-depth: 1` CI checkout has exactly one — the PR's
+// own head — and diffing a branch against itself is empty, which reads as a
+// clean pass. Elimination is only sound when the population is complete, and in
+// a shallow checkout it never is.
+
+type RungTrust = 'authoritative' | 'inferred';
+
+interface GitRung {
+  /** Names the signal in the unresolved reason, so a reader can go look. */
+  readonly label: string;
+  readonly trust: RungTrust;
+  /** The candidate this signal yields, already trust-filtered, or `null`. */
+  readonly read: (repoRoot: string, runGit: GitRefReader) => string | null;
+}
+
+/** Whether `name` is a branch this repository actually has. */
+function branchExists(repoRoot: string, runGit: GitRefReader, name: string): boolean {
+  for (const prefix of [ORIGIN_PREFIX, 'refs/heads/']) {
+    const found = runGit(repoRoot, ['rev-parse', '--verify', '--quiet', `${prefix}${name}`]);
+    if (found !== null && found.trim().length > 0) return true;
+  }
+  return false;
+}
+
+const GIT_RUNGS: readonly GitRung[] = [
+  {
+    label: `git symbolic-ref ${ORIGIN_HEAD_REF}`,
+    trust: 'authoritative',
+    read: (repoRoot, runGit) => {
+      // The command answers with a full ref UNDER that prefix. Anchor the strip:
+      // an unanchored `.replace` hands anything else back whole, and
+      // `refs/heads/main` passes the allowlist unscathed — a ref path laundered
+      // into a branch name. A ref that is not under the prefix is no answer.
+      const ref = runGit(repoRoot, ['symbolic-ref', ORIGIN_HEAD_REF])?.trim();
+      return ref?.startsWith(ORIGIN_PREFIX)
+        ? trustedGitRefName(ref.slice(ORIGIN_PREFIX.length))
+        : null;
+    },
+  },
+  {
+    label: 'git remote show origin',
+    trust: 'authoritative',
+    read: (repoRoot, runGit) => {
+      // Asks the remote directly, so it answers where no local ref was ever
+      // written. It is a network round trip — bounded by the reader's timeout —
+      // and it is only reached once the free local rung above has come up empty.
+      // A remote with no HEAD prints `(unknown)`, which the allowlist rejects on
+      // its parentheses without needing a case of its own.
+      const shown = runGit(repoRoot, ['remote', 'show', 'origin']);
+      return trustedGitRefName(shown?.match(REMOTE_SHOW_HEAD)?.[1]);
+    },
+  },
+  {
+    label: 'git config init.defaultBranch (verified to exist)',
+    trust: 'inferred',
+    read: (repoRoot, runGit) => {
+      const configured = trustedGitRefName(
+        runGit(repoRoot, ['config', '--get', 'init.defaultBranch'])?.trim(),
+      );
+      if (!configured) return null;
+      return branchExists(repoRoot, runGit, configured) ? configured : null;
+    },
+  },
+];
+
 /**
  * Resolve the base branch of the repository at `repoRoot`: the host's own
- * `defaultBranch` when a provider supplies one, else `origin/HEAD`, else
- * `unresolved`.
+ * `defaultBranch` when a provider supplies one, else the git ladder above,
+ * else `unresolved`.
  *
  * `runGit` is a test seam; production callers pass two arguments.
  */
@@ -113,21 +218,47 @@ export async function resolveBaseBranch(
     if (hosted) return { kind: 'resolved', branch: hosted };
   }
 
-  // `symbolic-ref refs/remotes/origin/HEAD` answers with a full ref UNDER that
-  // prefix. Anchor the strip: an unanchored `.replace` hands anything else back
-  // whole, and `refs/heads/main` passes the allowlist unscathed — a ref path
-  // laundered into a branch name. A ref that is not under the prefix is no
-  // answer.
-  const ref = runGit(repoRoot, ['symbolic-ref', ORIGIN_HEAD_REF])?.trim();
-  const local = ref?.startsWith(ORIGIN_PREFIX)
-    ? trustedGitRefName(ref.slice(ORIGIN_PREFIX.length))
-    : null;
-  if (local) return { kind: 'resolved', branch: local };
+  for (const rung of GIT_RUNGS) {
+    const branch = rung.read(repoRoot, runGit);
+    if (branch) return { kind: 'resolved', branch };
+  }
 
+  // The reason enumerates what was asked, with each signal's trust class, so the
+  // gate carrying it can tell an operator which knob would fix their repository
+  // rather than only that something was missing.
+  const tried = [
+    `the VCS provider [${provider ? 'authoritative' : 'not supplied'}]`,
+    ...GIT_RUNGS.map((rung) => `'${rung.label}' [${rung.trust}]`),
+  ].join(', ');
   return {
     kind: 'unresolved',
-    reason:
-      `no default branch for '${repoRoot}': neither the VCS provider nor ` +
-      `'git symbolic-ref ${ORIGIN_HEAD_REF}' returned a trusted ref name`,
+    reason: `no default branch for '${repoRoot}': nothing answered — tried ${tried}`,
   };
+}
+
+/**
+ * The discriminant a carrier stamps on itself when it could not learn which
+ * branch its diff was supposed to be scoped against. Read by the gate verdict
+ * normalizer through the generic skip descriptor, so it needs no arm of its own.
+ */
+export const BASE_BRANCH_UNRESOLVED = 'base-branch-unresolved';
+
+/**
+ * The base a diff-scoped caller should measure against: the ref it was handed,
+ * else the repository's detected default branch.
+ *
+ * The precedence lives here rather than at each call site because "an explicit
+ * ref wins" and "an absent one is detected, never invented" are one rule, and a
+ * rule copied ten times is a rule that drifts. An explicit ref short-circuits
+ * detection entirely: the caller already answered the question, so there is
+ * nothing to ask git — which also keeps a caller that always supplies a base
+ * free of a subprocess it never needed.
+ */
+export async function resolveDiffBase(
+  repoRoot: string,
+  explicit: string | undefined,
+): Promise<BaseBranchResolution> {
+  const given = explicit?.trim();
+  if (given) return { kind: 'resolved', branch: given };
+  return resolveBaseBranch(repoRoot);
 }

--- a/src/vcs/resolve-base-branch.ts
+++ b/src/vcs/resolve-base-branch.ts
@@ -1,0 +1,133 @@
+// ─── Base-Branch Resolution ──────────────────────────────────────────────────
+//
+// One seam answering "what does this repository call its default branch".
+//
+// The answer is either a name that was DETECTED or a typed `unresolved` — never
+// an invented literal. A gate that silently diffs against a branch the governed
+// repository does not have reports a scoped verdict it never actually scoped;
+// `unresolved` is what lets it say so instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { runCommandSync } from '../utils/process.js';
+import type { VcsProvider } from './provider.js';
+
+/**
+ * The repository's detected default branch, or a statement that nothing
+ * answered. Two arms only: a fallback string arm is the defect this replaces.
+ */
+export type BaseBranchResolution =
+  | { readonly kind: 'resolved'; readonly branch: string }
+  | { readonly kind: 'unresolved'; readonly reason: string };
+
+/**
+ * Reads a git ref from `repoRoot`, or `null` when git cannot answer. Injected so
+ * the fallback and rejected-ref arms are exercisable without a fixture repo.
+ */
+export type GitRefReader = (repoRoot: string, args: readonly string[]) => string | null;
+
+const ORIGIN_HEAD_REF = 'refs/remotes/origin/HEAD';
+const ORIGIN_PREFIX = 'refs/remotes/origin/';
+
+// The two arms answer from different trust classes, so they need different
+// rules; holding both to one rule is what silently discards a real branch.
+//
+// The git arm parses a name out of a command's stdout — whatever the process
+// wrote, in whatever state the repository is in. It keeps the strict ALLOWLIST
+// both private detectors applied before this seam replaced them: trusted only
+// when every character is one an ordinary git ref carries.
+//
+// The provider arm is the host's own typed record of its default branch,
+// returned by an API call rather than scraped. That name is real by
+// construction, and the allowlist rejects real ones — `feature/日本語` is a
+// branch GitHub will happily carry. So this arm gets a safety FLOOR instead:
+// reject what cannot be a git ref or could escape into a shell, and accept
+// every other name the host reports.
+//
+// Both floors exist because callers interpolate the result into a git
+// invocation, and on Windows `runCommandSync` routes shim commands through a
+// shell. An untrusted name counts as no answer rather than as a branch.
+
+const TRUSTED_REF_NAME = /^[a-zA-Z0-9/_.-]+$/;
+
+/**
+ * Characters and sequences a hosted branch name must not carry: ASCII control
+ * codes and whitespace, the punctuation git itself forbids in a ref name, the
+ * shell metacharacters that could break out of an argument, and git's revision
+ * syntax (`..`, `@{`) which would re-point a range rather than name a branch.
+ */
+const UNSAFE_IN_BRANCH_NAME = /[\p{Cc}\s~^:?*[\\;&|$`'"<>(){}!]|\.\.|@\{/u;
+
+function trustedGitRefName(candidate: string | undefined): string | null {
+  const name = candidate?.trim();
+  if (!name) return null;
+  return TRUSTED_REF_NAME.test(name) ? name : null;
+}
+
+function safeHostedBranchName(candidate: string | undefined): string | null {
+  const name = candidate?.trim();
+  if (!name) return null;
+  return UNSAFE_IN_BRANCH_NAME.test(name) ? null : name;
+}
+
+const readGitRef: GitRefReader = (repoRoot, args) => {
+  try {
+    const stdout = runCommandSync('git', args, {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return typeof stdout === 'string' ? stdout : stdout.toString('utf-8');
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * A provider that cannot answer is not a failure: the GitLab and Azure DevOps
+ * partials throw `UnsupportedOperationError` from `getRepository`, and a network
+ * or auth fault is equally just "no answer" — resolution falls through to git.
+ */
+async function providerDefaultBranch(provider: VcsProvider): Promise<string | undefined> {
+  try {
+    return (await provider.getRepository()).defaultBranch;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the base branch of the repository at `repoRoot`: the host's own
+ * `defaultBranch` when a provider supplies one, else `origin/HEAD`, else
+ * `unresolved`.
+ *
+ * `runGit` is a test seam; production callers pass two arguments.
+ */
+export async function resolveBaseBranch(
+  repoRoot: string,
+  provider?: VcsProvider,
+  runGit: GitRefReader = readGitRef,
+): Promise<BaseBranchResolution> {
+  if (provider) {
+    const hosted = safeHostedBranchName(await providerDefaultBranch(provider));
+    if (hosted) return { kind: 'resolved', branch: hosted };
+  }
+
+  // `symbolic-ref refs/remotes/origin/HEAD` answers with a full ref UNDER that
+  // prefix. Anchor the strip: an unanchored `.replace` hands anything else back
+  // whole, and `refs/heads/main` passes the allowlist unscathed — a ref path
+  // laundered into a branch name. A ref that is not under the prefix is no
+  // answer.
+  const ref = runGit(repoRoot, ['symbolic-ref', ORIGIN_HEAD_REF])?.trim();
+  const local = ref?.startsWith(ORIGIN_PREFIX)
+    ? trustedGitRefName(ref.slice(ORIGIN_PREFIX.length))
+    : null;
+  if (local) return { kind: 'resolved', branch: local };
+
+  return {
+    kind: 'unresolved',
+    reason:
+      `no default branch for '${repoRoot}': neither the VCS provider nor ` +
+      `'git symbolic-ref ${ORIGIN_HEAD_REF}' returned a trusted ref name`,
+  };
+}

--- a/src/verbs/composite.ts
+++ b/src/verbs/composite.ts
@@ -160,6 +160,25 @@ function adaptArgsWithEventStore<T>(handler: (args: T) => ToolResult | Promise<T
 }
 
 /**
+ * Like {@link adaptArgs}, but threads the dispatch-time `ctx.projectConfig` into
+ * the handler's args. For a handler that resolves its own VCS provider: without
+ * the config the factory never sees `.exarchos.yml`'s `vcs.provider` and falls
+ * back to hostname detection, so an explicitly configured host is ignored. An
+ * arg-level `projectConfig` (a test's override) still wins, matching
+ * {@link adaptLadderGate}.
+ */
+function adaptArgsWithConfig<T>(handler: (args: T) => ToolResult | Promise<ToolResult>): ActionHandler {
+  return async (args, _stateDir, ctx) => {
+    const enriched =
+      ctx?.projectConfig !== undefined &&
+      (args as { projectConfig?: unknown }).projectConfig === undefined
+        ? { ...(args as Record<string, unknown>), projectConfig: ctx.projectConfig }
+        : args;
+    return handler(enriched as unknown as T);
+  };
+}
+
+/**
  * Wraps a typed handler that takes `(args, stateDir, eventStore)` — the
  * canonical shape for orchestrate handlers that need to append events.
  * Threads `ctx.eventStore` as the third positional arg so handlers
@@ -490,7 +509,9 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   assess_refactor_scope: adaptArgsWithEventStore(handleAssessRefactorScope),
   check_pr_comments: adaptArgs(handleCheckPrComments),
   validate_pr_body: adaptWithOptionalEventStore(handleValidatePrBody),
-  validate_pr_stack: adaptArgs(handleValidatePrStack),
+  // Resolves its own provider when the caller hands none, so it needs the config
+  // the factory reads `vcs.provider` from — see adaptArgsWithConfig.
+  validate_pr_stack: adaptArgsWithConfig(handleValidatePrStack),
   debug_review_gate: adaptArgs(handleDebugReviewGate),
   extract_fix_tasks: adaptArgsWithStateDirAndEventStore(handleExtractFixTasks),
   classify_review_items: adaptArgsWithEventStore(handleClassifyReviewItems),

--- a/src/verbs/composite.ts
+++ b/src/verbs/composite.ts
@@ -164,14 +164,21 @@ function adaptArgsWithEventStore<T>(handler: (args: T) => ToolResult | Promise<T
  * {@link adaptLadderGate}.
  */
 function adaptArgsWithConfig<T>(handler: (args: T) => ToolResult | Promise<ToolResult>): ActionHandler {
-  return async (args, _stateDir, ctx) => {
-    const enriched =
-      ctx?.projectConfig !== undefined &&
-      (args as { projectConfig?: unknown }).projectConfig === undefined
-        ? { ...(args as Record<string, unknown>), projectConfig: ctx.projectConfig }
-        : args;
-    return handler(enriched as unknown as T);
-  };
+  // Composed onto `adaptArgs` rather than repeating it. The erasure from
+  // `Record<string, unknown>` to `T` is one escape hatch that every adapter in
+  // this file needs exactly once; writing a second copy of it here bought a
+  // duplicate assertion for no extra checking. `args` is already a
+  // `Record<string, unknown>`, so reading and spreading it needs no assertion
+  // of its own either.
+  const inner = adaptArgs(handler);
+  return async (args, stateDir, ctx) =>
+    inner(
+      ctx?.projectConfig !== undefined && args.projectConfig === undefined
+        ? { ...args, projectConfig: ctx.projectConfig }
+        : args,
+      stateDir,
+      ctx,
+    );
 }
 
 /**

--- a/src/verbs/gates/check-integration-suite.ts
+++ b/src/verbs/gates/check-integration-suite.ts
@@ -1,21 +1,37 @@
 // ─── Integration Suite Gate (#1329) ──────────────────────────────────────────
 //
-// Runs the FULL vitest suite against the integration tip (worktree-aware
-// repoRoot, #1330 resolver) and folds file-LOAD failures into the failure
-// count. A file that fails at IMPORT is counted by vitest as "1 failed suite /
-// 0 failed tests" — invisible to per-task gates that only inspect failed
-// tests. This gate makes a load cascade a hard FAIL.
+// Runs the governed repository's whole test suite against the integration tip
+// (worktree-aware repoRoot, #1330 resolver), using the command the LAYERED test
+// runtime resolver lands on for that repository — override, `.exarchos.yml`, a
+// user-declared toolchain, a committed task runner, then the built-in registry —
+// and reading the result through the carrier that repository's runner produces.
 //
-// Wiring into a runbook is T-07's job; this task only registers the action.
+// On a runner that reports per-suite counts, file-LOAD failures are folded into
+// the failure count: a file that fails at IMPORT is counted by vitest as "1
+// failed suite / 0 failed tests" — invisible to per-task gates that only inspect
+// failed tests — and this gate makes that cascade a hard FAIL. On a runner whose
+// only output is an exit code, that code is the verdict, and the carrier says so
+// rather than reporting counts nobody measured.
+//
+// A repository for which no test command resolves gets neither, and neither does
+// a run whose process never started or never finished: the gate reports that it
+// could not conclude. It never invents a verdict to fill the gap.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { runCommandSync } from '../../utils/process.js';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { runDurableGateProducer } from './durable-gate-producer.js';
+import { resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { runGatePreflight } from '../pure/gate-preflight.js';
-import { runIntegrationSuite } from '../pure/integration-suite.js';
-import type { RunCommandFn, CommandResult } from '../pure/static-analysis.js';
+import {
+  runIntegrationSuite,
+  type IntegrationCommandResult,
+  type IntegrationRunCommandFn,
+  type IntegrationSuiteRun,
+  type IntegrationSuiteSkipReason,
+} from '../pure/integration-suite.js';
+import { assertNever } from '../../contract/error-families.js';
 
 // ─── Argument & Result Types ─────────────────────────────────────────────────
 
@@ -24,7 +40,7 @@ interface CheckIntegrationSuiteArgs {
   /**
    * Repository root to run the suite against. A literal path is used verbatim;
    * the special value `'auto'` resolves to the calling delegation's agent
-   * worktree (#1330, reusing the T-04 resolver); omitting it falls back to
+   * worktree (#1330, reusing the shared worktree resolver); omitting it falls back to
    * `process.cwd()` for non-delegation callers. For the post-merge use this
    * should point at the integration tip's worktree.
    */
@@ -38,11 +54,17 @@ interface CheckIntegrationSuiteArgs {
   readonly taskId?: string;
   readonly branch?: string;
   readonly baseBranch?: string;
-  /** npm script that emits vitest JSON. Defaults to `test:run`. */
+  /**
+   * An npm script that emits vitest JSON, for a repository whose script name
+   * the resolver cannot know. When absent — the normal case — the command comes
+   * from the layered resolver. There is no default: a script name this
+   * repository happens to use is not one a governed repository has.
+   */
   readonly testScript?: string;
 }
 
-interface CheckIntegrationSuiteResult {
+/** The carrier for a runner that reports per-suite counts. */
+interface CountedSuiteCarrier {
   readonly passed: boolean;
   /** failedTests + loadFailures — the load cascade can never read as 0. */
   readonly failCount: number;
@@ -53,17 +75,54 @@ interface CheckIntegrationSuiteResult {
   readonly totalTests: number;
   readonly report: string;
   /**
-   * True when the runner produced no parseable vitest JSON. The gate fails
-   * closed in this case (passed=false, failCount>=1); the flag tells callers
-   * the failure stems from unparseable output rather than authoritative counts.
+   * True when the runner RAN and produced no parseable vitest JSON. The gate
+   * fails closed in this case (passed=false, failCount>=1); the flag tells
+   * callers the failure stems from unparseable output rather than authoritative
+   * counts. A runner that never started does not reach this carrier at all — it
+   * is indeterminate, not a failed suite.
    */
   readonly parseError: boolean;
-  /**
-   * When `parseError`, WHY: `'spawn-failure'` (the test command could not run)
-   * vs `'shape-mismatch'` (ran, output unparseable) — #1537. Unset on clean parse.
-   */
-  readonly parseFailureKind?: 'spawn-failure' | 'shape-mismatch';
 }
+
+/**
+ * The carrier for a runner whose only output is an exit code — the majority of
+ * the declared toolchains. It carries NO counts, because none were measured;
+ * stamping zeros would be the false green the counted carrier exists to stop.
+ */
+interface ExitCodeSuiteCarrier {
+  readonly passed: boolean;
+  readonly exitCode: number;
+  readonly report: string;
+}
+
+/**
+ * The carrier for a run that reached no verdict: no test command could be
+ * resolved, or the runner never ran to a conclusion.
+ *
+ * `passed` is ABSENT, deliberately — `false` would name a failure nothing
+ * observed and `true` would mint proof nothing produced. `skipped` is the same
+ * marker the static-analysis gate stamps, so `normalizeGateVerdict` reads this
+ * as `indeterminate` and the durable evidence row records that verdict with its
+ * reason.
+ *
+ * What that row does NOT do, for this gate class, is stop anything: the
+ * projection folds it for audit/shadow visibility only, and the admission
+ * evaluator that would deny on an indeterminate verdict never adjudicates a
+ * `verification-ladder:*` requirement because no edge obligation claims one. The
+ * reader that acts is the caller, on the `report` — see the survey on
+ * `runIntegrationSuite`, which is where that claim is kept honest.
+ */
+interface IndeterminateSuiteCarrier {
+  readonly skipped: true;
+  readonly skipReason: IntegrationSuiteSkipReason;
+  readonly reason: string;
+  readonly report: string;
+}
+
+type CheckIntegrationSuiteResult =
+  | CountedSuiteCarrier
+  | ExitCodeSuiteCarrier
+  | IndeterminateSuiteCarrier;
 
 // ─── Command Runner Adapter ─────────────────────────────────────────────────
 
@@ -73,9 +132,13 @@ interface CheckIntegrationSuiteResult {
  * classification to this set keeps a process that DID run from being mislabeled:
  * a non-zero exit carries a numeric `status`, and an output overflow surfaces as
  * `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` (a string `code` with no `status`) even
- * though the suite ran to completion. Both must stay `shape-mismatch`, not
- * `spawn-failure` (#1537 follow-up). Set membership — not "any string code" — is
- * the discriminant.
+ * though the suite ran to completion. Neither may be read as "never started".
+ * Set membership — not "any string code" — is the discriminant.
+ *
+ * Membership is what decides whether the run is a verdict or an unknown, so a
+ * missing member is a silent mis-verdict rather than a missing feature: with
+ * `EINVAL` absent the gate read a launch that never happened as a suite that
+ * failed.
  */
 const SPAWN_ERROR_CODES: ReadonlySet<string> = new Set([
   'ENOENT', // command / file does not exist
@@ -83,6 +146,15 @@ const SPAWN_ERROR_CODES: ReadonlySet<string> = new Set([
   'EPERM', // operation not permitted
   'ENOTDIR', // a path component is not a directory
   'ENOMEM', // could not allocate to fork the child
+  // On Windows, `execFile*` refuses to launch a `.cmd`/`.bat` shim directly
+  // since the CVE-2024-27980 fix and raises EINVAL — the normal failure shape
+  // for a package-manager or task-runner shim that `utils/process.ts` does not
+  // recognize as needing a shell. The layered resolver can now name any of those
+  // (`task test`, `just test`, `mise run test`), so this arm went from exotic to
+  // routine at the same moment the command source widened.
+  'EINVAL',
+  'ENOEXEC', // the file exists but is not an executable image
+  'EAGAIN', // the fork itself was refused (resource limit)
 ]);
 
 /**
@@ -100,29 +172,69 @@ export function isSpawnFailure(err: { status?: number; code?: string }): boolean
 }
 
 /**
- * Wraps execFileSync to match the RunCommandFn signature. A non-zero exit
- * (the suite failed) is returned as a CommandResult, not thrown — vitest's
- * JSON summary is still on stdout in that case.
+ * The wall clock the suite runner is given, in milliseconds.
+ *
+ * Stated here rather than left to the platform default (there is none —
+ * `execFileSync` waits forever), because without a bound a wedged runner wedges
+ * the gate, and a gate that never returns is worse than one that reports it
+ * could not conclude. Generous on purpose: a real integration suite legitimately
+ * runs for many minutes, and a bound this loose can only be reached by a hang.
+ */
+export const INTEGRATION_SUITE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * The errno a runner killed for exceeding its time limit reports. It carries no
+ * numeric exit `status` (the kill, not the suite, ended it), which is why it can
+ * never be read as a verdict.
+ */
+const TIMEOUT_ERROR_CODE = 'ETIMEDOUT';
+
+/**
+ * True for an error that means the runner was killed at its time limit rather
+ * than deciding anything. Exported so the classification is unit-testable.
+ */
+export function isTimeoutFailure(err: { status?: number; code?: string }): boolean {
+  return typeof err.status !== 'number' && err.code === TIMEOUT_ERROR_CODE;
+}
+
+/**
+ * Wraps execFileSync to match the runner seam. A non-zero exit (the suite
+ * failed) is returned as a result, not thrown — vitest's JSON summary is still
+ * on stdout in that case.
  *
  * @internal Exported so WFQ-003 can prove the real spawn → parse chain without
- * executing the repository's own suite.
+ * executing the repository's own suite. `timeoutMs` is overridable for the same
+ * reason: the kill path is provable against a real child process without
+ * waiting out the production bound.
  */
-export const execCommandRunner: RunCommandFn = (
+export const execCommandRunner: IntegrationRunCommandFn = (
   cmd: string,
   args: readonly string[],
-  options?: { cwd?: string },
-): CommandResult => {
+  options?: { readonly cwd?: string; readonly timeoutMs?: number },
+): IntegrationCommandResult => {
   try {
     const output = runCommandSync(cmd, args as string[], {
       encoding: 'utf-8',
       cwd: options?.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      // The integration suite is large; allow generous output + time.
+      // The integration suite is large; allow generous output + a bounded wall
+      // clock, so "could not run" is a producible outcome instead of a hang.
       maxBuffer: 64 * 1024 * 1024,
+      timeout: options?.timeoutMs ?? INTEGRATION_SUITE_TIMEOUT_MS,
     }) as string;
     return { exitCode: 0, stdout: output, stderr: '' };
   } catch (err: unknown) {
     const execErr = err as { status?: number; code?: string; stdout?: string; stderr?: string };
+    // Killed at the time limit: neither the truncated stdout nor the kill's
+    // status says anything about the suite, so the gate must not read either.
+    if (isTimeoutFailure(execErr)) {
+      return {
+        exitCode: execErr.status ?? 124,
+        stdout: execErr.stdout ?? '',
+        stderr: execErr.stderr ?? '',
+        timedOut: true,
+      };
+    }
     // A spawn failure (ENOENT/EACCES/…) has no numeric exit `status` AND carries
     // a recognized OS-level errno — the process never ran. Surface it as
     // `spawnError` so the gate can tell a missing/unrunnable test command apart
@@ -139,6 +251,44 @@ export const execCommandRunner: RunCommandFn = (
   }
 };
 
+// ─── Carrier ─────────────────────────────────────────────────────────────────
+
+/**
+ * Translate what the run established into the gate's advisory carrier by
+ * switching EXHAUSTIVELY on the run's own discriminant.
+ *
+ * The switch is the point: "the suite could not be run here" has to be handled
+ * at this boundary, so it can no longer arrive dressed as a failure with
+ * invented counts. `assertNever` fails the build before a future outcome can be
+ * folded silently into one of the existing verdicts.
+ */
+function carrierFor(suite: IntegrationSuiteRun): CheckIntegrationSuiteResult {
+  switch (suite.kind) {
+    case 'vitest-counts':
+      return {
+        passed: suite.passed,
+        failCount: suite.failCount,
+        loadFailures: suite.loadFailures,
+        failedTests: suite.failedTests,
+        failedSuites: suite.failedSuites,
+        totalTests: suite.totalTests,
+        report: suite.report,
+        parseError: suite.parseError,
+      };
+    case 'exit-code':
+      return { passed: suite.passed, exitCode: suite.exitCode, report: suite.report };
+    case 'indeterminate':
+      return {
+        skipped: true,
+        skipReason: suite.skipReason,
+        reason: suite.reason,
+        report: suite.report,
+      };
+    default:
+      return assertNever(suite, 'IntegrationSuiteRun');
+  }
+}
+
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
 /**
@@ -149,11 +299,11 @@ export async function handleCheckIntegrationSuite(
   args: CheckIntegrationSuiteArgs,
   stateDir: string,
   eventStore: EventStore,
-  runCommand: RunCommandFn = execCommandRunner,
+  runCommand: IntegrationRunCommandFn = execCommandRunner,
 ): Promise<ToolResult> {
-  // Preflight (DR-10): fail-fast on a miswired DispatchContext / absent
+  // Preflight: fail-fast on a miswired DispatchContext / absent
   // featureId (a missing eventStore is a wiring bug, not a transient error) and
-  // resolve the worktree-aware 'auto' repoRoot (#1330, T-04 resolver). taskId is
+  // resolve the worktree-aware 'auto' repoRoot (#1330). taskId is
   // optional for this post-merge gate, so it is not required here.
   const pre = await runGatePreflight(
     {
@@ -167,6 +317,7 @@ export async function handleCheckIntegrationSuite(
   );
   if (!pre.ok) return pre.result;
   const repoRoot = pre.repoRoot;
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
 
   return runDurableGateProducer(
     {
@@ -174,31 +325,26 @@ export async function handleCheckIntegrationSuite(
       featureId: args.featureId,
       ...(args.taskId ? { taskId: args.taskId } : {}),
       ...(args.branch ? { branch: args.branch } : {}),
-      baseRef: args.baseBranch ?? 'main',
+      // The diff base is a LABEL on the evidence subject here, not a range this
+      // gate reads — it runs the whole suite in the tree it was pointed at. So an
+      // unresolved base withholds the label rather than yielding Indeterminate:
+      // the gate still ran, it just cannot name a base it never used.
+      ...(base.kind === 'resolved' ? { baseRef: base.branch } : {}),
       repoRoot,
       stateDir,
       eventStore,
     },
     async () => {
-      // Run the full suite and fold load-failures into the failure count.
+      // Run the suite the detected toolchain declares, read the result through
+      // the carrier that toolchain produces, and report only what that carrier
+      // can actually establish.
       const suite = runIntegrationSuite({
         repoRoot,
         runCommand,
         testScript: args.testScript,
       });
 
-      const result: CheckIntegrationSuiteResult = {
-        passed: suite.passed,
-        failCount: suite.failCount,
-        loadFailures: suite.loadFailures,
-        failedTests: suite.failedTests,
-        failedSuites: suite.failedSuites,
-        totalTests: suite.totalTests,
-        report: suite.report,
-        parseError: suite.parseError,
-        ...(suite.parseFailureKind ? { parseFailureKind: suite.parseFailureKind } : {}),
-      };
-      return { success: true, data: result };
+      return { success: true, data: carrierFor(suite) };
     },
   );
 }

--- a/src/verbs/gates/check-polish-scope.ts
+++ b/src/verbs/gates/check-polish-scope.ts
@@ -15,6 +15,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ToolResult } from '../../format.js';
+import { resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -90,7 +91,7 @@ function isStructuralFile(filePath: string): boolean {
 
 // ─── Handler ───────────────────────────────────────────────────────────────
 
-export function handleCheckPolishScope(args: CheckPolishScopeArgs): ToolResult {
+export async function handleCheckPolishScope(args: CheckPolishScopeArgs): Promise<ToolResult> {
   // Validate required repoRoot
   if (!args.repoRoot) {
     return {
@@ -100,7 +101,19 @@ export function handleCheckPolishScope(args: CheckPolishScopeArgs): ToolResult {
   }
 
   const { repoRoot } = args;
-  const baseBranch = args.baseBranch ?? 'main';
+
+  // Scoping the diff is a precondition of this check, and an undetectable
+  // default branch fails it exactly as an unrunnable `git diff` does — so it
+  // reports through the same envelope rather than naming a scope violation
+  // nobody measured.
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
+  if (base.kind === 'unresolved') {
+    return {
+      success: false,
+      error: { code: 'DIFF_FAILED', message: base.reason },
+    };
+  }
+  const baseBranch = base.branch;
 
   const modifiedFiles = getModifiedFiles(repoRoot, baseBranch);
 

--- a/src/verbs/gates/context-economy.ts
+++ b/src/verbs/gates/context-economy.ts
@@ -8,6 +8,7 @@
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { emitGateEvent, getDiff } from './gate-utils.js';
+import { BASE_BRANCH_UNRESOLVED, resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { checkContextEconomy } from '../pure/context-economy.js';
 import { queryRuntimeMetrics } from '../../projections/telemetry/telemetry-queries.js';
 import type { RuntimeMetrics } from '../../projections/telemetry/telemetry-queries.js';
@@ -25,6 +26,32 @@ interface ContextEconomyResult {
   readonly findingCount: number;
   readonly report: string;
   readonly runtimeMetrics?: RuntimeMetrics;
+  /** Present only on the inconclusive carrier below. */
+  readonly skipped?: true;
+  readonly discriminant?: string;
+  readonly reason?: string;
+}
+
+const GATE_NAME = 'context-economy';
+const GATE_LAYER = 'quality';
+const GATE_DIMENSION = 'D3';
+
+/** Record the unscoped run. Fire-and-forget, matching the conclusive path. */
+async function emitUnscoped(
+  store: EventStore,
+  featureId: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await emitGateEvent(store, featureId, GATE_NAME, GATE_LAYER, false, {
+      dimension: GATE_DIMENSION,
+      phase: 'review',
+      findingCount: 0,
+      skipped: true,
+      discriminant: BASE_BRANCH_UNRESOLVED,
+      reason,
+    });
+  } catch { /* fire-and-forget */ }
 }
 
 // ─── Handler ───────────────────────────────────────────────────────────────
@@ -43,7 +70,31 @@ export async function handleContextEconomy(
   }
 
   const repoRoot = args.repoRoot || process.cwd();
-  const baseBranch = args.baseBranch || 'main';
+
+  // A diff needs two ends. Without a detected default branch this gate has one,
+  // and the honest report is that it could not scope its subject — an advisory
+  // carrier that normalizes to indeterminate, never a diff against a branch the
+  // repository may not have and never a silent pass.
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
+  if (base.kind === 'unresolved') {
+    const inconclusive: ContextEconomyResult = {
+      passed: false,
+      findingCount: 0,
+      report: base.reason,
+      skipped: true,
+      discriminant: BASE_BRANCH_UNRESOLVED,
+      reason: base.reason,
+    };
+    // Indeterminate is a VERDICT, so it is recorded like one. This action
+    // declares `gate.executed` unconditionally; returning success without it
+    // would leave the declaration and the handler saying different things, and
+    // it would leave the durable log unable to tell "could not be scoped" from
+    // "never invoked". The row is fail-closed (`passed: false`) and carries the
+    // skip markers, so no reader mistakes it for a gate that ran.
+    await emitUnscoped(eventStore, args.featureId, base.reason);
+    return { success: true, data: inconclusive };
+  }
+  const baseBranch = base.branch;
 
   // Get the diff — fail-closed if git is unavailable
   const diff = getDiff(repoRoot, baseBranch);
@@ -75,8 +126,8 @@ export async function handleContextEconomy(
 
   // Emit gate.executed event (fire-and-forget)
   try {
-    await emitGateEvent(store, args.featureId, 'context-economy', 'quality', passed, {
-      dimension: 'D3',
+    await emitGateEvent(store, args.featureId, GATE_NAME, GATE_LAYER, passed, {
+      dimension: GATE_DIMENSION,
       phase: 'review',
       findingCount,
     });

--- a/src/verbs/gates/contract-drift-handler.ts
+++ b/src/verbs/gates/contract-drift-handler.ts
@@ -21,6 +21,7 @@ import { runCommandSync } from '../../utils/process.js';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { defaultGitExec, resolvePolicySkip, SKIPPED_BY_POLICY } from './gate-utils.js';
+import { BASE_BRANCH_UNRESOLVED, resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { runGatePreflight } from '../pure/gate-preflight.js';
 import { runDurableGateProducer } from './durable-gate-producer.js';
 import type { RiskTier } from '../../workflow/verification-policy.js';
@@ -50,7 +51,11 @@ export interface ContractDriftHandlerArgs {
   readonly taskId: string;
   /** The task branch (HEAD side of the diff). Defaults to the current branch. */
   readonly branch?: string;
-  /** Base ref the branch diverged from (merge-base target). Defaults to 'main'. */
+  /**
+   * Base ref the branch diverged from (merge-base target). Omit it and the
+   * repository's default branch is DETECTED; when nothing detects one the gate
+   * reports an inconclusive verdict rather than assuming a name.
+   */
   readonly baseBranch?: string;
   /**
    * Repo to check. A literal path is used verbatim; `'auto'` resolves the
@@ -142,7 +147,7 @@ export async function handleContractDrift(
   );
   if (!pre.ok) return pre.result;
   const repoRoot = pre.repoRoot;
-  const baseRef = args.baseBranch || 'main';
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
 
   return runDurableGateProducer(
     {
@@ -150,7 +155,10 @@ export async function handleContractDrift(
       featureId: args.featureId,
       taskId: args.taskId,
       ...(args.branch ? { branch: args.branch } : {}),
-      baseRef,
+      // The evidence subject names the diff base it was scoped against. An
+      // unresolved base has no name to record, so the field is omitted rather
+      // than stamped with a literal the run never used.
+      ...(base.kind === 'resolved' ? { baseRef: base.branch } : {}),
       repoRoot,
       stateDir,
       eventStore,
@@ -175,6 +183,26 @@ export async function handleContractDrift(
           },
         };
       }
+
+      // A diff-scoped gate with no detected default branch cannot say what it
+      // measured. The carrier declares itself skipped so the durable row and
+      // the verdict agree it never ran, instead of scoping against a branch the
+      // governed repository may not have.
+      if (base.kind === 'unresolved') {
+        return {
+          success: true,
+          data: {
+            passed: false,
+            skipped: true,
+            drift: false,
+            breaking: [],
+            report: base.reason,
+            discriminant: BASE_BRANCH_UNRESOLVED,
+            reason: base.reason,
+          },
+        };
+      }
+      const baseRef = base.branch;
 
       const gitExec = args.gitExec ?? defaultGitExec;
       const runCommand = args.runCommand ?? defaultRunCommand;

--- a/src/verbs/gates/mock-boundary-handler.ts
+++ b/src/verbs/gates/mock-boundary-handler.ts
@@ -28,6 +28,7 @@
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { defaultGitExec, resolvePolicySkip, SKIPPED_BY_POLICY } from './gate-utils.js';
+import { BASE_BRANCH_UNRESOLVED, resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { runGatePreflight } from '../pure/gate-preflight.js';
 import { runDurableGateProducer } from './durable-gate-producer.js';
 import type { RiskTier } from '../../workflow/verification-policy.js';
@@ -86,7 +87,11 @@ export interface MockBoundaryHandlerArgs {
   readonly taskId: string;
   /** The task branch (HEAD side of the diff). Defaults to the current branch. */
   readonly branch?: string;
-  /** Base ref the branch diverged from (merge-base target). Defaults to 'main'. */
+  /**
+   * Base ref the branch diverged from (merge-base target). Omit it and the
+   * repository's default branch is DETECTED; when nothing detects one the gate
+   * reports an inconclusive verdict rather than assuming a name.
+   */
   readonly baseBranch?: string;
   /**
    * Repo to check. A literal path is used verbatim; `'auto'` resolves the
@@ -225,7 +230,7 @@ export async function handleMockBoundary(
   );
   if (!pre.ok) return pre.result;
   const repoRoot = pre.repoRoot;
-  const baseRef = args.baseBranch || 'main';
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
 
   return runDurableGateProducer(
     {
@@ -233,7 +238,10 @@ export async function handleMockBoundary(
       featureId: args.featureId,
       taskId: args.taskId,
       ...(args.branch ? { branch: args.branch } : {}),
-      baseRef,
+      // The evidence subject names the diff base it was scoped against. An
+      // unresolved base has no name to record, so the field is omitted rather
+      // than stamped with a literal the run never used.
+      ...(base.kind === 'resolved' ? { baseRef: base.branch } : {}),
       repoRoot,
       stateDir,
       eventStore,
@@ -257,6 +265,25 @@ export async function handleMockBoundary(
           },
         };
       }
+
+      // A diff-scoped gate with no detected default branch cannot say what it
+      // measured. The carrier declares itself skipped so the durable row and
+      // the verdict agree it never ran, instead of scoping against a branch the
+      // governed repository may not have.
+      if (base.kind === 'unresolved') {
+        return {
+          success: true,
+          data: {
+            passed: false,
+            skipped: true,
+            findings: [],
+            report: base.reason,
+            discriminant: BASE_BRANCH_UNRESOLVED,
+            reason: base.reason,
+          },
+        };
+      }
+      const baseRef = base.branch;
 
       const gitExec = args.gitExec ?? defaultGitExec;
       const loadConfig = args.loadConfig ?? loadExarchosConfig;

--- a/src/verbs/gates/needs-schema-sync.ts
+++ b/src/verbs/gates/needs-schema-sync.ts
@@ -7,6 +7,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import type { ToolResult } from '../../format.js';
+import { resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 
 // ─── Argument & Result Types ─────────────────────────────────────────────────
 
@@ -114,15 +115,13 @@ function buildReport(apiFiles: readonly string[]): string {
 
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
-export function handleNeedsSchemaSync(args: NeedsSchemaSyncArgs): ToolResult {
+export async function handleNeedsSchemaSync(args: NeedsSchemaSyncArgs): Promise<ToolResult> {
   if (!args.repoRoot) {
     return {
       success: false,
       error: { code: 'INVALID_INPUT', message: 'repoRoot is required' },
     };
   }
-
-  const baseBranch = args.baseBranch ?? 'main';
 
   let changedFiles: readonly string[];
 
@@ -139,8 +138,18 @@ export function handleNeedsSchemaSync(args: NeedsSchemaSyncArgs): ToolResult {
     const diffContent = readFileSync(args.diffFile, 'utf-8');
     changedFiles = getChangedFilesFromDiff(diffContent);
   } else {
+    // Only the git path needs a base — a supplied diff file already carries the
+    // comparison. An undetectable default branch fails the same precondition an
+    // unrunnable `git diff` does, and reports through the same envelope.
+    const base = await resolveDiffBase(args.repoRoot, args.baseBranch);
+    if (base.kind === 'unresolved') {
+      return {
+        success: false,
+        error: { code: 'GIT_ERROR', message: base.reason },
+      };
+    }
     try {
-      changedFiles = getChangedFilesFromGit(args.repoRoot, baseBranch);
+      changedFiles = getChangedFilesFromGit(args.repoRoot, base.branch);
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : 'git diff failed';

--- a/src/verbs/gates/operational-resilience.ts
+++ b/src/verbs/gates/operational-resilience.ts
@@ -8,6 +8,7 @@
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { emitGateEvent, getDiff } from './gate-utils.js';
+import { BASE_BRANCH_UNRESOLVED, resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { checkOperationalResilience } from '../pure/operational-resilience.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
@@ -22,6 +23,32 @@ interface OperationalResilienceResult {
   readonly passed: boolean;
   readonly findingCount: number;
   readonly report: string;
+  /** Present only on the inconclusive carrier below. */
+  readonly skipped?: true;
+  readonly discriminant?: string;
+  readonly reason?: string;
+}
+
+const GATE_NAME = 'operational-resilience';
+const GATE_LAYER = 'quality';
+const GATE_DIMENSION = 'D4';
+
+/** Record the unscoped run. Fire-and-forget, matching the conclusive path. */
+async function emitUnscoped(
+  store: EventStore,
+  featureId: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await emitGateEvent(store, featureId, GATE_NAME, GATE_LAYER, false, {
+      dimension: GATE_DIMENSION,
+      phase: 'review',
+      findingCount: 0,
+      skipped: true,
+      discriminant: BASE_BRANCH_UNRESOLVED,
+      reason,
+    });
+  } catch { /* fire-and-forget */ }
 }
 
 // ─── Handler ───────────────────────────────────────────────────────────────
@@ -40,7 +67,29 @@ export async function handleOperationalResilience(
   }
 
   const repoRoot = args.repoRoot || process.cwd();
-  const baseBranch = args.baseBranch || 'main';
+
+  // No detected default branch means no diff to judge — report that, rather
+  // than judging a diff against a branch the repository may not have.
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
+  if (base.kind === 'unresolved') {
+    const inconclusive: OperationalResilienceResult = {
+      passed: false,
+      findingCount: 0,
+      report: base.reason,
+      skipped: true,
+      discriminant: BASE_BRANCH_UNRESOLVED,
+      reason: base.reason,
+    };
+    // Indeterminate is a VERDICT, so it is recorded like one. This action
+    // declares `gate.executed` unconditionally; returning success without it
+    // would leave the declaration and the handler saying different things, and
+    // it would leave the durable log unable to tell "could not be scoped" from
+    // "never invoked". The row is fail-closed (`passed: false`) and carries the
+    // skip markers, so no reader mistakes it for a gate that ran.
+    await emitUnscoped(eventStore, args.featureId, base.reason);
+    return { success: true, data: inconclusive };
+  }
+  const baseBranch = base.branch;
 
   // Get the diff — fail-closed if git is unavailable
   const diff = getDiff(repoRoot, baseBranch);
@@ -70,8 +119,8 @@ export async function handleOperationalResilience(
 
   // Emit gate.executed event (fire-and-forget)
   try {
-    await emitGateEvent(eventStore, args.featureId, 'operational-resilience', 'quality', passed, {
-      dimension: 'D4',
+    await emitGateEvent(eventStore, args.featureId, GATE_NAME, GATE_LAYER, passed, {
+      dimension: GATE_DIMENSION,
       phase: 'review',
       findingCount,
     });

--- a/src/verbs/gates/post-merge.ts
+++ b/src/verbs/gates/post-merge.ts
@@ -1,6 +1,6 @@
 // ─── Post-Merge Gate Handler ────────────────────────────────────────────────
 //
-// Orchestrates the post-merge regression check (DR-4) at the
+// Orchestrates the post-merge regression check at the
 // synthesize -> cleanup boundary. Calls the pure TypeScript
 // checkPostMerge function and emits gate.executed events for
 // flywheel integration.
@@ -11,7 +11,8 @@ import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { emitGateEvent } from './gate-utils.js';
 import { checkPostMerge } from '../pure/post-merge.js';
-import type { CommandResult } from '../pure/post-merge.js';
+import type { CommandResult, PostMergeResult as PostMergeCheck } from '../pure/post-merge.js';
+import { classifyCommandFailure } from '../pure/command-outcome.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -23,11 +24,20 @@ interface PostMergeArgs {
 }
 
 interface PostMergeResult {
+  /** True only for `status: 'pass'`. An unmeasured check is never a pass. */
   readonly passed: boolean;
+  /**
+   * The check's own three-valued outcome. Carried alongside `passed` because
+   * `passed: false` alone cannot tell a regression the check OBSERVED from one
+   * it never got to look for, and the caller acts differently on each.
+   */
+  readonly status: PostMergeCheck['status'];
   readonly prUrl: string;
   readonly mergeSha: string;
   readonly findings: string[];
   readonly report: string;
+  /** Present only when `status` is `'indeterminate'`: which check could not run. */
+  readonly reason?: string;
 }
 
 // ─── Command Runner Adapter ─────────────────────────────────────────────────
@@ -35,9 +45,14 @@ interface PostMergeResult {
 /**
  * Wraps spawnSync to match the command runner signature expected by
  * the pure TypeScript checkPostMerge function. Routes through
- * `spawnCommandSync` so a resolved package-manager command (`checkPostMerge`
- * spawns `npm`) launches its `.cmd` shim on Windows — raw `spawnSync('npm', …)`
- * throws EINVAL since CVE-2024-27980 (Node >= 20.12.2). (#1623)
+ * `spawnCommandSync` so a resolved package-manager command launches its `.cmd`
+ * shim on Windows — raw `spawnSync('npm', …)` throws EINVAL since
+ * CVE-2024-27980 (Node >= 20.12.2). (#1623)
+ *
+ * A run that never started or was killed at its wall clock is reported through
+ * the dedicated fields rather than as `exitCode: 1`: the pure check reads them
+ * to keep "no regression was observed" from being written down as "a regression
+ * was observed".
  */
 function execCommandRunner(
   cmd: string,
@@ -51,10 +66,27 @@ function execCommandRunner(
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
+  if (result.error !== undefined) {
+    const failure = classifyCommandFailure({
+      ...(typeof result.status === 'number' ? { status: result.status } : {}),
+      code: (result.error as NodeJS.ErrnoException).code,
+      message: result.error.message,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    });
+    return {
+      exitCode: failure.exitCode,
+      stdout: failure.stdout,
+      stderr: failure.stderr || failure.detail,
+      ...(failure.kind === 'spawn' ? { spawnError: failure.detail } : {}),
+      ...(failure.kind === 'timeout' ? { timedOut: true } : {}),
+    };
+  }
+
   return {
     exitCode: result.status ?? 1,
     stdout: result.stdout ?? '',
-    stderr: result.stderr ?? result.error?.message ?? '',
+    stderr: result.stderr ?? '',
   };
 }
 
@@ -87,18 +119,25 @@ export async function handlePostMerge(
     };
   }
 
-  // Run the pure TypeScript post-merge check
+  // Run the pure TypeScript post-merge check. `repoRoot` is threaded, not just
+  // handed to the runner: the check resolves the test command from the same
+  // tree it runs it in, and passing one without the other would let it resolve
+  // this process's own toolchain and run it somewhere else.
   const cwd = args.repoRoot;
   const checkResult = await checkPostMerge({
     prUrl: args.prUrl,
     mergeSha: args.mergeSha,
+    ...(cwd !== undefined ? { repoRoot: cwd } : {}),
     runCommand: (cmd, cmdArgs) => execCommandRunner(cmd, cmdArgs, cwd),
   });
 
-  const passed = checkResult.status === 'pass';
-  const { findings, report } = checkResult;
+  const { status, findings, report, reason } = checkResult;
+  const passed = status === 'pass';
 
-  // Emit gate.executed event for flywheel integration (fire-and-forget)
+  // Emit gate.executed event for flywheel integration (fire-and-forget). The
+  // three-valued outcome travels with it: a row that says only `passed: false`
+  // cannot distinguish a regression that was found from a check that never ran,
+  // and the second one is not a finding anybody may act on.
   try {
     const store = eventStore;
     await emitGateEvent(store, args.featureId, 'post-merge', 'post-merge', passed, {
@@ -107,16 +146,20 @@ export async function handlePostMerge(
       prUrl: args.prUrl,
       mergeSha: args.mergeSha,
       findings,
+      status,
+      ...(reason !== undefined ? { reason } : {}),
     });
   } catch { /* fire-and-forget: emission failure must not break the gate check */ }
 
   // Build result
   const data: PostMergeResult = {
     passed,
+    status,
     prUrl: args.prUrl,
     mergeSha: args.mergeSha,
     findings,
     report,
+    ...(reason !== undefined ? { reason } : {}),
   };
 
   return { success: true, data };

--- a/src/verbs/gates/spec-coverage-check.ts
+++ b/src/verbs/gates/spec-coverage-check.ts
@@ -2,7 +2,20 @@
 //
 // Pure TypeScript port of scripts/spec-coverage-check.sh.
 // Verifies test coverage for spec compliance by checking plan references
-// against on-disk test files and optional vitest execution.
+// against on-disk test files and, optionally, exercising them by running the
+// governed repository's own resolved test suite.
+//
+// ── What the execution leg does and does not establish ──────────────────────
+// It runs the resolved test command WHOLE, once, and reports that. It does not
+// hand the runner a declared test path: which argv form selects a single file
+// is per-runner knowledge that the toolchain source of truth does not carry,
+// and the naive form is wrong in the dangerous direction — `cargo test <path>`
+// reads its argument as a test-NAME substring, matches nothing, and exits
+// zero, which is a green verdict over an unexecuted file. Running the suite is
+// the claim this check can actually back on every toolchain the resolver
+// resolves, and it strictly covers the declared files it collects. The one
+// thing it cannot see is a declared file the suite does not collect at all;
+// per-file selection returns here when the registry carries a selector form.
 // ────────────────────────────────────────────────────────────────────────────
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -10,6 +23,9 @@ import { runCommandSync } from '../../utils/process.js';
 import { join } from 'node:path';
 import { toPosix } from '../../utils/paths.js';
 import type { ToolResult } from '../../format.js';
+import { resolveTestRuntime, type ResolvedRuntime } from '../../config/test-runtime-resolver.js';
+import { splitCommand } from '../../config/tokenize-command.js';
+import { classifyCommandFailure, inconclusiveReason } from '../pure/command-outcome.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -37,7 +53,12 @@ export interface SpecCoverageCheckArgs {
 }
 
 interface CheckEntry {
-  readonly status: 'PASS' | 'FAIL' | 'SKIP';
+  /**
+   * `SKIP` is a decision — the caller waived execution — and may leave a green
+   * report. `INDETERMINATE` is the absence of one: the check could not be
+   * performed, so the gate certifies nothing.
+   */
+  readonly status: 'PASS' | 'FAIL' | 'SKIP' | 'INDETERMINATE';
   readonly name: string;
   readonly detail?: string;
 }
@@ -52,6 +73,14 @@ interface SpecCoverageResult {
   readonly missing: readonly string[];
   /** plan phase: declared paths that are not valid test-path declarations. */
   readonly malformed: readonly string[];
+  /**
+   * Checks that could not be performed, one reason each — a peer of `missing`
+   * and `malformed`, reported to whoever called this action and to nothing
+   * else. It is deliberately NOT the gate runner's `skipped` descriptor: this
+   * action is not registered as a gate class, so a carrier spelled in that
+   * vocabulary would be read by no one while looking as though it were.
+   */
+  readonly indeterminate: readonly string[];
   readonly report: string;
 }
 
@@ -204,13 +233,19 @@ function generateReport(
 
   const passCount = checks.filter((c) => c.status === 'PASS').length;
   const failCount = checks.filter((c) => c.status === 'FAIL').length;
+  const unrunnable = checks.filter((c) => c.status === 'INDETERMINATE').length;
   const total = passCount + failCount;
 
   lines.push('');
   lines.push('---');
   lines.push('');
 
-  if (failCount === 0 && totalTests > 0) {
+  if (unrunnable > 0) {
+    lines.push(
+      `**Result: INDETERMINATE** (${unrunnable} check(s) could not run; ` +
+        `${passCount}/${total} of the rest passed)`,
+    );
+  } else if (failCount === 0 && totalTests > 0) {
     lines.push(`**Result: PASS** (${passCount}/${total} checks passed)`);
   } else {
     lines.push(`**Result: FAIL** (${failCount}/${total} checks failed)`);
@@ -309,17 +344,69 @@ function runPlanSyntaxCheck(
     found: wellFormed,
     missing: [],
     malformed,
+    indeterminate: [],
     report,
   };
 
   return { success: true, data: result };
 }
 
+// ─── Suite Runner ───────────────────────────────────────────────────────────
+
+/**
+ * Wall clock the suite is given. Generous, because a real suite legitimately
+ * runs for minutes and a bound this loose can only be reached by a hang — and
+ * declared, because a check with no bound is a check that can stop returning.
+ */
+const SUITE_TIMEOUT_MS = 15 * 60 * 1000;
+
+type SuiteRunner =
+  | {
+      readonly kind: 'resolved';
+      readonly command: string;
+      readonly cmd: string;
+      readonly args: readonly string[];
+    }
+  | { readonly kind: 'indeterminate'; readonly reason: string };
+
+/**
+ * The governed repository's own test command, taken from the toolchain source
+ * of truth. Naming one runner here meant this check could only ever discharge
+ * its obligation in a single ecosystem; a repository whose runtime does not
+ * resolve now gets no verdict rather than a spawn that was never going to work.
+ */
+function resolveSuiteRunner(repoRoot: string): SuiteRunner {
+  let runtime: ResolvedRuntime;
+  try {
+    runtime = resolveTestRuntime(repoRoot);
+  } catch (err) {
+    return { kind: 'indeterminate', reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (runtime.source === 'unresolved' || runtime.test === null) {
+    return {
+      kind: 'indeterminate',
+      reason:
+        runtime.remediation ??
+        `no test command resolves for '${repoRoot}', so declared tests could not be exercised`,
+    };
+  }
+  try {
+    const { cmd, args } = splitCommand(runtime.test);
+    if (cmd === '') {
+      return { kind: 'indeterminate', reason: `empty test command: '${runtime.test}'` };
+    }
+    return { kind: 'resolved', command: runtime.test, cmd, args };
+  } catch (err) {
+    return { kind: 'indeterminate', reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 /**
  * Post-implementation coverage validation (WFQ-010). Every declared test file
- * must exist on disk and, unless `skipRun`, its tests must actually run and
- * pass. This is the gate that must remain honest: real passing tests, not mere
- * declarations.
+ * must exist on disk — checked per file — and, unless `skipRun`, the suite
+ * that collects them must actually run and pass. This is the gate that must
+ * remain honest: really-executed tests, not mere declarations, and no claim
+ * finer-grained than what was executed.
  */
 function runImplementationCoverageCheck(
   planFile: string,
@@ -356,18 +443,38 @@ function runImplementationCoverageCheck(
     }
   }
 
-  // Check: tests pass (unless skipRun)
+  // Check: the declared tests actually run and pass (unless skipRun). The
+  // claim is deliberately suite-shaped — see the module header for why a
+  // declared path is not appended to the resolved command.
   if (skipRun) {
     checks.push({ status: 'SKIP', name: 'Test execution (--skip-run)' });
   } else if (testFiles.length > 0 && missingList.length === 0) {
-    for (const testFile of testFiles) {
+    const runner = resolveSuiteRunner(repoRoot);
+    if (runner.kind === 'indeterminate') {
+      checks.push({
+        status: 'INDETERMINATE',
+        name: 'Test execution',
+        detail: runner.reason,
+      });
+    } else {
+      const name = `Declared tests exercised by \`${runner.command}\``;
       try {
-        runCommandSync('npx', ['vitest', 'run', '--root', repoRoot, testFile], {
+        runCommandSync(runner.cmd, runner.args, {
+          cwd: repoRoot,
+          timeout: SUITE_TIMEOUT_MS,
           stdio: 'pipe',
         });
-        checks.push({ status: 'PASS', name: `Test passes: ${testFile}` });
-      } catch {
-        checks.push({ status: 'FAIL', name: `Test passes: ${testFile}` });
+        checks.push({ status: 'PASS', name });
+      } catch (err: unknown) {
+        // A runner that never started, or one killed at its wall clock, decided
+        // nothing about these tests. Only a real non-zero exit is a failure.
+        const failure = classifyCommandFailure(err);
+        const reason = inconclusiveReason(runner.command, failure);
+        checks.push(
+          reason === null
+            ? { status: 'FAIL', name, detail: `exit code ${failure.exitCode}` }
+            : { status: 'INDETERMINATE', name: 'Test execution', detail: reason },
+        );
       }
     }
   }
@@ -385,7 +492,10 @@ function runImplementationCoverageCheck(
   );
 
   const failCount = checks.filter((c) => c.status === 'FAIL').length;
-  const passed = failCount === 0 && testFiles.length > 0;
+  const unrunnable = checks
+    .filter((c) => c.status === 'INDETERMINATE')
+    .map((c) => c.detail ?? c.name);
+  const passed = failCount === 0 && unrunnable.length === 0 && testFiles.length > 0;
 
   const result: SpecCoverageResult = {
     phase: 'post-implementation',
@@ -394,6 +504,7 @@ function runImplementationCoverageCheck(
     found,
     missing: missingList,
     malformed: [],
+    indeterminate: unrunnable,
     report,
   };
 

--- a/src/verbs/gates/static-analysis.ts
+++ b/src/verbs/gates/static-analysis.ts
@@ -4,13 +4,12 @@
 // durable evidence runner.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { runCommandSync } from '../../utils/process.js';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { runDurableGateProducer } from './durable-gate-producer.js';
+import { resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { runGatePreflight } from '../pure/gate-preflight.js';
-import { runStaticAnalysis } from '../pure/static-analysis.js';
-import type { RunCommandFn, CommandResult } from '../pure/static-analysis.js';
+import { execCommandRunner, runStaticAnalysis } from '../pure/static-analysis.js';
 
 // ─── Argument & Result Types ─────────────────────────────────────────────────
 
@@ -61,34 +60,6 @@ interface StaticAnalysisResult {
   readonly degraded?: boolean;
 }
 
-// ─── Command Runner Adapter ─────────────────────────────────────────────────
-
-/**
- * Wraps execFileSync to match the RunCommandFn signature expected by
- * the pure TypeScript runStaticAnalysis function.
- */
-const execCommandRunner: RunCommandFn = (
-  cmd: string,
-  args: readonly string[],
-  options?: { cwd?: string },
-): CommandResult => {
-  try {
-    const output = runCommandSync(cmd, args as string[], {
-      encoding: 'utf-8',
-      cwd: options?.cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }) as string;
-    return { exitCode: 0, stdout: output, stderr: '' };
-  } catch (err: unknown) {
-    const execErr = err as { status?: number; stdout?: string; stderr?: string };
-    return {
-      exitCode: execErr.status ?? 1,
-      stdout: execErr.stdout ?? '',
-      stderr: execErr.stderr ?? '',
-    };
-  }
-};
-
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
 export async function handleStaticAnalysis(
@@ -114,6 +85,7 @@ export async function handleStaticAnalysis(
   );
   if (!pre.ok) return pre.result;
   const repoRoot = pre.repoRoot;
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
 
   return runDurableGateProducer(
     {
@@ -121,7 +93,11 @@ export async function handleStaticAnalysis(
       featureId: args.featureId,
       ...(args.taskId ? { taskId: args.taskId } : {}),
       ...(args.branch ? { branch: args.branch } : {}),
-      baseRef: args.baseBranch ?? 'main',
+      // The diff base is a LABEL on the evidence subject here, not a range this
+      // gate reads — it lints and typechecks the tree it was pointed at. So an
+      // unresolved base withholds the label rather than yielding Indeterminate:
+      // the gate still ran, it just cannot name a base it never used.
+      ...(base.kind === 'resolved' ? { baseRef: base.branch } : {}),
       repoRoot,
       stateDir,
       eventStore,

--- a/src/verbs/gates/test-adequacy-handler.ts
+++ b/src/verbs/gates/test-adequacy-handler.ts
@@ -19,6 +19,7 @@ import { runCommandSync } from '../../utils/process.js';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { defaultGitExec, resolvePolicySkip, SKIPPED_BY_POLICY } from './gate-utils.js';
+import { resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { runGatePreflight } from '../pure/gate-preflight.js';
 import { runDurableGateProducer } from './durable-gate-producer.js';
 import { resolveTestRuntime } from '../../config/test-runtime-resolver.js';
@@ -33,6 +34,7 @@ import {
   interpretProbeVerdict,
   verdictOf,
   type ProbeResult,
+  type ProbeVerdict,
   type TestRunFn,
 } from './test-adequacy.js';
 import { assertNever } from '../../contract/error-families.js';
@@ -44,7 +46,11 @@ export interface TestAdequacyArgs {
   readonly taskId: string;
   /** The task branch (HEAD side of the diff). Defaults to the current branch. */
   readonly branch?: string;
-  /** Base ref the task diff is measured against. Defaults to 'main'. */
+  /**
+   * Base ref the task diff is measured against. Omit it and the repository's
+   * default branch is DETECTED; when nothing detects one the diff cannot be
+   * computed and the probe reports `diff-failed` rather than assuming a name.
+   */
   readonly baseBranch?: string;
   /**
    * Repo to probe. A literal path is used verbatim; `'auto'` resolves the
@@ -214,7 +220,7 @@ export async function handleTestAdequacy(
   );
   if (!pre.ok) return pre.result;
   const repoRoot = pre.repoRoot;
-  const baseRef = args.baseBranch || 'main';
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
 
   return runDurableGateProducer(
     {
@@ -222,7 +228,10 @@ export async function handleTestAdequacy(
       featureId: args.featureId,
       taskId: args.taskId,
       ...(args.branch ? { branch: args.branch } : {}),
-      baseRef,
+      // The evidence subject names the diff base it was scoped against. An
+      // unresolved base has no name to record, so the field is omitted rather
+      // than stamped with a literal the run never used.
+      ...(base.kind === 'resolved' ? { baseRef: base.branch } : {}),
       repoRoot,
       stateDir,
       eventStore,
@@ -251,6 +260,27 @@ export async function handleTestAdequacy(
           },
         };
       }
+
+      // No detected default branch means the task diff cannot be computed —
+      // which this gate already has a name for. `diff-failed` is one of the four
+      // discriminants the probe vocabulary is total over, and
+      // `INDETERMINATE_HANDLING` already rules on it: a diff we could not
+      // compute is an execution failure of a probe that was supposed to run, so
+      // it fails closed at EVERY tier. Minting a discriminant of our own here
+      // would put a second, unruled spelling of "could not run" alongside the
+      // four the tier policy is defined over — and `verdictOf` fails an
+      // unrecognised one closed anyway, so the parallel vocabulary would buy
+      // nothing but the drift.
+      if (base.kind === 'unresolved') {
+        return {
+          success: true,
+          data: carrierForVerdict(
+            { kind: 'indeterminate', cause: 'diff-failed', detail: base.reason },
+            args.riskTier,
+          ),
+        };
+      }
+      const baseRef = base.branch;
 
       const gitExec = args.gitExec ?? defaultGitExec;
       const runTests = args.runTests ?? buildDefaultRunTests(repoRoot);
@@ -316,15 +346,43 @@ interface AdequacyCarrier {
 function buildAdequacyCarrier(probe: ProbeResult, riskTier?: RiskTier): AdequacyCarrier {
   // `verdictOf` prefers the stamped union and otherwise reconstructs one
   // fail-closed, so even a legacy-shaped carrier is judged by the union.
-  const verdict = verdictOf(probe);
+  return carrierForVerdict(verdictOf(probe), riskTier, {
+    redObserved: probe.redObserved === true,
+    restoredClean: probe.restoredClean !== false,
+    probedTests: probe.probedTests ?? [],
+  });
+}
+
+/** The observable facts a carrier reports beside its verdict. */
+interface CarrierFacts {
+  readonly redObserved: boolean;
+  readonly restoredClean: boolean;
+  readonly probedTests: readonly string[];
+}
+
+/**
+ * The one place a carrier is built, so every path into this gate — a probe that
+ * ran, and a precondition that stopped one from running — is scored by the same
+ * tier policy. A caller that hand-assembled `passed` alongside a discriminant
+ * would be authoring the verdict, which is exactly what
+ * {@link interpretProbeVerdict} exists to be the sole authority on.
+ *
+ * Defaults describe a probe that never started: nothing was reverted, so there
+ * is nothing to have restored badly and no test was run.
+ */
+function carrierForVerdict(
+  verdict: ProbeVerdict,
+  riskTier?: RiskTier,
+  facts: CarrierFacts = { redObserved: false, restoredClean: true, probedTests: [] },
+): AdequacyCarrier {
   const interpretation = interpretProbeVerdict(verdict, riskTier);
 
   const base = {
     passed: interpretation.passed,
     disposition: interpretation.disposition,
-    redObserved: probe.redObserved === true,
-    restoredClean: probe.restoredClean !== false,
-    probedTests: probe.probedTests ?? [],
+    redObserved: facts.redObserved,
+    restoredClean: facts.restoredClean,
+    probedTests: facts.probedTests,
     ...(interpretation.report ? { report: interpretation.report } : {}),
   };
 

--- a/src/verbs/gates/verify-worktree-baseline.ts
+++ b/src/verbs/gates/verify-worktree-baseline.ts
@@ -3,8 +3,13 @@
 // Validates a worktree path, delegates project-type/test-command resolution to
 // the unified test runtime resolver (`config/test-runtime-resolver.ts`), runs
 // the resolved test command, and returns a structured markdown report.
-// Ported from scripts/verify-worktree-baseline.sh; migrated to resolver in
-// refactor #1199 T08, intentionally closing the prior Python detection gap.
+// Every toolchain the resolver knows is reachable here — the label and the
+// marker list both come from the registry, so neither can name a shorter set
+// than the detector actually uses.
+//
+// The baseline has THREE outcomes, not two: a runner that never started, or one
+// killed at its wall clock, measured nothing and must not be recorded as a
+// failing baseline.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { existsSync } from 'node:fs';
@@ -13,13 +18,23 @@ import { runCommandSync } from '../../utils/process.js';
 import type { ToolResult } from '../../format.js';
 import { resolveTestRuntime, type ResolvedRuntime } from '../../config/test-runtime-resolver.js';
 import { splitCommand } from '../../config/tokenize-command.js';
+import { BUILTIN_TOOLCHAINS, detectToolchain } from '../../config/toolchains.js';
+import { classifyCommandFailure, inconclusiveReason } from '../pure/command-outcome.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * Wall clock the baseline run is given. Declared rather than left to the
+ * platform default (there is none — `execFileSync` waits forever), because a
+ * check that can stop returning is worse than one that reports it could not
+ * conclude.
+ */
+const BASELINE_TIMEOUT_MS = 15 * 60 * 1000;
 
 interface VerifyWorktreeBaselineArgs {
   readonly worktreePath: string;
   /**
-   * T-08 (#1301): when supplied, the handler inspects the (main) worktree for
+   * #1301: when supplied, the handler inspects the (main) worktree for
    * uncommitted modifications and classifies each against this agent branch
    * tip. A working-tree blob byte-identical to the same path already committed
    * on the agent branch is flagged as a recoverable `leaked-committed` leak
@@ -30,7 +45,7 @@ interface VerifyWorktreeBaselineArgs {
   readonly agentBranch?: string;
 }
 
-// ─── T-08 (#1301): Leak Detection ─────────────────────────────────────────────
+// ─── Leak Detection (#1301) ──────────────────────────────────────────────────
 //
 // At merge time the orchestrator's MAIN worktree sometimes carries an
 // uncommitted modification that is byte-identical to a change already
@@ -38,8 +53,8 @@ interface VerifyWorktreeBaselineArgs {
 // leak"). Such a path FF-blocks the merge but is in fact safe to discard. This
 // backstop classifies each dirty path so the orchestrator can surface the
 // documented `git checkout -- <path>` remediation instead of treating the leak
-// as opaque dirt. INV-15: this is purely local git inspection — no
-// cross-process locking, no distributed primitives.
+// as opaque dirt. This is purely local git inspection — no cross-process
+// locking, no distributed primitives.
 
 type LeakClassification = 'leaked-committed' | 'dirty';
 
@@ -55,24 +70,16 @@ interface LeakDetection {
   readonly paths: readonly LeakPathEntry[];
 }
 
-type DetectedProjectType =
-  | 'Node.js'
-  | 'Node.js (bun)'
-  | 'Node.js (pnpm)'
-  | 'Node.js (yarn)'
-  | '.NET'
-  | 'Rust'
-  | 'Python';
-
 /**
- * Project type label. Detection paths use the narrow `DetectedProjectType`
- * union; config/override paths fall back to a source-tagged label when the
- * test command isn't in the built-in set.
+ * Human-readable project-type label. Detected repositories are labelled by the
+ * toolchain registry itself; config/override paths, which may name a command no
+ * toolchain owns, get a source tag instead.
  */
-type ProjectType = DetectedProjectType | 'Configured (.exarchos.yml)' | 'Override';
+const CONFIGURED_LABEL = 'Configured (.exarchos.yml)';
+const OVERRIDE_LABEL = 'Override';
 
 interface ProjectDetection {
-  readonly projectType: ProjectType;
+  readonly projectType: string;
   readonly testCommand: string;
   readonly cmd: string;
   readonly args: readonly string[];
@@ -81,22 +88,32 @@ interface ProjectDetection {
 // ─── Project Detection (delegates to resolver) ──────────────────────────────
 
 /**
- * Map a resolver test-command string to a human-readable project-type label.
- * Discriminates the widened `ProjectType` union from the resolver's
- * package-manager-aware test command.
+ * The registry's own label for whatever toolchain this worktree is.
+ *
+ * Previously derived by comparing the resolved test command against a list of
+ * command literals, which recognized four of the registry's toolchains and
+ * silently mislabelled the rest — and went stale the moment a command string
+ * changed. The registry already carries the label, so read it there: the
+ * package-manager nuance the literal list encoded (`pnpm test`, `bun test`)
+ * is not lost, because the report prints the resolved command on its own line.
  */
-function projectTypeFromTestCommand(test: string): DetectedProjectType | undefined {
-  if (test === 'npm run test:run') return 'Node.js';
-  if (test === 'bun test') return 'Node.js (bun)';
-  if (test === 'pnpm test') return 'Node.js (pnpm)';
-  if (test === 'yarn test') return 'Node.js (yarn)';
-  if (test === 'dotnet test') return '.NET';
-  if (test === 'cargo test') return 'Rust';
-  if (test === 'pytest') return 'Python';
-  return undefined;
+function projectTypeFromRegistry(worktreePath: string): string | undefined {
+  return detectToolchain(worktreePath)?.projectType;
 }
 
-function toProjectDetection(runtime: ResolvedRuntime): ProjectDetection | undefined {
+/**
+ * The marker files detection actually looks for, read off the registry so the
+ * "nothing recognized here" message cannot name a shorter list than the one the
+ * detector uses.
+ */
+function recognizedMarkers(): string {
+  return [...new Set(BUILTIN_TOOLCHAINS.flatMap((tc) => tc.markers))].join(', ');
+}
+
+function toProjectDetection(
+  runtime: ResolvedRuntime,
+  worktreePath: string,
+): ProjectDetection | undefined {
   // Honor the resolver's output regardless of source (#1109 MCP-parity):
   // a `.exarchos.yml`-supplied test command is just as authoritative as one
   // produced by detection, and overrides supplied to setup-worktree should be
@@ -113,18 +130,18 @@ function toProjectDetection(runtime: ResolvedRuntime): ProjectDetection | undefi
     return undefined;
   }
   if (cmd === '') return undefined;
-  // For config/override sources we may not have a built-in label for the test
-  // command (e.g., `make test`). Fall back to a source-tagged label so the
-  // report is still informative.
+  // A worktree may resolve a command with no toolchain behind it (a `make test`
+  // in `.exarchos.yml`, or an override). Fall back to a source-tagged label so
+  // the report is still informative.
   const projectType =
-    projectTypeFromTestCommand(runtime.test) ??
-    (runtime.source === 'config' ? 'Configured (.exarchos.yml)' : 'Override');
+    projectTypeFromRegistry(worktreePath) ??
+    (runtime.source === 'config' ? CONFIGURED_LABEL : OVERRIDE_LABEL);
   return { projectType, testCommand: runtime.test, cmd, args };
 }
 
 function detectProjectType(worktreePath: string): ProjectDetection | undefined {
   const runtime = resolveTestRuntime(worktreePath);
-  return toProjectDetection(runtime);
+  return toProjectDetection(runtime, worktreePath);
 }
 
 /** Run a git command in the worktree, returning trimmed stdout or `null` on error. */
@@ -177,7 +194,7 @@ function parsePorcelainPaths(porcelain: string): { path: string; tracked: boolea
 }
 
 /**
- * Blob-comparison helper (T-08 REFACTOR): is the working-tree content at
+ * Blob-comparison helper: is the working-tree content at
  * `path` byte-identical to the same path committed on `agentBranch`? Git
  * content-addresses blobs by SHA, so equal hashes ⇒ identical bytes. Returns
  * `false` if either side cannot be resolved (e.g. path absent on the branch).
@@ -233,13 +250,22 @@ function detectLeakedEdits(worktreePath: string, agentBranch: string): LeakDetec
 
 // ─── Report Formatting ──────────────────────────────────────────────────────
 
+/**
+ * What the baseline run established. `indeterminate` is not a softer `fail`:
+ * a runner that never started, or one killed at its wall clock, observed
+ * nothing about the worktree, and recording that as a failing baseline would
+ * send a caller off to fix tests that were never executed.
+ */
+type BaselineStatus = 'pass' | 'fail' | 'indeterminate';
+
 function formatReport(
   worktreePath: string,
   projectType: string,
   testCommand: string,
-  passed: boolean,
+  status: BaselineStatus,
   output: string,
   exitCode: number,
+  reason: string | undefined,
 ): string {
   const lines: string[] = [
     '## Baseline Verification Report',
@@ -258,8 +284,12 @@ function formatReport(
     '',
   ];
 
-  if (passed) {
+  if (status === 'pass') {
     lines.push('**Result: PASS** — baseline tests succeeded');
+  } else if (status === 'indeterminate') {
+    lines.push(
+      `**Result: INDETERMINATE** — the baseline was not measured (${reason ?? 'the command did not run to completion'})`,
+    );
   } else {
     lines.push(`**Result: FAIL** — baseline tests failed (exit code ${exitCode})`);
   }
@@ -309,14 +339,16 @@ export async function handleVerifyWorktreeBaseline(
       success: false,
       error: {
         code: 'UNKNOWN_PROJECT_TYPE',
-        message: `No recognized project files found in ${worktreePath} (package.json, *.csproj, Cargo.toml, pyproject.toml). Manual verification required.`,
+        message:
+          `No recognized project files found in ${worktreePath} (${recognizedMarkers()}). ` +
+          'Manual verification required.',
       },
     };
   }
 
   const { projectType, testCommand, cmd, args: cmdArgs } = detection;
 
-  // 3b. T-08 (#1301): merge-time leak backstop. Only runs when the caller
+  // 3b. Merge-time leak backstop (#1301). Only runs when the caller
   // supplies the agent branch tip to compare against — non-merge callers keep
   // the prior pure-baseline behavior.
   const leakDetection: LeakDetection | undefined = agentBranch
@@ -324,28 +356,54 @@ export async function handleVerifyWorktreeBaseline(
     : undefined;
 
   // 4. Run test command
-  let passed = true;
+  let status: BaselineStatus = 'pass';
   let output = '';
   let exitCode = 0;
+  let reason: string | undefined;
 
   try {
     output = runCommandSync(cmd, cmdArgs as string[], {
       encoding: 'utf-8',
       cwd: worktreePath,
+      timeout: BASELINE_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
     }) as string;
   } catch (err: unknown) {
-    const execError = err as { status?: number; stdout?: string; stderr?: string };
-    passed = false;
-    exitCode = execError.status ?? 1;
-    output = [execError.stdout ?? '', execError.stderr ?? ''].filter(Boolean).join('\n');
+    const failure = classifyCommandFailure(err);
+    exitCode = failure.exitCode;
+    output = [failure.stdout, failure.stderr].filter(Boolean).join('\n');
+    const inconclusive = inconclusiveReason(testCommand, failure);
+    if (inconclusive === null) {
+      status = 'fail';
+    } else {
+      status = 'indeterminate';
+      reason = inconclusive;
+      if (output === '') output = inconclusive;
+    }
   }
 
   // 5. Build report and return
-  const report = formatReport(worktreePath, projectType, testCommand, passed, output, exitCode);
+  const report = formatReport(
+    worktreePath,
+    projectType,
+    testCommand,
+    status,
+    output,
+    exitCode,
+    reason,
+  );
 
   return {
     success: true,
-    data: { passed, projectType, testCommand, report, ...(leakDetection ? { leakDetection } : {}) },
+    data: {
+      // Only an observed green baseline is a pass; an unmeasured one is not.
+      passed: status === 'pass',
+      status,
+      projectType,
+      testCommand,
+      report,
+      ...(reason !== undefined ? { reason } : {}),
+      ...(leakDetection ? { leakDetection } : {}),
+    },
   };
 }

--- a/src/verbs/gates/verify-worktree.ts
+++ b/src/verbs/gates/verify-worktree.ts
@@ -1,13 +1,15 @@
 // ─── Verify Worktree Orchestrate Action ──────────────────────────────────────
 //
-// Verifies that the current or provided working directory is inside a git
-// worktree (path contains '.worktrees/').
+// Verifies that the current or provided working directory is a *linked* git
+// worktree rather than the repository's main checkout.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { toPosix } from '../../utils/paths.js';
 import type { ToolResult } from '../../format.js';
+import type { GitExec } from '../pure/execute-merge.js';
+import { defaultGitExec } from './gate-utils.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -15,15 +17,69 @@ interface VerifyWorktreeArgs {
   readonly cwd?: string;
 }
 
+/** What git says the directory is. */
+type WorktreeMembership =
+  | { readonly kind: 'linked' }
+  | { readonly kind: 'main-checkout' }
+  | { readonly kind: 'outside'; readonly reason: string };
+
+// ─── Membership ─────────────────────────────────────────────────────────────
+
+/**
+ * Ask git whether `dir` is a linked worktree.
+ *
+ * A path substring cannot answer this. Where a repository keeps its worktrees
+ * is that repository's choice — `.worktrees/`, `worktrees/`, the harness-native
+ * `.claude/worktrees/`, or a directory outside the repo entirely — so testing
+ * for one spelling misses every other layout (this gate reported "not in a
+ * worktree" from inside a real one) and matches any unrelated directory that
+ * happens to use it. Git already holds the fact: a linked worktree has a
+ * private git dir beneath the shared one, so `--git-dir` and `--git-common-dir`
+ * differ, while in the main checkout they name the same path.
+ *
+ * One `rev-parse` answers all three questions; a non-zero exit means the
+ * directory is not inside a repository at all.
+ */
+function classifyWorktree(dir: string, gitExec: GitExec): WorktreeMembership {
+  const probe = gitExec(dir, [
+    'rev-parse',
+    '--is-inside-work-tree',
+    '--git-dir',
+    '--git-common-dir',
+  ]);
+
+  if (probe.exitCode !== 0) {
+    return { kind: 'outside', reason: firstLine(probe.stdout) || 'git rev-parse failed' };
+  }
+
+  const [insideWorkTree, gitDir, commonDir] = probe.stdout.trim().split(/\r?\n/);
+  if (insideWorkTree !== 'true') {
+    return { kind: 'outside', reason: 'not inside a git work tree' };
+  }
+  if (gitDir === undefined || commonDir === undefined) {
+    return { kind: 'outside', reason: 'git reported no git-dir/git-common-dir pair' };
+  }
+
+  // Either path may come back relative to `dir`; resolve both before comparing.
+  return path.resolve(dir, gitDir.trim()) === path.resolve(dir, commonDir.trim())
+    ? { kind: 'main-checkout' }
+    : { kind: 'linked' };
+}
+
+function firstLine(text: string): string {
+  return text.trim().split(/\r?\n/)[0]?.trim() ?? '';
+}
+
 // ─── Handler ────────────────────────────────────────────────────────────────
 
 export async function handleVerifyWorktree(
   args: VerifyWorktreeArgs,
   _stateDir: string,
+  gitExec: GitExec = defaultGitExec,
 ): Promise<ToolResult> {
   const rawPath = args.cwd ?? process.cwd();
-  // Normalize to POSIX so the `.worktrees/` substring check and the returned
-  // path are separator-agnostic (path.resolve emits backslashes on Windows).
+  // Normalize to POSIX so the returned path is separator-agnostic
+  // (path.resolve emits backslashes on Windows).
   const resolvedPath = toPosix(path.resolve(rawPath));
 
   if (!fs.existsSync(resolvedPath)) {
@@ -47,9 +103,9 @@ export async function handleVerifyWorktree(
     };
   }
 
-  const inWorktree = resolvedPath.includes('.worktrees/');
+  const membership = classifyWorktree(resolvedPath, gitExec);
 
-  if (inWorktree) {
+  if (membership.kind === 'linked') {
     return {
       success: true,
       data: {
@@ -60,12 +116,17 @@ export async function handleVerifyWorktree(
     };
   }
 
+  const reason =
+    membership.kind === 'main-checkout'
+      ? "it is the repository's main checkout"
+      : membership.reason;
+
   return {
     success: true,
     data: {
       passed: false,
       path: resolvedPath,
-      message: `Not in a worktree! Current directory: ${resolvedPath}. Expected: path containing '.worktrees/'. ABORTING — DO NOT proceed with file modifications.`,
+      message: `Not in a worktree! Current directory: ${resolvedPath} — ${reason}. Expected: a linked git worktree, whichever directory this repository keeps worktrees in. ABORTING — DO NOT proceed with file modifications.`,
     },
   };
 }

--- a/src/verbs/gates/workflow-determinism.ts
+++ b/src/verbs/gates/workflow-determinism.ts
@@ -8,6 +8,7 @@
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
 import { emitGateEvent, getDiff } from './gate-utils.js';
+import { BASE_BRANCH_UNRESOLVED, resolveDiffBase } from '../../vcs/resolve-base-branch.js';
 import { checkWorkflowDeterminism } from '../pure/workflow-determinism.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
@@ -22,6 +23,32 @@ interface WorkflowDeterminismResult {
   readonly passed: boolean;
   readonly findingCount: number;
   readonly report: string;
+  /** Present only on the inconclusive carrier below. */
+  readonly skipped?: true;
+  readonly discriminant?: string;
+  readonly reason?: string;
+}
+
+const GATE_NAME = 'workflow-determinism';
+const GATE_LAYER = 'quality';
+const GATE_DIMENSION = 'D5';
+
+/** Record the unscoped run. Fire-and-forget, matching the conclusive path. */
+async function emitUnscoped(
+  store: EventStore,
+  featureId: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await emitGateEvent(store, featureId, GATE_NAME, GATE_LAYER, false, {
+      dimension: GATE_DIMENSION,
+      phase: 'review',
+      findingCount: 0,
+      skipped: true,
+      discriminant: BASE_BRANCH_UNRESOLVED,
+      reason,
+    });
+  } catch { /* fire-and-forget */ }
 }
 
 // ─── Handler ───────────────────────────────────────────────────────────────
@@ -40,7 +67,29 @@ export async function handleWorkflowDeterminism(
   }
 
   const repoRoot = args.repoRoot || process.cwd();
-  const baseBranch = args.baseBranch || 'main';
+
+  // No detected default branch means no diff to judge — report that, rather
+  // than judging a diff against a branch the repository may not have.
+  const base = await resolveDiffBase(repoRoot, args.baseBranch);
+  if (base.kind === 'unresolved') {
+    const inconclusive: WorkflowDeterminismResult = {
+      passed: false,
+      findingCount: 0,
+      report: base.reason,
+      skipped: true,
+      discriminant: BASE_BRANCH_UNRESOLVED,
+      reason: base.reason,
+    };
+    // Indeterminate is a VERDICT, so it is recorded like one. This action
+    // declares `gate.executed` unconditionally; returning success without it
+    // would leave the declaration and the handler saying different things, and
+    // it would leave the durable log unable to tell "could not be scoped" from
+    // "never invoked". The row is fail-closed (`passed: false`) and carries the
+    // skip markers, so no reader mistakes it for a gate that ran.
+    await emitUnscoped(eventStore, args.featureId, base.reason);
+    return { success: true, data: inconclusive };
+  }
+  const baseBranch = base.branch;
 
   // Get the diff — fail-closed if git is unavailable
   const diff = getDiff(repoRoot, baseBranch);
@@ -58,8 +107,8 @@ export async function handleWorkflowDeterminism(
   // Emit gate.executed event (fire-and-forget)
   try {
     const store = eventStore;
-    await emitGateEvent(store, args.featureId, 'workflow-determinism', 'quality', passed, {
-      dimension: 'D5',
+    await emitGateEvent(store, args.featureId, GATE_NAME, GATE_LAYER, passed, {
+      dimension: GATE_DIMENSION,
       phase: 'review',
       findingCount,
     });

--- a/src/verbs/pure/command-outcome.ts
+++ b/src/verbs/pure/command-outcome.ts
@@ -1,0 +1,137 @@
+// ─── Command Failure Classification ─────────────────────────────────────────
+//
+// What a thrown `runCommandSync` / `execFileSync` error establishes about the
+// command that produced it. Three outcomes, because three are genuinely
+// different pieces of evidence and flattening them is what lets a gate report
+// a missing binary as a failing test:
+//
+//   • `exit`    — the process ran and returned a non-zero status. That IS a
+//                 verdict, and it is the only one of the three that is.
+//   • `spawn`   — the process was never created (ENOENT/EACCES/…). Nothing ran,
+//                 so nothing failed; the gate measured nothing.
+//   • `timeout` — the process was killed at its wall clock. Whatever it printed
+//                 is a truncated prefix and the status belongs to the kill, not
+//                 to the work.
+//
+// The discriminant is a NUMERIC EXIT STATUS first: a process that exited
+// produced a verdict whatever the code. Only a throw carrying no numeric
+// `status` can be one of the other two, and then a recognized errno decides
+// which. Set membership, not "any string code", so an output-ceiling kill
+// (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`) — which happens AFTER the process ran —
+// is not mistaken for a process that never started.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** What the failed command established. Only `exit` is a verdict. */
+export type CommandFailureKind = 'exit' | 'spawn' | 'timeout';
+
+export interface CommandFailure {
+  readonly kind: CommandFailureKind;
+  /**
+   * Not authoritative unless `kind` is `'exit'`. On the other two arms it is a
+   * placeholder in the command-not-found / timeout-kill tradition, present so
+   * callers with an exit-code-shaped carrier have something to put there.
+   */
+  readonly exitCode: number;
+  /** One line naming the cause, suitable for a gate's "could not run" reason. */
+  readonly detail: string;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * OS-level errno codes that mean the child was NEVER created. Restricting the
+ * classification to this set keeps a process that DID run from being mislabeled.
+ */
+const SPAWN_ERROR_CODES: ReadonlySet<string> = new Set([
+  'ENOENT', // command / file does not exist
+  'EACCES', // not permitted to execute the file
+  'EPERM', // operation not permitted
+  'ENOTDIR', // a path component is not a directory
+  'ENOMEM', // could not allocate to fork the child
+]);
+
+/** The errno a runner killed for exceeding its time limit reports. */
+const TIMEOUT_ERROR_CODE = 'ETIMEDOUT';
+
+/** Placeholder exit code for a command that never started. */
+const NOT_SPAWNED_EXIT_CODE = 127;
+
+/** Placeholder exit code for a command killed at its wall clock. */
+const TIMED_OUT_EXIT_CODE = 124;
+
+/** The fields a Node child-process failure carries that this reads. */
+interface ChildFailureShape {
+  readonly status?: unknown;
+  readonly code?: unknown;
+  readonly message?: unknown;
+  readonly stdout?: unknown;
+  readonly stderr?: unknown;
+}
+
+function asText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value instanceof Buffer) return value.toString('utf-8');
+  return '';
+}
+
+/**
+ * One line naming the cause. Node puts the useful part in `code` (`ENOENT`,
+ * `ETIMEDOUT`, …) and repeats the command plus, sometimes, an entire captured
+ * transcript in `message`; only the first line of the message is kept, because
+ * this string is a reason rather than a report of findings.
+ */
+function describe(code: string, message: string): string {
+  const firstLine = message.split('\n')[0]?.trim() ?? '';
+  if (code && firstLine) return `${code}: ${firstLine}`;
+  return code || firstLine || 'the command did not run to completion';
+}
+
+/**
+ * Classify a value thrown by a synchronous child-process call.
+ *
+ * Total over `unknown`: a non-object throw (a string, a rejected primitive)
+ * lands on the `exit` arm with the generic detail, which is the conservative
+ * reading — it is the arm that produces a finding rather than the arm that
+ * withdraws one.
+ */
+export function classifyCommandFailure(err: unknown): CommandFailure {
+  const shape: ChildFailureShape =
+    typeof err === 'object' && err !== null ? (err as ChildFailureShape) : {};
+  const stdout = asText(shape.stdout);
+  const stderr = asText(shape.stderr);
+  const code = typeof shape.code === 'string' ? shape.code : '';
+  const detail = describe(code, asText(shape.message));
+
+  if (typeof shape.status === 'number') {
+    return { kind: 'exit', exitCode: shape.status, detail, stdout, stderr };
+  }
+  if (code === TIMEOUT_ERROR_CODE) {
+    return { kind: 'timeout', exitCode: TIMED_OUT_EXIT_CODE, detail, stdout, stderr };
+  }
+  if (SPAWN_ERROR_CODES.has(code)) {
+    return { kind: 'spawn', exitCode: NOT_SPAWNED_EXIT_CODE, detail, stdout, stderr };
+  }
+  // Ended without a numeric status and without a recognized spawn/timeout
+  // errno — an output-ceiling kill or an unexpected signal. The process DID
+  // run, so this stays a verdict rather than becoming an unmeasured leg.
+  return { kind: 'exit', exitCode: 1, detail, stdout, stderr };
+}
+
+/**
+ * The reason text for an inconclusive command, phrased for a gate report.
+ * Returns `null` when the failure was an ordinary non-zero exit, which is a
+ * verdict and needs no explanation.
+ */
+export function inconclusiveReason(
+  command: string,
+  failure: CommandFailure,
+): string | null {
+  switch (failure.kind) {
+    case 'spawn':
+      return `\`${command}\` could not be started (${failure.detail}), so it decided nothing`;
+    case 'timeout':
+      return `\`${command}\` was killed for exceeding its time limit before it finished`;
+    case 'exit':
+      return null;
+  }
+}

--- a/src/verbs/pure/integration-suite.ts
+++ b/src/verbs/pure/integration-suite.ts
@@ -1,8 +1,10 @@
 /**
  * Integration Suite Gate (#1329)
  *
- * Runs the FULL vitest suite against the integration tip and folds
- * file-LOAD failures into the failure count.
+ * Runs the governed repository's FULL test suite against the integration tip.
+ * On a runner that reports per-suite counts it folds file-LOAD failures into
+ * the failure count; on a runner that reports only an exit code, the exit code
+ * is the verdict.
  *
  * The trap (#1329): when a test file throws at IMPORT time (a bad import,
  * a circular dependency, a type-only export consumed at runtime, …) vitest
@@ -10,14 +12,32 @@
  * inspect the failed-TEST count, see zero, and pass — while the integration
  * tip has 125 files failing to load and ~1899 tests that never got collected.
  *
+ * BOTH halves of the invocation are resolved, and from different authorities:
+ * the COMMAND from the layered test-runtime resolver (override > `.exarchos.yml`
+ * > user toolchains > task runner > built-in registry), and the RESULT CARRIER
+ * from the registry's carrier table. Appending vitest's `--reporter=json` to
+ * whatever command came back is what produced `cargo test --reporter=json` and
+ * `pytest --reporter=json` — an unknown flag that makes the runner exit before
+ * running anything, then read as a hard failure. The flag now travels ON the
+ * carrier descriptor and is appended only when the command actually invokes the
+ * runner that descriptor is about.
+ *
  * This module isolates the pure parsing logic (`parseVitestResult`) from the
  * external command invocation (`runIntegrationSuite`), so the fold-in rule is
- * unit-testable without executing vitest. The runner is injected via the same
- * `RunCommandFn` seam used by the static-analysis gate.
+ * unit-testable without executing vitest. The runner is injected via a seam
+ * shaped like the static-analysis gate's, widened by one field so a runner
+ * killed for exceeding its wall clock can say so.
  */
 
-import type { RunCommandFn } from './static-analysis.js';
-import { detectToolchain, type Toolchain } from '../../config/toolchains.js';
+import { assertNever } from '../../contract/error-families.js';
+import type { CommandResult } from './static-analysis.js';
+import { resolveTestRuntime } from '../../config/test-runtime-resolver.js';
+import {
+  detectToolchain,
+  resolveTestReportFormat,
+  type TestReportFormat,
+  type Toolchain,
+} from '../../config/toolchains.js';
 
 // ============================================================
 // PUBLIC TYPES
@@ -45,84 +65,336 @@ export interface IntegrationSuiteParse {
   readonly loadFailureFiles: readonly string[];
 }
 
+/**
+ * A {@link CommandResult} that can also report the runner was KILLED for
+ * exceeding its wall clock.
+ *
+ * A killed runner is neither a pass nor a failure: nothing observed the suite
+ * to a conclusion. It is distinct from `spawnError` (the process never started)
+ * and from a non-zero exit (it ran and decided), and both other outcomes would
+ * misreport it — which is why it is a field rather than a reused one.
+ */
+export interface IntegrationCommandResult extends CommandResult {
+  readonly timedOut?: boolean;
+}
+
+/**
+ * The external-runner seam. Shaped like the static-analysis gate's runner and
+ * accepted from the same callers: a runner that never times out simply omits
+ * the extra outcome and never reads the extra option.
+ */
+export type IntegrationRunCommandFn = (
+  cmd: string,
+  args: readonly string[],
+  options?: { readonly cwd?: string; readonly timeoutMs?: number },
+) => IntegrationCommandResult;
+
 export interface RunIntegrationSuiteInput {
   /** Repository root to run the suite against (worktree-aware). */
   readonly repoRoot: string;
   /** External command runner (dependency injection). */
-  readonly runCommand: RunCommandFn;
+  readonly runCommand: IntegrationRunCommandFn;
   /**
    * Explicit npm script that produces vitest JSON on stdout. When set it WINS
-   * over toolchain resolution (`npm run <script> -- --reporter=json`). When
-   * absent, the test command is resolved via the layered toolchain resolver
-   * (#1537) so the monorepo-root / workspace layout — or a `.exarchos.yml`
-   * override — picks the right command instead of a hardcoded `test:run`.
+   * over resolution (`npm run <script> -- --reporter=json`). When absent, the
+   * test command comes from the layered resolver, so a workspace layout, a
+   * committed task runner or an `.exarchos.yml` entry picks the command instead
+   * of a hardcoded `test:run`.
    */
   readonly testScript?: string | undefined;
   /**
-   * Toolchain detector seam (defaults to {@link detectToolchain}). Injected in
-   * tests; production may thread a config-aware detector so `.exarchos.yml`
-   * `toolchains:` overrides participate.
+   * Runtime-resolution seam (defaults to {@link resolveIntegrationRuntime}).
+   * ONE seam rather than two, because the command and the identity that decides
+   * how to read its output must describe the same repository — a fixture that
+   * supplied only one of them was how a test came to pin a composition the gate
+   * cannot produce.
    */
-  readonly detectToolchain?: (repoRoot: string) => Toolchain | undefined;
-}
-
-export interface RunIntegrationSuiteResult extends IntegrationSuiteParse {
-  /** True when the runner output could not be parsed as vitest JSON. */
-  readonly parseError: boolean;
-  /**
-   * When `parseError`, WHY the gate failed closed: `'spawn-failure'` (the runner
-   * command could not execute) vs `'shape-mismatch'` (it ran but emitted
-   * unparseable output). Unset on a clean parse. Lets operators tell a missing
-   * test command apart from a crashed/garbled reporter (#1537).
-   */
-  readonly parseFailureKind?: 'spawn-failure' | 'shape-mismatch';
-  /** Raw exit code from the runner. */
-  readonly exitCode: number;
-  /** Structured markdown report. */
-  readonly report: string;
-}
-
-// ============================================================
-// COMMAND RESOLUTION (#1537 / DR-15)
-// ============================================================
-
-/** A resolved test command split into an executable + argv. */
-export interface ResolvedTestCommand {
-  readonly cmd: string;
-  readonly args: readonly string[];
+  readonly resolveRuntime?: IntegrationRuntimeResolver;
 }
 
 /**
- * Resolve the integration-suite test command for `repoRoot`.
+ * Why the gate could not reach a verdict about this repository.
  *
- * Precedence (layered, #1537):
- *   1. An explicit `testScript` wins → `npm run <script> -- --reporter=json`.
- *   2. Otherwise the layered toolchain resolver's `commands.test` (which a
- *      config-aware `detect` lets `.exarchos.yml` override) — split into an
- *      executable + argv, with `--reporter=json` appended (after a `--`
- *      passthrough for script runners).
- *   3. Fallback when no toolchain is detected → node's `npm run test:run`.
+ * Every arm is producible by the SHIPPED composition — not merely by an
+ * injected seam. An arm nothing can reach is a control that only looks like
+ * one, so an arm is removed rather than left standing when the composition
+ * stops producing it.
+ */
+export type IntegrationSuiteSkipReason =
+  /** Nothing in the repository identified a project type. */
+  | 'no-toolchain'
+  /**
+   * A project was identified but no test command resolved for it — the layered
+   * resolver produced none (e.g. a Node package with no test script), or it
+   * failed while trying (e.g. an unreadable `.exarchos.yml`).
+   */
+  | 'no-test-command'
+  /** The runner could not be started, so its exit code decides nothing. */
+  | 'runner-unavailable'
+  /** The runner was killed for exceeding its wall clock. */
+  | 'runner-timeout';
+
+/**
+ * What one invocation of the resolved test command established.
+ *
+ * Three arms because the runner set produces three genuinely different kinds of
+ * evidence, and flattening them is what let a gate report counts it could not
+ * have measured. `exit-code` deliberately carries NO suite/test/load counts: on
+ * that carrier a load cascade and a failed assertion are indistinguishable from
+ * outside the runner, and reporting them as zero would be the same false green
+ * the fold-in rule exists to prevent.
+ */
+export type IntegrationSuiteRun =
+  | ({
+      readonly kind: 'vitest-counts';
+      /**
+       * True when the runner RAN but its output could not be parsed as vitest
+       * JSON. The gate fails closed on it: a zero exit can mask a crashed or
+       * garbled reporter, and the counts would then be a claim rather than a
+       * measurement.
+       *
+       * There is no second cause to discriminate any more. A runner that never
+       * started used to arrive here too, stamped `'spawn-failure'`, which minted
+       * `passed: false` for a suite nothing observed; that outcome is now
+       * `indeterminate` / `runner-unavailable` on both carriers.
+       */
+      readonly parseError: boolean;
+      /** Raw exit code from the runner. */
+      readonly exitCode: number;
+      /** Structured markdown report. */
+      readonly report: string;
+    } & IntegrationSuiteParse)
+  | {
+      readonly kind: 'exit-code';
+      /** The runner's own verdict: it exited zero, or it did not. */
+      readonly passed: boolean;
+      readonly exitCode: number;
+      readonly report: string;
+    }
+  | {
+      readonly kind: 'indeterminate';
+      readonly skipReason: IntegrationSuiteSkipReason;
+      readonly reason: string;
+      readonly report: string;
+    };
+
+// ============================================================
+// COMMAND RESOLUTION (#1537)
+// ============================================================
+
+/** The carrier arms a command can actually be READ through. */
+type RunnableReportFormat = Exclude<TestReportFormat, { readonly kind: 'unknown' }>;
+
+/**
+ * The carrier every runnable command falls back to.
+ *
+ * Reading an exit code is sound for ANY executable and appends nothing to its
+ * argv, so it is the floor rather than a degradation — the counted carrier is
+ * the enrichment that has to be earned.
+ */
+const EXIT_CODE_ONLY: RunnableReportFormat = { kind: 'exit-code-only' };
+
+/**
+ * What this repository's tests are, as the two authorities see it: the layered
+ * resolver says WHICH COMMAND, the registry says WHAT THE REPOSITORY IS.
+ *
+ * They are one value because they have to agree about one repository. Splitting
+ * them into two seams let a caller supply an identity without a command — which
+ * is not a state the shipped composition can be in.
+ */
+export interface IntegrationRuntime {
+  /** The test command the layered resolver landed on, or null when none did. */
+  readonly test: string | null;
+  /** The registry's identity for this repository, when it recognizes one. */
+  readonly toolchain: Toolchain | undefined;
+  /** The resolver's own guidance when nothing resolved. */
+  readonly remediation?: string | undefined;
+}
+
+export type IntegrationRuntimeResolver = (repoRoot: string) => IntegrationRuntime;
+
+/**
+ * The shipped resolution: the layered resolver for the command, the registry
+ * for the identity.
+ *
+ * Reading `commands.test` straight off the detected toolchain — which is what
+ * this replaced — sees only the built-in registry tier. A `pnpm`/`yarn`/`bun`
+ * repository, an `.exarchos.yml` `test:` entry and a committed task runner were
+ * all invisible to it, so every non-npm Node repository was handed `npm run
+ * test:run` and failed a rung it had no way to clear.
+ *
+ * May throw: an unreadable or schema-invalid `.exarchos.yml` is a hard failure
+ * inside the resolver. {@link resolveIntegrationCommand} converts that into an
+ * unrunnable resolution rather than letting it escape as a crash.
+ */
+export function resolveIntegrationRuntime(repoRoot: string): IntegrationRuntime {
+  const runtime = resolveTestRuntime(repoRoot);
+  return {
+    test: runtime.test,
+    toolchain: detectToolchain(repoRoot),
+    ...(runtime.remediation !== undefined ? { remediation: runtime.remediation } : {}),
+  };
+}
+
+/** A resolved test command: an executable, its argv, and the report it emits. */
+export interface RunnableTestCommand {
+  readonly kind: 'runnable';
+  readonly cmd: string;
+  readonly args: readonly string[];
+  /** How to READ what this command produces. The gate branches on this alone. */
+  readonly format: RunnableReportFormat;
+}
+
+/** No command could be composed, with the reason a reader can act on. */
+export interface UnrunnableTestCommand {
+  readonly kind: 'unrunnable';
+  readonly skipReason: IntegrationSuiteSkipReason;
+  readonly reason: string;
+}
+
+export type IntegrationCommandResolution = RunnableTestCommand | UnrunnableTestCommand;
+
+/**
+ * The Node package managers, which this module needs to recognize for two
+ * reasons that happen to name the same set.
+ *
+ * They need a `--` before a flag meant for the script they run rather than for
+ * the manager itself; and they are the invocations the registry's vitest-JSON
+ * carrier row is written about — that row's whole justification is that a Node
+ * repository's test command is a package-manager SCRIPT INDIRECTION. Any other
+ * executable arriving from a higher resolver layer (`pytest`, `task test`, a
+ * bare `mix`) is a runner nothing here knows, and handing it vitest's flag is
+ * precisely the unknown-flag failure this module exists to have removed.
+ */
+const NODE_SCRIPT_RUNNERS: ReadonlySet<string> = new Set(['npm', 'pnpm', 'yarn', 'bun']);
+
+/**
+ * The registry id whose row supplies the carrier for an explicitly-named npm
+ * script. Naming an npm script IS naming that ecosystem's runner, so the
+ * carrier is still looked up rather than assumed: nothing here spells a
+ * reporter flag, and if that row ever changes this arm follows it.
+ */
+const NPM_SCRIPT_TOOLCHAIN_ID = 'node';
+
+/** Split a shell-ish command string into an executable and its argv. */
+function splitCommand(command: string): { readonly cmd: string; readonly args: readonly string[] } {
+  const [cmd = '', ...args] = command.trim().split(/\s+/);
+  return { cmd, args };
+}
+
+/**
+ * Compose the argv for `command` under the carrier `toolchain` declares.
+ *
+ * The reporter flag is asked for on TWO conditions, not one: the identified
+ * toolchain's row must say a report is emitted, AND the command must actually
+ * invoke the runner that row is about. The second condition is what the layered
+ * resolver made necessary — with the command coming from any of five layers, a
+ * repository can now name `pytest` while still being identified as Node, and
+ * keying the flag on identity alone would re-create `pytest --reporter=json`
+ * through a different door.
+ *
+ * Everything else is spawned EXACTLY as resolved and read by its exit code. No
+ * command is ever altered on that path, which is why it cannot fail the way
+ * `cargo test --reporter=json` did.
+ */
+function composeCommand(command: string, toolchain: Toolchain | undefined): RunnableTestCommand {
+  const { cmd, args } = splitCommand(command);
+  const declared = toolchain ? resolveTestReportFormat(toolchain.id) : EXIT_CODE_ONLY;
+  if (declared.kind === 'vitest-json' && NODE_SCRIPT_RUNNERS.has(cmd)) {
+    return {
+      kind: 'runnable',
+      cmd,
+      args: [...args, '--', declared.reporterFlag],
+      format: declared,
+    };
+  }
+  return { kind: 'runnable', cmd, args, format: EXIT_CODE_ONLY };
+}
+
+/**
+ * Resolve the integration-suite test command for `repoRoot`, together with the
+ * carrier its runner produces.
+ *
+ * Precedence:
+ *   1. An explicit `testScript` wins → `npm run <script>`, under the carrier the
+ *      npm-script runner's registry row declares.
+ *   2. Otherwise the LAYERED resolver's test command (override > `.exarchos.yml`
+ *      direct > user `toolchains:` > committed task runner > built-in registry),
+ *      composed against the carrier the identified toolchain declares — and only
+ *      when the command invokes the runner that carrier is about.
+ *   3. No command, or a resolver that could not read the repository's own
+ *      configuration → `unrunnable`. There is no fallback command: the previous
+ *      one spawned this repository's own `npm run test:run` script name at any
+ *      governed repository that failed detection, which is a guess, not a
+ *      resolution.
  */
 export function resolveIntegrationCommand(
   repoRoot: string,
   testScript: string | undefined,
-  detect: (repoRoot: string) => Toolchain | undefined = detectToolchain,
-): ResolvedTestCommand {
+  resolveRuntime: IntegrationRuntimeResolver = resolveIntegrationRuntime,
+): IntegrationCommandResolution {
   if (testScript) {
-    return { cmd: 'npm', args: ['run', testScript, '--', '--reporter=json'] };
+    // Built here rather than through `composeCommand` so a script name that
+    // carries whitespace survives as ONE argument. The flag is still looked up
+    // rather than spelled: naming an npm script IS naming that ecosystem's
+    // runner, and if that row ever changes this arm follows it — down to the
+    // sound floor, which is what the second branch is. The registry answers
+    // `vitest-json` for this id today, so that branch is the row's tail rather
+    // than a second contract; what matters is that it degrades to running the
+    // script and reading its exit code instead of refusing to run at all.
+    const format = resolveTestReportFormat(NPM_SCRIPT_TOOLCHAIN_ID);
+    if (format.kind === 'vitest-json') {
+      return {
+        kind: 'runnable',
+        cmd: 'npm',
+        args: ['run', testScript, '--', format.reporterFlag],
+        format,
+      };
+    }
+    return { kind: 'runnable', cmd: 'npm', args: ['run', testScript], format: EXIT_CODE_ONLY };
   }
 
-  const resolved = detect(repoRoot)?.commands.test;
-  if (resolved && resolved.trim().length > 0) {
-    const [cmd = 'npm', ...rest] = resolved.trim().split(/\s+/);
-    // Script runners (npm/pnpm/yarn/bun) need the reporter flag AFTER a `--`
-    // passthrough; a direct runner (vitest, …) takes it inline.
-    const isScriptRunner = cmd === 'npm' || cmd === 'pnpm' || cmd === 'yarn' || cmd === 'bun';
-    const args = isScriptRunner ? [...rest, '--', '--reporter=json'] : [...rest, '--reporter=json'];
-    return { cmd, args };
+  let runtime: IntegrationRuntime;
+  try {
+    runtime = resolveRuntime(repoRoot);
+  } catch (err) {
+    // An unreadable or schema-invalid `.exarchos.yml` throws inside the layered
+    // resolver. That is still "no command could be resolved" — a crash out of a
+    // gate would take the whole runbook step with it and say less.
+    return {
+      kind: 'unrunnable',
+      skipReason: 'no-test-command',
+      reason: `the test command could not be resolved at '${repoRoot}': ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
   }
 
-  return { cmd: 'npm', args: ['run', 'test:run', '--', '--reporter=json'] };
+  const command = runtime.test?.trim();
+  if (!command) {
+    // Which of the two "nothing to run" cases this is turns on whether the
+    // repository looks like a project at all, not on which resolver layer was
+    // consulted: an unrecognized directory and a recognized project with no test
+    // script call for different fixes, and the resolver's own remediation names
+    // the second one precisely.
+    return runtime.toolchain
+      ? {
+          kind: 'unrunnable',
+          skipReason: 'no-test-command',
+          reason:
+            runtime.remediation ??
+            `no test command resolves for the '${runtime.toolchain.id}' project at '${repoRoot}'`,
+        }
+      : {
+          kind: 'unrunnable',
+          skipReason: 'no-toolchain',
+          reason:
+            runtime.remediation ??
+            `no recognized project type at '${repoRoot}', so there is no test command to run`,
+        };
+  }
+
+  return composeCommand(command, runtime.toolchain);
 }
 
 // ============================================================
@@ -334,10 +606,11 @@ export function parseVitestResult(raw: string): IntegrationSuiteParse | null {
 // ============================================================
 
 /**
- * Counts-not-transcripts cap (DR-7, audit O-4): a load cascade can list
- * hundreds of files. The report enumerates at most N of them, then a single
- * total-count line steers to the uncapped escape hatch (re-run the suite
- * locally). Fixed internal cap — NOT a schema param (that boundary is Task 022).
+ * Counts, not transcripts: a load cascade can list hundreds of files. The
+ * report enumerates at most N of them, then a single total-count line steers to
+ * the uncapped escape hatch (re-run the suite locally). A fixed internal cap,
+ * deliberately NOT a schema parameter — the caller has no basis for choosing a
+ * different number and a knob here would only make reports incomparable.
  */
 export const LOAD_FAILURE_LIST_CAP = 20;
 
@@ -381,29 +654,85 @@ function buildReport(repoRoot: string, parse: IntegrationSuiteParse): string {
   return lines.join('\n');
 }
 
+/**
+ * The report for a runner whose only output is an exit code.
+ *
+ * It states what it could not measure, so a reader never mistakes the absent
+ * counts for zeros. The verdict itself is complete: the runner was asked to run
+ * the suite and it either succeeded or it did not.
+ */
+function buildExitCodeReport(repoRoot: string, command: string, exitCode: number): string {
+  return [
+    '## Integration Suite Report',
+    '',
+    `**Repository:** \`${repoRoot}\``,
+    `**Command:** \`${command}\``,
+    '**Result carrier:** exit code — this invocation produces no machine-readable ' +
+      'summary the gate can read.',
+    '',
+    'Suite, test and load-failure counts are not reportable on this carrier: from ' +
+      'outside the runner a file that failed to load is indistinguishable from a ' +
+      'failed assertion. The exit code is the whole verdict — and a complete one: ' +
+      'a runner whose files fail to import still exits non-zero.',
+    '',
+    '---',
+    '',
+    exitCode === 0
+      ? '**Result: PASS** (runner exited 0)'
+      : `**Result: FAIL** (runner exited ${exitCode})`,
+  ].join('\n');
+}
+
+/**
+ * The report for a run that reached no verdict. Named as neither a pass nor a
+ * failure, because claiming either would report something nothing observed.
+ *
+ * It also has to say what to DO, and that is not padding. The carrier omits
+ * `passed`, which is honest but is also the only field anything downstream turns
+ * into a stop — see the reader survey on {@link runIntegrationSuite}. Until an
+ * admission requirement claims this gate's evidence, the caller reading this
+ * report IS the enforcement, so the report states the non-clearance instead of
+ * leaving it to be inferred.
+ */
+function buildIndeterminateReport(
+  repoRoot: string,
+  skipReason: IntegrationSuiteSkipReason,
+  reason: string,
+): string {
+  return [
+    '## Integration Suite Report',
+    '',
+    `**Repository:** \`${repoRoot}\``,
+    '',
+    `- **INDETERMINATE** (\`${skipReason}\`): ${reason}`,
+    '',
+    '---',
+    '',
+    '**Result: INDETERMINATE** — the suite did not run to a conclusion here, ' +
+      'so this is neither proof that it passes nor a finding that it fails.',
+    '',
+    '**This rung is NOT cleared.** Fix the cause above and re-run the gate. Do ' +
+      'not treat this result as a pass, and do not proceed past a step whose ' +
+      'failure policy is `stop`.',
+  ].join('\n');
+}
+
 // ============================================================
 // RUNNER
 // ============================================================
 
 /**
- * Run the full vitest suite against `repoRoot` and fold load-failures into the
- * failure count. Pure aside from the injected `runCommand`.
+ * The counted carrier's fail-closed result: the runner RAN and promised a
+ * machine-readable report that did not arrive.
  *
- * Invokes: `npm run <testScript> -- --reporter=json` in `repoRoot`. vitest
- * emits the JSON summary on stdout; we parse it via {@link parseVitestResult}.
+ * Failing closed here is a finding, not a guess — a zero exit is compatible with
+ * a crashed or garbled reporter, so trusting it would be the false green the
+ * fold-in rule exists to prevent. The counts it stamps are the minimum that
+ * cannot read as "nothing wrong"; the report says where they came from.
  */
-/**
- * Build a fail-closed result with a distinct `parseFailureKind` + report. Both
- * spawn-failure and shape-mismatch fail closed (counts non-authoritative), but
- * the kind + report make the cause actionable rather than a generic "no JSON".
- */
-function failClosed(
-  repoRoot: string,
-  exitCode: number,
-  kind: 'spawn-failure' | 'shape-mismatch',
-  detail: string,
-): RunIntegrationSuiteResult {
+function failClosed(repoRoot: string, exitCode: number, detail: string): IntegrationSuiteRun {
   return {
+    kind: 'vitest-counts',
     passed: false,
     failedSuites: 1,
     failedTests: 0,
@@ -412,7 +741,6 @@ function failClosed(
     failCount: 1,
     loadFailureFiles: [],
     parseError: true,
-    parseFailureKind: kind,
     exitCode,
     report: [
       '## Integration Suite Report',
@@ -423,48 +751,130 @@ function failClosed(
       '',
       '---',
       '',
-      `**Result: FAIL** (${kind === 'spawn-failure' ? 'runner spawn failure' : 'unparseable output'})`,
+      '**Result: FAIL** (unparseable output)',
     ].join('\n'),
   };
 }
 
-export function runIntegrationSuite(input: RunIntegrationSuiteInput): RunIntegrationSuiteResult {
-  const { repoRoot, runCommand, testScript, detectToolchain: detect } = input;
+/** No verdict, and why. */
+function indeterminate(
+  repoRoot: string,
+  skipReason: IntegrationSuiteSkipReason,
+  reason: string,
+): IntegrationSuiteRun {
+  return {
+    kind: 'indeterminate',
+    skipReason,
+    reason,
+    report: buildIndeterminateReport(repoRoot, skipReason, reason),
+  };
+}
 
-  // Resolve the test command via the layered toolchain resolver (#1537) so a
-  // monorepo-root / workspace layout — or an explicit testScript — picks the
-  // right command instead of a hardcoded `npm run test:run`.
-  const { cmd, args } = resolveIntegrationCommand(repoRoot, testScript, detect ?? detectToolchain);
-  const cmdResult = runCommand(cmd, args as string[], { cwd: repoRoot });
+/**
+ * Run the governed repository's test suite against `repoRoot`. Pure aside from
+ * the injected `runCommand`.
+ *
+ * The command comes from the layered resolver and the way its result is read
+ * comes from the registry's carrier table, so the three outcomes are:
+ *   • `vitest-counts`  — the runner emitted a per-suite JSON summary; load
+ *                        failures are folded into the failure count so a load
+ *                        cascade can never read as zero (#1329).
+ *   • `exit-code`      — the runner reports only an exit code, and that IS the
+ *                        verdict. Complete, and honest about what it omits.
+ *   • `indeterminate`  — no command could be resolved, or the runner never ran
+ *                        to a conclusion. Not a pass, not a failure.
+ *
+ * WHO READS AN INDETERMINATE, honestly surveyed — because the carrier used to
+ * carry prose asserting a guarantee that is not in the tree:
+ *   • `normalizeGateVerdict` maps the `skipped` marker to `'indeterminate'`, and
+ *     the durable `admission.evidence-recorded` row keeps the reason. That row
+ *     is folded into the workflow projection for AUDIT/SHADOW VISIBILITY ONLY —
+ *     the projection says so at the fold — so it alters no phase and no guard.
+ *   • the admission evaluator WOULD deny on an indeterminate gate, but it only
+ *     ever adjudicates requirements an edge obligation claims
+ *     (`req:gate:<gateId>:<edge>`). This gate stamps
+ *     `verification-ladder:integration-suite`, which no edge claims, so that
+ *     path never reaches this evidence.
+ *   • the runbook step carries `onFail: 'stop'`, and the runbook contract states
+ *     the projection is advisory — no step is halted on anyone's behalf.
+ * The enforcement is therefore the CALLER reading this carrier, which is why
+ * the indeterminate report states the non-clearance in words and why `passed`
+ * stays absent: a `false` here would be a red nothing observed, and a `true`
+ * would be proof nothing produced.
+ */
+export function runIntegrationSuite(input: RunIntegrationSuiteInput): IntegrationSuiteRun {
+  const { repoRoot, runCommand, testScript, resolveRuntime } = input;
 
-  // A runner-spawn failure (the command itself could not execute) is distinct
-  // from a JSON-shape mismatch (it ran but emitted unparseable output) — #1537.
-  if (cmdResult.spawnError) {
-    return failClosed(
+  const resolution = resolveIntegrationCommand(
+    repoRoot,
+    testScript,
+    resolveRuntime ?? resolveIntegrationRuntime,
+  );
+  if (resolution.kind === 'unrunnable') {
+    return indeterminate(repoRoot, resolution.skipReason, resolution.reason);
+  }
+
+  const { cmd, args, format } = resolution;
+  const cmdResult = runCommand(cmd, args, { cwd: repoRoot });
+
+  // ── Two outcomes that belong to no carrier ────────────────────────────────
+  // Both are checked BEFORE the carrier switch, because both describe a process
+  // that produced no evidence about the suite, and each carrier would misread
+  // them in its own way — one as a verdict, the other as a garbled report.
+
+  // Killed for exceeding its wall clock: whatever is on stdout is a truncated
+  // prefix and the exit status belongs to the kill, not to the suite.
+  if (cmdResult.timedOut === true) {
+    return indeterminate(
       repoRoot,
-      cmdResult.exitCode,
-      'spawn-failure',
+      'runner-timeout',
+      `\`${cmd}\` was killed for exceeding its time limit before the suite finished`,
+    );
+  }
+
+  // Never started: there is no exit code to read and no report to miss. This
+  // used to fail CLOSED on the counted carrier, minting `passed: false` for a
+  // suite nothing ran — a red that named a failure nobody observed, and one the
+  // exit-code carrier already refused to name for the very same event. The
+  // command comes from the repository's own configuration now, so "it could not
+  // be launched" is a configuration finding, not a test result.
+  if (cmdResult.spawnError) {
+    return indeterminate(
+      repoRoot,
+      'runner-unavailable',
       `runner failed to spawn (\`${cmd}\`: ${cmdResult.spawnError})`,
     );
   }
 
-  const parse = parseVitestResult(cmdResult.stdout);
-  if (parse === null) {
-    // Ran, but the output is not recognizable vitest JSON. Fail CLOSED — a
-    // zero exit here can mask a crashed/garbled reporter — and flag the kind so
-    // operators don't confuse it with a missing test command.
-    return failClosed(
-      repoRoot,
-      cmdResult.exitCode,
-      'shape-mismatch',
-      'runner produced no parseable vitest JSON (ran, but the output shape was unrecognized)',
-    );
-  }
+  switch (format.kind) {
+    case 'exit-code-only':
+      return {
+        kind: 'exit-code',
+        passed: cmdResult.exitCode === 0,
+        exitCode: cmdResult.exitCode,
+        report: buildExitCodeReport(repoRoot, [cmd, ...args].join(' '), cmdResult.exitCode),
+      };
+    case 'vitest-json': {
+      const parse = parseVitestResult(cmdResult.stdout);
+      if (parse === null) {
+        // Ran, but the output is not recognizable vitest JSON. Fail CLOSED — a
+        // zero exit here can mask a crashed or garbled reporter.
+        return failClosed(
+          repoRoot,
+          cmdResult.exitCode,
+          'runner produced no parseable vitest JSON (ran, but the output shape was unrecognized)',
+        );
+      }
 
-  return {
-    ...parse,
-    parseError: false,
-    exitCode: cmdResult.exitCode,
-    report: buildReport(repoRoot, parse),
-  };
+      return {
+        kind: 'vitest-counts',
+        ...parse,
+        parseError: false,
+        exitCode: cmdResult.exitCode,
+        report: buildReport(repoRoot, parse),
+      };
+    }
+    default:
+      return assertNever(format, 'TestReportFormat');
+  }
 }

--- a/src/verbs/pure/post-merge.ts
+++ b/src/verbs/pure/post-merge.ts
@@ -2,17 +2,25 @@
  * Post-Merge Regression Check
  *
  * Gate check for the synthesize -> cleanup boundary.
- * Verifies CI passed on the merge commit and runs the test suite
- * to detect regressions. CI status is queried via VcsProvider.
+ * Verifies CI passed on the merge commit and runs the merged repository's own
+ * resolved test suite to detect regressions. CI status is queried via
+ * VcsProvider.
  *
- * Exit code semantics (when used as a gate):
- *   0 = pass (CI green, tests pass)
- *   1 = findings (CI failure or test regression)
+ * `status` has THREE values, not two:
+ *   'pass'          — CI green and the suite ran and passed.
+ *   'fail'          — a regression was OBSERVED (CI failure, or a non-zero exit
+ *                     from a suite that really ran).
+ *   'indeterminate' — a check could not be performed: no test command resolves
+ *                     for this tree, the runner never started, or it was killed
+ *                     at its wall clock. Nothing failed; nothing was measured.
  */
 
 import type { VcsProvider, CiStatus, CiCheck as VcsCiCheck } from '../../vcs/provider.js';
 import { createVcsProvider } from '../../vcs/factory.js';
 import { runCommandSync } from '../../utils/process.js';
+import { resolveTestRuntime, type ResolvedRuntime } from '../../config/test-runtime-resolver.js';
+import { splitCommand } from '../../config/tokenize-command.js';
+import { classifyCommandFailure } from './command-outcome.js';
 
 // ============================================================
 // Types
@@ -22,11 +30,29 @@ export interface CommandResult {
   readonly exitCode: number;
   readonly stdout: string;
   readonly stderr: string;
+  /**
+   * Set when the command could not be SPAWNED at all — the process never ran,
+   * so `exitCode` is not authoritative and a non-zero value is not a
+   * regression. Distinct from an ordinary non-zero exit, which IS one.
+   */
+  readonly spawnError?: string;
+  /**
+   * Set when the runner was killed for exceeding its wall clock. The status
+   * belongs to the kill, not to the suite, so it decides nothing either.
+   */
+  readonly timedOut?: boolean;
 }
 
 export interface PostMergeOptions {
   prUrl: string;
   mergeSha: string;
+  /**
+   * The repository the regression check is about. It is BOTH where the test
+   * command is resolved from and where the default runner runs it, so the two
+   * can never disagree about which tree was measured. Defaults to the process's
+   * own directory, which is where the default runner already ran.
+   */
+  repoRoot?: string;
   /** Dependency-injected command runner for testing (used for test suite check). */
   runCommand?: (
     cmd: string,
@@ -37,7 +63,7 @@ export interface PostMergeOptions {
 }
 
 export interface PostMergeResult {
-  status: 'pass' | 'fail';
+  status: 'pass' | 'fail' | 'indeterminate';
   prUrl: string;
   mergeSha: string;
   passCount: number;
@@ -45,6 +71,14 @@ export interface PostMergeResult {
   results: string[];
   findings: string[];
   report: string;
+  /**
+   * Why `status` is `'indeterminate'`, when it is. Read by `handlePostMerge`,
+   * which surfaces it on the action's carrier and stamps it into the durable
+   * `gate.executed` row — so an unmeasured check is not recorded as an
+   * observed failure. `status` is the only discriminant; there is no second
+   * flag saying the same thing that could drift from it.
+   */
+  reason?: string;
 }
 
 // ============================================================
@@ -53,20 +87,24 @@ export interface PostMergeResult {
 
 function defaultCommandRunner(
   cmd: string,
-  args: readonly string[]
+  args: readonly string[],
+  cwd?: string
 ): CommandResult {
   try {
     const stdout = runCommandSync(cmd, args as string[], {
+      ...(cwd !== undefined ? { cwd } : {}),
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }) as string;
     return { exitCode: 0, stdout, stderr: '' };
   } catch (err: unknown) {
-    const execErr = err as { status?: number; stdout?: string; stderr?: string };
+    const failure = classifyCommandFailure(err);
     return {
-      exitCode: execErr.status ?? 1,
-      stdout: execErr.stdout ?? '',
-      stderr: execErr.stderr ?? '',
+      exitCode: failure.exitCode,
+      stdout: failure.stdout,
+      stderr: failure.stderr,
+      ...(failure.kind === 'spawn' ? { spawnError: failure.detail } : {}),
+      ...(failure.kind === 'timeout' ? { timedOut: true } : {}),
     };
   }
 }
@@ -78,16 +116,57 @@ function defaultCommandRunner(
 const PASSING_STATUSES: ReadonlySet<VcsCiCheck['status']> = new Set(['pass', 'skipped']);
 
 // ============================================================
+// Test-command resolution
+// ============================================================
+
+type TestCommandResolution =
+  | { readonly kind: 'resolved'; readonly command: string; readonly cmd: string; readonly args: readonly string[] }
+  | { readonly kind: 'indeterminate'; readonly reason: string };
+
+/**
+ * The command that re-runs the merged repository's suite, taken from the
+ * toolchain source of truth. Spelling one package manager's invocation here
+ * made this check undischargeable on every repository that does not use it,
+ * and a regression check that cannot run must say so rather than pass.
+ */
+function resolveTestCommand(repoRoot: string): TestCommandResolution {
+  let runtime: ResolvedRuntime;
+  try {
+    runtime = resolveTestRuntime(repoRoot);
+  } catch (err) {
+    return { kind: 'indeterminate', reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (runtime.source === 'unresolved' || runtime.test === null) {
+    return {
+      kind: 'indeterminate',
+      reason: runtime.remediation ?? `no test command resolves for '${repoRoot}'`,
+    };
+  }
+  try {
+    const { cmd, args } = splitCommand(runtime.test);
+    if (cmd === '') {
+      return { kind: 'indeterminate', reason: `empty test command: '${runtime.test}'` };
+    }
+    return { kind: 'resolved', command: runtime.test, cmd, args };
+  } catch (err) {
+    return { kind: 'indeterminate', reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ============================================================
 // Core logic
 // ============================================================
 
 export async function checkPostMerge(options: PostMergeOptions): Promise<PostMergeResult> {
   const { prUrl, mergeSha } = options;
-  const runCommand = options.runCommand ?? defaultCommandRunner;
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const runCommand =
+    options.runCommand ?? ((cmd, args) => defaultCommandRunner(cmd, args, repoRoot));
   const vcs = options.provider ?? await createVcsProvider();
 
   const results: string[] = [];
   const findings: string[] = [];
+  const unrunnable: string[] = [];
   let passCount = 0;
   let failCount = 0;
 
@@ -149,17 +228,41 @@ export async function checkPostMerge(options: PostMergeOptions): Promise<PostMer
   // CHECK 2: Test Suite
   // --------------------------------------------------------
   function checkTestSuite(): void {
-    const testResult = runCommand('npm', ['run', 'test:run']);
-
-    if (testResult.exitCode !== 0) {
-      findings.push(
-        `FINDING [D4] [HIGH] criterion="test-suite" evidence="npm run test:run failed (merge-sha: ${mergeSha})"`
-      );
-      checkFail('Test suite', 'npm run test:run failed');
+    const resolution = resolveTestCommand(repoRoot);
+    if (resolution.kind === 'indeterminate') {
+      unrunnable.push(`Test suite: ${resolution.reason}`);
+      results.push(`- **INDETERMINATE**: Test suite -- ${resolution.reason}`);
       return;
     }
 
-    checkPass('Test suite (npm run test:run passed)');
+    const testResult = runCommand(resolution.cmd, resolution.args);
+
+    // A runner that never started, or one killed at its wall clock, observed no
+    // regression — its exit status belongs to the failure to run, not to the
+    // suite. Checked before the exit code is read, because reading it would
+    // report a regression nobody measured.
+    if (testResult.timedOut === true) {
+      const detail = `\`${resolution.command}\` was killed for exceeding its time limit`;
+      unrunnable.push(`Test suite: ${detail}`);
+      results.push(`- **INDETERMINATE**: Test suite -- ${detail}`);
+      return;
+    }
+    if (testResult.spawnError !== undefined) {
+      const detail = `\`${resolution.command}\` could not be started (${testResult.spawnError})`;
+      unrunnable.push(`Test suite: ${detail}`);
+      results.push(`- **INDETERMINATE**: Test suite -- ${detail}`);
+      return;
+    }
+
+    if (testResult.exitCode !== 0) {
+      findings.push(
+        `FINDING [D4] [HIGH] criterion="test-suite" evidence="${resolution.command} failed (merge-sha: ${mergeSha})"`
+      );
+      checkFail('Test suite', `${resolution.command} failed`);
+      return;
+    }
+
+    checkPass(`Test suite (${resolution.command} passed)`);
   }
 
   // Execute checks
@@ -183,14 +286,23 @@ export async function checkPostMerge(options: PostMergeOptions): Promise<PostMer
   reportLines.push('---');
   reportLines.push('');
 
-  if (failCount === 0) {
+  if (unrunnable.length > 0) {
+    reportLines.push(
+      `**Result: INDETERMINATE** (${unrunnable.length} check(s) could not run; ` +
+        `${passCount}/${total} of the rest passed)`,
+    );
+  } else if (failCount === 0) {
     reportLines.push(`**Result: PASS** (${passCount}/${total} checks passed)`);
   } else {
     reportLines.push(`**Result: FAIL** (${failCount}/${total} checks failed)`);
   }
 
+  const status: PostMergeResult['status'] =
+    unrunnable.length > 0 ? 'indeterminate' : failCount === 0 ? 'pass' : 'fail';
+
   return {
-    status: failCount === 0 ? 'pass' : 'fail',
+    status,
+    ...(unrunnable.length > 0 ? { reason: unrunnable.join('; ') } : {}),
     prUrl,
     mergeSha,
     passCount,

--- a/src/verbs/pure/static-analysis.ts
+++ b/src/verbs/pure/static-analysis.ts
@@ -12,21 +12,35 @@
  *   'pass'  = EVERY applicable check ran and passed (warnings OK)
  *   'fail'  = errors found in one or more tools
  *   'skip'  = the gate is inconclusive. Two reasons produce it:
- *             'no-toolchain'        — no recognized project type at all
- *                                     (DR-4, docs/plans/archive/2026-05-04-v290-dogfood-bundle.md).
+ *             'no-toolchain'        — nothing this gate can run checks for. The
+ *                                     registry recognised no toolchain at all,
+ *                                     or it recognised one this gate has no
+ *                                     runner for. The report says which.
  *             'constituent-skipped' — a toolchain WAS detected and at least one
  *                                     constituent check did not run (missing
- *                                     npm script, or a --skip-* flag) while no
- *                                     check failed (DR-6). The dimension is
- *                                     DEGRADED, never PASS: a check that never
- *                                     ran is not evidence that it would pass.
+ *                                     npm script, a --skip-* flag, a command
+ *                                     that could not be launched, or a
+ *                                     toolchain that assembled no runnable leg
+ *                                     at all) while no check failed. The
+ *                                     dimension is DEGRADED, never PASS: a
+ *                                     check that never ran is not evidence that
+ *                                     it would pass.
  *             The `skipReason` field carries the reason code.
- *   'error' = usage error (missing repo root, no package.json)
+ *   'error' = usage error (missing repo root, no package.json, unreadable
+ *             `.exarchos.yml`)
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { detectToolchain, BUILTIN_TOOLCHAINS } from '../../config/toolchains.js';
+import { runCommandSync } from '../../utils/process.js';
+import { loadExarchosConfig } from '../../config/load-exarchos-config.js';
+import {
+  detectToolchain,
+  toolchainFromConfig,
+  BUILTIN_TOOLCHAINS,
+  type ConfigToolchain,
+  type Toolchain,
+} from '../../config/toolchains.js';
 
 // ============================================================
 // PUBLIC TYPES
@@ -52,12 +66,133 @@ export interface CommandResult {
  *
  * Abstracted to allow mocking in tests while retaining real execFileSync
  * in production use.
+ *
+ * `timeoutMs` is a REQUIREMENT on the runner, not a hint: a toolchain command
+ * that never returns must not become a gate that never returns. An
+ * implementation that cannot bound the wall clock should report the expiry the
+ * same way it reports an unspawnable binary — through `spawnError`, which says
+ * `exitCode` is not authoritative — because a command that was killed produced
+ * no evidence either way and must not read as a failure.
  */
 export type RunCommandFn = (
   cmd: string,
   args: readonly string[],
-  options?: { cwd?: string }
+  options?: { cwd?: string; timeoutMs?: number }
 ) => CommandResult;
+
+/**
+ * Wall-clock bound every command this gate spawns is given.
+ *
+ * Ten minutes is chosen to sit above a cold full-repository build or typecheck
+ * on a large governed repository and well below any human's patience for a
+ * gate that has stopped making progress. It is a single declared value rather
+ * than a per-call literal so the bound is one fact a reader can find and
+ * change, and so a spawn site that forgot it is visible as an omission.
+ */
+export const CHECK_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Output ceiling for one check, in bytes.
+ *
+ * Node's default is a megabyte, which a failing lint or typecheck run over a
+ * large repository exceeds routinely — and overflowing it kills the child, so
+ * the very run that had the most to say is the one whose verdict is lost. The
+ * ceiling is raised to where only a runaway can reach it; the transcript is
+ * capped for the reader separately (see the fail-detail cap below), which is a
+ * presentation concern and not a reason to stop reading the tool's output.
+ */
+export const CHECK_COMMAND_MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Exit code reported alongside a `spawnError`. The field's whole point is that
+ * the number is not authoritative, so this is a placeholder in the
+ * command-not-found tradition rather than something a caller may read.
+ */
+const NO_VERDICT_EXIT_CODE = 127;
+
+/**
+ * Describe a run that produced no verdict, in one line.
+ *
+ * Node puts the useful part in `code` (`ENOENT`, `ETIMEDOUT`, …) and repeats
+ * the command plus, sometimes, an entire captured transcript in `message`.
+ * Only the first line of the message is kept: this string is a reason a leg is
+ * inconclusive, not a report of findings, and it goes into the gate output
+ * uncapped.
+ */
+function describeRunFailure(err: { readonly code?: string; readonly message?: string }): string {
+  const firstLine = (err.message ?? '').split('\n')[0]?.trim() ?? '';
+  const code = typeof err.code === 'string' ? err.code : '';
+  if (code && firstLine) return `${code}: ${firstLine}`;
+  return code || firstLine || 'the command did not run to completion';
+}
+
+/**
+ * The runner this gate is composed with in production.
+ *
+ * It lives beside the contract it implements rather than in the handler,
+ * because the handler's own adapter was where the contract quietly stopped
+ * being honoured: it dropped `timeoutMs` (so nothing this gate spawned had a
+ * bounded wall clock) and never set `spawnError` (so a linter that could not be
+ * launched arrived as exit 1 and was read as a lint failure — a false red on a
+ * check that never ran).
+ *
+ * The discriminant is a NUMERIC EXIT STATUS, not an errno table. A process that
+ * exited produced a verdict, whatever the code; a throw that carries no numeric
+ * `status` means no verdict exists — the binary was not found, the wall-clock
+ * bound killed the run, the output ceiling killed it — and every one of those
+ * is inconclusive for this gate, which treats them all the same way. Callers
+ * that need to tell those apart classify the errno themselves; this one does
+ * not, so it does not carry a table it would have to keep correct.
+ */
+export const execCommandRunner: RunCommandFn = (
+  cmd: string,
+  args: readonly string[],
+  options?: { cwd?: string; timeoutMs?: number },
+): CommandResult => {
+  try {
+    const stdout = runCommandSync(cmd, args, {
+      encoding: 'utf-8',
+      cwd: options?.cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: CHECK_COMMAND_MAX_OUTPUT_BYTES,
+      timeout: options?.timeoutMs ?? CHECK_COMMAND_TIMEOUT_MS,
+    }) as string;
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err: unknown) {
+    const execErr = err as {
+      status?: number;
+      code?: string;
+      message?: string;
+      stdout?: string;
+      stderr?: string;
+    };
+    const stdout = typeof execErr.stdout === 'string' ? execErr.stdout : '';
+    const stderr = typeof execErr.stderr === 'string' ? execErr.stderr : '';
+    if (typeof execErr.status === 'number') {
+      return { exitCode: execErr.status, stdout, stderr };
+    }
+    return {
+      exitCode: NO_VERDICT_EXIT_CODE,
+      stdout,
+      stderr,
+      spawnError: describeRunFailure(execErr),
+    };
+  }
+};
+
+/**
+ * The part of a loaded `.exarchos.yml` this gate reads.
+ *
+ * Declared as what is consumed rather than as the loader's whole result, so the
+ * seam states its own requirement and a test can satisfy it without building a
+ * validated config document. The real loader satisfies it structurally.
+ */
+export interface ToolchainConfigSource {
+  readonly config: { readonly toolchains?: readonly ConfigToolchain[] | undefined };
+}
+
+/** Reads the repository's toolchain declarations, or null when it has none. */
+export type LoadToolchainConfigFn = (repoRoot: string) => ToolchainConfigSource | null;
 
 export interface StaticAnalysisInput {
   /** Repository root to analyze. */
@@ -68,15 +203,26 @@ export interface StaticAnalysisInput {
   readonly skipTypecheck?: boolean | undefined;
   /** External command runner (dependency injection). */
   readonly runCommand: RunCommandFn;
+  /**
+   * Reads the repository's `.exarchos.yml`, whose `toolchains:` block is the
+   * sanctioned way to extend or override what a repository is detected as.
+   * Injectable so the extension point is testable without a file on disk;
+   * unset means the real loader, which is what production uses.
+   */
+  readonly loadConfig?: LoadToolchainConfigFn | undefined;
 }
 
 /**
  * Reason code for a 'skip' status.
  *
- * - 'no-toolchain'        — no recognized project files in repoRoot (DR-4).
- * - 'constituent-skipped' — a toolchain was detected but at least one
- *                           constituent check did not run (DR-6). The gate is
- *                           DEGRADED/inconclusive: it may not report PASS.
+ * - 'no-toolchain'        — nothing this gate can run checks for: no recognized
+ *                           project files in repoRoot, or a toolchain it has no
+ *                           runner for.
+ * - 'constituent-skipped' — a toolchain was detected and at least one
+ *                           constituent check did not run — including the case
+ *                           where the toolchain assembled no runnable check at
+ *                           all. The gate is DEGRADED/inconclusive: it may not
+ *                           report PASS.
  */
 export type StaticAnalysisSkipReason = 'no-toolchain' | 'constituent-skipped';
 
@@ -84,15 +230,14 @@ export interface StaticAnalysisResult {
   /**
    * Overall status.
    *
-   * - 'pass'  — EVERY applicable check ran and passed. A single skipped
-   *             constituent forbids this value (DR-6).
+   * - 'pass'  — EVERY applicable check ran and passed, and there was at least
+   *             one. A single skipped constituent forbids this value, and so
+   *             does an empty set of them.
    * - 'fail'  — one or more checks failed
    * - 'skip'  — inconclusive; see `skipReason` for the reason code. Distinct
    *             from 'pass' so the gate does not falsely-green a repo with no
-   *             recognized toolchain (DR-4) or with a check that never ran
-   *             (DR-6). See DR-4 in v2.9 dogfood plan, DR-6 in
-   *             docs/specs/2026-08-04-wiring-closure-and-unified-integration-suite.md.
-   * - 'error' — usage error (missing/invalid repo root, etc.)
+   *             recognized toolchain, or with a check that never ran.
+   * - 'error' — usage error (missing/invalid repo root, unreadable config)
    */
   readonly status: 'pass' | 'fail' | 'skip' | 'error';
   /** Structured markdown report. */
@@ -106,21 +251,26 @@ export interface StaticAnalysisResult {
   /** Number of checks that failed. */
   readonly failCount: number;
   /**
-   * Number of constituent checks that did NOT run (missing script or
-   * --skip-* flag). Non-zero forces the aggregate away from 'pass' (DR-6).
+   * Number of constituent checks that did NOT run (missing script, --skip-*
+   * flag, a command that could not be launched, or a toolchain that declared
+   * nothing runnable). Non-zero forces the aggregate away from 'pass'.
    */
   readonly skipCount: number;
-  /** Detected project type (undefined if no recognized project). */
+  /**
+   * The registry's label for the detected toolchain, whether or not this gate
+   * could check it. Undefined only when nothing was detected at all — which is
+   * what separates "no project here" from "a project this gate cannot check".
+   */
   readonly projectType?: string | undefined;
 }
 
 // ============================================================
-// IMPORT-BOUNDARY LINT (SIV-3 Layer A, task 027)
+// IMPORT-BOUNDARY LINT (structural layer)
 // ============================================================
 //
 // The boundary-lint leg rides the static-analysis gate to enforce
 // architectural import boundaries (e.g. "domain core must not import the IO
-// facade"). It is Layer A of SIV-3: a *structural* boundary check on the
+// facade"). It is the STRUCTURAL half: a boundary check on the
 // module import graph.
 //
 // Decision (made at plan time): the leg is built on **dependency-cruiser**,
@@ -135,13 +285,14 @@ export interface StaticAnalysisResult {
 // graph, not the flow of tainted values through it, so Layer B is a SEPARATE
 // leg driven by a resolved taint engine (Semgrep) over a committed ruleset.
 //
-// Implementation decision (SIV-3B, #1529): the taint leg is driven by an
+// Implementation decision (#1529): the taint leg is driven by an
 // EXTERNAL resolved engine (Semgrep), not a hand-rolled TypeScript-compiler AST
 // walk. Rationale: (1) bundling the TS compiler into the shipped runtime to
 // re-implement dataflow is disproportionate; (2) one engine (Semgrep) serves
 // TS *and* the non-TS degrade the research names (CodeQL is the heavier
 // alternative), so the guarantee is language-agnostic with a single per-runtime
-// implementation (INV-4 parity) rather than a TS-only primary + a separate
+// implementation (one guarantee, at parity across runtimes) rather than a
+// TS-only primary + a separate
 // degrade; (3) the ruleset — not code — encodes BOTH halves of the invariant:
 // (a) raw IO (`JSON.parse` / `response.json()` / `req.body` / `fs.read*`) whose
 // result is not consumed by a registered parser, AND (b) out-of-band
@@ -150,7 +301,7 @@ export interface StaticAnalysisResult {
 // resolved convention (`parsers: ['src/parse/**']`) referenced by the ruleset,
 // not baked into this module.
 //
-// INV-4 degrade discipline: a repo with no `.dependency-cruiser.cjs` (or with
+// Degrade discipline: a repo with no `.dependency-cruiser.cjs` (or with
 // dependency-cruiser absent from the toolchain) yields a SKIP leg, never a
 // hard failure — exactly like the gate's "no lint script" SKIP. The leg only
 // blocks when a real config is present AND a real violation is found.
@@ -179,7 +330,7 @@ export interface BoundaryLintInput {
   readonly sources?: readonly string[];
 }
 
-/** Verdict of the import-boundary leg. SKIP is the INV-4 advisory degrade. */
+/** Verdict of the import-boundary leg. SKIP is the advisory degrade. */
 export interface BoundaryLintResult {
   readonly status: 'PASS' | 'FAIL' | 'SKIP';
   /** Human detail: the violation summary on FAIL, the skip reason on SKIP. */
@@ -235,7 +386,7 @@ export function runBoundaryLint(input: BoundaryLintInput): BoundaryLintResult {
     result = runCommand(
       'npx',
       ['depcruise', '--validate', configName, ...sources],
-      { cwd: repoRoot },
+      { cwd: repoRoot, timeoutMs: CHECK_COMMAND_TIMEOUT_MS },
     );
   } catch {
     // Tool absent / not resolvable → degrade to SKIP, never a hard failure.
@@ -254,7 +405,7 @@ export function runBoundaryLint(input: BoundaryLintInput): BoundaryLintResult {
 }
 
 // ============================================================
-// BOUNDARY-PARSE TAINT (SIV-3 Layer B, #1529)
+// BOUNDARY-PARSE TAINT (dataflow layer, #1529)
 // ============================================================
 //
 // "No raw IO into the core": untrusted input must cross a registered parser
@@ -263,7 +414,7 @@ export function runBoundaryLint(input: BoundaryLintInput): BoundaryLintResult {
 // (it sees imports, not value flow), so it rides its own resolved engine.
 //
 // The engine is Semgrep (resolved, not bundled — see the decision note above).
-// The leg follows the exact INV-4 degrade discipline as Layer A: it only runs
+// The leg follows the exact degrade discipline as Layer A: it only runs
 // when a repo OPTS IN by committing a taint ruleset at a known path, and a
 // missing ruleset OR a missing engine yields an advisory SKIP, never a hard
 // FAIL. A repo that declares no parse boundary is simply not subject to the
@@ -292,7 +443,7 @@ export interface RawIoTaintInput {
   readonly coreSources?: readonly string[];
 }
 
-/** Verdict of the boundary-parse taint leg. SKIP is the INV-4 advisory degrade. */
+/** Verdict of the boundary-parse taint leg. SKIP is the advisory degrade. */
 export interface RawIoTaintResult {
   readonly status: 'PASS' | 'FAIL' | 'SKIP';
   /** Human detail: the violation summary on FAIL, the skip reason on SKIP. */
@@ -349,7 +500,7 @@ export function runRawIoTaint(input: RawIoTaintInput): RawIoTaintResult {
     result = runCommand(
       'semgrep',
       ['--error', '--quiet', '--config', ruleset, ...coreSources],
-      { cwd: repoRoot },
+      { cwd: repoRoot, timeoutMs: CHECK_COMMAND_TIMEOUT_MS },
     );
   } catch {
     // Engine absent / not resolvable → degrade to SKIP, never a hard failure.
@@ -360,7 +511,7 @@ export function runRawIoTaint(input: RawIoTaintInput): RawIoTaintResult {
     // The runner reports an unspawnable engine (ENOENT/EACCES) via `spawnError`
     // rather than throwing — when it does, `exitCode` is NOT authoritative, so a
     // coincidental `1` must not read as a boundary finding. Degrade to SKIP,
-    // the same INV-4 discipline as the throw path above (and the contract the
+    // the same discipline as the throw path above (and the contract the
     // integration-suite gate already honors, #1537).
     return {
       status: 'SKIP',
@@ -373,7 +524,7 @@ export function runRawIoTaint(input: RawIoTaintInput): RawIoTaintResult {
   }
 
   // Exit 1 = findings (a real boundary violation) ⇒ FAIL. ANY OTHER non-zero
-  // code is inconclusive, not a violation ⇒ degrade to SKIP (INV-4), the same
+  // code is inconclusive, not a violation ⇒ degrade to SKIP, the same
   // discipline as a missing tool: semgrep exit ≥2 is an engine/config error,
   // and a negative code is signal death (a SIGKILL'd engine) — neither is
   // evidence of a boundary violation, so neither may hard-FAIL the build.
@@ -417,6 +568,24 @@ function hasNpmScript(packageJson: Record<string, unknown>, scriptName: string):
 }
 
 /**
+ * The reason a command produced no verdict, or null when its exit code is
+ * authoritative.
+ *
+ * `spawnError` is the runner's channel for "the process never ran to
+ * completion" — an unresolvable binary, or a run the wall-clock bound cut
+ * short. In both cases `exitCode` carries whatever the platform happened to
+ * put there, so reading it as a failure invents evidence: nothing was checked.
+ * The leg SKIPs, which the aggregate already treats as inconclusive and
+ * refuses to render as a pass. The taint leg above has always honoured this
+ * field; the lint and typecheck legs did not, so an unlaunchable linter read
+ * as a lint failure.
+ */
+function didNotRun(result: CommandResult): string | null {
+  if (!result.spawnError) return null;
+  return result.spawnError.trim() || 'the command did not run to completion';
+}
+
+/**
  * Read and parse package.json from a directory.
  * Returns `{ packageJson }` on success or `{ error }` on failure.
  */
@@ -434,12 +603,12 @@ function readPackageJson(
 }
 
 // ============================================================
-// FAIL-DETAIL CAP (DR-7a — counts-not-transcripts)
+// FAIL-DETAIL CAP (counts, not transcripts)
 // ============================================================
 //
 // A failing lint/typecheck run can emit hundreds of lines of transcript. Echoing
 // the whole dump into the gate response is the O-3 unbounded-echo the token-
-// economy audit named (DR-7): the reviewer pays for a 500-line wall of text when
+// economy audit named: the reviewer pays for a 500-line wall of text when
 // a first page + counts + a re-run hint is enough to triage. This caps the raw
 // detail to `FAIL_DETAIL_MAX_LINES`, then appends:
 //   (a) the total line count (so the reader knows how much was elided),
@@ -458,7 +627,7 @@ export const FAIL_DETAIL_MAX_LINES = 50;
 /**
  * Maximum distinct failing files enumerated in the per-file breakdown. Without
  * this cap a large cascade appends one line per file, so the "capped" detail can
- * still blow the DR-7 response budget the line cap exists to protect.
+ * still blow the response budget the line cap exists to protect.
  */
 export const FAIL_DETAIL_MAX_FILES = 20;
 
@@ -555,7 +724,12 @@ function runNpmCheck(
   }
 
   try {
-    const result = runCommand('npm', ['run', scriptName], { cwd: repoRoot });
+    const result = runCommand('npm', ['run', scriptName], {
+      cwd: repoRoot,
+      timeoutMs: CHECK_COMMAND_TIMEOUT_MS,
+    });
+    const unran = didNotRun(result);
+    if (unran) return { name, status: 'SKIP', detail: unran };
     if (result.exitCode === 0) {
       return { name, status: 'PASS' };
     }
@@ -573,43 +747,205 @@ function runNpmCheck(
 }
 
 // ============================================================
-// PROJECT TYPE DETECTION
+// WHICH TOOLCHAINS THIS GATE CAN CHECK
 // ============================================================
 
-type ProjectType = 'Node.js' | '.NET' | 'Rust' | 'Go';
-
 /**
- * Toolchain ids this gate has check-runners for, mapped to their report label.
- * Detection itself is delegated to the shared registry (single source of truth
- * for markers — this is where `.slnx`/`.sln` are recognized, #1507). The
- * registry detects many more toolchains; this gate only *runs checks* for the
- * four it has runners for and SKIPs the rest (honest no-toolchain).
+ * Toolchain ids this gate has runnable checks for.
+ *
+ * Detection is delegated wholesale to the shared registry, which is the single
+ * source of truth for markers and recognises considerably more toolchains than
+ * this set. Membership here answers the narrower question of whether a
+ * DETECTED toolchain has anything to run, and a non-member is an honest skip,
+ * never a pass.
+ *
+ * Exported because the difference between this set and the registry is the
+ * gate's real coverage, and an unmeasured difference is one that grows: a
+ * toolchain added to the registry with no runner here changed nothing that
+ * could be seen. `tests/architecture/gate-toolchain-coverage.test.ts` pins the
+ * uncovered ids by name so the list can only shrink.
+ *
+ * This set governs BUILT-IN toolchains. A repository that declares its own is
+ * admitted on different terms — see {@link isCheckable}.
  */
-const SUPPORTED_TOOLCHAINS: Readonly<Record<string, ProjectType>> = {
-  node: 'Node.js',
-  dotnet: '.NET',
-  rust: 'Rust',
-  go: 'Go',
-};
+export const SUPPORTED_TOOLCHAINS: ReadonlySet<string> = new Set([
+  'node',
+  'dotnet',
+  'rust',
+  'go',
+]);
 
-/** Markers (registry-sourced) for the gate's supported toolchains, for the SKIP message. */
-function supportedMarkers(): string[] {
-  return Object.keys(SUPPORTED_TOOLCHAINS).flatMap(
-    (id) => BUILTIN_TOOLCHAINS.find((t) => t.id === id)?.markers ?? [],
-  );
+/** Every marker the registry recognises, for an honest "nothing detected" report. */
+function allRegistryMarkers(): string[] {
+  return BUILTIN_TOOLCHAINS.flatMap((t) => t.markers);
+}
+
+// ============================================================
+// TOOLCHAIN RESOLUTION
+// ============================================================
+
+/** A detected toolchain plus where the declaration came from. */
+interface ToolchainResolution {
+  readonly toolchain: Toolchain | undefined;
+  /** True when the match came from the repository's own `toolchains:` block. */
+  readonly userDeclared: boolean;
 }
 
 /**
- * Detect project type via the shared toolchain registry, narrowed to the
- * toolchains this gate can actually check. Returns undefined when nothing is
- * detected or the detected toolchain has no runner here.
+ * Detect the repository's toolchain, letting its own `.exarchos.yml`
+ * `toolchains:` block participate.
+ *
+ * That block is the sanctioned way to extend or override detection, and every
+ * other consumer of the registry already passes it. This gate did not, so a
+ * repository could declare its commands, watch the test runtime honour them,
+ * and still be told static analysis had no runner for it.
+ *
+ * Throws whatever the loader throws. A `.exarchos.yml` that cannot be parsed or
+ * validated is not an absent one: continuing would mean running the gate
+ * against a detection the operator did not ask for and reporting the result as
+ * if nothing were wrong.
  */
-function detectProjectType(repoRoot: string): ProjectType | undefined {
-  const toolchain = detectToolchain(repoRoot);
-  if (toolchain && toolchain.id in SUPPORTED_TOOLCHAINS) {
-    return SUPPORTED_TOOLCHAINS[toolchain.id];
+function resolveToolchain(
+  repoRoot: string,
+  loadConfig: LoadToolchainConfigFn,
+): ToolchainResolution {
+  const declared = (loadConfig(repoRoot)?.config.toolchains ?? []).map(toolchainFromConfig);
+  if (declared.length === 0) {
+    return { toolchain: detectToolchain(repoRoot), userDeclared: false };
   }
-  return undefined;
+  const matched = detectToolchain(repoRoot, declared);
+  return { toolchain: matched, userDeclared: matched !== undefined && declared.includes(matched) };
+}
+
+/**
+ * Whether this gate has checks to run for a detected toolchain.
+ *
+ * Two different questions, deliberately answered differently. For a BUILT-IN
+ * toolchain the gate has to decide on the repository's behalf what a partial
+ * registry declaration should mean, and {@link SUPPORTED_TOOLCHAINS} is where
+ * that decision is recorded. A repository that declares its own toolchain has
+ * already made the decision itself by naming the commands, so refusing it would
+ * make the extension point advisory. Either way a toolchain that names nothing
+ * runnable is inconclusive, not a pass — see {@link runToolchainChecks}.
+ */
+function isCheckable(toolchain: Toolchain, userDeclared: boolean): boolean {
+  if (SUPPORTED_TOOLCHAINS.has(toolchain.id)) return true;
+  return userDeclared && declaresRunnableCheck(toolchain);
+}
+
+// ============================================================
+// CHECK LEGS: REGISTRY FIRST, SUPPLEMENTS BY EXCEPTION
+// ============================================================
+//
+// The commands are the registry's to declare. This gate used to re-derive one
+// literal per language beside a detection call that already knew the answer,
+// which is how the same knowledge came to disagree with itself elsewhere. So:
+// a detected toolchain's `commands.lint` and `commands.typecheck` ARE the lint
+// and typecheck legs, and only what the registry declines to declare is
+// supplied here — by exception, named, with the reason it cannot come from the
+// registry.
+//
+// Measured against the registry as it stands, the four toolchains this gate
+// runs split three ways:
+//   - go     — the registry's lint command is byte-identical to the literal
+//              this module used to carry. Pure duplication; now sourced.
+//   - rust   — the registry declares the linter and no typecheck command. The
+//              linter is taken as declared; `cargo check` remains a supplement.
+//   - dotnet — the registry declares neither leg for it.
+//   - node   — the registry's node commands do not answer this gate's question
+//              at all (see runNodeChecks).
+
+/** Which `--skip-*` flag suppresses a supplement leg. */
+type SkipAxis = 'lint' | 'typecheck' | 'both';
+
+interface SupplementLeg {
+  /** Report label. */
+  readonly name: string;
+  /** The command, exactly as it would be typed. */
+  readonly command: string;
+  /** `'both'` means the leg runs unless BOTH skip flags are set. */
+  readonly axis: SkipAxis;
+}
+
+/**
+ * Legs the registry does not declare, keyed by toolchain id, each with the
+ * reason it is here. An entry whose command the registry later declares has
+ * become a duplicate and should be deleted rather than kept in step.
+ */
+const COMMAND_SUPPLEMENTS: Readonly<Record<string, readonly SupplementLeg[]>> = {
+  // The registry declares no lint and no typecheck command for .NET. The
+  // compiler is both, and promoting warnings is what makes a build a check.
+  dotnet: [
+    { name: 'Build', command: 'dotnet build --no-restore -warnaserror', axis: 'both' },
+  ],
+  // The registry declares rust's linter but no typecheck command; a
+  // compile-only pass is the leg clippy does not stand in for.
+  rust: [{ name: 'Check', command: 'cargo check', axis: 'typecheck' }],
+};
+
+/**
+ * Tokens appended to a toolchain's declared linter so that what it finds
+ * actually fails the leg.
+ *
+ * A linter whose findings exit zero contributes a PASS while establishing
+ * nothing: the leg ran, and no outcome of it could have been a failure. Clippy
+ * is exactly that — its default level for most lints is `warn`, so a crate can
+ * be thick with findings and still exit 0. The registry declares the linter's
+ * IDENTITY, which is the right thing for it to own; whether a finding is
+ * allowed to block is this gate's question, and it is answered the same way the
+ * .NET leg answers it with `-warnaserror`.
+ *
+ * `go vet` needs no entry: it already exits non-zero on what it reports. An
+ * entry here is a claim that a toolchain's declared linter cannot fail without
+ * one, so adding a row is a decision, not a default.
+ */
+const LINT_FAILING_MODE: Readonly<Record<string, readonly string[]>> = {
+  rust: ['--', '-D', 'warnings'],
+};
+
+/**
+ * The promotion tokens for a declared lint command, or none.
+ *
+ * Withheld when the declared command already passes flags through to the
+ * compiler (a `--` separator): a repository that writes its own
+ * `cargo clippy -- …` has chosen its lint levels, and a second separator would
+ * corrupt the argv rather than harden it.
+ */
+function lintFailingMode(toolchainId: string, command: string): readonly string[] {
+  const promote = LINT_FAILING_MODE[toolchainId];
+  if (!promote) return [];
+  return command.trim().split(/\s+/).includes('--') ? [] : promote;
+}
+
+/** Split a declared command string into an executable plus argv. */
+function splitCommand(
+  command: string,
+): { readonly cmd: string; readonly args: readonly string[] } | null {
+  const [cmd, ...args] = command.trim().split(/\s+/).filter((p) => p.length > 0);
+  return cmd ? { cmd, args } : null;
+}
+
+/** Run one declared command, plus any appended tokens, as a named check leg. */
+function runDeclaredCheck(
+  name: string,
+  command: string,
+  extraArgs: readonly string[],
+  repoRoot: string,
+  runCommand: RunCommandFn,
+  skip: boolean,
+): CheckResult {
+  const parsed = splitCommand(command);
+  if (!parsed) {
+    return { name, status: 'SKIP', detail: 'no runnable command declared' };
+  }
+  return runGenericCheck(
+    name,
+    parsed.cmd,
+    [...parsed.args, ...extraArgs],
+    repoRoot,
+    runCommand,
+    skip,
+  );
 }
 
 // ============================================================
@@ -629,7 +965,12 @@ function runGenericCheck(
   }
 
   try {
-    const result = runCommand(cmd, args, { cwd: repoRoot });
+    const result = runCommand(cmd, args, {
+      cwd: repoRoot,
+      timeoutMs: CHECK_COMMAND_TIMEOUT_MS,
+    });
+    const unran = didNotRun(result);
+    if (unran) return { name, status: 'SKIP', detail: unran };
     if (result.exitCode === 0) {
       return { name, status: 'PASS' };
     }
@@ -646,9 +987,21 @@ function runGenericCheck(
 }
 
 // ============================================================
-// PLATFORM-SPECIFIC CHECK RUNNERS
+// PER-TOOLCHAIN CHECK ASSEMBLY
 // ============================================================
 
+/**
+ * The node legs, which are the one case the registry cannot answer.
+ *
+ * A node repository's lint and typecheck are package.json SCRIPTS, not
+ * commands: the registry declares no node linter precisely because there is no
+ * conventional invocation to declare, and its `tsc --noEmit` would run the
+ * compiler over whatever the working directory happens to be instead of the
+ * project the repository's own script targets. Going through the script also
+ * keeps the check on whatever package manager the repository uses. An absent
+ * script is a SKIP, which degrades the aggregate — a check that never ran is
+ * not evidence that it would have passed.
+ */
 function runNodeChecks(
   repoRoot: string,
   runCommand: RunCommandFn,
@@ -668,38 +1021,93 @@ function runNodeChecks(
   ];
 }
 
-function runDotnetChecks(
+/** Report label for the leg that stands in when a toolchain assembles none. */
+const NO_CHECKS_NAME = 'Applicable checks';
+
+/** Whether a toolchain declares a command this gate could run as a check. */
+function declaresRunnableCheck(toolchain: Toolchain): boolean {
+  return toolchain.commands.lint !== null || toolchain.commands.typecheck !== null;
+}
+
+/**
+ * Assemble and run the check legs for a detected toolchain: whatever the
+ * registry declares, plus this module's named supplements for what it does not.
+ *
+ * Returns at least one leg, always. A toolchain that assembles nothing runnable
+ * gets an explicit SKIP leg instead of an empty list, because an empty list is
+ * how a gate comes to report `PASS (0/0 checks passed)` — green off nothing at
+ * all, which is the one verdict this module exists to make unreachable. The
+ * substitution happens here rather than in the tally so the aggregate keeps a
+ * single rule (any skipped constituent degrades) instead of growing a special
+ * case for a count it should never see.
+ */
+function runToolchainChecks(
+  toolchain: Toolchain,
+  userDeclared: boolean,
   repoRoot: string,
   runCommand: RunCommandFn,
   skipLint: boolean,
   skipTypecheck: boolean,
 ): CheckResult[] {
+  const checks = assembleToolchainChecks(
+    toolchain,
+    userDeclared,
+    repoRoot,
+    runCommand,
+    skipLint,
+    skipTypecheck,
+  );
+  if (checks.length > 0) return checks;
+
   return [
-    runGenericCheck('Build', 'dotnet', ['build', '--no-restore', '-warnaserror'], repoRoot, runCommand, skipLint && skipTypecheck),
+    {
+      name: NO_CHECKS_NAME,
+      status: 'SKIP',
+      detail:
+        `nothing runnable is declared for ${toolchain.projectType} ` +
+        `(\`${toolchain.id}\`): no lint and no typecheck command`,
+    },
   ];
 }
 
-function runGoChecks(
+function assembleToolchainChecks(
+  toolchain: Toolchain,
+  userDeclared: boolean,
   repoRoot: string,
   runCommand: RunCommandFn,
   skipLint: boolean,
   skipTypecheck: boolean,
 ): CheckResult[] {
-  return [
-    runGenericCheck('Vet', 'go', ['vet', './...'], repoRoot, runCommand, skipLint),
-  ];
-}
+  // The script indirection is what a node repository gets when nobody has said
+  // otherwise. A repository that declares its own node lint/typecheck commands
+  // in `.exarchos.yml` has answered the question the indirection exists to
+  // answer, so its declaration is honoured instead; one that overrides node
+  // detection without naming either command still gets the scripts.
+  if (toolchain.id === 'node' && !(userDeclared && declaresRunnableCheck(toolchain))) {
+    return runNodeChecks(repoRoot, runCommand, skipLint, skipTypecheck);
+  }
 
-function runRustChecks(
-  repoRoot: string,
-  runCommand: RunCommandFn,
-  skipLint: boolean,
-  skipTypecheck: boolean,
-): CheckResult[] {
-  return [
-    runGenericCheck('Check', 'cargo', ['check'], repoRoot, runCommand, skipTypecheck),
-    runGenericCheck('Clippy', 'cargo', ['clippy', '--', '-D', 'warnings'], repoRoot, runCommand, skipLint),
-  ];
+  const checks: CheckResult[] = [];
+  const { lint, typecheck } = toolchain.commands;
+  if (lint) {
+    const promote = lintFailingMode(toolchain.id, lint);
+    checks.push(runDeclaredCheck('Lint', lint, promote, repoRoot, runCommand, skipLint));
+  }
+  if (typecheck) {
+    checks.push(runDeclaredCheck('Typecheck', typecheck, [], repoRoot, runCommand, skipTypecheck));
+  }
+
+  for (const leg of COMMAND_SUPPLEMENTS[toolchain.id] ?? []) {
+    const skip =
+      leg.axis === 'lint'
+        ? skipLint
+        : leg.axis === 'typecheck'
+          ? skipTypecheck
+          : skipLint && skipTypecheck;
+    checks.push(runDeclaredCheck(leg.name, leg.command, [], repoRoot, runCommand, skip));
+  }
+
+  return checks;
 }
 
 // ============================================================
@@ -744,24 +1152,47 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
     };
   }
 
-  // Detect project type
-  const projectType = detectProjectType(repoRoot);
+  let resolution: ToolchainResolution;
+  try {
+    resolution = resolveToolchain(repoRoot, input.loadConfig ?? loadExarchosConfig);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      status: 'error',
+      output: '',
+      error: `Cannot resolve the toolchain for ${repoRoot}: ${message}`,
+      passCount: 0,
+      failCount: 0,
+      skipCount: 0,
+    };
+  }
+  const { toolchain, userDeclared } = resolution;
 
-  if (!projectType) {
-    // T-10 / DR-4: no recognized toolchain returns 'skip' (inconclusive),
-    // NOT 'pass'. A pass would falsely-green any repo missing a toolchain
-    // marker. Callers (handler + convergence view) translate this into a
-    // skipped/inconclusive gate result rather than a passing one.
+  if (!toolchain || !isCheckable(toolchain, userDeclared)) {
+    // Nothing to run returns 'skip' (inconclusive), never 'pass' — a pass
+    // would falsely-green any repository this gate simply cannot check.
+    // Callers translate a skip into an inconclusive verdict, not a passing one.
+    //
+    // The two ways to get here are different facts and the report says which.
+    // Telling a Python repository that nothing recognised it is false: the
+    // registry recognised it fine, and it is this gate that has no runner.
+    const detected = toolchain
+      ? `Detected ${toolchain.projectType} (\`${toolchain.id}\`), which this gate has no static-analysis runner for`
+      : `No recognized project type (none of: ${allRegistryMarkers().join(', ')})`;
+    const verdictLine = toolchain
+      ? '**Result: SKIP** (no static-analysis runner for the detected toolchain)'
+      : '**Result: SKIP** (no applicable toolchain detected)';
+
     const output = [
       '## Static Analysis Report',
       '',
       `**Repository:** \`${repoRoot}\``,
       '',
-      `- **SKIP**: No recognized project type (none of: ${supportedMarkers().join(', ')})`,
+      `- **SKIP**: ${detected}`,
       '',
       '---',
       '',
-      '**Result: SKIP** (no applicable toolchain detected)',
+      verdictLine,
     ].join('\n');
 
     return {
@@ -771,28 +1202,21 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
       passCount: 0,
       failCount: 0,
       skipCount: 0,
-      projectType: undefined,
+      projectType: toolchain?.projectType,
     };
   }
 
-  // Run platform-specific checks
-  let checks: CheckResult[];
-  switch (projectType) {
-    case 'Node.js':
-      checks = runNodeChecks(repoRoot, runCommand, skipLint, skipTypecheck);
-      break;
-    case '.NET':
-      checks = runDotnetChecks(repoRoot, runCommand, skipLint, skipTypecheck);
-      break;
-    case 'Go':
-      checks = runGoChecks(repoRoot, runCommand, skipLint, skipTypecheck);
-      break;
-    case 'Rust':
-      checks = runRustChecks(repoRoot, runCommand, skipLint, skipTypecheck);
-      break;
-  }
+  const projectType = toolchain.projectType;
+  const checks = runToolchainChecks(
+    toolchain,
+    userDeclared,
+    repoRoot,
+    runCommand,
+    skipLint,
+    skipTypecheck,
+  );
 
-  // SIV-3 Layer A (task 027): fold the import-boundary leg into the report
+  // Fold the import-boundary leg into the report
   // ONLY when a `.dependency-cruiser.*` config is actually present. An absent
   // config produces an advisory SKIP from runBoundaryLint that we deliberately
   // do NOT append — the leg simply does not apply to repos that declare no
@@ -808,7 +1232,7 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
     });
   }
 
-  // SIV-3 Layer B (#1529): fold the boundary-parse taint leg in on the same
+  // Fold the boundary-parse taint leg in on the same
   // terms as Layer A — only when a repo has opted in with a committed taint
   // ruleset. An absent ruleset (or an unresolved engine) yields an advisory
   // SKIP we deliberately do NOT append, so the leg is invisible to repos that
@@ -824,7 +1248,7 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
 
   // Tally results.
   //
-  // DR-6: SKIP is tallied as a FIRST-CLASS outcome, not discarded. The gate
+  // SKIP is tallied as a FIRST-CLASS outcome, not discarded. The gate
   // previously counted only PASS/FAIL, so a constituent that never ran was
   // invisible to the verdict — a repo with no `lint` and no `quality-check`
   // script rendered `PASS (2/2)` off a single real check. A check that never
@@ -863,7 +1287,7 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
   outputLines.push('---');
   outputLines.push('');
 
-  // DR-6 precedence: FAIL ≻ DEGRADED ≻ PASS.
+  // Precedence: FAIL ≻ DEGRADED ≻ PASS.
   //
   // A real failure still dominates (an operator must see the failure first);
   // otherwise ANY skipped constituent degrades the dimension. PASS is

--- a/src/verbs/team/post-delegation-check.ts
+++ b/src/verbs/team/post-delegation-check.ts
@@ -9,10 +9,13 @@
 
 import { existsSync } from 'node:fs';
 import { runCommandSync } from '../../utils/process.js';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { toPosix } from '../../utils/paths.js';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
+import { resolveTestRuntime, type ResolvedRuntime } from '../../config/test-runtime-resolver.js';
+import { splitCommand } from '../../config/tokenize-command.js';
+import { classifyCommandFailure, inconclusiveReason } from '../pure/command-outcome.js';
 import { resolveWorkflowState } from '../resolve-state.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -40,11 +43,13 @@ interface CheckCounts {
   pass: number;
   fail: number;
   skip: number;
+  /** Checks that could not run at all — neither observed nor waived. */
+  indeterminate: number;
 }
 
 type CheckResult = {
   readonly label: string;
-  readonly outcome: 'PASS' | 'FAIL' | 'SKIP';
+  readonly outcome: 'PASS' | 'FAIL' | 'SKIP' | 'INDETERMINATE';
   readonly detail?: string;
 };
 
@@ -60,6 +65,17 @@ function checkFail(label: string, detail: string): CheckResult {
 
 function checkSkip(label: string): CheckResult {
   return { label, outcome: 'SKIP' };
+}
+
+/**
+ * The check could not be performed. Distinct from SKIP, and the distinction is
+ * the whole point: a SKIP is a decision (the operator waived the leg, or there
+ * was nothing to test), so it may leave a green report; an INDETERMINATE is the
+ * absence of a decision, and a blocking gate must not read as verified when it
+ * measured nothing.
+ */
+function checkIndeterminate(label: string, detail: string): CheckResult {
+  return { label, outcome: 'INDETERMINATE', detail };
 }
 
 // ─── State Parsing (delegated to resolve-state.ts) ─────────────────────────
@@ -127,25 +143,66 @@ function checkWorktreeTests(
       continue;
     }
 
-    if (!existsSync(toPosix(join(wtPath, 'package.json')))) {
-      results.push(checkSkip(`Worktree tests: ${wt} (no package.json)`));
+    // Which command verifies this worktree is a toolchain fact, resolved from
+    // the toolchain source of truth. Probing for a package.json and skipping
+    // when it is absent made every worktree of a non-Node repository record a
+    // green SKIP from a blocking gate that had verified nothing at all.
+    const resolution = resolveWorktreeTestCommand(wtPath);
+    if (resolution.kind === 'indeterminate') {
+      results.push(checkIndeterminate(`Worktree tests: ${wt}`, resolution.reason));
       continue;
     }
 
     try {
-      runCommandSync('npm', ['run', 'test:run'], {
+      runCommandSync(resolution.cmd, resolution.args, {
         cwd: wtPath,
         encoding: 'utf-8',
         timeout: 120_000,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
       results.push(checkPass(`Worktree tests: ${wt}`));
-    } catch {
-      results.push(checkFail(`Worktree tests: ${wt}`, 'npm run test:run failed'));
+    } catch (err: unknown) {
+      // A runner that never started, or one killed at its time limit, tested
+      // nothing in this worktree. Only a real non-zero exit is a failure.
+      const failure = classifyCommandFailure(err);
+      const reason = inconclusiveReason(resolution.command, failure);
+      results.push(
+        reason === null
+          ? checkFail(`Worktree tests: ${wt}`, `${resolution.command} failed`)
+          : checkIndeterminate(`Worktree tests: ${wt}`, reason),
+      );
     }
   }
 
   return results;
+}
+
+type WorktreeTestCommand =
+  | { readonly kind: 'resolved'; readonly command: string; readonly cmd: string; readonly args: readonly string[] }
+  | { readonly kind: 'indeterminate'; readonly reason: string };
+
+function resolveWorktreeTestCommand(worktreePath: string): WorktreeTestCommand {
+  let runtime: ResolvedRuntime;
+  try {
+    runtime = resolveTestRuntime(worktreePath);
+  } catch (err) {
+    return { kind: 'indeterminate', reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (runtime.source === 'unresolved' || runtime.test === null) {
+    return {
+      kind: 'indeterminate',
+      reason: runtime.remediation ?? 'no test command resolves for this worktree',
+    };
+  }
+  try {
+    const { cmd, args } = splitCommand(runtime.test);
+    if (cmd === '') {
+      return { kind: 'indeterminate', reason: `empty test command: '${runtime.test}'` };
+    }
+    return { kind: 'resolved', command: runtime.test, cmd, args };
+  } catch (err) {
+    return { kind: 'indeterminate', reason: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 function checkStateConsistency(tasks: readonly TaskEntry[]): CheckResult {
@@ -197,7 +254,12 @@ function buildReport(
   lines.push('');
 
   const total = counts.pass + counts.fail;
-  if (counts.fail === 0) {
+  if (counts.indeterminate > 0) {
+    lines.push(
+      `**Result: INDETERMINATE** (${counts.indeterminate} check(s) could not run; ` +
+        `${counts.pass}/${total} of the rest passed)`,
+    );
+  } else if (counts.fail === 0) {
     lines.push(`**Result: PASS** (${counts.pass}/${total} checks passed)`);
   } else {
     lines.push(`**Result: FAIL** (${counts.fail}/${total} checks failed)`);
@@ -205,6 +267,14 @@ function buildReport(
 
   return lines.join('\n');
 }
+
+/** Outcome → counter field. One mapping, so a new outcome cannot go uncounted. */
+const COUNTER_FOR: Readonly<Record<CheckResult['outcome'], keyof CheckCounts>> = {
+  PASS: 'pass',
+  FAIL: 'fail',
+  SKIP: 'skip',
+  INDETERMINATE: 'indeterminate',
+};
 
 // ─── Handler ────────────────────────────────────────────────────────────────
 
@@ -220,11 +290,11 @@ export async function handlePostDelegationCheck(args: PostDelegationCheckArgs): 
   const state = resolveResult.state as unknown as StateFile;
   const { tasks = [] } = state;
   const checks: CheckResult[] = [];
-  const counts: CheckCounts = { pass: 0, fail: 0, skip: 0 };
+  const counts: CheckCounts = { pass: 0, fail: 0, skip: 0, indeterminate: 0 };
 
   function addCheck(result: CheckResult): void {
     checks.push(result);
-    counts[result.outcome === 'PASS' ? 'pass' : result.outcome === 'FAIL' ? 'fail' : 'skip']++;
+    counts[COUNTER_FOR[result.outcome]]++;
   }
 
   // Check 1: State file valid (already passed by parsing)
@@ -255,7 +325,11 @@ export async function handlePostDelegationCheck(args: PostDelegationCheckArgs): 
   // Check 5: State consistency
   addCheck(checkStateConsistency(tasks));
 
-  const passed = counts.fail === 0;
+  // A check that could not run leaves the gate with nothing to certify, so it
+  // cannot pass — and it is not a failure either, which is why the count is
+  // reported separately from `fail` rather than folded into it. The reasons
+  // themselves are in the report, beside the check they belong to.
+  const passed = counts.fail === 0 && counts.indeterminate === 0;
   const report = buildReport(stateFile ?? featureId ?? 'event-store', tasks, checks, counts);
 
   return {

--- a/src/verbs/team/prepare-synthesis.ts
+++ b/src/verbs/team/prepare-synthesis.ts
@@ -8,6 +8,15 @@
 import { execSync, execFileSync } from 'node:child_process';
 import type { ToolResult } from '../../format.js';
 import type { EventStore } from '../../events/store.js';
+import { runCommandSync } from '../../utils/process.js';
+import { resolveTestRuntime, type ResolvedRuntime } from '../../config/test-runtime-resolver.js';
+import { splitCommand } from '../../config/tokenize-command.js';
+import { classifyCommandFailure, inconclusiveReason } from '../pure/command-outcome.js';
+import {
+  detectToolchain,
+  resolveTestReportFormat,
+  type TestReportFormat,
+} from '../../config/toolchains.js';
 import { resolveWorkflowState } from '../resolve-state.js';
 import { emitGateEvent } from '../gates/gate-utils.js';
 import type { ResolvedProjectConfig } from '../../config/resolve.js';
@@ -27,15 +36,26 @@ interface SynthesisReadinessState {
 
 interface TestResult {
   passed: boolean;
-  passCount: number;
-  failCount: number;
+  /**
+   * Counts are present only when the resolved runner's carrier reports them.
+   * A runner whose whole verdict is its exit code has no counts to report, and
+   * a zero there would read as "ran, found nothing" rather than "not reported".
+   */
+  passCount?: number;
+  failCount?: number;
   output?: string;
+  /** The leg could not run at all: neither a pass nor a failure was observed. */
+  indeterminate?: true;
+  reason?: string;
 }
 
 interface TypecheckResult {
   passed: boolean;
   errorCount: number;
   errors?: string[];
+  /** The leg could not run at all: neither a pass nor a failure was observed. */
+  indeterminate?: true;
+  reason?: string;
 }
 
 interface StackResult {
@@ -52,39 +72,192 @@ interface PrepareSynthesisResult {
   typecheck: TypecheckResult;
   document: DocumentLegResult;
   stack: StackResult;
+  /**
+   * The carrier's own statement that it could not run to a conclusion.
+   *
+   * `prepare_synthesis` is a registered gate class, so this action's result
+   * really does reach `readGateSkipDescriptor` through the canonical runner,
+   * where it becomes an `indeterminate` verdict instead of a readiness answer
+   * the gate never computed. Set only when a leg went UNMEASURED and no other
+   * leg failed — an observed failure is a finding, and must stay one.
+   */
+  skipped?: true;
+  reason?: string;
+}
+
+// ─── Verification-Leg Resolution ───────────────────────────────────────────
+//
+// The tests and typecheck legs run the GOVERNED repository's own commands.
+// Which commands those are is a toolchain fact, so it is resolved from the
+// toolchain source of truth rather than spelled here: a literal package-manager
+// invocation makes both legs undischargeable on any repository that is not a
+// Node one, and this gate blocks synthesis.
+//
+// A repository whose runtime does not resolve gets NO verdict — not a pass, and
+// not a skip that reads as green. That is the `indeterminate` arm.
+
+/** Commands to run, plus how to read what the test runner prints. */
+interface ResolvedLegs {
+  readonly kind: 'resolved';
+  readonly test: string;
+  /** `null` when the resolved toolchain has no typecheck step at all. */
+  readonly typecheck: string | null;
+  readonly carrier: TestReportFormat;
+}
+
+interface UnresolvedLegs {
+  readonly kind: 'indeterminate';
+  readonly reason: string;
+}
+
+type LegResolution = ResolvedLegs | UnresolvedLegs;
+
+/**
+ * How the resolved test runner reports its result.
+ *
+ * Consulted only when the command came from built-in DETECTION. Every other
+ * layer — an override, `.exarchos.yml`, a user-declared toolchain, a committed
+ * task runner — supplies a command the built-in carrier table says nothing
+ * about, and reading a detected toolchain's row for it would attribute one
+ * runner's output grammar to another.
+ */
+function resolveCarrier(repoRoot: string, runtime: ResolvedRuntime): TestReportFormat {
+  if (runtime.source !== 'detection') {
+    return {
+      kind: 'unknown',
+      reason:
+        `the test command was supplied by '${runtime.source}' rather than by toolchain ` +
+        'detection, so how its runner reports a result is unknown',
+    };
+  }
+  return resolveTestReportFormat(detectToolchain(repoRoot)?.id ?? '');
+}
+
+function resolveLegs(repoRoot: string): LegResolution {
+  let runtime: ResolvedRuntime;
+  try {
+    runtime = resolveTestRuntime(repoRoot);
+  } catch (err) {
+    return { kind: 'indeterminate', reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (runtime.source === 'unresolved' || runtime.test === null) {
+    return {
+      kind: 'indeterminate',
+      reason:
+        runtime.remediation ??
+        `no test command resolves for '${repoRoot}', so the suite could not be run`,
+    };
+  }
+  return {
+    kind: 'resolved',
+    test: runtime.test,
+    typecheck: runtime.typecheck,
+    carrier: resolveCarrier(repoRoot, runtime),
+  };
+}
+
+// ─── Command Execution ─────────────────────────────────────────────────────
+
+/**
+ * `repoRoot` is threaded as `cwd` on every leg below: the process this MCP
+ * server happens to have been launched in is never an implicit scan surface —
+ * the caller must name the tree it wants judged.
+ */
+interface CommandOutcome {
+  readonly ok: boolean;
+  readonly text: string;
+  /**
+   * Set when the run produced no verdict — the command could not be started,
+   * or it was killed at its wall clock. `ok: false` alone would make both read
+   * as a leg that ran and failed.
+   */
+  readonly inconclusive?: string;
+}
+
+function decodeStreams(chunks: readonly unknown[]): string {
+  return chunks
+    .map((chunk) => {
+      if (typeof chunk === 'string') return chunk;
+      if (chunk instanceof Buffer) return chunk.toString('utf-8');
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+/**
+ * Run a resolved command in `repoRoot`. argv form, not a shell string: the
+ * resolver's command may carry quoted arguments, and a shell would also give a
+ * crafted `.exarchos.yml` value somewhere to hide. `runCommandSync` is what
+ * still launches a package-manager `.cmd` shim on Windows.
+ */
+function runResolvedCommand(
+  command: string,
+  repoRoot: string,
+  timeoutMs: number,
+): CommandOutcome {
+  let cmd: string;
+  let args: readonly string[];
+  try {
+    ({ cmd, args } = splitCommand(command));
+  } catch (err) {
+    const text = err instanceof Error ? err.message : String(err);
+    return { ok: false, text, inconclusive: `\`${command}\` is not tokenizable: ${text}` };
+  }
+  if (cmd === '') {
+    return {
+      ok: false,
+      text: `empty command: '${command}'`,
+      inconclusive: `\`${command}\` resolves to no executable`,
+    };
+  }
+  try {
+    const output = runCommandSync(cmd, args, {
+      cwd: repoRoot,
+      encoding: 'buffer',
+      timeout: timeoutMs,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { ok: true, text: decodeStreams([output]) };
+  } catch (err: unknown) {
+    const failure = classifyCommandFailure(err);
+    const text = decodeStreams([failure.stdout, failure.stderr]);
+    const reason = inconclusiveReason(command, failure);
+    return {
+      ok: false,
+      text: text === '' && reason !== null ? reason : text,
+      ...(reason === null ? {} : { inconclusive: reason }),
+    };
+  }
 }
 
 // ─── Test Runner ───────────────────────────────────────────────────────────
 
-/**
- * `repoRoot` is threaded as `cwd` on every leg below (DR-8 / #1756): the
- * process this MCP server happens to have been launched in is never an
- * implicit scan surface — the caller must name the tree it wants judged.
- */
-function runTestSuite(repoRoot: string): TestResult {
-  try {
-    const output = execSync('npm run test:run', {
-      cwd: repoRoot,
-      encoding: 'buffer',
-      timeout: 120_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const text = output.toString('utf-8');
-    const { passCount, failCount } = parseTestOutput(text);
-    return { passed: true, passCount, failCount, output: text };
-  } catch (err: unknown) {
-    const execError = err as { stdout?: Buffer; stderr?: Buffer; status?: number };
-    const text = [execError.stdout, execError.stderr]
-      .filter((chunk): chunk is Buffer => chunk instanceof Buffer)
-      .map((chunk) => chunk.toString('utf-8'))
-      .join('\n');
-    const { passCount, failCount } = parseTestOutput(text);
-    return { passed: false, passCount, failCount, output: text };
+function runTestSuite(repoRoot: string, legs: ResolvedLegs): TestResult {
+  const outcome = runResolvedCommand(legs.test, repoRoot, 120_000);
+  if (outcome.inconclusive !== undefined) {
+    // The suite was not observed. Counts scraped from a truncated or empty
+    // transcript would be counts of nothing, so none are reported.
+    return { passed: false, indeterminate: true, reason: outcome.inconclusive, output: outcome.text };
   }
+  return {
+    passed: outcome.ok,
+    ...parseTestOutput(outcome.text, legs.carrier),
+    output: outcome.text,
+  };
 }
 
-function parseTestOutput(output: string): { passCount: number; failCount: number } {
-  // Match patterns like "10 passed" and "2 failed"
+/**
+ * Pass/fail counts, when the carrier says the runner prints them in a shape
+ * this parse understands. Anything else reports no counts rather than a count
+ * scraped out of a grammar it was never written for — the verdict itself comes
+ * from the exit code, which every runner carries honestly.
+ */
+function parseTestOutput(
+  output: string,
+  carrier: TestReportFormat,
+): { passCount?: number; failCount?: number } {
+  if (carrier.kind !== 'vitest-json') return {};
   const passMatch = output.match(/(\d+)\s+passed/);
   const failMatch = output.match(/(\d+)\s+failed/);
   return {
@@ -95,28 +268,39 @@ function parseTestOutput(output: string): { passCount: number; failCount: number
 
 // ─── Typecheck Runner ──────────────────────────────────────────────────────
 
-function runTypecheck(repoRoot: string): TypecheckResult {
-  try {
-    execSync('npm run typecheck', {
-      cwd: repoRoot,
-      encoding: 'buffer',
-      timeout: 60_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { passed: true, errorCount: 0 };
-  } catch (err: unknown) {
-    const execError = err as { stdout?: Buffer; stderr?: Buffer; status?: number };
-    const text = [execError.stdout, execError.stderr]
-      .filter((chunk): chunk is Buffer => chunk instanceof Buffer)
-      .map((chunk) => chunk.toString('utf-8'))
-      .join('\n');
-    const errors = parseTypecheckErrors(text);
-    return { passed: false, errorCount: errors.length, errors };
+function runTypecheck(repoRoot: string, legs: ResolvedLegs): TypecheckResult {
+  // A null typecheck command is the RESOLVER'S OWN 'unresolved' answer for that
+  // field, not a project's withdrawal of the obligation. Reading it as a
+  // withdrawal turned every repository the resolver could not answer for into a
+  // green typecheck leg — proof minted from an absence. Only an explicit
+  // `typecheck:` in `.exarchos.yml` (or an override) discharges this leg; until
+  // one exists the obligation stands, unmeasured.
+  if (legs.typecheck === null) {
+    return {
+      passed: false,
+      errorCount: 0,
+      indeterminate: true,
+      reason:
+        `no typecheck command resolves for '${repoRoot}'. Declare one under ` +
+        '`typecheck:` in .exarchos.yml, or pass an override.',
+    };
   }
+  const outcome = runResolvedCommand(legs.typecheck, repoRoot, 60_000);
+  if (outcome.ok) return { passed: true, errorCount: 0 };
+  if (outcome.inconclusive !== undefined) {
+    return { passed: false, errorCount: 0, indeterminate: true, reason: outcome.inconclusive };
+  }
+  const errors = parseTypecheckErrors(outcome.text);
+  return { passed: false, errorCount: errors.length, errors };
 }
 
+/**
+ * Diagnostic lines from a failed typecheck. TypeScript's `error TS….` prefix is
+ * recognized because it lets the count mean something; any other compiler's
+ * output is reported whole rather than counted as zero errors on a leg that
+ * demonstrably failed.
+ */
 function parseTypecheckErrors(output: string): string[] {
-  // Match lines like "error TS2322: ..."
   const errorLines = output.split('\n').filter((line) => line.includes('error TS'));
   return errorLines.length > 0 ? errorLines : output.trim() ? [output.trim()] : [];
 }
@@ -162,7 +346,7 @@ function verifyStack(repoRoot: string): StackResult {
   }
 }
 
-// ─── DR-2: Document-Readiness Leg (#1594) ───────────────────────────────────
+// ─── Document-Readiness Leg (#1594) ─────────────────────────────────────────
 
 export type DocumentLegConfig = ResolvedProjectConfig['synthesis']['documentLeg'];
 
@@ -194,8 +378,8 @@ export interface DocumentLegResult {
  * — otherwise the leg is uncovered. Pure: the caller supplies the changed-file
  * list (from `git diff --name-only`), so the rule itself is deterministic and
  * directly testable. No doc-bearing surface touched ⇒ auto-waive (the
- * no-ceremony default for ordinary changes). INV-6: no workflow-type branch —
- * the same rule holds for every workflow type.
+ * no-ceremony default for ordinary changes). No workflow-type branch — the
+ * same rule holds for every workflow type.
  */
 export function evaluateDocumentLeg(
   files: readonly string[],
@@ -290,8 +474,8 @@ function checkTaskCompletion(
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 /**
- * `repoRoot` is REQUIRED, not defaulted (DR-8 / #1756): before this task the
- * handler had no field at all naming the tree a readiness verdict was for,
+ * `repoRoot` is REQUIRED, not defaulted (#1756). With no field naming the tree
+ * a readiness verdict was for,
  * so every subprocess leg silently measured the ambient `process.cwd()` the
  * MCP server happened to be launched in. A required field makes an
  * unrelated-tree verdict a compile-time impossibility for every in-repo
@@ -385,7 +569,7 @@ async function executePrepareSynthesis(
       return { success: true, data: result };
     }
 
-    // 3b. DR-8 / #1756: from here on every leg shells out and must be told
+    // 3b. #1756: from here on every leg shells out and must be told
     //     which tree to measure. Refuse rather than silently falling back to
     //     the server's own ambient `process.cwd()` — a verdict about the
     //     wrong repo is worse than no verdict. (Deliberately checked AFTER
@@ -436,19 +620,27 @@ async function executePrepareSynthesis(
     }
     const repoRoot = args.repoRoot;
 
-    // 4. Run test suite
-    const tests = runTestSuite(repoRoot);
+    // 4. Resolve the two command legs from the toolchain source of truth, then
+    //    run them. An unresolvable runtime runs nothing and concludes nothing.
+    const legs = resolveLegs(repoRoot);
+
+    const tests: TestResult = legs.kind === 'resolved'
+      ? runTestSuite(repoRoot, legs)
+      : { passed: false, indeterminate: true, reason: legs.reason };
 
     // 5. Emit gate.executed event for test-suite (feeds flywheel)
     await emitGateEvent(store, streamId, 'test-suite', 'CI', tests.passed, {
       dimension: 'D1',
       phase: 'synthesize',
-      passCount: tests.passCount,
-      failCount: tests.failCount,
+      ...(tests.passCount !== undefined ? { passCount: tests.passCount } : {}),
+      ...(tests.failCount !== undefined ? { failCount: tests.failCount } : {}),
+      ...(tests.indeterminate ? { indeterminate: true, reason: tests.reason } : {}),
     });
 
     // 6. Run typecheck
-    const typecheck = runTypecheck(repoRoot);
+    const typecheck: TypecheckResult = legs.kind === 'resolved'
+      ? runTypecheck(repoRoot, legs)
+      : { passed: false, errorCount: 0, indeterminate: true, reason: legs.reason };
 
     // 7. Emit gate.executed event for typecheck (feeds flywheel)
     await emitGateEvent(store, streamId, 'typecheck', 'CI', typecheck.passed, {
@@ -456,12 +648,14 @@ async function executePrepareSynthesis(
       phase: 'synthesize',
       errorCount: typecheck.errorCount,
       errors: typecheck.errors,
+      ...(typecheck.indeterminate ? { indeterminate: true } : {}),
+      ...(typecheck.reason !== undefined ? { reason: typecheck.reason } : {}),
     });
 
     // 8. Verify branch stack
     const stack = verifyStack(repoRoot);
 
-    // 9. Evaluate the document-readiness leg (DR-2, #1594) and emit its gate.
+    // 9. Evaluate the document-readiness leg (#1594) and emit its gate.
     //    Roster order is task-completion→tests→typecheck→document→stack; gate
     //    EMISSION order here is immaterial (the readiness view folds
     //    gate.executed by name), so the leg is evaluated after the stack check.
@@ -509,12 +703,37 @@ async function executePrepareSynthesis(
       && readiness.stackHealthy;
 
     const allBlockers: string[] = [];
-    if (!readiness.testsPass) allBlockers.push('Test suite failed');
-    if (!readiness.typecheckPass) allBlockers.push('Typecheck failed');
+    const unmeasured: string[] = [];
+    if (tests.indeterminate) {
+      const why = tests.reason ?? 'no test command resolved';
+      unmeasured.push(`Test suite: ${why}`);
+      allBlockers.push(`Test suite could not be run — ${why}`);
+    } else if (!readiness.testsPass) {
+      allBlockers.push('Test suite failed');
+    }
+    if (typecheck.indeterminate) {
+      const why = typecheck.reason ?? 'no typecheck command resolved';
+      unmeasured.push(`Typecheck: ${why}`);
+      allBlockers.push(`Typecheck could not be run — ${why}`);
+    } else if (!readiness.typecheckPass) {
+      allBlockers.push('Typecheck failed');
+    }
     if (!readiness.documentReady) {
       allBlockers.push(documentLeg.message ?? 'Documentation not updated for a doc-bearing change');
     }
     if (!readiness.stackHealthy) allBlockers.push('Stack not healthy');
+
+    // An unmeasured leg makes the readiness answer unavailable rather than
+    // negative — but only while nothing else actually FAILED. A gate that
+    // observed a failure has produced a finding, and declaring itself skipped
+    // would erase the one thing it did establish.
+    const observedFailure =
+      !readiness.tasksComplete
+      || (!tests.indeterminate && !readiness.testsPass)
+      || (!typecheck.indeterminate && !readiness.typecheckPass)
+      || !readiness.documentReady
+      || !readiness.stackHealthy;
+    const unconcluded = unmeasured.length > 0 && !observedFailure;
 
     const result: PrepareSynthesisResult = {
       ready,
@@ -524,6 +743,7 @@ async function executePrepareSynthesis(
       typecheck,
       document: documentLeg,
       stack,
+      ...(unconcluded ? { skipped: true as const, reason: unmeasured.join('; ') } : {}),
     };
 
     return { success: true, data: result };

--- a/src/verbs/team/setup-worktree.ts
+++ b/src/verbs/team/setup-worktree.ts
@@ -4,7 +4,7 @@
 // validation steps: gitignore, branch, worktree, npm install, baseline tests.
 // ────────────────────────────────────────────────────────────────────────────
 
-import { existsSync, appendFileSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { runCommandSync } from '../../utils/process.js';
 import { join } from 'node:path';
@@ -103,16 +103,21 @@ function formatReport(
 
   const pass = checks.filter((c) => c.status === 'pass').length;
   const fail = checks.filter((c) => c.status === 'fail').length;
+  const skip = checks.filter((c) => c.status === 'skip').length;
   const total = pass + fail;
 
   lines.push('');
   lines.push('---');
   lines.push('');
 
+  // A skipped check settled nothing, so it rides in the headline. Left out, a
+  // run whose gitignore (or install, or baseline) step never ran reads as a
+  // clean sweep of the checks that did.
+  const skipped = skip > 0 ? `, ${skip} skipped` : '';
   if (fail === 0) {
-    lines.push(`**Result: PASS** (${pass}/${total} checks passed)`);
+    lines.push(`**Result: PASS** (${pass}/${total} checks passed${skipped})`);
   } else {
-    lines.push(`**Result: FAIL** (${fail}/${total} checks failed)`);
+    lines.push(`**Result: FAIL** (${fail}/${total} checks failed${skipped})`);
   }
 
   return lines.join('\n');
@@ -120,30 +125,22 @@ function formatReport(
 
 // ─── Step Functions ─────────────────────────────────────────────────────────
 
-// DR-1 (T-07, #1203): direct-read the repo's `.gitignore`. The previous
-// implementation used `git check-ignore -q .worktrees/`, which honors any
-// ignore source (global excludes, .git/info/exclude, parent globs). When
-// a non-repo source matched, the function reported PASS without writing
-// to the repo file — a fresh clone or CI run then saw `.worktrees/` as
-// untracked, breaking subsequent `merge_orchestrate` preflights.
-//
-// New contract: PASS means "the repo's `.gitignore` lists `.worktrees/`."
-// The detail string reflects exactly which path the function took
-// (already present / added / created with entry).
-//
-// fix-007 (review #1213): orchestration-only — read/format helpers
-// extracted below so each concern (read vs error formatting vs control
-// flow) sits in its own function and stays easy to read in isolation.
-function ensureGitignored(repoRoot: string): CheckResult {
-  const gitignorePath = toPosix(join(repoRoot, '.gitignore'));
+/** The one name this step reports under. */
+const GITIGNORE_CHECK = '.worktrees is gitignored';
 
-  let detail: 'already present' | 'added' | 'created with entry';
-  let needsAppend: boolean;
-  // CodeRabbit #7: when the existing .gitignore lacks a trailing newline,
-  // a bare append produces `dist.worktrees/\n` (single concatenated line)
-  // instead of two distinct entries. Prepend a newline if needed so the
-  // boundary is preserved.
-  let prependNewline = false;
+// Membership is read directly from the repo's own `.gitignore`, never from
+// `git check-ignore -q`, which also honors global excludes, `.git/info/exclude`
+// and parent globs. When a non-repo source matched, this step reported PASS
+// while a fresh clone or CI run still saw `.worktrees/` as untracked, breaking
+// subsequent `merge_orchestrate` preflights. PASS means exactly "the repo's
+// `.gitignore` lists `.worktrees/`".
+//
+// This step reports; it never writes. A governed repository's `.gitignore` is
+// that repository's own source, and a governance tool that edits it becomes a
+// silent author of a file it does not own. So a missing entry is NAMED — skip,
+// with the file and the line to add — and left to whoever owns the file.
+function checkGitignored(repoRoot: string): CheckResult {
+  const gitignorePath = toPosix(join(repoRoot, '.gitignore'));
 
   if (existsSync(gitignorePath)) {
     const readResult = readGitignoreLines(gitignorePath);
@@ -152,35 +149,22 @@ function ensureGitignored(repoRoot: string): CheckResult {
     }
 
     if (containsWorktreesEntry(readResult.contents)) {
-      return { name: '.worktrees is gitignored', status: 'pass', detail: 'already present' };
-    }
-
-    detail = 'added';
-    needsAppend = true;
-    prependNewline =
-      readResult.contents.length > 0 && !readResult.contents.endsWith('\n');
-  } else {
-    detail = 'created with entry';
-    needsAppend = true;
-  }
-
-  if (needsAppend) {
-    try {
-      const payload = (prependNewline ? '\n' : '') + '.worktrees/\n';
-      appendFileSync(gitignorePath, payload);
-    } catch (err) {
-      const verb = detail === 'created with entry' ? 'create' : 'append to';
-      return formatGitignoreError(`Failed to ${verb} ${gitignorePath}`, err);
+      return { name: GITIGNORE_CHECK, status: 'pass', detail: 'already present' };
     }
   }
 
-  return { name: '.worktrees is gitignored', status: 'pass', detail };
+  return {
+    name: GITIGNORE_CHECK,
+    status: 'skip',
+    detail:
+      `'.worktrees/' is not listed in ${gitignorePath}, so worktrees will show as untracked. ` +
+      "Add a '.worktrees/' line to that file.",
+  };
 }
 
 /**
- * fix-007 (#1213): I/O wrapper that returns either the file contents or a
- * structured error. Centralizes the readFileSync try/catch so the
- * orchestrator can stay flat.
+ * I/O wrapper returning either the file contents or a structured error, so the
+ * orchestrating function above stays flat.
  */
 type ReadGitignoreResult =
   | { kind: 'ok'; contents: string }
@@ -195,14 +179,13 @@ function readGitignoreLines(gitignorePath: string): ReadGitignoreResult {
 }
 
 /**
- * fix-007 (#1213): single-source formatter for the gitignore-step CheckResult
- * `fail` shape. Keeps the `${prefix}: ${message}` convention in one place so
- * any future adjustment to the detail string lives in one function.
+ * Single-source formatter for the gitignore-step `fail` shape, keeping the
+ * `${prefix}: ${message}` convention in one place.
  */
 function formatGitignoreError(prefix: string, err: unknown): CheckResult {
   const message = err instanceof Error ? err.message : String(err);
   return {
-    name: '.worktrees is gitignored',
+    name: GITIGNORE_CHECK,
     status: 'fail',
     detail: `${prefix}: ${message}`,
   };
@@ -578,8 +561,8 @@ async function runSetupWorktreeSteps(
 
   const checks: CheckResult[] = [];
 
-  // Step 1: Ensure .worktrees is gitignored
-  checks.push(ensureGitignored(args.repoRoot));
+  // Step 1: report whether .worktrees is gitignored (report only — never write)
+  checks.push(checkGitignored(args.repoRoot));
 
   // Steps 2+3: Create branch + worktree atomically through the single typed
   // VCS mutation owner. Idempotency (keyed on the worktree path) makes a

--- a/src/verbs/vcs/check-coderabbit.ts
+++ b/src/verbs/vcs/check-coderabbit.ts
@@ -2,7 +2,7 @@
 //
 // Queries CodeRabbit review state on PRs via VcsProvider. For each PR,
 // fetches review status, filters to CodeRabbit bot reviewers, and classifies:
-// approved -> pass, NONE -> pass, else -> fail.
+// approved -> pass, absent reviewer -> indeterminate, else -> fail.
 //
 // Migrated from direct `gh api` calls to VcsProvider.getReviewStatus().
 // ─────────────────────────────────────────────────────────────────────────────
@@ -22,14 +22,29 @@ export interface CheckCoderabbitArgs {
 export interface PrReviewResult {
   readonly pr: number;
   readonly state: string;
-  readonly verdict: 'pass' | 'fail' | 'skip';
+  readonly verdict: 'pass' | 'fail' | 'skip' | 'indeterminate';
 }
 
 interface CheckCoderabbitResult {
   readonly passed: boolean;
   readonly report: string;
   readonly results: readonly PrReviewResult[];
+  /** Present only when a PR carried no review from the recognized reviewer. */
+  readonly skipped?: true;
+  readonly discriminant?: string;
+  readonly reason?: string;
 }
+
+/**
+ * The discriminant carried when the recognized reviewer never reviewed.
+ *
+ * Exported because the outcome has a READER: the synthesize skill's step 4
+ * branches on it to tell an unmeasured obligation from a disproof, and without
+ * that branch a repository the vendor does not watch reads `passed: false` and
+ * is sent to a fix cycle that cannot fix anything. Naming the constant is what
+ * lets the guard on that documentation follow a rename.
+ */
+export const CODERABBIT_REVIEWER_ABSENT = 'coderabbit-reviewer-absent';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -90,8 +105,12 @@ export async function handleCheckCoderabbit(
         (r) => CODERABBIT_LOGINS.has(r.login),
       );
 
+      // An absent reviewer is not an approval. The check exists to establish
+      // that this reviewer looked at the PR, and nothing here establishes that
+      // — so it yields no verdict rather than the pass it used to mint, which
+      // read as coverage on every repository the reviewer does not watch.
       if (coderabbitReviewers.length === 0) {
-        results.push({ pr, state: 'NONE', verdict: 'pass' });
+        results.push({ pr, state: 'NONE', verdict: 'indeterminate' });
         continue;
       }
 
@@ -109,8 +128,12 @@ export async function handleCheckCoderabbit(
     }
   }
 
-  // Compute overall pass (skip doesn't count as fail)
-  const allPassed = results.every((r) => r.verdict !== 'fail');
+  // Overall verdict. `skip` is a withdrawn subject (an unusable PR number, so
+  // there was never an obligation); `indeterminate` is an OWED one that went
+  // unmeasured, so it withholds the pass instead of being counted as one.
+  const failCount = results.filter((r) => r.verdict === 'fail').length;
+  const unmeasured = results.filter((r) => r.verdict === 'indeterminate');
+  const allPassed = failCount === 0 && unmeasured.length === 0;
 
   // Build markdown report
   const lines: string[] = [];
@@ -124,16 +147,29 @@ export async function handleCheckCoderabbit(
     lines.push(`| #${r.pr} | ${r.state} | ${r.verdict} |`);
   }
   lines.push('');
+  const unmeasuredReason =
+    `no CodeRabbit review found on ${unmeasured.length} PR(s): ` +
+    `${unmeasured.map((r) => `#${r.pr}`).join(', ')}`;
   if (allPassed) {
     lines.push('**Result: PASS** — all PRs passed CodeRabbit review');
-  } else {
-    const failCount = results.filter((r) => r.verdict === 'fail').length;
+  } else if (failCount > 0) {
     lines.push(`**Result: FAIL** — ${failCount} PR(s) did not pass CodeRabbit review`);
+  } else {
+    lines.push(`**Result: INDETERMINATE** — ${unmeasuredReason}`);
   }
 
   const report = lines.join('\n');
 
-  const result: CheckCoderabbitResult = { passed: allPassed, report, results };
+  const result: CheckCoderabbitResult = {
+    passed: allPassed,
+    report,
+    results,
+    // Only when nothing FAILED but something went unmeasured: a real disproof
+    // is a conclusion, and stamping it as a skip would hide it.
+    ...(failCount === 0 && unmeasured.length > 0
+      ? { skipped: true, discriminant: CODERABBIT_REVIEWER_ABSENT, reason: unmeasuredReason }
+      : {}),
+  };
 
   return { success: true, data: result };
 }

--- a/src/verbs/vcs/validate-pr-stack.ts
+++ b/src/verbs/vcs/validate-pr-stack.ts
@@ -7,12 +7,23 @@
 import type { VcsProvider, PrSummary } from '../../vcs/provider.js';
 import { requiresGitHub } from '../../vcs/require-github.js';
 import { createVcsProvider } from '../../vcs/factory.js';
+import type { ResolvedProjectConfig } from '../../config/resolve.js';
 import type { ToolResult } from '../../format.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface ValidatePrStackArgs {
   readonly baseBranch: string;
+  /**
+   * The resolved project config, injected by the dispatch adapter.
+   *
+   * It is what makes `.exarchos.yml`'s `vcs.provider` reach the factory. Without
+   * it the factory falls through to detection, which reads the git remote's
+   * HOSTNAME — so a self-hosted GitLab at `git.acme.internal`, or an enterprise
+   * GitHub, matches no pattern and resolves to the GitHub default. That is the
+   * setting being ignored precisely where a project stated it explicitly.
+   */
+  readonly projectConfig?: ResolvedProjectConfig;
 }
 
 interface PrEntry {
@@ -35,9 +46,6 @@ export async function handleValidatePrStack(
   args: ValidatePrStackArgs,
   provider?: VcsProvider,
 ): Promise<ToolResult> {
-  const vcsGuard = requiresGitHub(provider, 'validate_pr_stack');
-  if (vcsGuard) return vcsGuard;
-
   // 1. Validate args
   if (!args.baseBranch) {
     return {
@@ -47,7 +55,26 @@ export async function handleValidatePrStack(
   }
 
   const { baseBranch } = args;
-  const vcs = provider ?? await createVcsProvider();
+
+  // The guard runs against the RESOLVED provider, not the parameter.
+  //
+  // The composed router calls this handler with its args and nothing else, so
+  // `provider` is always undefined in production — and `requiresGitHub` reads an
+  // absent provider as "unconfigured, GitHub is implicit" and waves it through.
+  // Guarding the parameter therefore declared a graceful skip that no real call
+  // could ever reach: a GitLab or Azure DevOps repository fell past it into
+  // `listPrs`, which throws `UnsupportedOperationError` on both partials, and a
+  // BLOCKING synthesis gate reported a hard `GH_CLI_ERROR` for an obligation
+  // that simply does not apply to that host. Resolving first is what makes the
+  // declared skip reachable without the router having to hand the provider in.
+  //
+  // The config goes WITH the request: `createVcsProvider` consults
+  // `config.vcs.provider` first and only auto-detects when nothing was declared,
+  // so calling it bare would silently demote an explicit setting to a hostname
+  // guess.
+  const vcs = provider ?? (await createVcsProvider({ config: args.projectConfig }));
+  const vcsGuard = requiresGitHub(vcs, 'validate_pr_stack');
+  if (vcsGuard) return vcsGuard;
 
   // 2. Query open PRs via VcsProvider
   let prSummaries: PrSummary[];

--- a/tests/acceptance/ladder-off-node.test.ts
+++ b/tests/acceptance/ladder-off-node.test.ts
@@ -1,0 +1,548 @@
+/**
+ * The top rung of the verification ladder is satisfiable off Node.
+ *
+ * `check_integration_suite` is a BLOCKING, high-tier ladder gate. It used to
+ * resolve its command from the toolchain registry and then append vitest's
+ * `--reporter=json` to whatever came back — `cargo test --reporter=json`,
+ * `dotnet test --reporter=json`, `pytest --reporter=json` — an unknown flag that
+ * makes the runner exit before running anything, read back as a hard failure. On
+ * eleven of the twelve declared toolchains the rung could not be cleared at all.
+ *
+ * The property under test is stated over the LIVE registry rather than a list
+ * written here: a hand-written denominator cannot notice a toolchain being
+ * added, which is the failure mode this file exists to make impossible. Every
+ * case below is generated from `BUILTIN_TOOLCHAINS`, and the flag set the
+ * property quantifies over is generated from the carrier table.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// The durable producer needs an event store, a phase attempt and a trusted
+// dispatch context — all of which belong to the recording path, not to the
+// verdict this file is about. Passing the provider through keeps the subject to
+// what the gate concludes and how it says so.
+vi.mock('../../src/verbs/gates/durable-gate-producer.js', () => ({
+  runDurableGateProducer: (_scope: unknown, executeProvider: () => Promise<unknown>) =>
+    executeProvider(),
+}));
+
+import {
+  BUILTIN_TOOLCHAINS,
+  resolveTestReportFormat,
+  type Toolchain,
+} from '../../src/config/toolchains.js';
+import type { EventStore } from '../../src/events/store.js';
+import type { ToolResult } from '../../src/format.js';
+import {
+  execCommandRunner,
+  handleCheckIntegrationSuite,
+} from '../../src/verbs/gates/check-integration-suite.js';
+import { normalizeGateVerdict } from '../../src/verbs/gates/gate-utils.js';
+import {
+  resolveIntegrationCommand,
+  runIntegrationSuite,
+  type IntegrationCommandResult,
+  type IntegrationRuntime,
+} from '../../src/verbs/pure/integration-suite.js';
+
+// ─── Denominators, all derived ───────────────────────────────────────────────
+
+/**
+ * Every reporter flag any toolchain's carrier asks for. The "no toolchain gets
+ * another toolchain's flag" property quantifies over THIS set, so a carrier arm
+ * that starts asking for a new flag is covered the day it lands.
+ */
+const REPORTER_FLAGS: ReadonlySet<string> = new Set(
+  BUILTIN_TOOLCHAINS.flatMap((toolchain) => {
+    const format = resolveTestReportFormat(toolchain.id);
+    return format.kind === 'vitest-json' ? [format.reporterFlag] : [];
+  }),
+);
+
+/** The toolchain the registry declares under `id`, or a failure to find it. */
+function builtin(id: string): Toolchain {
+  const found = BUILTIN_TOOLCHAINS.find((toolchain) => toolchain.id === id);
+  if (!found) throw new Error(`the registry no longer declares a '${id}' toolchain`);
+  return found;
+}
+
+/** The tokens the registry declares as this toolchain's test command. */
+function declaredCommand(toolchain: Toolchain): readonly string[] {
+  return (toolchain.commands.test ?? '').trim().split(/\s+/);
+}
+
+/**
+ * The runtime a repository of this toolchain resolves to when no higher layer
+ * contributes: the registry supplies both the command and the identity.
+ *
+ * Derived from the toolchain rather than written out, so a registry row that
+ * changes its command is followed here instead of being shadowed by a literal.
+ */
+function registryRuntime(toolchain: Toolchain): IntegrationRuntime {
+  return { test: toolchain.commands.test, toolchain };
+}
+
+// ─── Gate harness ────────────────────────────────────────────────────────────
+
+/** Roots this file creates, removed together in the file's own teardown. */
+const scratchRoots: string[] = [];
+
+function scratch(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  scratchRoots.push(root);
+  return root;
+}
+
+/** A path with no project markers at all. */
+let emptyRepo = '';
+/** A real Rust repository — the toolchain is read off the tree, not passed in. */
+let rustRepo = '';
+/** Where the gate is told to keep state. Unique per run, and removed after. */
+let stateDir = '';
+
+beforeAll(() => {
+  emptyRepo = scratch('ladder-off-node-empty-');
+  rustRepo = scratch('ladder-off-node-rust-');
+  stateDir = scratch('ladder-off-node-state-');
+  writeFileSync(join(rustRepo, 'Cargo.toml'), '[package]\nname = "governed"\n', 'utf-8');
+});
+
+afterAll(() => {
+  for (const root of scratchRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const mockStore = {
+  append: vi.fn().mockResolvedValue(undefined),
+  query: vi.fn().mockResolvedValue([]),
+} as unknown as EventStore;
+
+/**
+ * Drive the REAL gate against a real directory, with only the spawn replaced.
+ *
+ * The toolchain is not an argument of the gate — it is read off the repository —
+ * so a case about a non-Node repository has to hand it a non-Node repository.
+ */
+async function runGateAt(
+  repoRoot: string,
+  result: IntegrationCommandResult,
+): Promise<{ readonly tool: ToolResult; readonly argv: readonly string[][] }> {
+  const argv: string[][] = [];
+  const tool = await handleCheckIntegrationSuite(
+    { featureId: 'feat-off-node', repoRoot },
+    stateDir,
+    mockStore,
+    (cmd, args) => {
+      argv.push([cmd, ...args]);
+      return result;
+    },
+  );
+  return { tool, argv };
+}
+
+// ─── The property, over the live registry ────────────────────────────────────
+
+describe('every declared toolchain composes only its own reporter flag', () => {
+  it('TheRegistryIsANonEmptyDenominator', () => {
+    // A property quantified over an empty set is not a proof of anything. The
+    // floor is the measured registry size; growing the registry is fine, and
+    // emptying it must not read as a clean run.
+    expect(BUILTIN_TOOLCHAINS.length).toBeGreaterThanOrEqual(12);
+    expect(REPORTER_FLAGS.size).toBeGreaterThanOrEqual(1);
+  });
+
+  it.each(BUILTIN_TOOLCHAINS.map((toolchain) => [toolchain.id, toolchain] as const))(
+    'BuiltinToolchain_ReceivesNoForeignReporterFlag [%s]',
+    (_id, toolchain) => {
+      const resolution = resolveIntegrationCommand('/governed', undefined, () =>
+        registryRuntime(toolchain),
+      );
+      expect(resolution.kind).toBe('runnable');
+      if (resolution.kind !== 'runnable') return;
+
+      const format = resolveTestReportFormat(toolchain.id);
+      const ownFlag = format.kind === 'vitest-json' ? format.reporterFlag : null;
+      const foreign = [...REPORTER_FLAGS].filter((flag) => flag !== ownFlag);
+      for (const flag of foreign) {
+        expect(resolution.args).not.toContain(flag);
+      }
+
+      // …and what IS spawned is the registry's own command, unaltered up to the
+      // point where the carrier's flag may be appended.
+      const declared = declaredCommand(toolchain);
+      const composed = [resolution.cmd, ...resolution.args];
+      expect(composed.slice(0, declared.length)).toEqual(declared);
+    },
+  );
+
+  it('CargoTest_DoesNotReceiveReporterJson', () => {
+    const resolution = resolveIntegrationCommand('/governed', undefined, () =>
+      registryRuntime(builtin('rust')),
+    );
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['cargo', 'test']);
+    expect(resolution.format.kind).toBe('exit-code-only');
+  });
+
+  it('DotnetTest_DoesNotReceiveReporterJson', () => {
+    const resolution = resolveIntegrationCommand('/governed', undefined, () =>
+      registryRuntime(builtin('dotnet')),
+    );
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['dotnet', 'test']);
+  });
+});
+
+// ─── …and no LAYER may smuggle one in either ─────────────────────────────────
+//
+// The registry is no longer the only thing that can name the command: the
+// layered resolver puts an `.exarchos.yml` entry, a user-declared toolchain and
+// a committed task runner ahead of it. Quantifying the property over registry
+// rows alone would therefore stop covering the composition the gate actually
+// runs, so these cases pin the OTHER direction — a foreign runner arriving from
+// a higher layer at a repository the registry still identifies as Node.
+
+describe('a command from a higher resolver layer keeps its own carrier', () => {
+  it('ConfigDeclaredPytest_AtANodeRepo_GetsNoReporterFlag', () => {
+    // `.exarchos.yml` may say `test: pytest` in a tree that also has a
+    // package.json. Keying the reporter flag on the DETECTED identity alone
+    // would spawn `pytest --reporter=json` — the same unknown-flag failure,
+    // re-entered through the resolver rather than the registry.
+    const resolution = resolveIntegrationCommand('/governed', undefined, () => ({
+      test: 'pytest -q',
+      toolchain: builtin('node'),
+    }));
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['pytest', '-q']);
+    expect(resolution.format.kind).toBe('exit-code-only');
+    for (const flag of REPORTER_FLAGS) {
+      expect(resolution.args).not.toContain(flag);
+    }
+  });
+
+  it('TaskRunnerCommand_GetsNoReporterFlag', () => {
+    const resolution = resolveIntegrationCommand('/governed', undefined, () => ({
+      test: 'task test',
+      toolchain: builtin('node'),
+    }));
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['task', 'test']);
+    expect(resolution.format.kind).toBe('exit-code-only');
+  });
+
+  it.each(['pnpm test', 'yarn test', 'bun run test:run'])(
+    'NonNpmNodeCommand_IsSpawnedAsResolved_AndStillRead [%s]',
+    (command) => {
+      // The false-red this lane closes: a pnpm/yarn/bun repository used to be
+      // handed the registry's `npm run test:run` and fail a rung it had no way
+      // to clear. The resolved command is spawned as-is, and because it is still
+      // a Node script indirection the counted carrier survives.
+      const resolution = resolveIntegrationCommand('/governed', undefined, () => ({
+        test: command,
+        toolchain: builtin('node'),
+      }));
+      const declared = command.split(' ');
+      expect(resolution.kind).toBe('runnable');
+      if (resolution.kind !== 'runnable') return;
+      const composed = [resolution.cmd, ...resolution.args];
+      expect(composed.slice(0, declared.length)).toEqual(declared);
+      expect(resolution.format.kind).toBe('vitest-json');
+      expect(composed.slice(declared.length)).toEqual(['--', '--reporter=json']);
+    },
+  );
+});
+
+// ─── The rung is clearable on an exit-code runner ────────────────────────────
+
+describe('an exit-code runner produces a complete verdict', () => {
+  it('ExitCodeToolchain_ZeroExit_ClearsTheRung', () => {
+    const run = runIntegrationSuite({
+      repoRoot: '/governed',
+      resolveRuntime: () => registryRuntime(builtin('rust')),
+      runCommand: () => ({ exitCode: 0, stdout: 'test result: ok. 41 passed', stderr: '' }),
+    });
+    expect(run.kind).toBe('exit-code');
+    if (run.kind !== 'exit-code') return;
+    expect(run.passed).toBe(true);
+    expect(run.report).toContain('**Result: PASS**');
+  });
+
+  it('ExitCodeToolchain_NonZeroExit_FailsTheRung', () => {
+    const run = runIntegrationSuite({
+      repoRoot: '/governed',
+      resolveRuntime: () => registryRuntime(builtin('python')),
+      runCommand: () => ({ exitCode: 1, stdout: '1 failed, 40 passed', stderr: '' }),
+    });
+    expect(run.kind).toBe('exit-code');
+    if (run.kind !== 'exit-code') return;
+    expect(run.passed).toBe(false);
+  });
+
+  it('ExitCodeToolchain_ReportsNoCountsItCouldNotMeasure', () => {
+    const run = runIntegrationSuite({
+      repoRoot: '/governed',
+      resolveRuntime: () => registryRuntime(builtin('go')),
+      runCommand: () => ({ exitCode: 0, stdout: 'ok  	example/pkg	0.01s', stderr: '' }),
+    });
+    expect(run.kind).toBe('exit-code');
+    if (run.kind !== 'exit-code') return;
+    // A zero here would be a claim, not a measurement: from outside the runner a
+    // file that failed to load is indistinguishable from a failed assertion.
+    expect(run).not.toHaveProperty('loadFailures');
+    expect(run).not.toHaveProperty('failCount');
+    expect(run.report).toContain('not reportable on this carrier');
+  });
+});
+
+// ─── The rung is clearable on a real non-Node repository ─────────────────────
+
+describe('the blocking ladder gate clears on a Rust repository', () => {
+  it('RustRepo_GreenSuite_MintsProof', async () => {
+    const { tool, argv } = await runGateAt(rustRepo, {
+      exitCode: 0,
+      stdout: 'test result: ok. 41 passed; 0 failed',
+      stderr: '',
+    });
+
+    // The spawn is the registry's command, with nothing appended.
+    expect(argv).toEqual([['cargo', 'test']]);
+    const data = tool.data as Record<string, unknown>;
+    expect(data.passed).toBe(true);
+    expect(normalizeGateVerdict(tool)).toBe('pass');
+  });
+
+  it('RustRepo_RedSuite_ReportsTheFailure', async () => {
+    const { tool } = await runGateAt(rustRepo, {
+      exitCode: 101,
+      stdout: 'test result: FAILED. 3 failed',
+      stderr: '',
+    });
+
+    const data = tool.data as Record<string, unknown>;
+    expect(data.passed).toBe(false);
+    expect(normalizeGateVerdict(tool)).toBe('fail');
+  });
+});
+
+// ─── Indeterminate, in the existing vocabulary ───────────────────────────────
+
+describe('a gate that cannot run says so', () => {
+  it('NoToolchain_IsIndeterminate_NotNpmFallback', async () => {
+    const { tool, argv } = await runGateAt(emptyRepo, {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    // Nothing was spawned, and in particular not this repository's own script
+    // name against a repository that never declared it.
+    expect(argv).toEqual([]);
+    expect(JSON.stringify(tool.data)).not.toContain('test:run');
+
+    const data = tool.data as Record<string, unknown>;
+    expect(data.skipped).toBe(true);
+    expect(data.skipReason).toBe('no-toolchain');
+    // Neither a failure that was never observed nor proof that was never produced.
+    expect(data).not.toHaveProperty('passed');
+    expect(normalizeGateVerdict(tool)).toBe('indeterminate');
+  });
+
+  it('NoTestCommand_IsIndeterminate_AndCarriesTheResolverSGuidance', () => {
+    // A project the registry recognizes for which no layer produced a test
+    // command — a Node package with no test script is the everyday case. The
+    // gate cannot conclude, and the resolver's own remediation is what a reader
+    // can act on, so it is the reason rather than a restatement of the id.
+    const run = runIntegrationSuite({
+      repoRoot: '/governed',
+      resolveRuntime: () => ({
+        test: null,
+        toolchain: builtin('node'),
+        remediation: 'package.json is missing a "test:run" script.',
+      }),
+      runCommand: () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.skipReason).toBe('no-test-command');
+    expect(run.reason).toContain('test:run');
+    expect(run).not.toHaveProperty('passed');
+  });
+
+  it('IndeterminateReport_SaysTheRungIsNotCleared', () => {
+    // `passed` is absent, and nothing downstream converts an indeterminate gate
+    // verdict into a stop for this gate class — the projection folds the
+    // evidence row for visibility only. The report is therefore where the
+    // non-clearance has to be stated, or an honest unknown reads as a pass.
+    const run = runIntegrationSuite({
+      repoRoot: '/governed',
+      resolveRuntime: () => ({ test: null, toolchain: undefined }),
+      runCommand: () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.report).toContain('NOT cleared');
+  });
+
+  it('ProjectDeclaredRunner_IsRunAndReadByItsExitCode_NotShutOut', () => {
+    // A project that declares its own toolchain in `.exarchos.yml` names a
+    // runner the carrier table does not know. That used to be indeterminate,
+    // which withheld the rung from every such project; the exit code of the
+    // command they declared is a complete verdict, so the gate takes it. What it
+    // must NOT do is guess a reporter flag for a runner it cannot identify.
+    const custom: Toolchain = {
+      id: 'acme-runner',
+      projectType: 'Acme',
+      markers: [],
+      commands: {
+        test: 'acme verify',
+        typecheck: null,
+        install: null,
+        mutation: null,
+        lint: null,
+        contract: null,
+      },
+    };
+    const spawned: string[][] = [];
+    const run = runIntegrationSuite({
+      repoRoot: '/governed',
+      resolveRuntime: () => registryRuntime(custom),
+      runCommand: (cmd, args) => {
+        spawned.push([cmd, ...args]);
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    expect(spawned).toEqual([['acme', 'verify']]);
+    for (const flag of REPORTER_FLAGS) {
+      expect(spawned[0]).not.toContain(flag);
+    }
+    expect(run.kind).toBe('exit-code');
+    if (run.kind !== 'exit-code') return;
+    expect(run.passed).toBe(true);
+  });
+
+  it('SpawnFailure_IsIndeterminate_OnBothCarriers', () => {
+    // A process that never started produced no evidence about the suite, so
+    // neither carrier may read one out of it. The counted carrier used to mint
+    // `passed: false` here — a red naming a failure nobody observed, and one the
+    // exit-code carrier already refused to name for the same event.
+    for (const toolchain of [builtin('node'), builtin('rust')]) {
+      const run = runIntegrationSuite({
+        repoRoot: '/governed',
+        resolveRuntime: () => registryRuntime(toolchain),
+        runCommand: () => ({ exitCode: 127, stdout: '', stderr: '', spawnError: 'EINVAL' }),
+      });
+      expect(run.kind).toBe('indeterminate');
+      if (run.kind !== 'indeterminate') continue;
+      expect(run.skipReason).toBe('runner-unavailable');
+      expect(run).not.toHaveProperty('passed');
+    }
+  });
+
+  it('MissingBinary_ThroughTheProductionRunner_IsIndeterminate', () => {
+    // End to end through the REAL spawn, so the chain is proven rather than
+    // assumed link by link: a launch that fails → the errno classifier → the
+    // `spawnError` field → an indeterminate verdict. A stub can only assert the
+    // last link, and the one that broke was the first — an errno the classifier
+    // did not recognize, read as a suite that failed.
+    const run = runIntegrationSuite({
+      repoRoot: process.cwd(),
+      testScript: 'test:run',
+      runCommand: (_cmd, _args, options) =>
+        execCommandRunner('exarchos-no-such-binary-6f2a91', [], options),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.skipReason).toBe('runner-unavailable');
+    expect(run).not.toHaveProperty('passed');
+    expect(run.report).toContain('NOT cleared');
+  });
+
+  it('HungRunner_YieldsIndeterminate', () => {
+    // The PRODUCTION runner against a real child process that never exits: the
+    // kill path is proven, not stubbed. The bound is overridden so the case
+    // costs half a second instead of the production wall clock.
+    const run = runIntegrationSuite({
+      repoRoot: process.cwd(),
+      testScript: 'test:run',
+      runCommand: (_cmd, _args, options) =>
+        execCommandRunner(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+          ...options,
+          timeoutMs: 500,
+        }),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.skipReason).toBe('runner-timeout');
+    expect(run.report).toContain('INDETERMINATE');
+  });
+});
+
+// ─── The Node path is untouched ──────────────────────────────────────────────
+
+describe('VitestRepo_BehaviourUnchanged', () => {
+  const GREEN = JSON.stringify({
+    numFailedTestSuites: 0,
+    numFailedTests: 0,
+    numTotalTests: 42,
+    testResults: [],
+  });
+
+  /** The #1329 shape: one suite failed, zero tests failed. */
+  const LOAD_CASCADE = JSON.stringify({
+    numFailedTestSuites: 1,
+    numFailedTests: 0,
+    numTotalTests: 50,
+    testResults: [{ name: '/repo/src/broken.test.ts', status: 'failed', assertionResults: [] }],
+  });
+
+  it('ThisRepo_StillResolvesTheVitestJsonCommand', () => {
+    const resolution = resolveIntegrationCommand(process.cwd(), undefined);
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect(resolution.cmd).toBe('npm');
+    expect(resolution.args).toEqual(['run', 'test:run', '--', '--reporter=json']);
+  });
+
+  it('ThisRepo_GreenRun_StillParsesToPass', () => {
+    const run = runIntegrationSuite({
+      repoRoot: process.cwd(),
+      runCommand: () => ({ exitCode: 0, stdout: GREEN, stderr: '' }),
+    });
+    expect(run.kind).toBe('vitest-counts');
+    if (run.kind !== 'vitest-counts') return;
+    expect(run.passed).toBe(true);
+    expect(run.totalTests).toBe(42);
+    expect(run.parseError).toBe(false);
+  });
+
+  it('ThisRepo_LoadCascade_StillFoldsIntoTheFailureCount', () => {
+    const run = runIntegrationSuite({
+      repoRoot: process.cwd(),
+      runCommand: () => ({ exitCode: 1, stdout: LOAD_CASCADE, stderr: '' }),
+    });
+    expect(run.kind).toBe('vitest-counts');
+    if (run.kind !== 'vitest-counts') return;
+    expect(run.passed).toBe(false);
+    expect(run.loadFailures).toBe(1);
+    expect(run.failCount).toBe(1);
+  });
+
+  it('ThisRepo_UnparseableOutput_StillFailsClosed', () => {
+    const run = runIntegrationSuite({
+      repoRoot: process.cwd(),
+      runCommand: () => ({ exitCode: 0, stdout: 'not vitest json', stderr: '' }),
+    });
+    expect(run.kind).toBe('vitest-counts');
+    if (run.kind !== 'vitest-counts') return;
+    expect(run.passed).toBe(false);
+    expect(run.parseError).toBe(true);
+  });
+});

--- a/tests/architecture/gate-toolchain-coverage.test.ts
+++ b/tests/architecture/gate-toolchain-coverage.test.ts
@@ -1,0 +1,189 @@
+/**
+ * How much of the toolchain registry the static-analysis gate can actually
+ * check.
+ *
+ * The gate detects through the registry and runs checks for a subset of it.
+ * That is a defensible arrangement — the gate skips honestly for the rest, and
+ * a skip is inconclusive, never a pass. What was not defensible is that the
+ * subset was invisible: `SUPPORTED_TOOLCHAINS` had no reader outside its own
+ * module, so a toolchain added to the registry with no runner behind it
+ * reddened nothing anywhere. The shortfall grew for free.
+ *
+ * This file makes the difference a measured, named quantity. Both sides are
+ * LIVE imports, not a captured JSON snapshot: the point is to compare the gate
+ * against the registry as it is right now, and a capture would let both drift
+ * together while every assertion stayed green.
+ *
+ * The pinned list below can only shrink. Add a toolchain to the registry and
+ * the uncovered set grows past the pin; wire a runner and it falls below.
+ * Either way the equality names the id that moved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BUILTIN_TOOLCHAINS } from '../../src/config/toolchains.js';
+import { SUPPORTED_TOOLCHAINS } from '../../src/verbs/pure/static-analysis.js';
+
+/**
+ * Registry toolchains the static-analysis gate cannot check today, each with
+ * the reason it is still on this list.
+ *
+ * A defect ledger, not an allowance. Every entry means a repository of that
+ * kind gets an inconclusive gate — which fails safe, and which is also the
+ * reason the top rung of the verification ladder is unreachable there. A
+ * repository can lift its own entry by declaring the commands in `.exarchos.yml`
+ * `toolchains:`; the entries below are what it gets when it has not, which is
+ * the case this list is a ledger of.
+ */
+const UNCOVERED_TOOLCHAINS: Readonly<Record<string, string>> = {
+  python: 'the registry declares a linter (ruff) but no typecheck command; admitting it means deciding what a repository that lints with flake8 or pylint gets',
+  'java-gradle': 'the registry declares neither a lint nor a typecheck command for it; the gradle task names are per-project',
+  'java-maven': 'the registry declares neither a lint nor a typecheck command for it; the maven plugin bindings are per-project',
+  ruby: 'the registry declares a linter (rubocop) but no typecheck command; a repository without a rubocop config would get a hard tool failure rather than a skip',
+  php: 'the registry declares neither a lint nor a typecheck command for it; composer script names are per-project',
+  elixir: 'the registry declares a linter (credo) but no typecheck command; credo is an optional dependency, so its absence must degrade rather than fail',
+  swift: 'the registry declares neither a lint nor a typecheck command for it; the conventional linter is a third-party tool the registry does not name',
+  cmake: 'the registry declares neither a lint nor a typecheck command for it; the compiler and its warning flags are chosen by the project, not the build system',
+};
+
+/**
+ * The registry ids no runner covers.
+ *
+ * Takes its inputs as arguments rather than reading the imports directly, so
+ * the same computation the live assertion depends on can be re-run against a
+ * seeded registry. A guard that cannot be shown to fail is a guard nobody has
+ * checked.
+ */
+function uncoveredIds(
+  registry: readonly { readonly id: string }[],
+  supported: ReadonlySet<string>,
+): string[] {
+  return registry
+    .map((t) => t.id)
+    .filter((id) => !supported.has(id))
+    .sort();
+}
+
+const PINNED = Object.keys(UNCOVERED_TOOLCHAINS).sort();
+
+/**
+ * The two legs this gate runs. A shortfall entry has to account for both of
+ * them, because "no runner" is always a statement about what the registry
+ * declares for each.
+ */
+const LEG_TERMS: readonly RegExp[] = [/\blint(?:er|ing)?\b/i, /\btypecheck\b/i];
+
+/**
+ * Whether a shortfall reason explains the shortfall.
+ *
+ * A length threshold does not: thirty repeated characters clear it, and so does
+ * any placeholder long enough to look like prose. What cannot be faked without
+ * actually writing the reason is SAYING WHAT THE REGISTRY DECLARES FOR EACH
+ * LEG — a reader can check that claim against the registry, and an author who
+ * has not looked cannot produce it. The distinct-word floor is a second, weaker
+ * condition that rules out a sentence assembled from one repeated word.
+ *
+ * Exported shape (a plain function taking the reason) so the guard can be run
+ * against a seeded ledger below. A predicate that has never been shown to
+ * reject anything is a predicate nobody has checked.
+ */
+function reasonIsSubstantive(reason: string): boolean {
+  const words = reason.toLowerCase().match(/[a-z][a-z-]+/g) ?? [];
+  if (new Set(words).size < 8) return false;
+  return LEG_TERMS.every((term) => term.test(reason));
+}
+
+describe('static-analysis toolchain coverage', () => {
+  it('GateToolchainCoverage_Denominator_IsNonEmptyOnBothSides', () => {
+    // Neither side may be empty. An emptied registry would make the shortfall
+    // vanish and every comparison below pass over nothing; an emptied runner
+    // set would make the whole gate a skip while still reading as consistent.
+    expect(BUILTIN_TOOLCHAINS.length).toBeGreaterThan(0);
+    expect(SUPPORTED_TOOLCHAINS.size).toBeGreaterThan(0);
+    expect(PINNED.length).toBeGreaterThan(0);
+  });
+
+  it('GateToolchainCoverage_EveryRunner_NamesARegistryToolchain', () => {
+    const registryIds = new Set<string>(BUILTIN_TOOLCHAINS.map((t) => t.id));
+    const phantom = [...SUPPORTED_TOOLCHAINS].filter((id) => !registryIds.has(id)).sort();
+
+    expect(
+      phantom,
+      'the gate claims to run checks for ids the registry does not declare, so detection can never produce them',
+    ).toEqual([]);
+  });
+
+  it('SupportedToolchains_ShortfallIsAsserted', () => {
+    expect(
+      uncoveredIds(BUILTIN_TOOLCHAINS, SUPPORTED_TOOLCHAINS),
+      'the set of registry toolchains with no static-analysis runner changed; update UNCOVERED_TOOLCHAINS — removing an entry when a runner lands, adding one only with the reason it cannot be covered yet',
+    ).toEqual(PINNED);
+  });
+
+  it('SupportedToolchains_CoverageAndShortfall_PartitionTheRegistry', () => {
+    // Equality on the uncovered set alone would still hold if a registry id
+    // were counted twice or if a supported id were also pinned as uncovered.
+    expect(SUPPORTED_TOOLCHAINS.size + PINNED.length).toBe(BUILTIN_TOOLCHAINS.length);
+    expect(new Set(BUILTIN_TOOLCHAINS.map((t) => t.id)).size).toBe(BUILTIN_TOOLCHAINS.length);
+  });
+
+  it('SupportedToolchains_EveryShortfallEntry_CarriesAReason', () => {
+    // An entry with a blank or perfunctory reason is an omission wearing a
+    // name, and the list would stop being a ledger of decisions.
+    const unexplained = Object.entries(UNCOVERED_TOOLCHAINS)
+      .filter(([, reason]) => !reasonIsSubstantive(reason))
+      .map(([id]) => id);
+
+    expect(
+      unexplained,
+      'shortfall entries whose reason does not say what the registry declares for the lint and typecheck legs',
+    ).toEqual([]);
+  });
+
+  it('SupportedToolchains_NoTwoEntries_ShareAReason', () => {
+    // A reason copied from the row above is about the toolchain it was written
+    // for, not this one. Two identical ledger rows are one decision claiming to
+    // be two.
+    const reasons = Object.values(UNCOVERED_TOOLCHAINS).map((r) => r.trim().toLowerCase());
+
+    expect(new Set(reasons).size, 'a shortfall reason is repeated verbatim').toBe(reasons.length);
+  });
+
+  it('FillerReason_RedensTheGuard', () => {
+    // The kill fixture for the reason check. The predicate it replaced asserted
+    // a string length, which thirty repeated characters satisfy — so it could
+    // name an unexplained entry only by accident.
+    expect(reasonIsSubstantive('x'.repeat(120))).toBe(false);
+    expect(reasonIsSubstantive('reason to be supplied later, pending a decision')).toBe(false);
+    // Long and wordy, but it accounts for neither leg.
+    expect(
+      reasonIsSubstantive('this ecosystem is unusual and nobody on the team has wired it up yet'),
+    ).toBe(false);
+    // Half an account is still not one.
+    expect(reasonIsSubstantive('the registry declares a linter for it but nothing else')).toBe(
+      false,
+    );
+    // And a real entry from the ledger above passes.
+    expect(reasonIsSubstantive(UNCOVERED_TOOLCHAINS['python'] ?? '')).toBe(true);
+  });
+
+  it('NewToolchain_WithoutARunner_RedensTheGuard', () => {
+    // The kill fixture. Seeding the real registry would mean editing a module
+    // another change is holding open, so the seed goes through the same
+    // function the live assertion calls, with the same runner set.
+    const seeded = [...BUILTIN_TOOLCHAINS, { id: 'zig' }];
+    const withSeed = uncoveredIds(seeded, SUPPORTED_TOOLCHAINS);
+
+    expect(withSeed).toContain('zig');
+    expect(withSeed).not.toEqual(PINNED);
+  });
+
+  it('RetiredRunner_AlsoRedensTheGuard', () => {
+    // The other direction: a runner quietly dropped must not read as covered
+    // just because the registry did not move.
+    const fewer = new Set([...SUPPORTED_TOOLCHAINS].filter((id) => id !== 'go'));
+    const withoutGo = uncoveredIds(BUILTIN_TOOLCHAINS, fewer);
+
+    expect(withoutGo).toContain('go');
+    expect(withoutGo).not.toEqual(PINNED);
+  });
+});

--- a/tests/architecture/no-literal-base-branch.test.ts
+++ b/tests/architecture/no-literal-base-branch.test.ts
@@ -1,0 +1,124 @@
+/**
+ * No gate module invents a base branch.
+ *
+ * Ten of the modules under `src/verbs/gates/` defaulted the diff base to the
+ * literal `'main'`. That is a name a governed repository need not have, and a
+ * gate that diffs against a branch which does not exist reports a scope it
+ * never measured — the failure is silent in both directions, because a
+ * repository whose trunk is `master`, `develop` or `trunk` gets either an empty
+ * diff (nothing flagged, reads as a pass) or a git error the gate converts into
+ * its own vocabulary.
+ *
+ * The replacement is `resolveBaseBranch`, which answers with a DETECTED name or
+ * a typed `unresolved`. This file is what keeps the eleventh site from being
+ * written: the literal is cheap to reach for, the seam is one import away, and
+ * nothing else in the tree can tell the two apart.
+ *
+ * Scope is `src/verbs/gates/` deliberately. Other trees still carry the
+ * literal — `verbs/review/review-diff.ts`, `verbs/tasks/extract-intent.ts` and
+ * `verbs/team/prepare-synthesis.ts` each hold one — and pinning them here as
+ * expected offenders would turn this guard vacuous the moment they are fixed.
+ * They are named in prose so a reader knows the sweep is partial, not complete.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const GATES_DIR = fileURLToPath(new URL('../../src/verbs/gates/', import.meta.url));
+
+/**
+ * A base-branch default written as a literal: `?? 'main'`, `|| "main"`, or the
+ * same with the name spelled `master`.
+ *
+ * Matching the DEFAULTING form rather than the bare string is what keeps this
+ * from firing on the many legitimate mentions of the word — a comment, an error
+ * message, a test fixture name. The two operators are the whole vocabulary a
+ * fallback is written in.
+ */
+const LITERAL_BASE_DEFAULT = /(?:\?\?|\|\|)\s*(['"`])(?:main|master)\1/;
+
+interface Offender {
+  readonly file: string;
+  readonly line: number;
+  readonly text: string;
+}
+
+/**
+ * Scan a set of `name -> source` pairs.
+ *
+ * Takes its subject as an argument so the same matcher the live assertion runs
+ * can be pointed at a seeded violation. A guard nobody has watched fail is a
+ * guard nobody has checked.
+ */
+function findLiteralBaseDefaults(sources: ReadonlyMap<string, string>): Offender[] {
+  const offenders: Offender[] = [];
+  for (const [file, source] of sources) {
+    source.split('\n').forEach((text, index) => {
+      if (LITERAL_BASE_DEFAULT.test(text)) {
+        offenders.push({ file, line: index + 1, text: text.trim() });
+      }
+    });
+  }
+  return offenders;
+}
+
+function gateSources(): ReadonlyMap<string, string> {
+  const sources = new Map<string, string>();
+  for (const entry of readdirSync(GATES_DIR, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.ts')) continue;
+    sources.set(entry.name, readFileSync(join(GATES_DIR, entry.name), 'utf-8'));
+  }
+  return sources;
+}
+
+describe('Base-branch resolution: the gate surface never invents a branch', () => {
+  it('NoGateModule_ContainsALiteralMainFallback', () => {
+    const sources = gateSources();
+
+    // Guard the guard on the DENOMINATOR: a glob that stopped matching, or a
+    // directory that moved, would report zero offenders for the same reason a
+    // clean tree does.
+    expect(
+      sources.size,
+      'no gate modules were read — the scan resolved nothing, so an empty result proves nothing',
+    ).toBeGreaterThan(30);
+
+    const offenders = findLiteralBaseDefaults(sources);
+    expect(
+      offenders.map((o) => `${o.file}:${o.line}  ${o.text}`),
+      'a gate must not default its diff base to a literal branch name — call ' +
+        '`resolveDiffBase(repoRoot, args.baseBranch)` and, when it answers ' +
+        '`unresolved`, report the cause in the gate\'s own verdict vocabulary ' +
+        '(inconclusive, or the fail-closed cause its policy already names). ' +
+        'Whichever it is, still emit the row the action declares',
+    ).toEqual([]);
+  });
+
+  it('SeededLiteralFallback_IsDetected', () => {
+    // The same matcher, over a subject that must fail. Without this the
+    // assertion above is green whether the pattern works or not.
+    const seeded = new Map([
+      ['seeded-nullish.ts', "  const baseRef = args.baseBranch ?? 'main';\n"],
+      ['seeded-or.ts', '  const baseBranch = args.baseBranch || "master";\n'],
+    ]);
+
+    expect(findLiteralBaseDefaults(seeded).map((o) => o.file).sort()).toEqual([
+      'seeded-nullish.ts',
+      'seeded-or.ts',
+    ]);
+  });
+
+  it('MentioningTheBranchName_IsNotAViolation', () => {
+    // The matcher targets the defaulting form, not the word. A gate is free to
+    // name a branch in a message, a comment, or a comparison.
+    const innocent = new Map([
+      ['comment.ts', "// the repository's trunk is usually called 'main'\n"],
+      ['comparison.ts', "  if (branch === 'main') return true;\n"],
+      ['message.ts', "  return `no such branch: 'main'`;\n"],
+    ]);
+
+    expect(findLiteralBaseDefaults(innocent)).toEqual([]);
+  });
+});

--- a/tests/integration/gate-config-severity.test.ts
+++ b/tests/integration/gate-config-severity.test.ts
@@ -123,7 +123,15 @@ describe('gate config severity', () => {
   ) {
     await seedActivePhaseAttempt(ctx.eventStore, featureId);
     return runAsTrustedCaller(ctx.stateDir, () =>
-      handleOrchestrate({ action, featureId, taskId, repoRoot: '/fake/repo' }, ctx),
+      // `baseBranch` is explicit because this suite's subject is the config
+      // knob, not base-branch detection. Since the diff base stopped defaulting
+      // to a literal, a repoRoot with no discoverable default branch makes the
+      // gate report `diff-failed` before it ever reaches the probe — which
+      // would make the assertions below pass for the wrong reason.
+      handleOrchestrate(
+        { action, featureId, taskId, repoRoot: '/fake/repo', baseBranch: 'main' },
+        ctx,
+      ),
     );
   }
 

--- a/tests/integration/worktree-membership.test.ts
+++ b/tests/integration/worktree-membership.test.ts
@@ -1,0 +1,95 @@
+// ─── Worktree membership agrees with git (real repository) ───────────────────
+//
+// The unit suite stubs `git rev-parse`. This one runs the gate against a real
+// repository with a real linked worktree, because the defect it replaced was
+// precisely a predicate that looked right and disagreed with git: a
+// `.worktrees/` substring test, which reports "not in a worktree" from inside
+// the harness-native `.claude/worktrees/` layout.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { handleVerifyWorktree } from '../../src/verbs/gates/verify-worktree.js';
+
+const STATE_DIR = join(tmpdir(), 'exarchos-verify-worktree-state');
+
+let root = '';
+let mainCheckout = '';
+let harnessWorktree = '';
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+async function verdictFor(dir: string): Promise<boolean> {
+  const result = await handleVerifyWorktree({ cwd: dir }, STATE_DIR);
+  expect(result.success).toBe(true);
+  return (result.data as { passed: boolean }).passed;
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'exarchos-worktree-'));
+  mainCheckout = join(root, 'repo');
+  mkdirSync(mainCheckout);
+
+  git(mainCheckout, ['init', '-b', 'main']);
+  git(mainCheckout, ['config', 'user.email', 'test@example.com']);
+  git(mainCheckout, ['config', 'user.name', 'Exarchos Test']);
+  writeFileSync(join(mainCheckout, 'README.md'), '# fixture\n');
+  git(mainCheckout, ['add', 'README.md']);
+  git(mainCheckout, ['commit', '-m', 'initial']);
+
+  // The harness's own layout, nested two levels under a dot-directory.
+  harnessWorktree = join(mainCheckout, '.claude', 'worktrees', 'feature-x');
+  git(mainCheckout, ['worktree', 'add', '-b', 'feature-x', harnessWorktree]);
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe('verify_worktree against a real repository', () => {
+  it('ClaudeWorktreesLayout_IsRecognized', async () => {
+    // The retired predicate tested for a `.worktrees/` substring, which this
+    // path does not contain.
+    expect(harnessWorktree.replace(/\\/g, '/').includes('.worktrees/')).toBe(false);
+
+    await expect(verdictFor(harnessWorktree)).resolves.toBe(true);
+  });
+
+  it('MainCheckout_IsNotAWorktree', async () => {
+    await expect(verdictFor(mainCheckout)).resolves.toBe(false);
+  });
+
+  it('MembershipComesFromGit_NotASubstring', async () => {
+    // `git worktree list --porcelain` is the authority: its first block is the
+    // main worktree, every later block a linked one. The gate must agree with
+    // that partition for every path git names, whatever the paths are spelled.
+    const listed = git(mainCheckout, ['worktree', 'list', '--porcelain'])
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('worktree '))
+      .map((line) => line.slice('worktree '.length).trim());
+
+    expect(listed.length).toBeGreaterThan(1);
+    const [primary, ...linked] = listed;
+    if (primary === undefined) throw new Error('git listed no worktrees');
+
+    await expect(verdictFor(primary)).resolves.toBe(false);
+    for (const path of linked) {
+      await expect(verdictFor(path)).resolves.toBe(true);
+    }
+  });
+
+  it('DirectoryOutsideAnyRepository_IsNotAWorktree', async () => {
+    const loose = join(root, 'loose');
+    mkdirSync(loose);
+
+    await expect(verdictFor(loose)).resolves.toBe(false);
+  });
+});

--- a/tests/unit/config/test-report-format.test.ts
+++ b/tests/unit/config/test-report-format.test.ts
@@ -1,0 +1,101 @@
+// ─── Test report carrier — the result side of the toolchain SoT ─────────────
+//
+// The runner COMMAND resolves from the toolchain registry; before this seam its
+// RESULT CARRIER did not, so the integration-suite gate appended vitest's
+// `--reporter=json` to every resolved command (`cargo test --reporter=json`)
+// and parsed vitest JSON only.
+//
+// Three properties are load-bearing here:
+//   - resolution is TOTAL over the registry (measured against the live array,
+//     never a hand-listed id set — a hand-list passes by shrinking with it);
+//   - an id outside the registry lands on the `unknown` arm, so the gate can
+//     report indeterminate instead of guessing;
+//   - the reporter flag rides on the descriptor, so no consumer can hand one
+//     runner another runner's flag.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  BUILTIN_TOOLCHAINS,
+  resolveTestReportFormat,
+} from '../../../src/config/toolchains.js';
+
+describe('resolveTestReportFormat (per-runner result carrier)', () => {
+  it('EveryBuiltinToolchain_HasAReportFormat', () => {
+    const ids = BUILTIN_TOOLCHAINS.map((t) => t.id);
+
+    // Denominator first: the loop below proves nothing if the registry is
+    // empty, and it must not silently shrink under the guard either.
+    expect(ids.length).toBeGreaterThanOrEqual(12);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    const unresolved = ids.filter((id) => resolveTestReportFormat(id).kind === 'unknown');
+    expect(unresolved).toEqual([]);
+  });
+
+  it('UnknownToolchain_ResolvesUnknownArm', () => {
+    // Anti-vacuity: this asserts something only while `zig` really is outside
+    // the registry.
+    const id = 'zig';
+    expect(BUILTIN_TOOLCHAINS.some((t) => t.id === id)).toBe(false);
+
+    const format = resolveTestReportFormat(id);
+    expect(format.kind).toBe('unknown');
+    if (format.kind === 'unknown') {
+      // The reason names the id, so an indeterminate verdict is actionable.
+      expect(format.reason).toContain(id);
+    }
+  });
+
+  it('Descriptor_CarriesItsOwnReporterFlag', () => {
+    const ids = BUILTIN_TOOLCHAINS.map((t) => t.id);
+    expect(ids.length).toBeGreaterThanOrEqual(12);
+
+    // Which ids carry a reporter flag is the whole claim, so it is pinned as a
+    // SET. Sampling the complement — naming `rust` and `python` and trusting
+    // the rest — is what lets a wrong flag reappear on `go` or `dotnet` without
+    // anything going red.
+    const vitestIds = ids.filter((id) => resolveTestReportFormat(id).kind === 'vitest-json');
+    expect([...vitestIds].sort()).toEqual(['node']);
+
+    for (const id of vitestIds) {
+      const arm = resolveTestReportFormat(id);
+      if (arm.kind === 'vitest-json') {
+        // The consumer reads the flag off the descriptor rather than spelling it.
+        expect(arm.reporterFlag).toBe('--reporter=json');
+      }
+    }
+
+    // Every remaining id — the denominator is the live registry minus the
+    // vitest set, never a literal list — carries the exit code and nothing to
+    // append. This is the measured defect: `cargo test --reporter=json`.
+    const exitCodeIds = ids.filter((id) => !vitestIds.includes(id));
+    expect(exitCodeIds.length).toBe(ids.length - vitestIds.length);
+    for (const id of exitCodeIds) {
+      expect(resolveTestReportFormat(id)).toEqual({ kind: 'exit-code-only' });
+    }
+  });
+
+  it('MissingEntry_IsACompileError', () => {
+    // The compile-time half of this claim is NOT here, and cannot be: the tests
+    // tsconfig excludes `unit/**`, so a `@ts-expect-error` in this file would be
+    // checked by no compiler. It lives in the subject module as the exported
+    // `_Toolchains_CarrierRows_CoverExactlyTheRegistry` proof alias, which
+    // `npm run typecheck` does read.
+    //
+    // This is its runtime twin: what the compile device buys is that a registry
+    // entry with no carrier row can never reach a consumer as a silent
+    // `unknown`. Measured over the live registry, against a control proving the
+    // `unknown` arm is reachable at all — otherwise the first half would hold
+    // just as well if the arm were unreachable by construction.
+    const silentlyUnknown = BUILTIN_TOOLCHAINS.filter(
+      (t) => resolveTestReportFormat(t.id).kind === 'unknown',
+    ).map((t) => t.id);
+    expect(silentlyUnknown).toEqual([]);
+
+    const offRegistry = 'toolchain-the-registry-does-not-carry';
+    expect(BUILTIN_TOOLCHAINS.some((t) => t.id === offRegistry)).toBe(false);
+    expect(resolveTestReportFormat(offRegistry).kind).toBe('unknown');
+  });
+});

--- a/tests/unit/config/test-report-format.test.ts
+++ b/tests/unit/config/test-report-format.test.ts
@@ -57,7 +57,19 @@ describe('resolveTestReportFormat (per-runner result carrier)', () => {
     // the rest — is what lets a wrong flag reappear on `go` or `dotnet` without
     // anything going red.
     const vitestIds = ids.filter((id) => resolveTestReportFormat(id).kind === 'vitest-json');
-    expect([...vitestIds].sort()).toEqual(['node']);
+    // Both directions, so neither a new id silently acquiring the flag nor
+    // `node` silently losing it can pass — the set claim, unweakened. Written
+    // as two checks rather than one sorted comparison because the sorted form
+    // reads as a parity between two derived populations, and the right-hand
+    // side here is a literal: `BUILTIN_TOOLCHAINS` and `resolveTestReportFormat`
+    // are the same authority, so there is no second one to take a parity
+    // against. This form also NAMES the offending id instead of printing two
+    // lists that differ.
+    expect(
+      vitestIds.filter((id) => id !== 'node'),
+      'an id acquired the vitest-json report format',
+    ).toEqual([]);
+    expect(vitestIds, 'node lost the vitest-json report format').toContain('node');
 
     for (const id of vitestIds) {
       const arm = resolveTestReportFormat(id);

--- a/tests/unit/projections/task-store/event-sourced-task-store.test.ts
+++ b/tests/unit/projections/task-store/event-sourced-task-store.test.ts
@@ -221,8 +221,14 @@ describe('EventSourcedTaskStore (#1272)', () => {
   });
 
   it('EventSourcedTaskStore_ListTasks_ReturnsCreatedTasks', async () => {
-    const t1 = await store.createTask({ ttl: 1000 }, 'r1', sampleRequest);
-    const t2 = await store.createTask({ ttl: 2000 }, 'r2', sampleRequest);
+    // TTLs long enough that they cannot expire DURING the test. `expiresAt` is
+    // `createdAt + ttl` on the wall clock and `listTasks` reaps on read, so the
+    // previous 1000ms/2000ms pair made this a race against its own runtime:
+    // on a slow runner the first task was reaped before the cold read and the
+    // listing came back one short. That reports as a hydration bug, which is
+    // the one thing this case is supposed to be able to tell you about.
+    const t1 = await store.createTask({ ttl: 600_000 }, 'r1', sampleRequest);
+    const t2 = await store.createTask({ ttl: 600_000 }, 'r2', sampleRequest);
     const { tasks } = await store.listTasks();
     const ids = tasks.map((t) => t.taskId).sort();
     expect(ids).toEqual([t1.taskId, t2.taskId].sort());

--- a/tests/unit/runbooks/definitions.shape.test.ts
+++ b/tests/unit/runbooks/definitions.shape.test.ts
@@ -106,6 +106,27 @@ describe('Runbook parameter shape (DR-3 / T-05): delegation stamp threading', ()
     expect(SYNTHESIS_FLOW.templateVars).toContain('repoRoot');
   });
 
+  it('SynthesisFlow_UsesCreatePrAction_NotBashGh', () => {
+    // The canonical flow used to create the PR with a `native:bash` `gh` step,
+    // which only a GitHub repository can run — and silently so, because the
+    // runbook surface never resolves a native step against the registry, so no
+    // check could report that the recipe did not apply to the host. The
+    // registered action goes through the provider seam all three implement.
+    const step = SYNTHESIS_FLOW.steps.find((s) => s.action === 'create_pr');
+    expect(step, 'synthesis-flow must create the PR through the registered action').toBeDefined();
+    expect(step?.tool).toBe('exarchos_orchestrate');
+
+    // Nothing in the flow reaches for the CLI directly any more.
+    const nativeGh = SYNTHESIS_FLOW.steps.filter(
+      (s) => s.tool.startsWith('native:') && /gh|pr[_-]?create/i.test(s.action),
+    );
+    expect(nativeGh.map((s) => `${s.tool}.${s.action}`)).toEqual([]);
+
+    // The seam-backed action records `pr.created` itself, so the runbook must
+    // say so — an agent reads `autoEmits` to decide it need not append the row.
+    expect(SYNTHESIS_FLOW.autoEmits).toContain('pr.created');
+  });
+
   it('CheckStaticAnalysis_NeverBindsTheStamp_T04Exclusion', () => {
     // T-04 deliberately did NOT bind riskTier/boundaryTouching on
     // check_static_analysis — its registry schema rejects those fields. If a

--- a/tests/unit/vcs/resolve-base-branch.test.ts
+++ b/tests/unit/vcs/resolve-base-branch.test.ts
@@ -1,10 +1,46 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   resolveBaseBranch,
+  resolveDiffBase,
+  BASE_BRANCH_UNRESOLVED,
   type GitRefReader,
 } from '../../../src/vcs/resolve-base-branch.js';
 import { GitLabProvider } from '../../../src/vcs/gitlab.js';
 import type { VcsProvider } from '../../../src/vcs/provider.js';
+
+const SRC_DIR = fileURLToPath(new URL('../../../src/', import.meta.url));
+
+/** Every `.ts` under `src/`, keyed by its path relative to `src/`. */
+function sourceTree(): ReadonlyMap<string, string> {
+  const sources = new Map<string, string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        sources.set(relative(SRC_DIR, full).split('\\').join('/'), readFileSync(full, 'utf-8'));
+      }
+    }
+  };
+  walk(SRC_DIR);
+  return sources;
+}
+
+/**
+ * The names of the sources carrying `needle`, sorted.
+ *
+ * Takes its subject as an argument so the same scan the live assertion runs can
+ * be pointed at a seeded violation.
+ */
+function filesContaining(sources: ReadonlyMap<string, string>, needle: string): string[] {
+  return [...sources]
+    .filter(([, source]) => source.includes(needle))
+    .map(([file]) => file)
+    .sort();
+}
 
 /** A provider whose only interesting method is `getRepository`. */
 function makeProvider(getRepository: VcsProvider['getRepository']): VcsProvider {
@@ -26,7 +62,23 @@ function makeProvider(getRepository: VcsProvider['getRepository']): VcsProvider 
 }
 
 const noGit: GitRefReader = () => null;
-const gitReturning = (stdout: string): GitRefReader => () => stdout;
+
+/**
+ * The reader keyed by git SUBCOMMAND, because the resolver now asks several
+ * questions and a stub that answers them all with one string cannot tell a
+ * ladder that stopped early from one that fell all the way through — it would
+ * make the rung order untestable and would feed `refs/heads/main` to a rung that
+ * expects a bare branch name.
+ */
+type GitSubcommand = 'symbolic-ref' | 'remote' | 'config' | 'rev-parse';
+type GitAnswers = Partial<Record<GitSubcommand, string | null>>;
+
+function gitStub(answers: GitAnswers): GitRefReader {
+  return (_repoRoot, args) => answers[args[0] as GitSubcommand] ?? null;
+}
+
+/** The common case: only `symbolic-ref` answers. */
+const gitReturning = (stdout: string): GitRefReader => gitStub({ 'symbolic-ref': stdout });
 
 describe('resolveBaseBranch', () => {
   it('PrefersProviderDefaultBranch', async () => {
@@ -123,5 +175,168 @@ describe('resolveBaseBranch', () => {
     const result = await resolveBaseBranch('/repo', provider, gitReturning('refs/remotes/origin/develop\n'));
 
     expect(result).toEqual({ kind: 'resolved', branch: 'develop' });
+  });
+
+  // ─── The rungs below origin/HEAD ─────────────────────────────────────────
+
+  it('NoOriginHead_TheRemoteIsAskedDirectly', async () => {
+    // `git init` + `git remote add` never writes `refs/remotes/origin/HEAD`, and
+    // neither do most CI checkouts. One rung meant that whole population — real
+    // repositories with perfectly ordinary default branches — resolved
+    // `unresolved` and took their gates offline.
+    const runGit = vi.fn(
+      gitStub({ remote: 'HEAD branch: develop\n  Remote branches:\n    develop tracked\n' }),
+    );
+
+    const result = await resolveBaseBranch('/repo', undefined, runGit);
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'develop' });
+    expect(runGit).toHaveBeenCalledWith('/repo', ['remote', 'show', 'origin']);
+  });
+
+  it('RemoteWithNoHead_IsNotABranchNamedUnknown', async () => {
+    // `git remote show` prints a literal `(unknown)` for a remote with no HEAD.
+    const result = await resolveBaseBranch(
+      '/repo',
+      undefined,
+      gitStub({ remote: 'HEAD branch: (unknown)\n' }),
+    );
+
+    expect(result.kind).toBe('unresolved');
+    expect(JSON.stringify(result)).not.toContain('unknown)');
+  });
+
+  it('LocalRefWins_AndTheNetworkIsNeverTouched', async () => {
+    // Trust order, and cost order with it: a local ref that already records the
+    // remote's HEAD makes the round trip pointless.
+    const runGit = vi.fn(
+      gitStub({
+        'symbolic-ref': 'refs/remotes/origin/trunk\n',
+        remote: 'HEAD branch: develop\n',
+      }),
+    );
+
+    const result = await resolveBaseBranch('/repo', undefined, runGit);
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'trunk' });
+    expect(runGit).not.toHaveBeenCalledWith('/repo', ['remote', 'show', 'origin']);
+  });
+
+  it('InferredDefault_IsAcceptedOnlyAfterTheBranchIsSeenToExist', async () => {
+    // `init.defaultBranch` describes what name NEW repositories get, so it is a
+    // guess about THIS one. Confirming the branch exists is what separates the
+    // guess from the invented literal this seam replaced.
+    const runGit = vi.fn(
+      gitStub({ config: 'trunk\n', 'rev-parse': 'a1b2c3d4\n' }),
+    );
+
+    const result = await resolveBaseBranch('/repo', undefined, runGit);
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'trunk' });
+    expect(runGit).toHaveBeenCalledWith('/repo', [
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      'refs/remotes/origin/trunk',
+    ]);
+  });
+
+  it('InferredDefault_NamingAMissingBranch_IsNoAnswer', async () => {
+    // The guess named `trunk`; this repository does not have it. Returning it
+    // would be the invented literal wearing a config file as a disguise.
+    const result = await resolveBaseBranch(
+      '/repo',
+      undefined,
+      gitStub({ config: 'trunk\n', 'rev-parse': null }),
+    );
+
+    expect(result.kind).toBe('unresolved');
+    expect(JSON.stringify(result)).not.toContain('trunk');
+  });
+
+  it('UnresolvedReason_NamesEverySignalAndItsTrustClass', async () => {
+    // The reason is the only thing an operator sees when a gate reports that it
+    // could not scope itself. It has to say which knobs were consulted, and
+    // which of them would have been a guess.
+    const result = await resolveBaseBranch('/repo', undefined, noGit);
+
+    expect(result.kind).toBe('unresolved');
+    if (result.kind !== 'unresolved') return;
+    for (const signal of [
+      'symbolic-ref',
+      'git remote show origin',
+      'init.defaultBranch',
+      'authoritative',
+      'inferred',
+    ]) {
+      expect(result.reason, `the reason must name '${signal}'`).toContain(signal);
+    }
+  });
+});
+
+describe('resolveDiffBase', () => {
+  it('ExplicitRefWins_AndNeverAsksGit', async () => {
+    // A caller that already named its base has answered the question. Consulting
+    // git anyway would spawn a subprocess per gate invocation for nothing.
+    const result = await resolveDiffBase('/repo', 'release/2026.09');
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'release/2026.09' });
+  });
+
+  it('BlankExplicitRef_IsNoAnswer_NotABranch', async () => {
+    // `''` and `'  '` reach here from optional schema fields and from callers
+    // threading an unset value. Treating either as a ref would build
+    // `git diff '   ...HEAD'`.
+    for (const blank of ['', '   ']) {
+      const result = await resolveDiffBase('/definitely-not-a-repo-xyz', blank);
+      expect(result.kind, `blank ref ${JSON.stringify(blank)} must not resolve`).toBe(
+        'unresolved',
+      );
+    }
+  });
+
+  it('AbsentExplicitRef_FallsThroughToDetection', async () => {
+    // No provider is passed by a diff-reading gate, so detection is the git arm.
+    // Pointing at a path that is not a repository exercises the failure edge
+    // without a fixture: git cannot answer, and the answer is typed.
+    const result = await resolveDiffBase('/definitely-not-a-repo-xyz', undefined);
+
+    expect(result.kind).toBe('unresolved');
+    expect(JSON.stringify(result)).not.toContain('"branch"');
+  });
+
+  it('DiscriminantText_LivesInExactlyOnePlace', () => {
+    // Several gate carriers stamp this discriminant, and asserting the constant
+    // equals its own literal proves nothing about them: rename it and both sides
+    // move together, so the assertion stays green while a hand-typed copy
+    // elsewhere becomes a SECOND spelling of the same inconclusive verdict.
+    //
+    // What catches that is the absence of copies — every carrier reaches the
+    // text by importing the constant, so a rename cannot leave one behind.
+    const sources = sourceTree();
+
+    // Guard the guard on the DENOMINATOR: a moved directory reports zero
+    // holders for the same reason a clean tree does.
+    expect(
+      sources.size,
+      'no sources were read — the scan resolved nothing, so its result proves nothing',
+    ).toBeGreaterThan(100);
+
+    expect(
+      filesContaining(sources, BASE_BRANCH_UNRESOLVED),
+      'the discriminant text belongs to its declaration alone; carriers import ' +
+        'the constant',
+    ).toEqual(['vcs/resolve-base-branch.ts']);
+  });
+
+  it('SeededCopyOfTheDiscriminant_IsDetected', () => {
+    // The same scan over a subject that must fail, so the assertion above is
+    // known to be capable of failing at all.
+    const seeded = new Map([
+      ['carrier.ts', `  discriminant: '${BASE_BRANCH_UNRESOLVED}',\n`],
+      ['innocent.ts', '  discriminant: SOME_OTHER_CAUSE,\n'],
+    ]);
+
+    expect(filesContaining(seeded, BASE_BRANCH_UNRESOLVED)).toEqual(['carrier.ts']);
   });
 });

--- a/tests/unit/vcs/resolve-base-branch.test.ts
+++ b/tests/unit/vcs/resolve-base-branch.test.ts
@@ -1,3 +1,10 @@
+// @oracle-sources: ../../../src/vcs/resolve-base-branch.ts, the src/ tree walked at test time for callers
+//
+// The census below compares the module that DECLARES the resolver against the
+// live source tree walked for uses of it. Neither side is written down here: a
+// hand-listed caller set would keep naming a caller after it was deleted, and
+// keep missing one that was added.
+
 import { describe, it, expect, vi } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';

--- a/tests/unit/vcs/resolve-base-branch.test.ts
+++ b/tests/unit/vcs/resolve-base-branch.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveBaseBranch,
+  type GitRefReader,
+} from '../../../src/vcs/resolve-base-branch.js';
+import { GitLabProvider } from '../../../src/vcs/gitlab.js';
+import type { VcsProvider } from '../../../src/vcs/provider.js';
+
+/** A provider whose only interesting method is `getRepository`. */
+function makeProvider(getRepository: VcsProvider['getRepository']): VcsProvider {
+  return {
+    name: 'github',
+    createPr: vi.fn(),
+    checkCi: vi.fn(),
+    mergePr: vi.fn(),
+    addComment: vi.fn(),
+    addReply: vi.fn(),
+    getReviewStatus: vi.fn(),
+    listPrs: vi.fn(),
+    getPrComments: vi.fn(),
+    getPrDiff: vi.fn(),
+    createIssue: vi.fn(),
+    searchIssuesByMarker: vi.fn(),
+    getRepository,
+  };
+}
+
+const noGit: GitRefReader = () => null;
+const gitReturning = (stdout: string): GitRefReader => () => stdout;
+
+describe('resolveBaseBranch', () => {
+  it('PrefersProviderDefaultBranch', async () => {
+    const provider = makeProvider(
+      vi.fn().mockResolvedValue({ nameWithOwner: 'acme/widget', defaultBranch: 'trunk' }),
+    );
+    const runGit = vi.fn(gitReturning('refs/remotes/origin/develop\n'));
+
+    const result = await resolveBaseBranch('/repo', provider, runGit);
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'trunk' });
+    // The host answered, so git is never consulted.
+    expect(runGit).not.toHaveBeenCalled();
+  });
+
+  it('FallsBackToSymbolicRef', async () => {
+    const runGit = vi.fn(gitReturning('refs/remotes/origin/develop\n'));
+
+    const result = await resolveBaseBranch('/repo', undefined, runGit);
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'develop' });
+    expect(runGit).toHaveBeenCalledWith('/repo', ['symbolic-ref', 'refs/remotes/origin/HEAD']);
+  });
+
+  it('Unresolved_IsTyped_NotMain', async () => {
+    const result = await resolveBaseBranch('/repo', undefined, noGit);
+
+    expect(result.kind).toBe('unresolved');
+    expect(JSON.stringify(result)).not.toContain('"branch"');
+    expect(result).not.toMatchObject({ branch: 'main' });
+    if (result.kind === 'unresolved') {
+      expect(result.reason).toContain('/repo');
+    }
+  });
+
+  it('UnsupportedProviderOperation_IsNotACrash', async () => {
+    // GitLab and Azure DevOps both throw UnsupportedOperationError here.
+    const provider = new GitLabProvider({});
+    await expect(provider.getRepository()).rejects.toThrow('getRepository is not yet supported');
+
+    const result = await resolveBaseBranch('/repo', provider, gitReturning('refs/remotes/origin/develop\n'));
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'develop' });
+  });
+
+  it('RefNameFailingTheSanitizer_IsNotTrusted', async () => {
+    const hostile = 'main;rm -rf /';
+    const provider = makeProvider(
+      vi.fn().mockResolvedValue({ nameWithOwner: 'acme/widget', defaultBranch: hostile }),
+    );
+
+    // Neither source is trusted on its own, so neither can be laundered into a
+    // branch. Both floors have to reject it: the resolved name is interpolated
+    // into a git invocation, and on Windows that can route through a shell.
+    const fromProvider = await resolveBaseBranch('/repo', provider, noGit);
+    const fromGit = await resolveBaseBranch(
+      '/repo',
+      undefined,
+      gitReturning(`refs/remotes/origin/${hostile}\n`),
+    );
+
+    expect(fromProvider.kind).toBe('unresolved');
+    expect(fromGit.kind).toBe('unresolved');
+    expect(JSON.stringify([fromProvider, fromGit])).not.toContain('rm -rf');
+  });
+
+  it('HostedNonAsciiBranchName_IsNotDiscarded', async () => {
+    // The host's typed record of its own default branch is real by
+    // construction. An ASCII allowlist would reject this name, reporting
+    // `unresolved` for a repository whose default branch plainly exists.
+    const provider = makeProvider(
+      vi.fn().mockResolvedValue({ nameWithOwner: 'acme/widget', defaultBranch: 'feature/日本語' }),
+    );
+
+    const result = await resolveBaseBranch('/repo', provider, noGit);
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'feature/日本語' });
+  });
+
+  it('RefOutsideTheOriginPrefix_IsNotLaundered', async () => {
+    // `refs/heads/main` carries only allowlisted characters, so an unanchored
+    // prefix strip hands the whole ref path back as if it were a branch name.
+    const result = await resolveBaseBranch('/repo', undefined, gitReturning('refs/heads/main\n'));
+
+    expect(result.kind).toBe('unresolved');
+    expect(JSON.stringify(result)).not.toContain('refs/heads/main');
+  });
+
+  it('EmptyProviderDefaultBranch_FallsThrough', async () => {
+    const provider = makeProvider(
+      vi.fn().mockResolvedValue({ nameWithOwner: 'acme/widget', defaultBranch: '' }),
+    );
+
+    const result = await resolveBaseBranch('/repo', provider, gitReturning('refs/remotes/origin/develop\n'));
+
+    expect(result).toEqual({ kind: 'resolved', branch: 'develop' });
+  });
+});

--- a/tests/unit/verbs/gates/check-integration-suite.test.ts
+++ b/tests/unit/verbs/gates/check-integration-suite.test.ts
@@ -34,6 +34,7 @@ import {
   LOAD_FAILURE_LIST_CAP,
 } from '../../../../src/verbs/pure/integration-suite.js';
 import type { Toolchain } from '../../../../src/config/toolchains.js';
+import type { IntegrationRuntime } from '../../../../src/verbs/pure/integration-suite.js';
 
 const STATE_DIR = '/tmp/test-integration-suite';
 
@@ -66,6 +67,21 @@ function vitestLoadFailureJson(): string {
   });
 }
 
+/**
+ * The gate's arguments for a case about what it CONCLUDES, not about how it
+ * resolves a command.
+ *
+ * `testScript` is load-bearing here, and not a workaround: the gate resolves its
+ * command from the repository for real, so a literal `repoRoot` that is not a
+ * repository resolves nothing and the runner is never called. Naming the script
+ * is the production input for exactly that situation — a repository whose script
+ * name the resolver cannot know — and it keeps these cases about the carrier
+ * instead of about detection, which has its own suite.
+ */
+function gateArgs(repoRoot: string) {
+  return { featureId: 'feat-1', repoRoot, testScript: 'test:run' };
+}
+
 /** A runner stub that returns the given vitest JSON on stdout with a non-zero exit. */
 function stubRunnerReturning(json: string, exitCode = 1) {
   return vi.fn(
@@ -90,11 +106,9 @@ describe('handleCheckIntegrationSuite', () => {
     // Arrange — runner emits the #1329 shape: 1 failed SUITE, 0 failed TESTS.
     const runner = stubRunnerReturning(vitestLoadFailureJson());
 
-    const args = { featureId: 'feat-1', repoRoot: '/repo' };
-
     // Act
     const result = await handleCheckIntegrationSuite(
-      args,
+      gateArgs('/repo'),
       STATE_DIR,
       mockStore as unknown as EventStore,
       runner,
@@ -127,7 +141,7 @@ describe('handleCheckIntegrationSuite', () => {
 
     // Act
     const result = await handleCheckIntegrationSuite(
-      { featureId: 'feat-1', repoRoot: '/repo' },
+      gateArgs('/repo'),
       STATE_DIR,
       mockStore as unknown as EventStore,
       runner,
@@ -146,7 +160,7 @@ describe('handleCheckIntegrationSuite', () => {
 
     // Act
     await handleCheckIntegrationSuite(
-      { featureId: 'feat-1', repoRoot: '/repo' },
+      gateArgs('/repo'),
       STATE_DIR,
       mockStore as unknown as EventStore,
       runner,
@@ -161,7 +175,7 @@ describe('handleCheckIntegrationSuite', () => {
 
     // Act
     await handleCheckIntegrationSuite(
-      { featureId: 'feat-1', repoRoot: '/worktrees/agent-x' },
+      gateArgs('/worktrees/agent-x'),
       STATE_DIR,
       mockStore as unknown as EventStore,
       runner,
@@ -182,7 +196,7 @@ describe('handleCheckIntegrationSuite', () => {
 
     // Act
     const result = await handleCheckIntegrationSuite(
-      { featureId: 'feat-1', repoRoot: '/repo' },
+      gateArgs('/repo'),
       STATE_DIR,
       mockStore as unknown as EventStore,
       runner,
@@ -198,7 +212,7 @@ describe('handleCheckIntegrationSuite', () => {
   it('CheckIntegrationSuite_MissingFeatureId_ReturnsError', async () => {
     const runner = stubRunnerReturning(vitestLoadFailureJson());
     const result = await handleCheckIntegrationSuite(
-      { featureId: '' },
+      { featureId: '', testScript: 'test:run' },
       STATE_DIR,
       mockStore as unknown as EventStore,
       runner,
@@ -233,7 +247,7 @@ describe('handleCheckIntegrationSuite', () => {
 
     // Act
     const result = await handleCheckIntegrationSuite(
-      { featureId: 'feat-1', repoRoot: '/repo' },
+      gateArgs('/repo'),
       STATE_DIR,
       mockStore as unknown as EventStore,
       runner,
@@ -348,7 +362,22 @@ describe('parseVitestResult', () => {
 
 describe('isSpawnFailure spawn-vs-shape classification (#1537)', () => {
   it('classifies recognized OS-level errnos with no numeric status as spawn failures', () => {
-    for (const code of ['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR', 'ENOMEM']) {
+    for (const code of [
+      'ENOENT',
+      'EACCES',
+      'EPERM',
+      'ENOTDIR',
+      'ENOMEM',
+      // EINVAL is how Windows reports a `.cmd`/`.bat` shim that `execFile*`
+      // refuses to launch since the CVE-2024-27980 fix. Missing from the set, it
+      // read as a suite that failed rather than a launch that never happened —
+      // and the layered resolver can now name shims (`task`, `just`, `mise`) the
+      // shell-launch allowlist does not cover, so it is the routine case, not an
+      // exotic one.
+      'EINVAL',
+      'ENOEXEC',
+      'EAGAIN',
+    ]) {
       expect(isSpawnFailure({ code })).toBe(true);
     }
   });
@@ -376,13 +405,23 @@ describe('isSpawnFailure spawn-vs-shape classification (#1537)', () => {
 });
 
 describe('check_integration_suite command resolution (#1537, DR-15)', () => {
-  function stubToolchain(test: string | null): Toolchain {
-    return {
-      id: 'stub',
-      projectType: 'Stub',
-      markers: [],
+  /**
+   * A resolved runtime for a Node repository.
+   *
+   * Fixture RE-POINTED from an invented `id: 'stub'`: the id is what selects the
+   * result carrier, and 'stub' names no registry row, so a case asserting the
+   * vitest-JSON flag was describing a repository the registry cannot identify.
+   * The behaviour under test — the command comes from resolution rather than a
+   * hardcoded script name — is unchanged.
+   */
+  function nodeRuntime(test: string | null): IntegrationRuntime {
+    const toolchain: Toolchain = {
+      id: 'node',
+      projectType: 'Node.js',
+      markers: ['package.json'],
       commands: { test, typecheck: null, install: null, mutation: null, lint: null, contract: null },
     };
+    return { test, toolchain };
   }
 
   const passingVitestJson = JSON.stringify({
@@ -400,7 +439,7 @@ describe('check_integration_suite command resolution (#1537, DR-15)', () => {
         seen.push({ cmd, args });
         return { exitCode: 0, stdout: passingVitestJson, stderr: '' };
       },
-      detectToolchain: () => stubToolchain('npm run ws:test'),
+      resolveRuntime: () => nodeRuntime('npm run ws:test'),
     });
     // The command comes from the toolchain resolver, not a hardcoded test:run.
     expect(seen).toHaveLength(1);
@@ -418,7 +457,7 @@ describe('check_integration_suite command resolution (#1537, DR-15)', () => {
         seen.push({ cmd, args });
         return { exitCode: 0, stdout: passingVitestJson, stderr: '' };
       },
-      detectToolchain: () => stubToolchain('npm run should-not-be-used'),
+      resolveRuntime: () => nodeRuntime('npm run should-not-be-used'),
     });
     expect(seen[0].args).toContain('test:ci');
     expect(seen[0].args).not.toContain('should-not-be-used');
@@ -430,15 +469,19 @@ describe('check_integration_suite command resolution (#1537, DR-15)', () => {
     const result = runIntegrationSuite({
       repoRoot: '/monorepo',
       runCommand: (): CommandResult => ({ exitCode: 0, stdout: passingVitestJson, stderr: '' }),
-      detectToolchain: () => stubToolchain('npm run test:run'),
+      resolveRuntime: () => nodeRuntime('npm run test:run'),
     });
     expect(result.parseError).toBe(false);
     expect(result.passed).toBe(true);
     expect(result.totalTests).toBe(42);
   });
 
-  it('checkIntegrationSuite_RunnerSpawnFailure_DistinctFromJsonShapeMismatch', () => {
-    const spawn = runIntegrationSuite({
+  it('checkIntegrationSuite_RunnerNeverStarted_IsNotTheSameAsRanAndGarbled', () => {
+    // The two used to be two flavours of the SAME fail-closed verdict, told
+    // apart only by a `parseFailureKind` label. They are different outcomes: a
+    // runner that ran and returned unreadable output is a finding about the
+    // suite, and a runner that never started is not a reading of anything.
+    const neverStarted = runIntegrationSuite({
       repoRoot: '/repo',
       runCommand: (): CommandResult => ({
         exitCode: 127,
@@ -446,26 +489,28 @@ describe('check_integration_suite command resolution (#1537, DR-15)', () => {
         stderr: 'command not found',
         spawnError: 'ENOENT',
       }),
-      detectToolchain: () => stubToolchain('npm run test:run'),
+      resolveRuntime: () => nodeRuntime('npm run test:run'),
     });
-    const shape = runIntegrationSuite({
+    const ranAndGarbled = runIntegrationSuite({
       repoRoot: '/repo',
       runCommand: (): CommandResult => ({ exitCode: 0, stdout: 'not json at all', stderr: '' }),
-      detectToolchain: () => stubToolchain('npm run test:run'),
+      resolveRuntime: () => nodeRuntime('npm run test:run'),
     });
 
-    // Both fail closed — counts are non-authoritative either way.
-    expect(spawn.passed).toBe(false);
-    expect(shape.passed).toBe(false);
-    // ...but the failure KIND is distinct and surfaced in the report (#1537).
-    expect(spawn.parseFailureKind).toBe('spawn-failure');
-    expect(shape.parseFailureKind).toBe('shape-mismatch');
-    expect(spawn.report).not.toBe(shape.report);
-    expect(spawn.report.toLowerCase()).toContain('spawn');
+    expect(neverStarted.kind).toBe('indeterminate');
+    expect(neverStarted).not.toHaveProperty('passed');
+    expect(ranAndGarbled.kind).toBe('vitest-counts');
+    expect(ranAndGarbled.passed).toBe(false);
+    expect(ranAndGarbled.parseError).toBe(true);
+    expect(neverStarted.report).not.toBe(ranAndGarbled.report);
+    expect(neverStarted.report.toLowerCase()).toContain('spawn');
   });
 
   it('resolveIntegrationCommand_ExplicitScript_TakesPrecedence', () => {
-    const r = resolveIntegrationCommand('/repo', 'my:test', () => stubToolchain('cargo test'));
+    const r = resolveIntegrationCommand('/repo', 'my:test', () => ({
+      test: 'cargo test',
+      toolchain: undefined,
+    }));
     expect(r.cmd).toBe('npm');
     expect(r.args).toEqual(['run', 'my:test', '--', '--reporter=json']);
   });

--- a/tests/unit/verbs/gates/check-polish-scope.test.ts
+++ b/tests/unit/verbs/gates/check-polish-scope.test.ts
@@ -14,6 +14,24 @@ function gitDiffOutput(files: readonly string[]): string {
   return files.join('\n') + (files.length > 0 ? '\n' : '');
 }
 
+/**
+ * Route the two git calls the handler now makes.
+ *
+ * The base branch is DETECTED (`git symbolic-ref refs/remotes/origin/HEAD`)
+ * rather than assumed, so a single `mockReturnValue` would hand the file list
+ * back to the detector as well — and a file list is not a ref, so every test
+ * would take the unresolved path.
+ */
+function mockGit(files: readonly string[], defaultBranch: string | null = 'main'): void {
+  mockedExecFileSync.mockImplementation(((_cmd: string, args: readonly string[]) => {
+    if (args[0] === 'symbolic-ref') {
+      if (defaultBranch === null) throw new Error('no origin/HEAD');
+      return `refs/remotes/origin/${defaultBranch}\n`;
+    }
+    return gitDiffOutput(files);
+  }) as unknown as typeof execFileSync);
+}
+
 describe('Check Polish Scope', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -21,12 +39,10 @@ describe('Check Polish Scope', () => {
   });
 
   it('under limits — 3 files, 1 module → scopeOk: true', async () => {
-    mockedExecFileSync.mockReturnValue(
-      gitDiffOutput(['src/foo.ts', 'src/bar.ts', 'src/baz.ts']),
-    );
+    mockGit(['src/foo.ts', 'src/bar.ts', 'src/baz.ts']);
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(true);
     const data = result.data as CheckPolishScopeResult;
@@ -39,19 +55,17 @@ describe('Check Polish Scope', () => {
   });
 
   it('file count exceeds 5 → scopeOk: false', async () => {
-    mockedExecFileSync.mockReturnValue(
-      gitDiffOutput([
+    mockGit([
         'src/a.ts',
         'src/b.ts',
         'src/c.ts',
         'src/d.ts',
         'src/e.ts',
         'src/f.ts',
-      ]),
-    );
+    ]);
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(true);
     const data = result.data as CheckPolishScopeResult;
@@ -62,12 +76,10 @@ describe('Check Polish Scope', () => {
   });
 
   it('module boundaries crossed (>2 dirs) → scopeOk: false', async () => {
-    mockedExecFileSync.mockReturnValue(
-      gitDiffOutput(['src/a.ts', 'lib/b.ts', 'tests/c.ts']),
-    );
+    mockGit(['src/a.ts', 'lib/b.ts', 'tests/c.ts']);
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(true);
     const data = result.data as CheckPolishScopeResult;
@@ -77,9 +89,7 @@ describe('Check Polish Scope', () => {
   });
 
   it('missing test files → scopeOk: false', async () => {
-    mockedExecFileSync.mockReturnValue(
-      gitDiffOutput(['src/foo.ts', 'src/bar.ts']),
-    );
+    mockGit(['src/foo.ts', 'src/bar.ts']);
     // foo.test.ts exists, bar.test.ts does not
     mockedExistsSync.mockImplementation((p) => {
       const path = String(p);
@@ -87,7 +97,7 @@ describe('Check Polish Scope', () => {
     });
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(true);
     const data = result.data as CheckPolishScopeResult;
@@ -96,12 +106,10 @@ describe('Check Polish Scope', () => {
   });
 
   it('architectural docs needed — structural files across >1 module → scopeOk: false', async () => {
-    mockedExecFileSync.mockReturnValue(
-      gitDiffOutput(['src/index.ts', 'lib/utils.ts']),
-    );
+    mockGit(['src/index.ts', 'lib/utils.ts']);
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(true);
     const data = result.data as CheckPolishScopeResult;
@@ -110,21 +118,19 @@ describe('Check Polish Scope', () => {
   });
 
   it('multiple triggers fire together', async () => {
-    mockedExecFileSync.mockReturnValue(
-      gitDiffOutput([
+    mockGit([
         'src/a.ts',
         'src/b.ts',
         'lib/c.ts',
         'tests/d.ts',
         'pkg/e.ts',
         'pkg/index.ts',
-      ]),
-    );
+    ]);
     // No test files exist
     mockedExistsSync.mockReturnValue(false);
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(true);
     const data = result.data as CheckPolishScopeResult;
@@ -140,10 +146,10 @@ describe('Check Polish Scope', () => {
   });
 
   it('empty diff → scopeOk: true', async () => {
-    mockedExecFileSync.mockReturnValue('');
+    mockGit([]);
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(true);
     const data = result.data as CheckPolishScopeResult;
@@ -154,12 +160,14 @@ describe('Check Polish Scope', () => {
   });
 
   it('both git diff attempts fail → DIFF_FAILED error', async () => {
-    mockedExecFileSync.mockImplementation(() => {
+    mockedExecFileSync.mockImplementation(((_cmd: string, args: readonly string[]) => {
+      // The base resolves; only the diff itself fails.
+      if (args[0] === 'symbolic-ref') return 'refs/remotes/origin/main\n';
       throw new Error('git diff failed');
-    });
+    }) as unknown as typeof execFileSync);
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    const result = handleCheckPolishScope({ repoRoot: '/repo' });
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('DIFF_FAILED');
@@ -168,16 +176,35 @@ describe('Check Polish Scope', () => {
     expect(result.data).toBeUndefined();
   });
 
-  it('default baseBranch is "main"', async () => {
-    mockedExecFileSync.mockReturnValue(gitDiffOutput(['src/foo.ts']));
+  it('DetectsTheDefaultBranch_RatherThanAssumingMain', async () => {
+    mockGit(['src/foo.ts'], 'trunk');
 
     const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
-    handleCheckPolishScope({ repoRoot: '/repo' });
+    await handleCheckPolishScope({ repoRoot: '/repo' });
 
     expect(mockedExecFileSync).toHaveBeenCalledWith(
       'git',
-      ['diff', '--name-only', 'main...HEAD'],
+      ['diff', '--name-only', 'trunk...HEAD'],
       expect.objectContaining({ cwd: '/repo' }),
+    );
+  });
+
+  it('UnresolvedBase_ReportsIt_AndNeverDiffsAgainstMain', async () => {
+    mockGit(['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts', 'src/e.ts', 'src/f.ts'], null);
+
+    const { handleCheckPolishScope } = await import('../../../../src/verbs/gates/check-polish-scope.js');
+    const result = await handleCheckPolishScope({ repoRoot: '/repo' });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('DIFF_FAILED');
+    // The six files above would have tripped the file-count trigger. Nothing is
+    // reported, because nothing was measured — a scope verdict against a branch
+    // the repository may not have is not a verdict.
+    expect(result.data).toBeUndefined();
+    expect(mockedExecFileSync).not.toHaveBeenCalledWith(
+      'git',
+      ['diff', '--name-only', 'main...HEAD'],
+      expect.anything(),
     );
   });
 });

--- a/tests/unit/verbs/gates/context-economy.test.ts
+++ b/tests/unit/verbs/gates/context-economy.test.ts
@@ -50,6 +50,18 @@ import { handleContextEconomy } from '../../../../src/verbs/gates/context-econom
 
 const STATE_DIR = '/tmp/test-context-economy';
 
+/**
+ * The tests below hand the gate an explicit base so they measure the gate, not
+ * the machine: without one the handler DETECTS the repository's default branch,
+ * and a checkout with no `origin/HEAD` (a CI clone, a fresh worktree) would send
+ * every case down the inconclusive path. The detection path has its own case at
+ * the bottom of each file.
+ */
+const BASE = 'main';
+
+/** A path that is not a git repository, so detection cannot answer. */
+const NO_REPO = '/exarchos-not-a-repository';
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('handleContextEconomy', () => {
@@ -83,7 +95,7 @@ describe('handleContextEconomy', () => {
         findings: [],
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleContextEconomy(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -113,7 +125,7 @@ describe('handleContextEconomy', () => {
         ],
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleContextEconomy(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -140,7 +152,7 @@ describe('handleContextEconomy', () => {
         findings: [],
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       await handleContextEconomy(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(mockEmitGateEvent).toHaveBeenCalledTimes(1);
@@ -167,7 +179,7 @@ describe('handleContextEconomy', () => {
         findings: [],
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       await handleContextEconomy(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(mockEmitGateEvent).toHaveBeenCalledTimes(1);
@@ -182,7 +194,7 @@ describe('handleContextEconomy', () => {
     it('handleContextEconomy_GitDiffFails_ReturnsError', async () => {
       mockGetDiff.mockReturnValue(null);
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleContextEconomy(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(false);
@@ -240,7 +252,7 @@ describe('handleContextEconomy', () => {
       mockTelemetryState.totalTokens = 5000;
       mockTelemetryState.totalInvocations = 10;
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleContextEconomy(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -273,7 +285,7 @@ describe('handleContextEconomy', () => {
       mockTelemetryState.totalTokens = 0;
       mockTelemetryState.totalInvocations = 0;
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleContextEconomy(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -291,6 +303,65 @@ describe('handleContextEconomy', () => {
       expect(data.runtimeMetrics.sessionTokens).toBe(0);
       expect(data.runtimeMetrics.toolCount).toBe(0);
       expect(data.runtimeMetrics.totalInvocations).toBe(0);
+    });
+  });
+
+  // ─── Base-branch resolution ──────────────────────────────────────────────
+
+  describe('base branch', () => {
+    it('handleContextEconomy_UnresolvedBase_IsInconclusive_NotPass', async () => {
+      // No explicit base and no detectable default branch: there is no diff to
+      // judge. The carrier says so instead of reporting a clean review of a
+      // range that was never computed.
+      const result = await handleContextEconomy(
+        { featureId: 'feat-1', repoRoot: NO_REPO },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { passed: boolean; skipped?: boolean; discriminant?: string };
+      expect(data.passed).toBe(false);
+      expect(data.skipped).toBe(true);
+      expect(data.discriminant).toBe('base-branch-unresolved');
+      // The diff was never attempted, so nothing was judged.
+      expect(mockGetDiff).not.toHaveBeenCalled();
+
+      // Indeterminate is a verdict, and this action declares `gate.executed`
+      // UNCONDITIONALLY. A success carrier without it is the drift the
+      // post-dispatch emission verifier reports — and it leaves the durable log
+      // unable to tell an unscoped run from one that never happened.
+      expect(mockEmitGateEvent).toHaveBeenCalledTimes(1);
+      const [, streamId, gateName, layer, passed, details] = mockEmitGateEvent.mock.calls[0]!;
+      expect(streamId).toBe('feat-1');
+      expect(gateName).toBe('context-economy');
+      expect(layer).toBe('quality');
+      // Fail-closed on the wire, and the markers say WHY, so no reader takes it
+      // for a gate that ran and found a fault.
+      expect(passed).toBe(false);
+      expect(details).toMatchObject({
+        skipped: true,
+        discriminant: 'base-branch-unresolved',
+        findingCount: 0,
+      });
+    });
+
+    it('handleContextEconomy_ExplicitBase_IsUsedVerbatim', async () => {
+      mockGetDiff.mockReturnValue('diff --git a/foo.ts b/foo.ts\n');
+      vi.mocked(checkContextEconomy).mockReturnValue({
+        pass: true,
+        findings: [],
+        checksRun: 1,
+        checksPassed: 1,
+      });
+
+      await handleContextEconomy(
+        { featureId: 'feat-1', repoRoot: '/repo', baseBranch: 'release/2026.09' },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      expect(mockGetDiff).toHaveBeenCalledWith('/repo', 'release/2026.09');
     });
   });
 });

--- a/tests/unit/verbs/gates/contract-drift-handler.test.ts
+++ b/tests/unit/verbs/gates/contract-drift-handler.test.ts
@@ -132,6 +132,45 @@ describe('check_contract_drift registration + dispatch + steer', () => {
       'contracts verify shape, not meaning — keep exactly ONE semantic test for this boundary; delete redundant shape assertions',
     );
   });
+
+  it('UnresolvedBase_IsInconclusive_NotAPassAndNotADriftFinding', async () => {
+    // `/fake/repo` is not a repository, so no default branch can be detected and
+    // none was supplied. This gate compares generated contract artifacts across
+    // a diff range; with one end missing there is no range, and reporting
+    // `drift: false` would be a clean bill of health for a comparison that never
+    // ran.
+    const arm = await makeArm('contract-nobase-');
+    arms.push(arm);
+
+    const args: ContractDriftHandlerArgs = {
+      featureId: 'feat-nobase',
+      taskId: 'T-nobase',
+      repoRoot: '/fake/repo',
+      gitExec: gitMergeBase,
+      runCommand: cmdRunner({ diff: { code: 0, out: 'no breaking changes' } }),
+    };
+    const result = await handleContractDrift(args, arm.ctx.stateDir, arm.ctx.eventStore);
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      passed: boolean;
+      skipped?: boolean;
+      drift?: boolean;
+      discriminant?: string;
+      reason?: string;
+    };
+    expect(data.passed).toBe(false);
+    expect(data.skipped).toBe(true);
+    expect(data.discriminant).toBe('base-branch-unresolved');
+    expect(data.reason).toContain('no default branch');
+
+    // The carrier's skip marker is what makes the PROOF verdict inconclusive.
+    // Without it the row would read `fail`, naming a drift finding nobody
+    // observed; with `passed:true` it would mint proof from a gate that never
+    // ran. Indeterminate is the only honest one, and it fails closed.
+    const { normalizeGateVerdict } = await import('../../../../src/verbs/gates/gate-utils.js');
+    expect(normalizeGateVerdict(result)).toBe('indeterminate');
+  });
 });
 
 // ─── helper: a temp repo wiring a resolvable contract via .exarchos.yml ───────

--- a/tests/unit/verbs/gates/mock-boundary-handler.test.ts
+++ b/tests/unit/verbs/gates/mock-boundary-handler.test.ts
@@ -13,7 +13,10 @@ import { EventStore } from '../../../../src/events/store.js';
 import type { DispatchContext } from '../../../../src/dispatch/core/dispatch.js';
 import { handleOrchestrate } from '../../../../src/verbs/composite.js';
 import { TOOL_REGISTRY } from '../../../../src/registry.js';
-import { steerForFinding } from '../../../../src/verbs/gates/mock-boundary-handler.js';
+import {
+  handleMockBoundary,
+  steerForFinding,
+} from '../../../../src/verbs/gates/mock-boundary-handler.js';
 import type { GitExec } from '../../../../src/verbs/pure/execute-merge.js';
 import { rmrf } from '../../../../tools/test-helpers/temp-dir.js';
 
@@ -159,5 +162,44 @@ describe('check_mock_boundary registration + dispatch + steer', () => {
     expect(steer).toMatch(/hermetic fixture/i);
     expect(steer).toMatch(/contract-verified stub/i);
     expect(steer).toMatch(/a fake/i);
+  });
+
+  it('UnresolvedBase_IsInconclusive_NotACleanBoundaryReport', async () => {
+    // `/fake/repo` is not a repository, so no default branch can be detected and
+    // none was supplied. This gate reads the diff for mocks of unowned
+    // dependencies; with no diff there are no findings, and `findings: []` would
+    // report a clean boundary that was never inspected.
+    const arm = await makeArm('mock-boundary-nobase-');
+    arms.push(arm);
+
+    const result = await handleMockBoundary(
+      {
+        featureId: 'feat-nobase',
+        taskId: 'T-nobase',
+        repoRoot: '/fake/repo',
+        gitExec: gitEmptyDiff,
+      },
+      arm.ctx.stateDir,
+      arm.ctx.eventStore,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      passed: boolean;
+      skipped?: boolean;
+      findings?: unknown[];
+      discriminant?: string;
+      reason?: string;
+    };
+    expect(data.passed).toBe(false);
+    expect(data.skipped).toBe(true);
+    expect(data.discriminant).toBe('base-branch-unresolved');
+    expect(data.reason).toContain('no default branch');
+
+    // The carrier's skip marker is what makes the PROOF verdict inconclusive.
+    // `fail` would name a boundary violation nobody observed; `pass` would mint
+    // proof from a gate that never ran. Indeterminate fails closed instead.
+    const { normalizeGateVerdict } = await import('../../../../src/verbs/gates/gate-utils.js');
+    expect(normalizeGateVerdict(result)).toBe('indeterminate');
   });
 });

--- a/tests/unit/verbs/gates/needs-schema-sync.test.ts
+++ b/tests/unit/verbs/gates/needs-schema-sync.test.ts
@@ -21,6 +21,33 @@ import { handleNeedsSchemaSync } from '../../../../src/verbs/gates/needs-schema-
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+/**
+ * Route the two git calls the handler now makes.
+ *
+ * The base branch is DETECTED (`git symbolic-ref refs/remotes/origin/HEAD`)
+ * rather than assumed, so a single `mockReturnValue` would hand the diff output
+ * back to the detector as well — and a file list is not a ref, so every test
+ * would take the unresolved path. Each test says what the repository's default
+ * branch is and what the diff returned.
+ */
+function mockGit(diffOutput: string, defaultBranch: string | null = 'main'): void {
+  mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+    const argv = args as readonly string[];
+    if (argv[0] === 'symbolic-ref') {
+      if (defaultBranch === null) throw new Error('no origin/HEAD');
+      return `refs/remotes/origin/${defaultBranch}\n`;
+    }
+    // Below `symbolic-ref` the resolver walks a LADDER of further git reads. A
+    // stub that answered every one of them with the diff would hand a file path
+    // to the rung that reads `init.defaultBranch` and see it resolved as a
+    // branch — so the stub answers the subcommand this handler actually issues
+    // and refuses the rest, which is what a repository with no detectable
+    // default branch does.
+    if (argv[0] !== 'diff') throw new Error(`git ${String(argv[0])}: no answer`);
+    return diffOutput;
+  });
+}
+
 type ResultData = {
   syncNeeded: boolean;
   report: string;
@@ -41,8 +68,8 @@ describe('handleNeedsSchemaSync', () => {
   // ─── Input Validation ───────────────────────────────────────────────────
 
   describe('input validation', () => {
-    it('returns error when repoRoot is empty', () => {
-      const result = handleNeedsSchemaSync({ repoRoot: '' });
+    it('returns error when repoRoot is empty', async () => {
+      const result = await handleNeedsSchemaSync({ repoRoot: '' });
       expect(result.success).toBe(false);
       expect(result.error?.code).toBe('INVALID_INPUT');
       expect(result.error?.message).toContain('repoRoot');
@@ -52,12 +79,11 @@ describe('handleNeedsSchemaSync', () => {
   // ─── No API Files Changed ──────────────────────────────────────────────
 
   describe('no API files changed', () => {
-    it('returns syncNeeded: false when no files match API patterns', () => {
-      mockExecFileSync.mockReturnValue(
-        'src/Utils/Helper.cs\nsrc/Services/FooService.cs\n',
+    it('returns syncNeeded: false when no files match API patterns', async () => {
+      mockGit('src/Utils/Helper.cs\nsrc/Services/FooService.cs\n',
       );
 
-      const result = handleNeedsSchemaSync({ repoRoot: '/repo' });
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(result.success).toBe(true);
       const data = getData(result);
@@ -70,12 +96,11 @@ describe('handleNeedsSchemaSync', () => {
   // ─── Endpoints.cs Changed ─────────────────────────────────────────────
 
   describe('Endpoints.cs changed', () => {
-    it('returns syncNeeded: true when Endpoints.cs is modified', () => {
-      mockExecFileSync.mockReturnValue(
-        'src/Api/UsersEndpoints.cs\nsrc/Startup.cs\n',
+    it('returns syncNeeded: true when Endpoints.cs is modified', async () => {
+      mockGit('src/Api/UsersEndpoints.cs\nsrc/Startup.cs\n',
       );
 
-      const result = handleNeedsSchemaSync({ repoRoot: '/repo' });
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(result.success).toBe(true);
       const data = getData(result);
@@ -88,12 +113,11 @@ describe('handleNeedsSchemaSync', () => {
   // ─── Models/*.cs Changed ──────────────────────────────────────────────
 
   describe('Models/*.cs changed', () => {
-    it('returns syncNeeded: true when Models/*.cs is modified', () => {
-      mockExecFileSync.mockReturnValue(
-        'src/Models/User.cs\nsrc/README.md\n',
+    it('returns syncNeeded: true when Models/*.cs is modified', async () => {
+      mockGit('src/Models/User.cs\nsrc/README.md\n',
       );
 
-      const result = handleNeedsSchemaSync({ repoRoot: '/repo' });
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(result.success).toBe(true);
       const data = getData(result);
@@ -105,9 +129,8 @@ describe('handleNeedsSchemaSync', () => {
   // ─── Multiple API Patterns Matched ────────────────────────────────────
 
   describe('multiple API patterns matched', () => {
-    it('returns all matched API files', () => {
-      mockExecFileSync.mockReturnValue(
-        [
+    it('returns all matched API files', async () => {
+      mockGit([
           'src/Api/OrdersEndpoints.cs',
           'src/Models/Order.cs',
           'src/Requests/CreateOrderRequest.cs',
@@ -117,7 +140,7 @@ describe('handleNeedsSchemaSync', () => {
         ].join('\n') + '\n',
       );
 
-      const result = handleNeedsSchemaSync({ repoRoot: '/repo' });
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(result.success).toBe(true);
       const data = getData(result);
@@ -136,12 +159,11 @@ describe('handleNeedsSchemaSync', () => {
   // ─── Non-API .cs Files ────────────────────────────────────────────────
 
   describe('non-API .cs files', () => {
-    it('returns syncNeeded: false for non-API .cs files', () => {
-      mockExecFileSync.mockReturnValue(
-        'src/Services/AuthService.cs\nsrc/Helpers/StringHelper.cs\nsrc/Program.cs\n',
+    it('returns syncNeeded: false for non-API .cs files', async () => {
+      mockGit('src/Services/AuthService.cs\nsrc/Helpers/StringHelper.cs\nsrc/Program.cs\n',
       );
 
-      const result = handleNeedsSchemaSync({ repoRoot: '/repo' });
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(result.success).toBe(true);
       const data = getData(result);
@@ -153,7 +175,7 @@ describe('handleNeedsSchemaSync', () => {
   // ─── diffFile Mode ────────────────────────────────────────────────────
 
   describe('diffFile mode', () => {
-    it('parses pre-computed diff to extract file paths', () => {
+    it('parses pre-computed diff to extract file paths', async () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(
         [
@@ -175,7 +197,7 @@ describe('handleNeedsSchemaSync', () => {
         ].join('\n'),
       );
 
-      const result = handleNeedsSchemaSync({
+      const result = await handleNeedsSchemaSync({
         repoRoot: '/repo',
         diffFile: '/tmp/changes.diff',
       });
@@ -191,10 +213,10 @@ describe('handleNeedsSchemaSync', () => {
       expect(mockExecFileSync).not.toHaveBeenCalled();
     });
 
-    it('returns error when diffFile does not exist', () => {
+    it('returns error when diffFile does not exist', async () => {
       mockExistsSync.mockReturnValue(false);
 
-      const result = handleNeedsSchemaSync({
+      const result = await handleNeedsSchemaSync({
         repoRoot: '/repo',
         diffFile: '/tmp/missing.diff',
       });
@@ -208,10 +230,10 @@ describe('handleNeedsSchemaSync', () => {
   // ─── Empty Diff ───────────────────────────────────────────────────────
 
   describe('empty diff', () => {
-    it('returns syncNeeded: false when diff is empty', () => {
-      mockExecFileSync.mockReturnValue('');
+    it('returns syncNeeded: false when diff is empty', async () => {
+      mockGit('');
 
-      const result = handleNeedsSchemaSync({ repoRoot: '/repo' });
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(result.success).toBe(true);
       const data = getData(result);
@@ -220,43 +242,84 @@ describe('handleNeedsSchemaSync', () => {
     });
   });
 
-  // ─── Default baseBranch ───────────────────────────────────────────────
+  // ─── Base-branch resolution ───────────────────────────────────────────
 
-  describe('default baseBranch', () => {
-    it('defaults baseBranch to "main"', () => {
-      mockExecFileSync.mockReturnValue('');
+  describe('base branch', () => {
+    it('DetectsTheDefaultBranch_RatherThanAssumingMain', async () => {
+      mockGit('', 'trunk');
 
-      handleNeedsSchemaSync({ repoRoot: '/repo' });
+      await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(mockExecFileSync).toHaveBeenCalledWith(
         'git',
-        ['diff', '--name-only', 'main...HEAD'],
+        ['diff', '--name-only', 'trunk...HEAD'],
         expect.objectContaining({ cwd: '/repo' }),
       );
     });
 
-    it('uses custom baseBranch when provided', () => {
-      mockExecFileSync.mockReturnValue('');
+    it('uses custom baseBranch when provided', async () => {
+      mockGit('');
 
-      handleNeedsSchemaSync({ repoRoot: '/repo', baseBranch: 'develop' });
+      await handleNeedsSchemaSync({ repoRoot: '/repo', baseBranch: 'develop' });
 
       expect(mockExecFileSync).toHaveBeenCalledWith(
         'git',
         ['diff', '--name-only', 'develop...HEAD'],
         expect.objectContaining({ cwd: '/repo' }),
       );
+      // An explicit base short-circuits detection entirely.
+      expect(mockExecFileSync).not.toHaveBeenCalledWith(
+        'git',
+        ['symbolic-ref', 'refs/remotes/origin/HEAD'],
+        expect.anything(),
+      );
+    });
+
+    it('UnresolvedBase_ReportsIt_AndNeverDiffsAgainstMain', async () => {
+      mockGit('src/Api/Endpoints.cs\n', null);
+
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GIT_ERROR');
+      // The point of the check: no diff was attempted against an invented base,
+      // so the API file above is neither reported nor silently missed.
+      expect(mockExecFileSync).not.toHaveBeenCalledWith(
+        'git',
+        ['diff', '--name-only', 'main...HEAD'],
+        expect.anything(),
+      );
+    });
+
+    it('SuppliedDiffFile_NeedsNoBaseAtAll', async () => {
+      // The comparison already happened; nothing here has to detect a branch.
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('+++ b/src/Api/Endpoints.cs\n');
+      mockGit('', null);
+
+      const result = await handleNeedsSchemaSync({
+        repoRoot: '/repo',
+        diffFile: '/tmp/changes.diff',
+      });
+
+      expect(result.success).toBe(true);
+      expect(getData(result).syncNeeded).toBe(true);
     });
   });
 
   // ─── Git Error Handling ───────────────────────────────────────────────
 
   describe('git error handling', () => {
-    it('returns GIT_ERROR when all git diff attempts fail', () => {
-      mockExecFileSync.mockImplementation(() => {
+    it('returns GIT_ERROR when all git diff attempts fail', async () => {
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        // The base resolves; only the diff itself fails.
+        if ((args as readonly string[])[0] === 'symbolic-ref') {
+          return 'refs/remotes/origin/main\n';
+        }
         throw new Error('git diff failed');
       });
 
-      const result = handleNeedsSchemaSync({ repoRoot: '/repo' });
+      const result = await handleNeedsSchemaSync({ repoRoot: '/repo' });
 
       expect(result.success).toBe(false);
       expect(result.error?.code).toBe('GIT_ERROR');

--- a/tests/unit/verbs/gates/operational-resilience.test.ts
+++ b/tests/unit/verbs/gates/operational-resilience.test.ts
@@ -35,6 +35,18 @@ import { handleOperationalResilience } from '../../../../src/verbs/gates/operati
 
 const STATE_DIR = '/tmp/test-operational-resilience';
 
+/**
+ * The tests below hand the gate an explicit base so they measure the gate, not
+ * the machine: without one the handler DETECTS the repository's default branch,
+ * and a checkout with no `origin/HEAD` (a CI clone, a fresh worktree) would send
+ * every case down the inconclusive path. The detection path has its own case at
+ * the bottom of each file.
+ */
+const BASE = 'main';
+
+/** A path that is not a git repository, so detection cannot answer. */
+const NO_REPO = '/exarchos-not-a-repository';
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('handleOperationalResilience', () => {
@@ -67,7 +79,7 @@ describe('handleOperationalResilience', () => {
         findings: [],
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleOperationalResilience(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -93,7 +105,7 @@ describe('handleOperationalResilience', () => {
         ],
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleOperationalResilience(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -115,7 +127,7 @@ describe('handleOperationalResilience', () => {
         findings: [],
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       await handleOperationalResilience(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(mockEmitGateEvent).toHaveBeenCalledTimes(1);
@@ -136,12 +148,49 @@ describe('handleOperationalResilience', () => {
     it('handleOperationalResilience_GitDiffFails_ReturnsError', async () => {
       mockGetDiff.mockReturnValue(null);
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleOperationalResilience(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(false);
       expect(result.error?.code).toBe('DIFF_ERROR');
       expect(checkOperationalResilience).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Base-branch resolution ──────────────────────────────────────────────
+
+  describe('base branch', () => {
+    it('handleOperationalResilience_UnresolvedBase_IsInconclusive_NotPass', async () => {
+      const result = await handleOperationalResilience(
+        { featureId: 'feat-1', repoRoot: NO_REPO },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { passed: boolean; skipped?: boolean; discriminant?: string };
+      expect(data.passed).toBe(false);
+      expect(data.skipped).toBe(true);
+      expect(data.discriminant).toBe('base-branch-unresolved');
+      expect(mockGetDiff).not.toHaveBeenCalled();
+
+      // Indeterminate is a verdict, and this action declares `gate.executed`
+      // UNCONDITIONALLY. A success carrier without it is the drift the
+      // post-dispatch emission verifier reports — and it leaves the durable log
+      // unable to tell an unscoped run from one that never happened.
+      expect(mockEmitGateEvent).toHaveBeenCalledTimes(1);
+      const [, streamId, gateName, layer, passed, details] = mockEmitGateEvent.mock.calls[0]!;
+      expect(streamId).toBe('feat-1');
+      expect(gateName).toBe('operational-resilience');
+      expect(layer).toBe('quality');
+      // Fail-closed on the wire, and the markers say WHY, so no reader takes it
+      // for a gate that ran and found a fault.
+      expect(passed).toBe(false);
+      expect(details).toMatchObject({
+        skipped: true,
+        discriminant: 'base-branch-unresolved',
+        findingCount: 0,
+      });
     });
   });
 });

--- a/tests/unit/verbs/gates/post-merge.test.ts
+++ b/tests/unit/verbs/gates/post-merge.test.ts
@@ -236,4 +236,68 @@ describe('handlePostMerge', () => {
     expect(callArgs.mergeSha).toBe('abc1234');
     expect(typeof callArgs.runCommand).toBe('function');
   });
+
+  // ─── Test 6: repoRoot reaches BOTH resolution and execution ────────────
+
+  it('handlePostMerge_ThreadsRepoRootIntoTheCheck_NotOnlyIntoTheRunner', async () => {
+    // The check resolves the test command from a tree and runs it in a tree.
+    // Handing the runner a cwd while leaving the check to resolve from this
+    // process's own directory would measure one tree with another's command.
+    mockCheckPostMerge.mockReturnValue(makePassingResult());
+
+    await handlePostMerge(
+      {
+        featureId: 'feat-123',
+        prUrl: 'https://github.com/org/repo/pull/42',
+        mergeSha: 'abc1234',
+        repoRoot: '/merged/tip',
+      },
+      STATE_DIR,
+      mockStore as unknown as EventStore,
+    );
+
+    const callArgs = mockCheckPostMerge.mock.calls[0][0] as { repoRoot?: string };
+    expect(callArgs.repoRoot).toBe('/merged/tip');
+  });
+
+  // ─── Test 7: the indeterminate arm survives the caller ─────────────────
+
+  it('handlePostMerge_IndeterminateCheck_IsNotCollapsedToAFailure', async () => {
+    // The pure check's third outcome used to die at this boundary: the caller
+    // read only `status === 'pass'` and dropped the rest, so a check that never
+    // ran was recorded as a regression that did.
+    mockCheckPostMerge.mockReturnValue({
+      status: 'indeterminate' as const,
+      reason: 'Test suite: `cargo test` could not be started (ENOENT)',
+      prUrl: 'https://github.com/org/repo/pull/42',
+      mergeSha: 'abc1234',
+      passCount: 1,
+      failCount: 0,
+      results: ['- **INDETERMINATE**: Test suite'],
+      findings: [],
+      report: '## Post-Merge Regression Report\n\n**Result: INDETERMINATE**',
+    });
+
+    const result = await handlePostMerge(
+      { featureId: 'feat-123', prUrl: 'https://github.com/org/repo/pull/42', mergeSha: 'abc1234' },
+      STATE_DIR,
+      mockStore as unknown as EventStore,
+    );
+
+    const data = result.data as { passed: boolean; status: string; reason?: string };
+    expect(data.passed).toBe(false);
+    expect(data.status).toBe('indeterminate');
+    expect(data.reason).toContain('ENOENT');
+
+    // …and the durable row carries the same three-valued outcome, so a reader
+    // of the log can tell it apart from an observed regression.
+    const [, event] = mockStore.append.mock.calls[0] as [
+      string,
+      { data: { passed: boolean; details: Record<string, unknown> } },
+    ];
+    expect(event.data.passed).toBe(false);
+    expect(event.data.details.status).toBe('indeterminate');
+    expect(event.data.details.reason).toContain('ENOENT');
+    expect(event.data.details.findings).toEqual([]);
+  });
 });

--- a/tests/unit/verbs/gates/spec-coverage-check.test.ts
+++ b/tests/unit/verbs/gates/spec-coverage-check.test.ts
@@ -2,7 +2,8 @@
 //
 // Tests for the TypeScript port of scripts/spec-coverage-check.sh.
 // Verifies test coverage for spec compliance by checking plan references
-// against on-disk test files and optional vitest execution.
+// against on-disk test files and, optionally, running the governed
+// repository's own resolved test suite.
 // ────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -56,6 +57,36 @@ const PLAN_WITHOUT_TESTS = [
   'Implement the widget.',
 ].join('\n');
 
+// The gate resolves its runner from the governed repository's toolchain, so a
+// fixture repo has to look like one. `/repo` is a Node repo carrying the script
+// the resolver's npm profile looks for.
+const NODE_MANIFEST = JSON.stringify({ scripts: { 'test:run': 'vitest run' } });
+
+/** `existsSync` for a resolvable Node repo at `/repo`, plus the named paths. */
+function nodeRepoFs(...present: readonly string[]): (p: unknown) => boolean {
+  const paths = new Set<string>(['/repo', '/repo/plan.md', '/repo/package.json', ...present]);
+  return (p: unknown) => paths.has(String(p));
+}
+
+/** `readFileSync` answering the manifest for package.json and the plan otherwise. */
+function planAndManifest(plan: string): (p: unknown) => string {
+  return (p: unknown) => (String(p).endsWith('package.json') ? NODE_MANIFEST : plan);
+}
+
+/** What `execFileSync` throws when the process RAN and exited non-zero. */
+function exitFailure(status: number): Error & { status: number } {
+  return Object.assign(new Error(`Command failed with exit code ${status}`), { status });
+}
+
+/**
+ * What `execFileSync` throws when the process never ran (`ENOENT`) or was
+ * killed at its wall clock (`ETIMEDOUT`): an errno and NO numeric `status`,
+ * which is exactly what makes the exit code unreadable.
+ */
+function spawnFailure(code: string): Error & { code: string } {
+  return Object.assign(new Error(`spawnSync npm ${code}`), { code });
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('handleSpecCoverageCheck', () => {
@@ -67,15 +98,10 @@ describe('handleSpecCoverageCheck', () => {
 
   it('allTestFilesExistAndPass_returnsPassed', () => {
     // Plan file exists, repo root exists
-    mockedExistsSync.mockImplementation((p: unknown) => {
-      const path = String(p);
-      if (path === '/repo/plan.md') return true;
-      if (path === '/repo') return true;
-      if (path === '/repo/src/widget.test.ts') return true;
-      if (path === '/repo/src/utils.test.ts') return true;
-      return false;
-    });
-    mockedReadFileSync.mockReturnValue(PLAN_WITH_TWO_TESTS);
+    mockedExistsSync.mockImplementation(
+      nodeRepoFs('/repo/src/widget.test.ts', '/repo/src/utils.test.ts'),
+    );
+    mockedReadFileSync.mockImplementation(planAndManifest(PLAN_WITH_TWO_TESTS));
     mockedExecFileSync.mockReturnValue(Buffer.from(''));
 
     const result = handleSpecCoverageCheck({
@@ -157,22 +183,12 @@ describe('handleSpecCoverageCheck', () => {
   // ─── 4. Test execution fails ──────────────────────────────────────────
 
   it('testExecutionFails_returnsFailedWithReport', () => {
-    mockedExistsSync.mockImplementation((p: unknown) => {
-      const path = String(p);
-      if (path === '/repo/plan.md') return true;
-      if (path === '/repo') return true;
-      if (path === '/repo/src/widget.test.ts') return true;
-      if (path === '/repo/src/utils.test.ts') return true;
-      return false;
-    });
-    mockedReadFileSync.mockReturnValue(PLAN_WITH_TWO_TESTS);
-    mockedExecFileSync.mockImplementation((_cmd: unknown, args?: unknown) => {
-      const argsArr = args as readonly string[];
-      // First test passes, second fails
-      if (argsArr && argsArr.some((a: string) => a.includes('utils.test.ts'))) {
-        throw new Error('Test failed');
-      }
-      return Buffer.from('');
+    mockedExistsSync.mockImplementation(
+      nodeRepoFs('/repo/src/widget.test.ts', '/repo/src/utils.test.ts'),
+    );
+    mockedReadFileSync.mockImplementation(planAndManifest(PLAN_WITH_TWO_TESTS));
+    mockedExecFileSync.mockImplementation(() => {
+      throw exitFailure(1);
     });
 
     const result = handleSpecCoverageCheck({
@@ -183,10 +199,13 @@ describe('handleSpecCoverageCheck', () => {
     expect(result.success).toBe(true);
     const data = result.data as {
       passed: boolean;
+      indeterminate: readonly string[];
       report: string;
     };
     expect(data.passed).toBe(false);
     expect(data.report).toContain('FAIL');
+    // A real non-zero exit IS a verdict, so nothing is unmeasured here.
+    expect(data.indeterminate).toEqual([]);
   });
 
   // ─── 5. skipRun skips execution ───────────────────────────────────────
@@ -219,6 +238,126 @@ describe('handleSpecCoverageCheck', () => {
     expect(data.found).toBe(2);
     // execFileSync should NOT have been called
     expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  // ─── 5b. The runner comes from the toolchain, not from a literal ───────
+
+  it('SpecCoverage_DoesNotSpawnNpxVitest', () => {
+    mockedExistsSync.mockImplementation(nodeRepoFs('/repo/src/widget.test.ts'));
+    mockedReadFileSync.mockImplementation(
+      planAndManifest(makePlanWithTests(['src/widget.test.ts'])),
+    );
+    mockedExecFileSync.mockReturnValue(Buffer.from(''));
+
+    const result = handleSpecCoverageCheck({ planFile: '/repo/plan.md', repoRoot: '/repo' });
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    const [program, argv] = mockedExecFileSync.mock.calls[0] as [string, readonly string[]];
+    // The resolver's npm profile, not a hard-coded vitest invocation.
+    expect(program).not.toBe('npx');
+    expect(program).toBe('npm');
+    expect(argv).toEqual(['run', 'test:run']);
+  });
+
+  it('SpecCoverage_DeclaredPathIsNotAppendedToTheResolvedCommand', () => {
+    // The resolver hands back a WHOLE-SUITE command. A declared test path
+    // appended to one is not a file selector on most runners — `cargo test
+    // <path>` filters by test NAME, matches nothing, and exits zero, which is a
+    // green verdict over a file that never ran. Two declared files, ONE spawn,
+    // and neither path anywhere in the argv.
+    mockedExistsSync.mockImplementation(
+      nodeRepoFs('/repo/src/widget.test.ts', '/repo/src/utils.test.ts'),
+    );
+    mockedReadFileSync.mockImplementation(planAndManifest(PLAN_WITH_TWO_TESTS));
+    mockedExecFileSync.mockReturnValue(Buffer.from(''));
+
+    const result = handleSpecCoverageCheck({ planFile: '/repo/plan.md', repoRoot: '/repo' });
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    const [, argv] = mockedExecFileSync.mock.calls[0] as [string, readonly string[]];
+    expect(argv.length).toBeGreaterThan(0);
+    for (const token of argv) {
+      expect(token).not.toContain('.test.ts');
+    }
+    // …and the report does not claim a per-file verdict it did not produce.
+    const { report } = result.data as { report: string };
+    expect(report).not.toContain('Test passes: src/widget.test.ts');
+  });
+
+  it('SpecCoverage_UnresolvedRuntime_IsIndeterminate_NotGreen', () => {
+    // A governed repository with no resolvable test runtime: the declared file
+    // exists, so nothing FAILS — the old literal spawn would have been the only
+    // thing standing between this and a green verdict on an unverified repo.
+    mockedExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      return path === '/repo' || path === '/repo/plan.md' || path === '/repo/src/widget.test.ts';
+    });
+    mockedReadFileSync.mockReturnValue(makePlanWithTests(['src/widget.test.ts']));
+
+    const result = handleSpecCoverageCheck({ planFile: '/repo/plan.md', repoRoot: '/repo' });
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      passed: boolean;
+      indeterminate: readonly string[];
+      report: string;
+    };
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+    expect(data.passed).toBe(false);
+    expect(data.indeterminate).toHaveLength(1);
+    expect(data.indeterminate[0]).toBeTruthy();
+    expect(data.report).toContain('INDETERMINATE');
+  });
+
+  it('SpecCoverage_RunnerNeverStarts_IsIndeterminate_NotAFailingTest', () => {
+    // ENOENT: the command could not be launched, so it decided nothing about
+    // the declared tests. Reporting it as a test failure sends the reader off
+    // to fix tests that were never executed.
+    mockedExistsSync.mockImplementation(nodeRepoFs('/repo/src/widget.test.ts'));
+    mockedReadFileSync.mockImplementation(
+      planAndManifest(makePlanWithTests(['src/widget.test.ts'])),
+    );
+    mockedExecFileSync.mockImplementation(() => {
+      throw spawnFailure('ENOENT');
+    });
+
+    const result = handleSpecCoverageCheck({ planFile: '/repo/plan.md', repoRoot: '/repo' });
+
+    const data = result.data as {
+      passed: boolean;
+      indeterminate: readonly string[];
+      report: string;
+    };
+    expect(data.passed).toBe(false);
+    expect(data.indeterminate).toHaveLength(1);
+    expect(data.indeterminate[0]).toContain('ENOENT');
+    expect(data.report).toContain('INDETERMINATE');
+    // Discriminating: an unmeasured leg is NOT counted among the failures.
+    expect(data.report).not.toContain('**Result: FAIL**');
+  });
+
+  it('SpecCoverage_RunnerTimesOut_IsIndeterminate_NotAFailingTest', () => {
+    mockedExistsSync.mockImplementation(nodeRepoFs('/repo/src/widget.test.ts'));
+    mockedReadFileSync.mockImplementation(
+      planAndManifest(makePlanWithTests(['src/widget.test.ts'])),
+    );
+    mockedExecFileSync.mockImplementation(() => {
+      throw spawnFailure('ETIMEDOUT');
+    });
+
+    const result = handleSpecCoverageCheck({ planFile: '/repo/plan.md', repoRoot: '/repo' });
+
+    const data = result.data as {
+      passed: boolean;
+      indeterminate: readonly string[];
+      report: string;
+    };
+    expect(data.passed).toBe(false);
+    expect(data.indeterminate).toHaveLength(1);
+    expect(data.indeterminate[0]).toContain('time limit');
+    expect(data.report).toContain('INDETERMINATE');
   });
 
   // ─── 6. Plan file not found ───────────────────────────────────────────
@@ -549,15 +688,10 @@ describe('handleSpecCoverageCheck — post-implementation phase (WFQ-010)', () =
   it('postImplementationPhase_FilesExistAndPass_Passes', () => {
     // Exit proof (b, positive): once the files exist and their tests really
     // run and pass, the post-implementation phase passes.
-    mockedExistsSync.mockImplementation((p: unknown) => {
-      const path = String(p);
-      if (path === '/repo/plan.md') return true;
-      if (path === '/repo') return true;
-      if (path === '/repo/src/widget.test.ts') return true;
-      if (path === '/repo/src/utils.test.ts') return true;
-      return false;
-    });
-    mockedReadFileSync.mockReturnValue(PLAN_WITH_TWO_TESTS);
+    mockedExistsSync.mockImplementation(
+      nodeRepoFs('/repo/src/widget.test.ts', '/repo/src/utils.test.ts'),
+    );
+    mockedReadFileSync.mockImplementation(planAndManifest(PLAN_WITH_TWO_TESTS));
     mockedExecFileSync.mockReturnValue(Buffer.from(''));
 
     const result = handleSpecCoverageCheck({
@@ -568,28 +702,19 @@ describe('handleSpecCoverageCheck — post-implementation phase (WFQ-010)', () =
 
     expect(result.success).toBe(true);
     expect((result.data as { passed: boolean }).passed).toBe(true);
-    // Real execution happened for both declared tests.
-    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+    // Real execution happened — once, over the repository's own suite.
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('postImplementationPhase_FilesExistButTestsFail_Fails', () => {
     // Post-implementation stays honest: present files whose tests do NOT pass
     // still fail.
-    mockedExistsSync.mockImplementation((p: unknown) => {
-      const path = String(p);
-      if (path === '/repo/plan.md') return true;
-      if (path === '/repo') return true;
-      if (path === '/repo/src/widget.test.ts') return true;
-      if (path === '/repo/src/utils.test.ts') return true;
-      return false;
-    });
-    mockedReadFileSync.mockReturnValue(PLAN_WITH_TWO_TESTS);
-    mockedExecFileSync.mockImplementation((_cmd: unknown, args?: unknown) => {
-      const argsArr = args as readonly string[];
-      if (argsArr && argsArr.some((a: string) => a.includes('utils.test.ts'))) {
-        throw new Error('Test failed');
-      }
-      return Buffer.from('');
+    mockedExistsSync.mockImplementation(
+      nodeRepoFs('/repo/src/widget.test.ts', '/repo/src/utils.test.ts'),
+    );
+    mockedReadFileSync.mockImplementation(planAndManifest(PLAN_WITH_TWO_TESTS));
+    mockedExecFileSync.mockImplementation(() => {
+      throw exitFailure(1);
     });
 
     const result = handleSpecCoverageCheck({

--- a/tests/unit/verbs/gates/static-analysis.parity.test.ts
+++ b/tests/unit/verbs/gates/static-analysis.parity.test.ts
@@ -36,6 +36,11 @@ import * as path from 'node:path';
 const mockRunStaticAnalysis = vi.fn();
 vi.mock('../../../../src/verbs/pure/static-analysis.js', () => ({
   runStaticAnalysis: (...args: unknown[]) => mockRunStaticAnalysis(...args),
+  // The handler composes the pure module's runner rather than declaring one of
+  // its own, so the mock has to supply it — an omission here fails the import,
+  // not the assertion, which is the right way round. It is never called: the
+  // mocked `runStaticAnalysis` above is what would have used it.
+  execCommandRunner: () => ({ exitCode: 0, stdout: '', stderr: '' }),
 }));
 
 import { EventStore } from '../../../../src/events/store.js';

--- a/tests/unit/verbs/gates/test-adequacy.handler.test.ts
+++ b/tests/unit/verbs/gates/test-adequacy.handler.test.ts
@@ -79,6 +79,9 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
         taskId: 'T-01',
         branch: 'feature/x',
         repoRoot: '/fake/repo',
+        // Explicit, so the case measures routing rather than whether this
+        // machine's checkout happens to have an `origin/HEAD`.
+        baseBranch: 'main',
       },
       ctx,
     );
@@ -125,6 +128,7 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
         featureId: 'feat-nonew',
         taskId: 'T-nonew',
         repoRoot: '/fake/repo',
+        baseBranch: 'main',
       },
       ctx,
     );
@@ -167,6 +171,9 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
         featureId: 'feat-oneshot',
         taskId: 'T-oneshot',
         repoRoot: '/fake/repo',
+        // Explicit: without it the gate stops at base resolution and the probe
+        // verdict this case is about is never reached.
+        baseBranch: 'main',
       },
       // Provide projectConfig so config-aware severity resolution engages.
       { ...ctx, projectConfig: DEFAULTS } as DispatchContext,
@@ -192,6 +199,7 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
       taskId: 'T-02',
       branch: 'feature/idem',
       repoRoot: '/fake/repo',
+      baseBranch: 'main',
       operationId: 'op-fixed-123',
     };
 
@@ -207,5 +215,72 @@ describe('check_test_adequacy routing + idempotency (task 014)', () => {
         (e.data as { gateName?: string }).gateName === 'test-adequacy',
     );
     expect(gateEvents).toHaveLength(0);
+  });
+
+  it('CheckTestAdequacy_UnresolvedBase_IsDiffFailed_AndNeverProbes', async () => {
+    // `/fake/repo` is not a repository, so no default branch can be detected
+    // and no explicit one was supplied. The probe reverts source hunks derived
+    // from a diff — with no base there is no diff, so running it would probe an
+    // empty change set and report a clean kill probe that never happened.
+    const ctx = await makeCtx();
+
+    const result = await handleOrchestrate(
+      {
+        action: 'check_test_adequacy',
+        featureId: 'feat-nobase',
+        taskId: 'T-nobase',
+        repoRoot: '/fake/repo',
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      passed: boolean;
+      skipped?: boolean;
+      disposition?: string;
+      discriminant?: string;
+      report?: string;
+    };
+    expect(mockRunProbe).not.toHaveBeenCalled();
+
+    // The cause is named in the gate's OWN vocabulary. `diff-failed` is one of
+    // the four discriminants `INDETERMINATE_HANDLING` is total over, so the
+    // per-cause tier policy already rules on it; minting a discriminant of our
+    // own would put a second, unruled spelling of "could not run" beside the
+    // four the policy is defined over.
+    expect(data.discriminant).toBe('diff-failed');
+    expect(data.report).toContain('no default branch');
+
+    // And the ruling is that ruling, not a softer one invented here: a diff the
+    // gate could not compute is an execution failure of a probe that was
+    // supposed to run, so it blocks at EVERY tier and is never an advisory skip.
+    expect(data.disposition).toBe('blocked');
+    expect(data.passed).toBe(false);
+    expect(data.skipped).toBeUndefined();
+  });
+
+  it('CheckTestAdequacy_UnresolvedBase_BlocksEvenAtTheLowestTier', async () => {
+    // The tier axis is where an unmeasured obligation usually degrades to an
+    // advisory skip. `diff-failed` is declared `always-blocking`, so it must not
+    // — and pinning the low tier is what proves the handler routed through the
+    // policy rather than reproducing part of it.
+    const ctx = await makeCtx();
+
+    const result = await handleOrchestrate(
+      {
+        action: 'check_test_adequacy',
+        featureId: 'feat-nobase-low',
+        taskId: 'T-nobase-low',
+        repoRoot: '/fake/repo',
+        riskTier: 'low',
+      },
+      ctx,
+    );
+
+    const data = result.data as { passed: boolean; disposition?: string; skipped?: boolean };
+    expect(data.disposition).toBe('blocked');
+    expect(data.passed).toBe(false);
+    expect(data.skipped).toBeUndefined();
   });
 });

--- a/tests/unit/verbs/gates/test-adequacy.integration.test.ts
+++ b/tests/unit/verbs/gates/test-adequacy.integration.test.ts
@@ -129,6 +129,10 @@ describe('check_test_adequacy acceptance (kill probe through handleOrchestrate)'
         taskId: 'T-01',
         branch,
         repoRoot,
+        // The fixture repo is `git init`ed with no remote, so nothing can
+        // DETECT a default branch. The caller knows it and says so — which is
+        // the precedence the resolver encodes, not a workaround for it.
+        baseBranch: 'main',
       },
       ctx,
     );

--- a/tests/unit/verbs/gates/test-adequacy.parity.test.ts
+++ b/tests/unit/verbs/gates/test-adequacy.parity.test.ts
@@ -48,6 +48,9 @@ const PARITY_ARGS = {
   taskId: 'T-parity',
   branch: 'feature/parity',
   repoRoot: PARITY_REPO_ROOT,
+  // Explicit, so both arms measure the same subject regardless of whether the
+  // machine running them has an `origin/HEAD` to detect.
+  baseBranch: 'main',
 } as const;
 
 function makePassResult() {

--- a/tests/unit/verbs/gates/test-adequacy.toolchain-globs.test.ts
+++ b/tests/unit/verbs/gates/test-adequacy.toolchain-globs.test.ts
@@ -97,6 +97,8 @@ describe('check_test_adequacy toolchain test-glob threading (FIX-3)', () => {
           taskId: 'T-py',
           branch: 'feature/py',
           repoRoot,
+          // The fixture repo has no remote, so the base cannot be detected.
+          baseBranch: 'main',
           runTests,
         },
         ctx,

--- a/tests/unit/verbs/gates/unscoped-gate-emission.test.ts
+++ b/tests/unit/verbs/gates/unscoped-gate-emission.test.ts
@@ -1,0 +1,221 @@
+// ─── An unscoped gate still records its verdict ──────────────────────────────
+//
+// Every gate here declares `gate.executed` with `condition: 'always'`. That is a
+// promise about the HANDLER: run it to completion and the row lands. The
+// post-dispatch emission verifier reads the promise back off the registration
+// after the handler returns and reports the difference, so a handler that
+// returns `success: true` down a new early-exit — without appending — is drift
+// between the declaration and the implementation, and it blocks under the
+// default enforcement mode.
+//
+// The early exit in question is "no diff base could be detected". It is a
+// VERDICT (indeterminate), not an absence: the gate was invoked, it ran, and it
+// concluded that it could not scope its subject. Without a row, the durable log
+// cannot tell that from a gate nobody ever called — which is the same class of
+// hole the base-branch literal left behind, one layer further in.
+//
+// Two production shapes reach the same obligation and both are covered here:
+// the three quality gates that append through `emitGateEvent` directly, and the
+// three per-task ladder gates whose row is minted by the canonical runner from
+// the evidence record. The runner path is the one that would silently regress
+// if a future edit moved the base check outside `executeProvider`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createInMemoryResolver } from '../../../../src/workflow/capabilities/resolver.js';
+import {
+  deriveMcpCallerIdentity,
+  snapshotCallerAuthorization,
+} from '../../../../src/dispatch/caller-identity.js';
+import {
+  mintDispatchContext,
+  runWithDispatchContext,
+} from '../../../../src/dispatch/dispatch-context.js';
+import type { EventStore } from '../../../../src/events/store.js';
+import type { WorkflowEvent } from '../../../../src/events/schemas.js';
+import type { ToolResult } from '../../../../src/format.js';
+import { normalizeGateVerdict } from '../../../../src/verbs/gates/gate-utils.js';
+import { handleContextEconomy } from '../../../../src/verbs/gates/context-economy.js';
+import { handleOperationalResilience } from '../../../../src/verbs/gates/operational-resilience.js';
+import { handleWorkflowDeterminism } from '../../../../src/verbs/gates/workflow-determinism.js';
+import { handleContractDrift } from '../../../../src/verbs/gates/contract-drift-handler.js';
+import { handleMockBoundary } from '../../../../src/verbs/gates/mock-boundary-handler.js';
+import { handleTestAdequacy } from '../../../../src/verbs/gates/test-adequacy-handler.js';
+
+const FEATURE_ID = 'feature-unscoped';
+const TASK_ID = 'task-unscoped';
+const PHASE_ATTEMPT = 'phase-attempt:implement-unscoped';
+
+/** The minimum store the handlers and the canonical runner read and write. */
+class RecordingStore {
+  readonly events: WorkflowEvent[] = [];
+
+  constructor() {
+    this.events.push({
+      id: 'seed-event',
+      streamId: FEATURE_ID,
+      sequence: 1,
+      type: 'workflow.started',
+      timestamp: '2026-08-22T00:00:00.000Z',
+      data: {
+        featureId: FEATURE_ID,
+        workflowType: 'feature',
+        phaseAttemptId: PHASE_ATTEMPT,
+      },
+    } as unknown as WorkflowEvent);
+  }
+
+  async query(
+    streamId: string,
+    filters?: { readonly type?: string },
+  ): Promise<WorkflowEvent[]> {
+    return this.events.filter(
+      (event) =>
+        event.streamId === streamId &&
+        (filters?.type === undefined || event.type === filters.type),
+    );
+  }
+
+  async append(
+    streamId: string,
+    event: Omit<WorkflowEvent, 'id' | 'streamId' | 'sequence'>,
+  ): Promise<WorkflowEvent> {
+    const persisted = {
+      ...event,
+      id: `event-${this.events.length + 1}`,
+      streamId,
+      sequence: this.events.length + 1,
+      timestamp: event.timestamp ?? '2026-08-22T00:01:00.000Z',
+    } as unknown as WorkflowEvent;
+    this.events.push(persisted);
+    return persisted;
+  }
+}
+
+function trustedContext(sessionId: string) {
+  const identity = deriveMcpCallerIdentity({ sessionId });
+  return mintDispatchContext(
+    undefined,
+    snapshotCallerAuthorization(
+      identity,
+      createInMemoryResolver(['fs:read', 'fs:write', 'shell:exec']),
+    ),
+  );
+}
+
+type GateId =
+  | 'context-economy'
+  | 'operational-resilience'
+  | 'workflow-determinism'
+  | 'contract-drift'
+  | 'mock-boundary'
+  | 'test-adequacy';
+
+/**
+ * Every gate that resolves a diff base and can conclude it has none.
+ *
+ * `check_static_analysis` is deliberately absent: it lints and typechecks the
+ * tree it was pointed at, so the base is a LABEL on its evidence rather than a
+ * range it reads. It withholds the label and still runs, so it has no
+ * inconclusive exit to cover here. `check_integration_suite` is likewise out of
+ * scope for this file.
+ */
+const GATES: readonly GateId[] = [
+  'context-economy',
+  'operational-resilience',
+  'workflow-determinism',
+  'contract-drift',
+  'mock-boundary',
+  'test-adequacy',
+];
+
+describe('a gate that cannot scope itself still records the verdict', () => {
+  const dirs: string[] = [];
+  let repoRoot: string;
+  let stateDir: string;
+  let store: RecordingStore;
+
+  beforeEach(async () => {
+    // Not a repository and not inside one, so no rung of the detection ladder
+    // can answer — the production shape of the case, without a fixture repo.
+    repoRoot = await mkdtemp(join(tmpdir(), 'unscoped-repo-'));
+    stateDir = await mkdtemp(join(tmpdir(), 'unscoped-state-'));
+    dirs.push(repoRoot, stateDir);
+    store = new RecordingStore();
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function run(gate: GateId): Promise<ToolResult> {
+    const eventStore = store as unknown as EventStore;
+    // NOTE: no `baseBranch` anywhere below — that omission is the subject.
+    const common = { featureId: FEATURE_ID, taskId: TASK_ID, repoRoot };
+    const invoke = async (): Promise<ToolResult> => {
+      switch (gate) {
+        case 'context-economy':
+          return handleContextEconomy(common, stateDir, eventStore);
+        case 'operational-resilience':
+          return handleOperationalResilience(common, stateDir, eventStore);
+        case 'workflow-determinism':
+          return handleWorkflowDeterminism(common, stateDir, eventStore);
+        case 'contract-drift':
+          return handleContractDrift(common, stateDir, eventStore);
+        case 'mock-boundary':
+          return handleMockBoundary(common, stateDir, eventStore);
+        case 'test-adequacy':
+          return handleTestAdequacy(common, stateDir, eventStore);
+      }
+    };
+    return await runWithDispatchContext(trustedContext(`unscoped-${gate}`), invoke);
+  }
+
+  function gateRows(): WorkflowEvent[] {
+    return store.events.filter((event) => event.type === 'gate.executed');
+  }
+
+  it.each(GATES)('UnscopedRun_StillAppendsGateExecuted [%s]', async (gate) => {
+    const result = await run(gate);
+
+    // The handler completed, so the unconditional contract applies to it.
+    expect(result.success).toBe(true);
+    expect(
+      gateRows().length,
+      `${gate} returned success without the gate.executed it declares ` +
+        "with condition 'always' — the emission verifier reads that as drift",
+    ).toBe(1);
+  });
+
+  it.each(GATES)('UnscopedRun_NeverMintsProof [%s]', async (gate) => {
+    const result = await run(gate);
+
+    // Fail-closed on the wire: admission requires `passed === true`, so an
+    // unscoped run can never discharge an obligation.
+    expect((gateRows()[0]?.data as { passed?: boolean } | undefined)?.passed).toBe(false);
+    // And never a pass in the proof vocabulary either. `fail` is acceptable for
+    // a gate whose own policy classes an uncomputable diff as an execution
+    // failure; `pass` is not acceptable for any of them.
+    expect(normalizeGateVerdict(result)).not.toBe('pass');
+  });
+
+  it('TheRowSaysWhy_SoAnUnscopedRunIsNotAnOrdinaryFailure', async () => {
+    // Without this the fail-closed row above is indistinguishable from a gate
+    // that ran and found a real fault, which would send an operator hunting for
+    // a defect instead of a missing `origin/HEAD`.
+    await run('context-economy');
+
+    const details = (gateRows()[0]?.data as { details?: Record<string, unknown> })?.details;
+    expect(details).toMatchObject({
+      skipped: true,
+      discriminant: 'base-branch-unresolved',
+    });
+    expect(String(details?.['reason'])).toContain('no default branch');
+  });
+});

--- a/tests/unit/verbs/gates/verify-worktree-baseline.test.ts
+++ b/tests/unit/verbs/gates/verify-worktree-baseline.test.ts
@@ -13,6 +13,7 @@ vi.mock('node:child_process', () => ({
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { handleVerifyWorktreeBaseline } from '../../../../src/verbs/gates/verify-worktree-baseline.js';
+import { BUILTIN_TOOLCHAINS } from '../../../../src/config/toolchains.js';
 
 // Helper: package.json contents declaring a `test:run` script (required by the
 // resolver's npm code path).
@@ -215,7 +216,10 @@ describe('handleVerifyWorktreeBaseline', () => {
 
     expect(result.success).toBe(true);
     const data = result.data as { passed: boolean; projectType: string; testCommand: string };
-    expect(data.projectType).toBe('Node.js (bun)');
+    // The label is the registry's toolchain label. The package manager is not
+    // a separate project TYPE — it is visible on the command, which the report
+    // prints on its own line.
+    expect(data.projectType).toBe('Node.js');
     expect(data.testCommand).toBe('bun test');
     const calls = vi.mocked(execFileSync).mock.calls;
     const bunCall = calls.find((c) => String(c[0]).replace(/\.cmd$/, '') === 'bun');
@@ -255,8 +259,10 @@ describe('handleVerifyWorktreeBaseline', () => {
     expect(result.success).toBe(true);
     const data = result.data as { passed: boolean; projectType: string; testCommand: string };
     expect(data.passed).toBe(true);
-    // pytest is in the built-in label set, so the projectType is recognized.
-    expect(data.projectType).toBe('Python');
+    // No Python marker is on disk — the command came from configuration alone,
+    // so the label says exactly that instead of inferring an ecosystem from the
+    // spelling of a command string.
+    expect(data.projectType).toBe('Configured (.exarchos.yml)');
     expect(data.testCommand).toBe('pytest');
   });
 
@@ -494,10 +500,114 @@ describe('handleVerifyWorktreeBaseline', () => {
 
     expect(result.success).toBe(true);
     const data = result.data as { passed: boolean; projectType: string; testCommand: string };
-    expect(data.projectType).toBe('Node.js (pnpm)');
+    expect(data.projectType).toBe('Node.js');
     expect(data.testCommand).toBe('pnpm test');
     const calls = vi.mocked(execFileSync).mock.calls;
     const pnpmCall = calls.find((c) => String(c[0]).replace(/\.cmd$/, '') === 'pnpm');
     expect(pnpmCall?.[1]).toEqual(['test']);
+  });
+
+  it('WorktreeBaseline_LabelComesFromTheRegistry_NotStringEquality', async () => {
+    // A Go worktree. `go test ./...` was in none of the seven command literals
+    // the label used to be derived from, so this repository — detected, runnable
+    // and named by the registry — used to be reported as "Override".
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p).replace(/\\/g, '/').replace(/^[A-Za-z]:/, '');
+      return s === '/worktree' || s === '/worktree/go.mod';
+    });
+    vi.mocked(readdirSync).mockReturnValue([]);
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      throw new Error(`unexpected readFileSync: ${String(p)}`);
+    });
+    vi.mocked(execFileSync).mockReturnValue('ok\n');
+
+    const result = await handleVerifyWorktreeBaseline({ worktreePath: '/worktree' }, stateDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { passed: boolean; projectType: string; testCommand: string };
+    expect(data.projectType).toBe('Go');
+    expect(data.testCommand).toBe('go test ./...');
+  });
+
+  it('WorktreeBaseline_UnknownProjectMessage_NamesEveryRegistryMarker', async () => {
+    // The "nothing recognized here" message used to list four marker files out
+    // of the registry's whole set, so eight ecosystems were told to look for
+    // files that had nothing to do with them.
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p).replace(/\\/g, '/').replace(/^[A-Za-z]:/, '');
+      return s === '/worktree';
+    });
+    vi.mocked(readdirSync).mockReturnValue([]);
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      throw new Error(`unexpected readFileSync: ${String(p)}`);
+    });
+    vi.mocked(execFileSync).mockReturnValue('.git\n');
+
+    const result = await handleVerifyWorktreeBaseline({ worktreePath: '/worktree' }, stateDir);
+
+    expect(result.success).toBe(false);
+    const message = result.error?.message ?? '';
+
+    // Non-empty-denominator floor. The loop below is a nested iteration over a
+    // live import: an emptied or renamed registry makes it iterate zero times
+    // and the test passes having asserted nothing. These two pin the
+    // denominator so the cover is a cover of something.
+    const markers = [...new Set(BUILTIN_TOOLCHAINS.flatMap((tc) => tc.markers))];
+    expect(BUILTIN_TOOLCHAINS.length).toBeGreaterThanOrEqual(12);
+    expect(markers.length).toBeGreaterThanOrEqual(BUILTIN_TOOLCHAINS.length);
+
+    for (const marker of markers) {
+      expect(message).toContain(marker);
+    }
+  });
+
+  // ─── A run that produced no verdict is not a failing baseline ──────────
+
+  it('WorktreeBaseline_RunnerNeverStarts_IsIndeterminate_NotFail', async () => {
+    // ENOENT carries no numeric exit status: the process never started, so it
+    // established nothing about this worktree's baseline. Reporting it as FAIL
+    // sends the caller off to fix tests that were never run.
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p).replace(/\\/g, '/').replace(/^[A-Za-z]:/, '');
+      return s === '/worktree' || s === '/worktree/Cargo.toml';
+    });
+    vi.mocked(readdirSync).mockReturnValue([]);
+    vi.mocked(execFileSync).mockImplementation((cmd: unknown) => {
+      if (String(cmd) === 'git') return '.git\n';
+      throw Object.assign(new Error('spawnSync cargo ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = await handleVerifyWorktreeBaseline({ worktreePath: '/worktree' }, stateDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { passed: boolean; status: string; reason?: string; report: string };
+    expect(data.status).toBe('indeterminate');
+    expect(data.passed).toBe(false);
+    expect(data.reason).toContain('ENOENT');
+    expect(data.report).toContain('INDETERMINATE');
+    expect(data.report).not.toContain('**Result: FAIL**');
+  });
+
+  it('WorktreeBaseline_RunnerNonZeroExit_IsStillAFailingBaseline', async () => {
+    // Discriminating twin: a runner that RAN and exited non-zero is a real
+    // failing baseline and must stay one.
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p).replace(/\\/g, '/').replace(/^[A-Za-z]:/, '');
+      return s === '/worktree' || s === '/worktree/Cargo.toml';
+    });
+    vi.mocked(readdirSync).mockReturnValue([]);
+    vi.mocked(execFileSync).mockImplementation((cmd: unknown) => {
+      if (String(cmd) === 'git') return '.git\n';
+      throw Object.assign(new Error('test failures'), { status: 101, stdout: 'boom' });
+    });
+
+    const result = await handleVerifyWorktreeBaseline({ worktreePath: '/worktree' }, stateDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { passed: boolean; status: string; report: string };
+    expect(data.status).toBe('fail');
+    expect(data.passed).toBe(false);
+    expect(data.report).toContain('**Result: FAIL**');
+    expect(data.report).toContain('101');
   });
 });

--- a/tests/unit/verbs/gates/verify-worktree.test.ts
+++ b/tests/unit/verbs/gates/verify-worktree.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { ToolResult } from '../../../../src/format.js';
+import type { GitExec } from '../../../../src/verbs/pure/execute-merge.js';
 import { toPosix } from '../../../../src/utils/paths.js';
 
 vi.mock('node:fs');
@@ -21,7 +22,7 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
-// ─── Helper ──────────────────────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function mockDirExists(dirPath: string): void {
   const resolved = resolvedOf(dirPath);
@@ -34,40 +35,152 @@ function mockDirExists(dirPath: string): void {
   });
 }
 
+interface GitCall {
+  readonly dir: string;
+  readonly args: readonly string[];
+}
+
+/**
+ * A `git rev-parse --is-inside-work-tree --git-dir --git-common-dir` stub.
+ * `gitDir === commonDir` is the main checkout; differing paths are a linked
+ * worktree — exactly the distinction the handler reads.
+ */
+function stubRevParse(
+  lines: readonly string[],
+  calls: GitCall[] = [],
+  exitCode = 0,
+): GitExec {
+  return (dir, args) => {
+    calls.push({ dir, args: [...args] });
+    return { stdout: `${lines.join('\n')}\n`, exitCode };
+  };
+}
+
+const linkedWorktree = (repo: string, name: string): readonly string[] => [
+  'true',
+  `${repo}/.git/worktrees/${name}`,
+  `${repo}/.git`,
+];
+
+const mainCheckout = (): readonly string[] => ['true', '.git', '.git'];
+
+function dataOf(result: ToolResult): { passed: boolean; path: string; message: string } {
+  return result.data as { passed: boolean; path: string; message: string };
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('handleVerifyWorktree', () => {
-  it('returns passed when path is inside a worktree', async () => {
-    const worktreePath = '/foo/.worktrees/task-001/bar';
+  it('ClaudeWorktreesLayout_IsRecognized', async () => {
+    // The harness's own layout. The retired predicate tested for a
+    // `.worktrees/` substring, which this path does not contain — the gate
+    // aborted from inside a real worktree.
+    const worktreePath = '/repo/.claude/worktrees/feature-x';
+    expect(worktreePath.includes('.worktrees/')).toBe(false);
     mockDirExists(worktreePath);
 
-    const result: ToolResult = await handleVerifyWorktree({ cwd: worktreePath }, STATE_DIR);
+    const result = await handleVerifyWorktree(
+      { cwd: worktreePath },
+      STATE_DIR,
+      stubRevParse(linkedWorktree('/repo', 'feature-x')),
+    );
 
     expect(result.success).toBe(true);
-    const data = result.data as { passed: boolean; path: string; message: string };
+    const data = dataOf(result);
     expect(data.passed).toBe(true);
     expect(data.path).toBe(resolvedOf(worktreePath));
     expect(data.message).toContain('worktree');
   });
 
-  it('returns failed when path is not in a worktree', async () => {
-    const regularPath = '/foo/bar';
-    mockDirExists(regularPath);
+  it('MainCheckout_IsNotAWorktree', async () => {
+    const repoPath = '/repo';
+    mockDirExists(repoPath);
 
-    const result: ToolResult = await handleVerifyWorktree({ cwd: regularPath }, STATE_DIR);
+    const result = await handleVerifyWorktree(
+      { cwd: repoPath },
+      STATE_DIR,
+      stubRevParse(mainCheckout()),
+    );
 
     expect(result.success).toBe(true);
-    const data = result.data as { passed: boolean; path: string; message: string };
+    const data = dataOf(result);
     expect(data.passed).toBe(false);
-    expect(data.path).toBe(resolvedOf(regularPath));
     expect(data.message).toContain('Not in a worktree');
+    expect(data.message).toContain('main checkout');
+  });
+
+  it('MembershipComesFromGit_NotASubstring', async () => {
+    // A path that spells `.worktrees/` but is the main checkout: fails.
+    const spelledLikeAWorktree = '/repo/.worktrees/looks-right';
+    mockDirExists(spelledLikeAWorktree);
+    const calls: GitCall[] = [];
+
+    const spoofed = await handleVerifyWorktree(
+      { cwd: spelledLikeAWorktree },
+      STATE_DIR,
+      stubRevParse(mainCheckout(), calls),
+    );
+    expect(dataOf(spoofed).passed).toBe(false);
+
+    // A path that spells nothing but IS a linked worktree: passes.
+    const unnamedLayout = '/elsewhere/checkouts/wt-7';
+    mockDirExists(unnamedLayout);
+
+    const genuine = await handleVerifyWorktree(
+      { cwd: unnamedLayout },
+      STATE_DIR,
+      stubRevParse(['true', '/repo/.git/worktrees/wt-7', '/repo/.git'], calls),
+    );
+    expect(dataOf(genuine).passed).toBe(true);
+
+    // Both verdicts came from git, asked at the directory under test.
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.args).toContain('rev-parse');
+      expect(call.args).toContain('--git-common-dir');
+    }
+    expect(calls[0]?.dir).toBe(resolvedOf(spelledLikeAWorktree));
+    expect(calls[1]?.dir).toBe(resolvedOf(unnamedLayout));
+  });
+
+  it('returns failed with the git reason when the directory is not in a repository', async () => {
+    const looseDir = '/tmp/loose';
+    mockDirExists(looseDir);
+
+    const result = await handleVerifyWorktree(
+      { cwd: looseDir },
+      STATE_DIR,
+      stubRevParse(['fatal: not a git repository (or any of the parent directories): .git'], [], 128),
+    );
+
+    expect(result.success).toBe(true);
+    const data = dataOf(result);
+    expect(data.passed).toBe(false);
+    expect(data.message).toContain('not a git repository');
+  });
+
+  it('returns failed inside a bare repository', async () => {
+    const bareDir = '/repo.git';
+    mockDirExists(bareDir);
+
+    const result = await handleVerifyWorktree(
+      { cwd: bareDir },
+      STATE_DIR,
+      stubRevParse(['false', '.', '.']),
+    );
+
+    expect(dataOf(result).passed).toBe(false);
   });
 
   it('returns error for non-existent directory', async () => {
     const badPath = '/does/not/exist';
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    const result: ToolResult = await handleVerifyWorktree({ cwd: badPath }, STATE_DIR);
+    const result: ToolResult = await handleVerifyWorktree(
+      { cwd: badPath },
+      STATE_DIR,
+      stubRevParse(mainCheckout()),
+    );
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
@@ -75,26 +188,35 @@ describe('handleVerifyWorktree', () => {
   });
 
   it('defaults to process.cwd() when no cwd arg provided', async () => {
-    const fakeCwd = '/home/user/.worktrees/task-002/project';
+    const fakeCwd = '/home/user/checkouts/task-002';
     vi.spyOn(process, 'cwd').mockReturnValue(fakeCwd);
     mockDirExists(fakeCwd);
 
-    const result: ToolResult = await handleVerifyWorktree({}, STATE_DIR);
+    const result = await handleVerifyWorktree(
+      {},
+      STATE_DIR,
+      stubRevParse(linkedWorktree('/home/user/project', 'task-002')),
+    );
 
     expect(result.success).toBe(true);
-    const data = result.data as { passed: boolean; path: string };
+    const data = dataOf(result);
     expect(data.passed).toBe(true);
-    expect(data.path).toBe(fakeCwd);
+    expect(data.path).toBe(resolvedOf(fakeCwd));
   });
 
   it('resolves relative paths correctly', async () => {
     const resolvedPath = path.resolve('relative/path');
     mockDirExists(resolvedPath);
+    const calls: GitCall[] = [];
 
-    const result: ToolResult = await handleVerifyWorktree({ cwd: 'relative/path' }, STATE_DIR);
+    const result = await handleVerifyWorktree(
+      { cwd: 'relative/path' },
+      STATE_DIR,
+      stubRevParse(mainCheckout(), calls),
+    );
 
     expect(result.success).toBe(true);
-    const data = result.data as { path: string };
-    expect(path.isAbsolute(data.path)).toBe(true);
+    expect(path.isAbsolute(dataOf(result).path)).toBe(true);
+    expect(calls[0]?.dir).toBe(resolvedOf(resolvedPath));
   });
 });

--- a/tests/unit/verbs/gates/workflow-determinism.test.ts
+++ b/tests/unit/verbs/gates/workflow-determinism.test.ts
@@ -35,6 +35,18 @@ import { handleWorkflowDeterminism } from '../../../../src/verbs/gates/workflow-
 
 const STATE_DIR = '/tmp/test-workflow-determinism';
 
+/**
+ * The tests below hand the gate an explicit base so they measure the gate, not
+ * the machine: without one the handler DETECTS the repository's default branch,
+ * and a checkout with no `origin/HEAD` (a CI clone, a fresh worktree) would send
+ * every case down the inconclusive path. The detection path has its own case at
+ * the bottom of each file.
+ */
+const BASE = 'main';
+
+/** A path that is not a git repository, so detection cannot answer. */
+const NO_REPO = '/exarchos-not-a-repository';
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('handleWorkflowDeterminism', () => {
@@ -70,7 +82,7 @@ describe('handleWorkflowDeterminism', () => {
         report: '**Result: PASS** (4/4 checks passed)',
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleWorkflowDeterminism(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -99,7 +111,7 @@ describe('handleWorkflowDeterminism', () => {
         report: '**Result: FINDINGS** (3 findings detected)',
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleWorkflowDeterminism(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(true);
@@ -124,7 +136,7 @@ describe('handleWorkflowDeterminism', () => {
         report: '**Result: PASS** (4/4 checks passed)',
       });
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       await handleWorkflowDeterminism(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(mockEmitGateEvent).toHaveBeenCalledTimes(1);
@@ -145,12 +157,49 @@ describe('handleWorkflowDeterminism', () => {
     it('handleWorkflowDeterminism_GitDiffFails_ReturnsError', async () => {
       mockGetDiff.mockReturnValue(null);
 
-      const args = { featureId: 'feat-1' };
+      const args = { featureId: 'feat-1', baseBranch: BASE };
       const result = await handleWorkflowDeterminism(args, STATE_DIR, mockStore as unknown as EventStore);
 
       expect(result.success).toBe(false);
       expect(result.error?.code).toBe('DIFF_ERROR');
       expect(checkWorkflowDeterminism).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Base-branch resolution ──────────────────────────────────────────────
+
+  describe('base branch', () => {
+    it('handleWorkflowDeterminism_UnresolvedBase_IsInconclusive_NotPass', async () => {
+      const result = await handleWorkflowDeterminism(
+        { featureId: 'feat-1', repoRoot: NO_REPO },
+        STATE_DIR,
+        mockStore as unknown as EventStore,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { passed: boolean; skipped?: boolean; discriminant?: string };
+      expect(data.passed).toBe(false);
+      expect(data.skipped).toBe(true);
+      expect(data.discriminant).toBe('base-branch-unresolved');
+      expect(mockGetDiff).not.toHaveBeenCalled();
+
+      // Indeterminate is a verdict, and this action declares `gate.executed`
+      // UNCONDITIONALLY. A success carrier without it is the drift the
+      // post-dispatch emission verifier reports — and it leaves the durable log
+      // unable to tell an unscoped run from one that never happened.
+      expect(mockEmitGateEvent).toHaveBeenCalledTimes(1);
+      const [, streamId, gateName, layer, passed, details] = mockEmitGateEvent.mock.calls[0]!;
+      expect(streamId).toBe('feat-1');
+      expect(gateName).toBe('workflow-determinism');
+      expect(layer).toBe('quality');
+      // Fail-closed on the wire, and the markers say WHY, so no reader takes it
+      // for a gate that ran and found a fault.
+      expect(passed).toBe(false);
+      expect(details).toMatchObject({
+        skipped: true,
+        discriminant: 'base-branch-unresolved',
+        findingCount: 0,
+      });
     });
   });
 });

--- a/tests/unit/verbs/ladder-gate-evidence.test.ts
+++ b/tests/unit/verbs/ladder-gate-evidence.test.ts
@@ -252,8 +252,14 @@ describe('migrated ladder gate durable evidence', () => {
             runTests: async () => ({ passed: true, output: '' }),
           }, root, eventStore);
         case 'integration-suite':
+          // `testScript` is not decoration: this gate resolves its command from
+          // the repository, and `root` is a bare temp directory, so without a
+          // named script nothing resolves and the stub runner is never reached.
+          // These cases are about the durable-evidence plumbing every ladder gate
+          // shares — command resolution has its own suite — so the fixture names
+          // the script rather than growing a Node project around it.
           return handleCheckIntegrationSuite(
-            common,
+            { ...common, testScript: 'test:run' },
             root,
             eventStore,
             () => ({
@@ -377,6 +383,38 @@ describe('migrated ladder gate durable evidence', () => {
       });
     }
     expect(evidenceEvents()).toHaveLength(1);
+  });
+
+  it('IntegrationSuite_CannotResolveACommand_RecordsIndeterminateNotPass', async () => {
+    // The arm the shared table above cannot express: this gate is the only one
+    // whose carrier omits `passed` entirely. What it must NOT do is record proof.
+    // Nothing downstream turns this verdict into a stop for this gate class, so
+    // the evidence row saying `indeterminate` and the report saying the rung is
+    // not cleared are the whole of what the system has — which is exactly why
+    // they are pinned here rather than assumed.
+    const eventStore = store as unknown as EventStore;
+    const result = await runWithDispatchContext(
+      trustedContext('integration-suite-indeterminate'),
+      () =>
+        handleCheckIntegrationSuite(
+          { featureId, taskId, branch: 'feature/task-008', repoRoot: root },
+          root,
+          eventStore,
+          () => {
+            throw new Error('the runner must never be reached');
+          },
+        ),
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.skipped).toBe(true);
+    expect(data.skipReason).toBe('no-toolchain');
+    expect(data).not.toHaveProperty('passed');
+    expect(String(data.report)).toContain('NOT cleared');
+    expect(evidenceEvents()[0]?.data).toMatchObject({
+      evidence: { verdict: 'indeterminate' },
+    });
   });
 
   it('LadderGate_SameOperationIsIdempotent_NewOperationSupersedes', async () => {

--- a/tests/unit/verbs/prepare-synthesis.production-path.test.ts
+++ b/tests/unit/verbs/prepare-synthesis.production-path.test.ts
@@ -30,7 +30,7 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -73,6 +73,15 @@ function observedExecSyncCommands(): string[] {
   return vi.mocked(execSync).mock.calls.map((call) => String(call[0]));
 }
 
+/** The argv-form legs, rendered as a command line for the same comparison. */
+function observedExecFileCommands(): string[] {
+  return vi
+    .mocked(execFileSync)
+    .mock.calls.map((call) =>
+      [String(call[0]), ...((call[1] ?? []) as readonly string[])].join(' '),
+    );
+}
+
 describe('prepare_synthesis production path (DR-8 / #1756)', () => {
   const cleanups: Array<() => void> = [];
   let ctx: DispatchContext;
@@ -86,8 +95,15 @@ describe('prepare_synthesis production path (DR-8 / #1756)', () => {
     vi.clearAllMocks();
     const stateDir = mkdtempSync(path.join(os.tmpdir(), 'ps-prodpath-state-'));
     cleanups.push(() => rmrf(stateDir));
-    // A tree that is NOT `process.cwd()` — the whole point of the fixture.
+    // A tree that is NOT `process.cwd()` — the whole point of the fixture. It
+    // carries a manifest because the two command legs resolve their commands
+    // from the governed repository's own toolchain; a bare tree resolves
+    // nothing and the legs correctly decline to run.
     repoRoot = mkdtempSync(path.join(os.tmpdir(), 'ps-prodpath-repo-'));
+    writeFileSync(
+      path.join(repoRoot, 'package.json'),
+      JSON.stringify({ scripts: { 'test:run': 'vitest run', typecheck: 'tsc --noEmit' } }),
+    );
     cleanups.push(() => rmrf(repoRoot));
 
     const eventStore = new EventStore(stateDir);
@@ -151,8 +167,10 @@ describe('prepare_synthesis production path (DR-8 / #1756)', () => {
     expect(cwds).not.toContain(process.cwd());
 
     // The named legs, by the command each issues — so a future refactor that
-    // drops one cannot pass on the count alone.
-    const commands = observedExecSyncCommands();
+    // drops one cannot pass on the count alone. The two toolchain legs are argv
+    // spawns of the RESOLVED command (here, the fixture manifest's npm profile);
+    // the git legs are still shell-form.
+    const commands = [...observedExecSyncCommands(), ...observedExecFileCommands()];
     expect(commands).toContain('npm run test:run');
     expect(commands).toContain('npm run typecheck');
     expect(commands.some((c) => c.startsWith('git log '))).toBe(true);

--- a/tests/unit/verbs/pure/command-outcome.test.ts
+++ b/tests/unit/verbs/pure/command-outcome.test.ts
@@ -1,0 +1,104 @@
+// ─── Command Failure Classification Tests ───────────────────────────────────
+//
+// The discriminant these tests pin is the one the gates depend on: a process
+// that EXITED produced a verdict; a process that never started, or was killed
+// at its wall clock, produced none. Every gate in this lane branches on that
+// distinction, so a regression here turns "nothing was measured" back into
+// "something failed" at five call sites at once.
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyCommandFailure,
+  inconclusiveReason,
+} from '../../../../src/verbs/pure/command-outcome.js';
+
+/** An `execFileSync` throw for a process that ran and exited non-zero. */
+function exited(status: number, extra: Record<string, unknown> = {}): unknown {
+  return Object.assign(new Error(`Command failed with exit code ${status}`), {
+    status,
+    ...extra,
+  });
+}
+
+/** An `execFileSync` throw carrying an errno and NO numeric exit status. */
+function errno(code: string, extra: Record<string, unknown> = {}): unknown {
+  return Object.assign(new Error(`spawnSync somecmd ${code}`), { code, ...extra });
+}
+
+describe('classifyCommandFailure', () => {
+  it('NumericStatus_IsAVerdict', () => {
+    const failure = classifyCommandFailure(exited(1));
+    expect(failure.kind).toBe('exit');
+    expect(failure.exitCode).toBe(1);
+  });
+
+  it('NumericStatus_WinsOverAnErrno', () => {
+    // The status is checked FIRST on purpose. A process that exited decided
+    // something, whatever incidental `code` the error also carries.
+    const failure = classifyCommandFailure(exited(2, { code: 'ENOENT' }));
+    expect(failure.kind).toBe('exit');
+    expect(failure.exitCode).toBe(2);
+  });
+
+  it.each(['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR', 'ENOMEM'])(
+    'SpawnErrno_%s_IsNotAVerdict',
+    (code) => {
+      const failure = classifyCommandFailure(errno(code));
+      expect(failure.kind).toBe('spawn');
+      expect(failure.detail).toContain(code);
+    },
+  );
+
+  it('Timeout_IsItsOwnArm_NotASpawnFailure', () => {
+    const failure = classifyCommandFailure(errno('ETIMEDOUT'));
+    expect(failure.kind).toBe('timeout');
+  });
+
+  it('OutputCeilingKill_StaysAVerdict_NotASpawnFailure', () => {
+    // The child DID run; the ceiling killed it afterwards. Folding this into
+    // `spawn` would withdraw a finding the runner really produced.
+    const failure = classifyCommandFailure(errno('ERR_CHILD_PROCESS_STDIO_MAXBUFFER'));
+    expect(failure.kind).toBe('exit');
+  });
+
+  it('CapturesBothStreams_IncludingBuffers', () => {
+    const failure = classifyCommandFailure(
+      exited(1, { stdout: Buffer.from('out'), stderr: 'err' }),
+    );
+    expect(failure.stdout).toBe('out');
+    expect(failure.stderr).toBe('err');
+  });
+
+  it('DetailKeepsOnlyTheFirstMessageLine', () => {
+    const failure = classifyCommandFailure(
+      Object.assign(new Error('boom\nline two\nline three'), { code: 'ENOENT' }),
+    );
+    expect(failure.detail).toBe('ENOENT: boom');
+  });
+
+  it('NonObjectThrow_LandsOnTheVerdictArm', () => {
+    // Total over `unknown`, and conservative: the arm that keeps a finding,
+    // not the arm that withdraws one.
+    const failure = classifyCommandFailure('a bare string');
+    expect(failure.kind).toBe('exit');
+    expect(failure.detail).toBeTruthy();
+  });
+});
+
+describe('inconclusiveReason', () => {
+  it('ExitFailure_HasNoReason', () => {
+    expect(inconclusiveReason('npm test', classifyCommandFailure(exited(1)))).toBeNull();
+  });
+
+  it('SpawnFailure_NamesTheCommandAndTheCause', () => {
+    const reason = inconclusiveReason('cargo test', classifyCommandFailure(errno('ENOENT')));
+    expect(reason).toContain('cargo test');
+    expect(reason).toContain('ENOENT');
+  });
+
+  it('Timeout_SaysItWasKilled_NotThatItFailed', () => {
+    const reason = inconclusiveReason('pytest', classifyCommandFailure(errno('ETIMEDOUT')));
+    expect(reason).toContain('time limit');
+    expect(reason).not.toContain('failed');
+  });
+});

--- a/tests/unit/verbs/pure/integration-suite.test.ts
+++ b/tests/unit/verbs/pure/integration-suite.test.ts
@@ -1,0 +1,417 @@
+// ─── Integration suite: command resolution, carriers and wall clock ──────────
+//
+// The gate resolves the two halves of its invocation from two authorities — the
+// COMMAND from the layered test-runtime resolver, and how to READ its result
+// from the registry's carrier table. These cases pin the seams between them:
+// which argv is composed, which outcome each carrier can honestly produce, and
+// what happens when the runner never reaches a conclusion.
+//
+// The per-toolchain property ("no toolchain receives another toolchain's
+// reporter flag", quantified over the live registry) lives in the acceptance
+// tier beside the end-to-end gate cases.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const runCommandSyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../src/utils/process.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../src/utils/process.js')>();
+  return { ...actual, runCommandSync: runCommandSyncSpy };
+});
+
+import type { Toolchain } from '../../../../src/config/toolchains.js';
+import {
+  execCommandRunner,
+  isTimeoutFailure,
+  INTEGRATION_SUITE_TIMEOUT_MS,
+} from '../../../../src/verbs/gates/check-integration-suite.js';
+import {
+  resolveIntegrationCommand,
+  resolveIntegrationRuntime,
+  runIntegrationSuite,
+  type IntegrationCommandResult,
+  type IntegrationRuntime,
+} from '../../../../src/verbs/pure/integration-suite.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** A toolchain double: `id` decides which carrier row the registry offers. */
+function toolchain(id: string, test: string | null): Toolchain {
+  return {
+    id,
+    projectType: id,
+    markers: [],
+    commands: { test, typecheck: null, install: null, mutation: null, lint: null, contract: null },
+  };
+}
+
+/**
+ * A resolved runtime double. ONE value carries both halves, mirroring the seam,
+ * so a case cannot accidentally describe a repository whose command and identity
+ * disagree — a shape the shipped composition never produces.
+ */
+function runtime(id: string | null, test: string | null): IntegrationRuntime {
+  return { test, toolchain: id === null ? undefined : toolchain(id, test) };
+}
+
+/** Scratch repositories for the cases that exercise the REAL layered resolver. */
+const scratchRoots: string[] = [];
+
+function scratchRepo(files: Readonly<Record<string, string>>): string {
+  const root = mkdtempSync(join(tmpdir(), 'integration-suite-resolver-'));
+  scratchRoots.push(root);
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(root, name), body, 'utf-8');
+  }
+  return root;
+}
+
+afterAll(() => {
+  for (const root of scratchRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const GREEN_JSON = JSON.stringify({
+  numFailedTestSuites: 0,
+  numFailedTests: 0,
+  numTotalTests: 7,
+  testResults: [],
+});
+
+function returning(result: Partial<IntegrationCommandResult>) {
+  return () => ({ exitCode: 0, stdout: '', stderr: '', ...result });
+}
+
+// ─── Command resolution ──────────────────────────────────────────────────────
+
+describe('resolveIntegrationCommand', () => {
+  it('ExplicitScript_TakesPrecedenceAndKeepsTheReporterFlag', () => {
+    const resolution = resolveIntegrationCommand('/repo', 'my:test', () =>
+      runtime('rust', 'cargo test'),
+    );
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect(resolution.cmd).toBe('npm');
+    expect(resolution.args).toEqual(['run', 'my:test', '--', '--reporter=json']);
+  });
+
+  it('ScriptRunner_PutsTheReporterFlagAfterThePassthrough', () => {
+    const resolution = resolveIntegrationCommand('/repo', undefined, () =>
+      runtime('node', 'npm run ws:test'),
+    );
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual([
+      'npm',
+      'run',
+      'ws:test',
+      '--',
+      '--reporter=json',
+    ]);
+  });
+
+  it('NonPackageManagerCommand_AtANodeRepo_IsSpawnedUnaltered', () => {
+    // Contract CHANGED with the layered resolver. The reporter flag used to be
+    // appended to any command a vitest-JSON toolchain produced, on the reasoning
+    // that a `node` row means a vitest runner. That reasoning holds only while
+    // the registry is the sole source of the command; now that an `.exarchos.yml`
+    // entry or a task runner outranks it, the head token is the only evidence of
+    // WHICH runner is being launched. Anything that is not a Node package
+    // manager is spawned exactly as resolved and read by its exit code — the
+    // sound floor, never an unknown flag.
+    const resolution = resolveIntegrationCommand('/repo', undefined, () =>
+      runtime('node', 'vitest run'),
+    );
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['vitest', 'run']);
+    expect(resolution.format.kind).toBe('exit-code-only');
+  });
+
+  it('ExitCodeToolchain_IsSpawnedExactlyAsDeclared', () => {
+    const resolution = resolveIntegrationCommand('/repo', undefined, () =>
+      runtime('go', 'go test ./...'),
+    );
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['go', 'test', './...']);
+    expect(resolution.format.kind).toBe('exit-code-only');
+  });
+
+  it('NoToolchain_IsUnrunnable_NotAnNpmFallback', () => {
+    const resolution = resolveIntegrationCommand('/repo', undefined, () => runtime(null, null));
+    expect(resolution.kind).toBe('unrunnable');
+    if (resolution.kind !== 'unrunnable') return;
+    expect(resolution.skipReason).toBe('no-toolchain');
+    // The old fallback spawned THIS repository's script name at any repository
+    // that failed detection. Nothing may name it here.
+    expect(JSON.stringify(resolution)).not.toContain('test:run');
+  });
+
+  it('ProjectWithNoResolvedTestCommand_IsUnrunnable', () => {
+    // Fixture RE-POINTED, behaviour unchanged: the null now sits on the resolved
+    // runtime rather than on a registry row, because the resolver — not the
+    // registry — is what can fail to produce a command in the shipped path.
+    const resolution = resolveIntegrationCommand('/repo', undefined, () => runtime('go', null));
+    expect(resolution.kind).toBe('unrunnable');
+    if (resolution.kind !== 'unrunnable') return;
+    expect(resolution.skipReason).toBe('no-test-command');
+  });
+
+  it('ResolverRemediation_IsTheReason_NotARestatementOfTheId', () => {
+    const resolution = resolveIntegrationCommand('/repo', undefined, () => ({
+      test: null,
+      toolchain: toolchain('node', 'npm run test:run'),
+      remediation: 'package.json is missing a "test:run" script.',
+    }));
+    expect(resolution.kind).toBe('unrunnable');
+    if (resolution.kind !== 'unrunnable') return;
+    expect(resolution.reason).toBe('package.json is missing a "test:run" script.');
+  });
+
+  it('AThrowingResolver_IsUnrunnable_NotACrash', () => {
+    // An unreadable or schema-invalid `.exarchos.yml` throws inside the layered
+    // resolver. A gate that dies takes its whole runbook step with it and says
+    // less than one that reports it could not resolve a command.
+    const resolution = resolveIntegrationCommand('/repo', undefined, () => {
+      throw new Error('.exarchos.yml: unexpected token');
+    });
+    expect(resolution.kind).toBe('unrunnable');
+    if (resolution.kind !== 'unrunnable') return;
+    expect(resolution.skipReason).toBe('no-test-command');
+    expect(resolution.reason).toContain('unexpected token');
+  });
+
+  it('UnknownToolchainId_IsRunnable_OnTheExitCodeCarrier', () => {
+    // Contract CHANGED. A project declaring its own toolchain in `.exarchos.yml`
+    // used to be `unrunnable`, which withheld a blocking rung from every such
+    // project on the grounds that its carrier is unknown. Unknown carrier means
+    // "ask for nothing and read the exit code", which is sound for any
+    // executable — not "refuse to run".
+    const resolution = resolveIntegrationCommand('/repo', undefined, () =>
+      runtime('acme-runner', 'acme verify'),
+    );
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['acme', 'verify']);
+    expect(resolution.format.kind).toBe('exit-code-only');
+  });
+});
+
+// ─── The command really does come from the LAYERED resolver ──────────────────
+//
+// The seam above is a double; these cases run the shipped `resolveIntegrationRuntime`
+// against real directories, because "routes through the layered resolver" is a
+// claim about the default composition and a double cannot witness it.
+
+describe('resolveIntegrationRuntime (the shipped seam)', () => {
+  it('PnpmRepo_ResolvesPnpm_NotTheRegistrySNpmBaseline', () => {
+    // The false red this lane exists to close: the registry's node row declares
+    // `npm run test:run`, so every pnpm/yarn/bun repository was handed a command
+    // it does not have. The package-manager tier lives in the resolver, and the
+    // gate can only see it by asking the resolver.
+    const repo = scratchRepo({
+      'package.json': JSON.stringify({ name: 'governed', scripts: { test: 'vitest run' } }),
+      'pnpm-lock.yaml': "lockfileVersion: '9.0'\n",
+    });
+    expect(resolveIntegrationRuntime(repo).test).toBe('pnpm test');
+
+    const resolution = resolveIntegrationCommand(repo, undefined);
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual([
+      'pnpm',
+      'test',
+      '--',
+      '--reporter=json',
+    ]);
+  });
+
+  it('ConfigDeclaredCommand_OutranksTheRegistryRow', () => {
+    // `.exarchos.yml` sits above the built-in registry in the layered order. A
+    // gate reading `commands.test` off the detected toolchain never saw it.
+    const repo = scratchRepo({
+      'Cargo.toml': '[package]\nname = "governed"\n',
+      '.exarchos.yml': 'test: cargo nextest run\n',
+    });
+    expect(resolveIntegrationRuntime(repo).test).toBe('cargo nextest run');
+
+    const resolution = resolveIntegrationCommand(repo, undefined);
+    expect(resolution.kind).toBe('runnable');
+    if (resolution.kind !== 'runnable') return;
+    expect([resolution.cmd, ...resolution.args]).toEqual(['cargo', 'nextest', 'run']);
+  });
+
+  it('NodeRepoWithNoTestScript_ProducesTheNoTestCommandArm', () => {
+    // The arm exists because the SHIPPED composition reaches it, not because a
+    // double can be pointed at it: the layered resolver refuses a Node package
+    // with no test script, where reading `commands.test` off the registry row
+    // would have handed back `npm run test:run` and spawned a script the
+    // repository does not have.
+    const repo = scratchRepo({
+      'package.json': JSON.stringify({ name: 'governed', scripts: { build: 'tsc' } }),
+      'package-lock.json': JSON.stringify({ name: 'governed', lockfileVersion: 3 }),
+    });
+    const resolution = resolveIntegrationCommand(repo, undefined);
+    expect(resolution.kind).toBe('unrunnable');
+    if (resolution.kind !== 'unrunnable') return;
+    expect(resolution.skipReason).toBe('no-test-command');
+    expect(resolution.reason).toContain('test:run');
+  });
+
+  it('UnrecognizedDirectory_ResolvesNothing_AndNamesNoCommand', () => {
+    const repo = scratchRepo({ 'README.md': '# nothing here\n' });
+    const resolved = resolveIntegrationRuntime(repo);
+    expect(resolved.test).toBeNull();
+    expect(resolved.toolchain).toBeUndefined();
+
+    const resolution = resolveIntegrationCommand(repo, undefined);
+    expect(resolution.kind).toBe('unrunnable');
+    if (resolution.kind !== 'unrunnable') return;
+    expect(resolution.skipReason).toBe('no-toolchain');
+  });
+});
+
+// ─── What each carrier can honestly conclude ─────────────────────────────────
+
+describe('runIntegrationSuite carriers', () => {
+  it('UnrunnableCommand_NeverSpawnsAnything', () => {
+    const runCommand = vi.fn(returning({}));
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      runCommand,
+      resolveRuntime: () => runtime(null, null),
+    });
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(run.kind).toBe('indeterminate');
+  });
+
+  it('ExitCodeCarrier_SpawnFailure_IsIndeterminate_NotAFailedSuite', () => {
+    // The exit code of a process that never started is not a verdict about a
+    // suite that never ran.
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      resolveRuntime: () => runtime('rust', 'cargo test'),
+      runCommand: returning({ exitCode: 127, spawnError: 'ENOENT' }),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.skipReason).toBe('runner-unavailable');
+  });
+
+  it('VitestCarrier_SpawnFailure_IsIndeterminateToo_NotAFailedSuite', () => {
+    // Contract CHANGED. This carrier used to fail CLOSED on a spawn failure and
+    // mint `passed: false` — a red naming a failure nobody observed, for the
+    // very same event the exit-code carrier already refused to name. Failing
+    // closed is right for a runner that RAN and garbled its report; it is not a
+    // reading of a process that never started.
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      resolveRuntime: () => runtime('node', 'npm run test:run'),
+      runCommand: returning({ exitCode: 127, spawnError: 'ENOENT' }),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.skipReason).toBe('runner-unavailable');
+    expect(run.reason).toContain('ENOENT');
+    expect(run).not.toHaveProperty('passed');
+  });
+
+  it('VitestCarrier_RanButGarbled_StillFailsClosed', () => {
+    // The other half of the split above, kept explicit so the change is a
+    // NARROWING of the fail-closed rule rather than its removal: a runner that
+    // ran and returned zero with unreadable output is still a finding, because a
+    // clean exit is compatible with a crashed reporter.
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      resolveRuntime: () => runtime('node', 'npm run test:run'),
+      runCommand: returning({ exitCode: 0, stdout: 'certainly not json' }),
+    });
+    expect(run.kind).toBe('vitest-counts');
+    if (run.kind !== 'vitest-counts') return;
+    expect(run.passed).toBe(false);
+    expect(run.parseError).toBe(true);
+    expect(run.failCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('VitestCarrier_GreenJson_ParsesTheCounts', () => {
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      resolveRuntime: () => runtime('node', 'npm run test:run'),
+      runCommand: returning({ stdout: GREEN_JSON }),
+    });
+    expect(run.kind).toBe('vitest-counts');
+    if (run.kind !== 'vitest-counts') return;
+    expect(run.passed).toBe(true);
+    expect(run.totalTests).toBe(7);
+  });
+
+  it('ExitCodeCarrier_DoesNotParseStdout', () => {
+    // Whatever a non-vitest runner prints, the exit code is the verdict — the
+    // gate must not try to read counts out of it and must not fail closed for
+    // failing to.
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      resolveRuntime: () => runtime('python', 'pytest'),
+      runCommand: returning({ exitCode: 0, stdout: '===== 12 passed in 0.4s =====' }),
+    });
+    expect(run.kind).toBe('exit-code');
+    if (run.kind !== 'exit-code') return;
+    expect(run.passed).toBe(true);
+  });
+});
+
+// ─── The wall clock ──────────────────────────────────────────────────────────
+
+describe('a runner that never finishes', () => {
+  it('TimedOutRunner_IsIndeterminate_OnTheExitCodeCarrier', () => {
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      resolveRuntime: () => runtime('rust', 'cargo test'),
+      runCommand: returning({ exitCode: 124, timedOut: true }),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.skipReason).toBe('runner-timeout');
+  });
+
+  it('TimedOutRunner_IsIndeterminate_OnTheVitestCarrier', () => {
+    // Truncated stdout would otherwise be read as a garbled reporter and fail
+    // closed, naming a failure nobody observed.
+    const run = runIntegrationSuite({
+      repoRoot: '/repo',
+      resolveRuntime: () => runtime('node', 'npm run test:run'),
+      runCommand: returning({ exitCode: 124, stdout: '{"numFailedTests"', timedOut: true }),
+    });
+    expect(run.kind).toBe('indeterminate');
+    if (run.kind !== 'indeterminate') return;
+    expect(run.skipReason).toBe('runner-timeout');
+  });
+
+  it('TimeoutIsDeclared_NotDefaulted', () => {
+    runCommandSyncSpy.mockReset();
+    runCommandSyncSpy.mockReturnValue('');
+    execCommandRunner('cargo', ['test'], { cwd: '/repo' });
+
+    expect(runCommandSyncSpy).toHaveBeenCalledTimes(1);
+    const options = runCommandSyncSpy.mock.calls[0]?.[2] as { timeout?: number } | undefined;
+    // `execFileSync` has no default timeout: unstated means unbounded.
+    expect(options?.timeout).toBe(INTEGRATION_SUITE_TIMEOUT_MS);
+    expect(INTEGRATION_SUITE_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  it('TimeoutClassification_SeparatesAKillFromAnExitAndFromAMissingCommand', () => {
+    expect(isTimeoutFailure({ code: 'ETIMEDOUT' })).toBe(true);
+    // A process that exited carries a numeric status — it decided something.
+    expect(isTimeoutFailure({ code: 'ETIMEDOUT', status: 1 })).toBe(false);
+    // A command that does not exist is unavailable, not slow.
+    expect(isTimeoutFailure({ code: 'ENOENT' })).toBe(false);
+    expect(isTimeoutFailure({})).toBe(false);
+  });
+});

--- a/tests/unit/verbs/pure/post-merge.test.ts
+++ b/tests/unit/verbs/pure/post-merge.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { checkPostMerge } from '../../../../src/verbs/pure/post-merge.js';
 import type { VcsProvider, CiStatus, CiCheck } from '../../../../src/vcs/provider.js';
 
@@ -251,5 +254,94 @@ describe('checkPostMerge', () => {
 
     expect(result.status).toBe('pass');
     expect(result.passCount).toBe(2);
+  });
+
+  // ─── The test command comes from the toolchain, not from a literal ────
+
+  it('PostMerge_UsesResolvedCommand', async () => {
+    const provider = createMockProvider({ checkCi: { status: 'pass', checks: [] } });
+    const spawned: { cmd: string; args: readonly string[] }[] = [];
+    const testRunner = (cmd: string, args: readonly string[]) => {
+      spawned.push({ cmd, args });
+      return { exitCode: 0, stdout: 'ok', stderr: '' };
+    };
+
+    const result = await checkPostMerge({
+      prUrl: 'https://github.com/org/repo/pull/42',
+      mergeSha: 'abc1234',
+      // This repository resolves through the toolchain registry's node entry.
+      repoRoot: process.cwd(),
+      runCommand: testRunner,
+      provider,
+    });
+
+    expect(result.status).toBe('pass');
+    expect(spawned).toEqual([{ cmd: 'npm', args: ['run', 'test:run'] }]);
+  });
+
+  it('PostMerge_UnresolvedRuntime_IsIndeterminate_NotPass', async () => {
+    const provider = createMockProvider({ checkCi: { status: 'pass', checks: [] } });
+    const runner = vi.fn(() => ({ exitCode: 0, stdout: 'ok', stderr: '' }));
+    const emptyTree = mkdtempSync(join(tmpdir(), 'post-merge-empty-'));
+
+    try {
+      const result = await checkPostMerge({
+        prUrl: 'https://github.com/org/repo/pull/42',
+        mergeSha: 'abc1234',
+        repoRoot: emptyTree,
+        runCommand: runner,
+        provider,
+      });
+
+      // Nothing was spawned, so nothing was verified — and the carrier says so
+      // instead of reporting a clean regression check.
+      expect(runner).not.toHaveBeenCalled();
+      expect(result.status).toBe('indeterminate');
+      expect(result.reason).toBeTruthy();
+      expect(result.report).toContain('INDETERMINATE');
+    } finally {
+      rmSync(emptyTree, { recursive: true, force: true });
+    }
+  });
+
+  // ─── A run that produced no verdict is not a regression ───────────────
+
+  it('PostMerge_RunnerNeverStarts_IsIndeterminate_NotARegression', async () => {
+    const provider = createMockProvider({ checkCi: { status: 'pass', checks: [] } });
+    const result = await checkPostMerge({
+      prUrl: 'https://github.com/org/repo/pull/42',
+      mergeSha: 'abc1234',
+      repoRoot: process.cwd(),
+      runCommand: () => ({
+        exitCode: 127,
+        stdout: '',
+        stderr: '',
+        spawnError: 'ENOENT: spawnSync npm ENOENT',
+      }),
+      provider,
+    });
+
+    expect(result.status).toBe('indeterminate');
+    expect(result.reason).toContain('ENOENT');
+    // Discriminating: no D4 finding is minted from a check that never ran.
+    expect(result.findings).toEqual([]);
+    expect(result.report).toContain('INDETERMINATE');
+  });
+
+  it('PostMerge_RunnerTimesOut_IsIndeterminate_NotARegression', async () => {
+    const provider = createMockProvider({ checkCi: { status: 'pass', checks: [] } });
+    const result = await checkPostMerge({
+      prUrl: 'https://github.com/org/repo/pull/42',
+      mergeSha: 'abc1234',
+      repoRoot: process.cwd(),
+      // A killed runner: the non-zero status belongs to the kill, and the
+      // truncated stdout says nothing about the suite.
+      runCommand: () => ({ exitCode: 124, stdout: 'partial', stderr: '', timedOut: true }),
+      provider,
+    });
+
+    expect(result.status).toBe('indeterminate');
+    expect(result.reason).toContain('time limit');
+    expect(result.findings).toEqual([]);
   });
 });

--- a/tests/unit/verbs/pure/static-analysis.parity.test.ts
+++ b/tests/unit/verbs/pure/static-analysis.parity.test.ts
@@ -11,10 +11,8 @@ import type { RunCommandFn, CommandResult } from '../../../../src/verbs/pure/sta
  *   - exit 0 → all checks pass, exit 1 → one or more fail
  *   - Missing scripts → SKIP (not counted in pass/fail totals)
  *
- * T-09 / DR-6 DEVIATION FROM BASH PARITY (deliberate, spec-mandated):
+ * DELIBERATE DEVIATION FROM BASH PARITY:
  *   The bash script let a SKIPped constituent leave the aggregate at PASS —
- *   that is precisely the defect DR-6 names
- *   (docs/specs/2026-08-04-wiring-closure-and-unified-integration-suite.md):
  *   `PASS (2/2)` rendered while `lint` and `quality-check` were silently
  *   skipped for absence of a script. Parity with the retired bash script is
  *   NO LONGER preserved for that case. A SKIP is now tallied first-class and
@@ -23,7 +21,24 @@ import type { RunCommandFn, CommandResult } from '../../../../src/verbs/pure/sta
  *   retained for the PASS (nothing skipped), FAIL and error cases.
  */
 
-// Mock node:fs so readPackageJson can resolve package.json without disk access
+// Mock node:fs so readPackageJson can resolve package.json without disk access.
+//
+// The fixture is a repository holding a package.json AND NOTHING ELSE. An
+// always-true `existsSync` was not that: it also claimed an `.exarchos.yml`,
+// and then handed back the package.json bytes when something read it — so the
+// gate saw a config file whose contents were a different file's. Naming the one
+// file that exists keeps the fixture describing a repository rather than a
+// filesystem that answers yes to everything.
+const FIXTURE_FILES: readonly string[] = ['package.json'];
+
+function fixtureHas(target: unknown): boolean {
+  const name = String(target).replace(/\\/g, '/');
+  // The repo root itself must still resolve — the gate stats it before anything
+  // else — so only a path that names a FILE is checked against the fixture.
+  if (!/\.[A-Za-z0-9]+$/.test(name)) return true;
+  return FIXTURE_FILES.some((file) => name.endsWith(`/${file}`) || name === file);
+}
+
 vi.mock('node:fs', () => ({
   readFileSync: vi.fn((_path: string) =>
     JSON.stringify({
@@ -33,7 +48,7 @@ vi.mock('node:fs', () => ({
       },
     })
   ),
-  existsSync: vi.fn(() => true),
+  existsSync: vi.fn((p: unknown) => fixtureHas(p)),
   statSync: vi.fn(() => ({ isDirectory: () => true })),
   // Defensive: detectToolchain lists the dir only for *.ext glob markers. Node
   // (an exact-name marker) short-circuits first today, but stub readdirSync so

--- a/tests/unit/verbs/pure/static-analysis.test.ts
+++ b/tests/unit/verbs/pure/static-analysis.test.ts
@@ -2,12 +2,25 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
 import {
   runStaticAnalysis,
+  execCommandRunner,
   FAIL_DETAIL_MAX_LINES,
   FAIL_DETAIL_MAX_FILES,
+  CHECK_COMMAND_TIMEOUT_MS,
 } from '../../../../src/verbs/pure/static-analysis.js';
-import type { StaticAnalysisResult, RunCommandFn } from '../../../../src/verbs/pure/static-analysis.js';
+import type {
+  StaticAnalysisResult,
+  RunCommandFn,
+  ToolchainConfigSource,
+} from '../../../../src/verbs/pure/static-analysis.js';
+import { BUILTIN_TOOLCHAINS, type ConfigToolchain } from '../../../../src/config/toolchains.js';
+
+/** A loaded `.exarchos.yml` carrying just the `toolchains:` block. */
+function configWithToolchains(toolchains: readonly ConfigToolchain[]): ToolchainConfigSource {
+  return { config: { toolchains } };
+}
 
 describe('runStaticAnalysis', () => {
   let tmpDir: string;
@@ -96,7 +109,7 @@ describe('runStaticAnalysis', () => {
     });
 
     it('output shows PASS markers for passing checks', () => {
-      // T-09 / DR-6: `quality-check` must be declared too — an undeclared
+      // `quality-check` must be declared too — an undeclared
       // constituent SKIPs, and a skipped constituent degrades the aggregate
       // off PASS. This test is about the PASS markers, so declare all three.
       const repoRoot = createPackageJson({
@@ -224,7 +237,7 @@ describe('runStaticAnalysis', () => {
         runCommand: runner,
       });
 
-      // T-09 / DR-6 (behavior change): this asserted `status === 'pass'`.
+      // Behavior change: this asserted `status === 'pass'`.
       // A `--skip-lint` flag means the lint check DID NOT RUN, and a check
       // that never ran is not evidence that it would have passed. The
       // aggregate is now DEGRADED/inconclusive, never PASS.
@@ -273,7 +286,7 @@ describe('runStaticAnalysis', () => {
         runCommand: successRunner(),
       });
 
-      // T-09 / DR-6 (behavior change): this asserted `status === 'pass'`.
+      // Behavior change: this asserted `status === 'pass'`.
       // The missing scripts still SKIP the individual checks (they are not
       // failures), but the DIMENSION can no longer render as a clean pass off
       // the one check that actually ran.
@@ -295,7 +308,7 @@ describe('runStaticAnalysis', () => {
         runCommand: successRunner(),
       });
 
-      // T-09 / DR-6 (behavior change): this asserted `status === 'pass'`.
+      // Behavior change: this asserted `status === 'pass'`.
       expect(result.status).not.toBe('pass');
       expect(result.status).toBe('skip');
       expect(result.passCount).toBe(1);
@@ -304,7 +317,7 @@ describe('runStaticAnalysis', () => {
     });
 
     it('every declared script running clean still reaches PASS', () => {
-      // Positive control for the two DR-6 assertions above: PASS is reachable
+      // Positive control for the two degrade assertions above: PASS is reachable
       // — it is the SKIP, not the new tally, that degrades the aggregate.
       const repoRoot = createPackageJson({
         lint: 'eslint .',
@@ -330,7 +343,7 @@ describe('runStaticAnalysis', () => {
   describe('warnings only', () => {
     it('warnings with exit 0 still passes', () => {
       // All three constituents declared so the only variable under test is the
-      // warning output (T-09 / DR-6: an undeclared script would SKIP → degrade).
+      // warning output (an undeclared script would SKIP → degrade).
       const repoRoot = createPackageJson({
         lint: 'eslint .',
         typecheck: 'tsc --noEmit',
@@ -358,10 +371,9 @@ describe('runStaticAnalysis', () => {
 
   describe('usage errors', () => {
     it('empty directory with no project files returns skip (no applicable toolchain)', () => {
-      // T-10: no-toolchain repos produce a 'skip' (inconclusive) result so
-      // the static-analysis gate cannot falsely-green a project that has
-      // no recognized toolchain. See DR-4 in
-      // docs/plans/archive/2026-05-04-v290-dogfood-bundle.md.
+      // A no-toolchain repo produces a 'skip' (inconclusive) result so the
+      // static-analysis gate cannot falsely-green a project that has no
+      // recognized toolchain.
       const emptyDir = path.join(tmpDir, 'empty');
       fs.mkdirSync(emptyDir, { recursive: true });
 
@@ -550,15 +562,15 @@ describe('runStaticAnalysis', () => {
         runCommand: successRunner(),
       });
 
-      // T-10: no-toolchain now resolves to 'skip' instead of 'pass' so the
-      // gate is honestly inconclusive rather than falsely-green.
+      // No-toolchain resolves to 'skip' instead of 'pass' so the gate is
+      // honestly inconclusive rather than falsely-green.
       expect(result.status).toBe('skip');
       expect(result.projectType).toBeUndefined();
       expect(result.passCount).toBe(0);
       expect(result.failCount).toBe(0);
     });
 
-    // ─── T-10: SKIP status for unsupported toolchains ──────────────────────
+    // ─── SKIP status for unsupported toolchains ───────────────────────────
 
     it('runStaticAnalysis_NoToolchainDetected_ReturnsSkipStatus', () => {
       // A directory with no recognized project file (no package.json,
@@ -613,6 +625,572 @@ describe('runStaticAnalysis', () => {
       });
 
       expect(result.projectType).toBe('Node.js');
+    });
+  });
+
+  // ============================================================
+  // COMMANDS COME FROM THE TOOLCHAIN REGISTRY
+  // ============================================================
+
+  describe('registry-sourced commands', () => {
+    function makeRepo(files: Record<string, string>): string {
+      const repoRoot = path.join(tmpDir, 'reg-' + Math.random().toString(36).slice(2));
+      fs.mkdirSync(repoRoot, { recursive: true });
+      for (const [name, content] of Object.entries(files)) {
+        fs.writeFileSync(path.join(repoRoot, name), content, 'utf-8');
+      }
+      return repoRoot;
+    }
+
+    /** What the registry declares for one toolchain, split into cmd + argv. */
+    function declaredLint(toolchainId: string): { cmd: string; args: string[] } {
+      const declared = BUILTIN_TOOLCHAINS.find((t) => t.id === toolchainId)?.commands.lint;
+      // Denominator: the assertions below are about a command the registry
+      // actually declares. If it stops declaring one, the test must say so
+      // rather than compare against nothing.
+      expect(declared, `the registry declares no lint command for '${toolchainId}'`).toBeTruthy();
+      const [cmd = '', ...args] = String(declared).trim().split(/\s+/);
+      return { cmd, args };
+    }
+
+    function spawns(runner: RunCommandFn): Array<{ cmd: string; args: string[] }> {
+      return (runner as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => ({
+        cmd: c[0] as string,
+        args: [...(c[1] as string[])],
+      }));
+    }
+
+    /** The lint spawn whose argv begins with what the registry declares. */
+    function lintSpawnFor(
+      runner: RunCommandFn,
+      toolchainId: string,
+    ): { cmd: string; args: string[] } | undefined {
+      const declared = declaredLint(toolchainId);
+      return spawns(runner).find(
+        (c) =>
+          c.cmd === declared.cmd &&
+          c.args.slice(0, declared.args.length).join(' ') ===
+            declared.args.join(' '),
+      );
+    }
+
+    it('Commands_ComeFromTheRegistry_NotAPerLanguageSwitch', () => {
+      // Go and Rust are the two supported toolchains whose linter the registry
+      // declares. The gate must spawn that command — change the registry entry
+      // and the gate follows, which is the whole point. A literal re-derived
+      // here would keep passing its own hardcoded shape. The declaration is the
+      // PREFIX of the spawn, not necessarily all of it: see the promotion test
+      // below for what may follow it and why.
+      for (const [id, marker, contents] of [
+        ['go', 'go.mod', 'module example.com/myapp'],
+        ['rust', 'Cargo.toml', '[package]\nname = "myapp"'],
+      ] as const) {
+        const runner = successRunner();
+        runStaticAnalysis({ repoRoot: makeRepo({ [marker]: contents }), runCommand: runner });
+
+        expect(
+          lintSpawnFor(runner, id),
+          `no spawn began with the registry's lint command for '${id}'`,
+        ).toBeDefined();
+      }
+    });
+
+    it('ClippyLeg_IsPromotedSoAFindingCanFailIt', () => {
+      // Bare `cargo clippy` leaves almost every lint at `warn`, which exits 0.
+      // A leg that cannot fail contributes a PASS while establishing nothing —
+      // the same "green off no evidence" the whole gate exists to refuse — so
+      // the declared linter is promoted to a denying one. This is the policy
+      // the .NET leg already states in its own declaration with `-warnaserror`.
+      const runner = successRunner();
+      runStaticAnalysis({
+        repoRoot: makeRepo({ 'Cargo.toml': '[package]\nname = "myapp"' }),
+        runCommand: runner,
+      });
+
+      const clippy = spawns(runner).filter((c) => c.args.includes('clippy'));
+      expect(clippy).toHaveLength(1);
+      expect(clippy[0]?.args.slice(-3)).toEqual(['--', '-D', 'warnings']);
+      // The registry's own declaration is still the head of the argv.
+      expect(lintSpawnFor(runner, 'rust')).toBeDefined();
+    });
+
+    it('GoVetLeg_IsNotPromoted_BecauseItAlreadyFails', () => {
+      // The promotion is a per-toolchain decision, not a blanket suffix. `go
+      // vet` exits non-zero on what it reports, so appending anything to it
+      // would be inventing a policy the toolchain does not need.
+      const runner = successRunner();
+      runStaticAnalysis({
+        repoRoot: makeRepo({ 'go.mod': 'module example.com/myapp' }),
+        runCommand: runner,
+      });
+
+      const vet = spawns(runner).filter((c) => c.cmd === declaredLint('go').cmd);
+      expect(vet).toHaveLength(1);
+      expect(vet[0]).toEqual(declaredLint('go'));
+    });
+
+    it('SupplementedLeg_SurvivesWhereTheRegistryDeclaresNothing', () => {
+      // Rust's compile-only pass and .NET's build have no registry source, so
+      // they stay declared here. Folding them away would silently drop a check.
+      const rustRunner = successRunner();
+      runStaticAnalysis({
+        repoRoot: makeRepo({ 'Cargo.toml': '[package]\nname = "myapp"' }),
+        runCommand: rustRunner,
+      });
+      expect(spawns(rustRunner)).toContainEqual({ cmd: 'cargo', args: ['check'] });
+
+      const dotnetRunner = successRunner();
+      runStaticAnalysis({
+        repoRoot: makeRepo({ 'MyApp.csproj': '<Project />' }),
+        runCommand: dotnetRunner,
+      });
+      expect(spawns(dotnetRunner)).toContainEqual({
+        cmd: 'dotnet',
+        args: ['build', '--no-restore', '-warnaserror'],
+      });
+    });
+
+    it('NodeLegs_StayScriptIndirections_NotTheRegistryCommand', () => {
+      // The registry's `tsc --noEmit` would run the compiler over the working
+      // directory instead of the project the repository's own script targets,
+      // and would bypass its package manager. Node keeps the script path.
+      const runner = successRunner();
+      runStaticAnalysis({
+        repoRoot: createPackageJson({ lint: 'eslint .', typecheck: 'tsc --noEmit' }),
+        runCommand: runner,
+      });
+
+      const calls = spawns(runner);
+      expect(calls.every((c) => c.cmd === 'npm')).toBe(true);
+      expect(calls).toContainEqual({ cmd: 'npm', args: ['run', 'typecheck'] });
+      expect(calls.some((c) => c.cmd === 'tsc')).toBe(false);
+    });
+
+    it('PythonRepo_IsNotToldNoProjectType', () => {
+      // The registry recognises Python perfectly well; it is this gate that has
+      // no runner. Reporting "nothing recognised your project" sends the reader
+      // looking for a missing marker that is right there.
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot: makeRepo({ 'pyproject.toml': '[project]\nname = "app"' }),
+        runCommand: runner,
+      });
+
+      expect(result.status).toBe('skip');
+      expect(result.skipReason).toBe('no-toolchain');
+      expect(result.projectType).toBe('Python');
+      expect(result.output).not.toContain('No recognized project type');
+      expect(result.output).toContain('Python');
+      expect(result.output).toContain('no static-analysis runner');
+      // Nothing was spawned: an unrunnable toolchain is not a half-run gate.
+      expect(spawns(runner)).toEqual([]);
+    });
+
+    it('NothingDetected_EnumeratesEveryMarkerTheRegistryKnows', () => {
+      // The old message listed only the four supported toolchains' markers, so
+      // a reader could not tell "not recognised" from "not runnable".
+      const result = runStaticAnalysis({
+        repoRoot: makeRepo({ 'README.md': '# Hello' }),
+        runCommand: successRunner(),
+      });
+
+      expect(result.status).toBe('skip');
+      expect(result.projectType).toBeUndefined();
+      expect(result.output).toContain('No recognized project type');
+      for (const marker of BUILTIN_TOOLCHAINS.flatMap((t) => t.markers)) {
+        expect(result.output).toContain(marker);
+      }
+    });
+  });
+
+  // ============================================================
+  // BOUNDED WALL CLOCK
+  // ============================================================
+
+  describe('command timeout', () => {
+    function makeRepo(files: Record<string, string>): string {
+      const repoRoot = path.join(tmpDir, 'to-' + Math.random().toString(36).slice(2));
+      fs.mkdirSync(repoRoot, { recursive: true });
+      for (const [name, content] of Object.entries(files)) {
+        fs.writeFileSync(path.join(repoRoot, name), content, 'utf-8');
+      }
+      return repoRoot;
+    }
+
+    it('TimeoutIsDeclared_NotDefaulted', () => {
+      expect(CHECK_COMMAND_TIMEOUT_MS).toBeGreaterThan(0);
+
+      // Every spawn site, across the script path, the registry path, the
+      // supplement path and the opt-in boundary leg. A site that forgot the
+      // bound is the failure this catches.
+      const repos = [
+        createPackageJson({ lint: 'eslint .', typecheck: 'tsc --noEmit' }),
+        makeRepo({ 'go.mod': 'module example.com/myapp' }),
+        makeRepo({ 'Cargo.toml': '[package]\nname = "myapp"' }),
+        makeRepo({ 'MyApp.csproj': '<Project />' }),
+        makeRepo({
+          'go.mod': 'module example.com/myapp',
+          '.dependency-cruiser.cjs': 'module.exports = { forbidden: [] };',
+        }),
+      ];
+
+      let totalCalls = 0;
+      for (const repoRoot of repos) {
+        const runner = successRunner();
+        runStaticAnalysis({ repoRoot, runCommand: runner });
+
+        const calls = (runner as ReturnType<typeof vi.fn>).mock.calls;
+        expect(calls.length, `no command spawned for ${repoRoot}`).toBeGreaterThan(0);
+        totalCalls += calls.length;
+        for (const call of calls) {
+          expect(call[2], `unbounded spawn: ${String(call[0])}`).toMatchObject({
+            timeoutMs: CHECK_COMMAND_TIMEOUT_MS,
+          });
+        }
+      }
+      // Denominator: the loop above proves nothing if it inspected no calls.
+      expect(totalCalls).toBeGreaterThanOrEqual(repos.length);
+    });
+
+    it('HungCommand_YieldsIndeterminate_NotAHang', () => {
+      // A run the bound cut short reports through `spawnError`, which says the
+      // exit code is not authoritative. The killed leg is inconclusive: it is
+      // not evidence of a failure, and it is certainly not a pass.
+      const repoRoot = createPackageJson({
+        lint: 'eslint .',
+        typecheck: 'tsc --noEmit',
+        'quality-check': 'echo quality',
+      });
+
+      const runner: RunCommandFn = vi.fn((_cmd: string, args: readonly string[]) =>
+        args.includes('typecheck')
+          ? {
+              exitCode: 1,
+              stdout: '',
+              stderr: '',
+              spawnError: `killed after ${CHECK_COMMAND_TIMEOUT_MS}ms`,
+            }
+          : { exitCode: 0, stdout: '', stderr: '' },
+      );
+
+      const result = runStaticAnalysis({ repoRoot, runCommand: runner });
+
+      expect(result.status).toBe('skip');
+      expect(result.skipReason).toBe('constituent-skipped');
+      expect(result.failCount).toBe(0);
+      expect(result.skipCount).toBe(1);
+      expect(result.output).toContain('SKIP');
+      expect(result.output).toContain('killed after');
+      expect(result.output).not.toContain('Result: PASS');
+    });
+
+    it('UnspawnableTool_Degrades_RatherThanReadingAsAFailure', () => {
+      // Same channel, different cause: a linter that is not installed produced
+      // no finding, so the leg is inconclusive rather than red.
+      const repoRoot = makeRepo({ 'go.mod': 'module example.com/myapp' });
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: vi.fn(() => ({
+          exitCode: 127,
+          stdout: '',
+          stderr: '',
+          spawnError: 'spawn go ENOENT',
+        })),
+      });
+
+      expect(result.status).toBe('skip');
+      expect(result.failCount).toBe(0);
+      expect(result.output).toContain('spawn go ENOENT');
+    });
+  });
+
+  // ============================================================
+  // THE RUNNER THE GATE IS ACTUALLY COMPOSED WITH
+  // ============================================================
+  //
+  // The degrades above are only worth anything if the runner production hands
+  // this gate can produce their inputs. The handler's old adapter could not: it
+  // dropped `timeoutMs` and never set `spawnError`, so every assertion about
+  // either was proving a property of the test's own stub. These exercise the
+  // real adapter against real child processes — no field is set by hand.
+
+  describe('production command runner', () => {
+    /** A binary that cannot exist, for the never-spawned path. */
+    const ABSENT_BINARY = 'exarchos-no-such-binary-b7f3a1';
+
+    it('ProductionRunner_ReportsARealExitCode_WithoutASpawnError', () => {
+      // The denominator for everything below: a process that DID run must come
+      // back as a verdict, or a runner that reported `spawnError` for every
+      // outcome would satisfy the degrade tests while destroying the gate.
+      const result = execCommandRunner(process.execPath, ['-e', 'process.exit(3)']);
+
+      expect(result.exitCode).toBe(3);
+      expect(result.spawnError).toBeUndefined();
+    });
+
+    it('ProductionRunner_CapturesStdout_OnSuccess', () => {
+      const result = execCommandRunner(process.execPath, ['-e', 'process.stdout.write("ok")']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('ok');
+      expect(result.spawnError).toBeUndefined();
+    });
+
+    it('ProductionRunner_SetsSpawnError_WhenTheBinaryDoesNotExist', () => {
+      const result = execCommandRunner(ABSENT_BINARY, []);
+
+      expect(result.spawnError, 'the production runner never reports a spawn failure').toBeTruthy();
+      expect(result.spawnError).toContain('ENOENT');
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it('ProductionRunner_HonoursTimeoutMs_AndReportsTheKillAsNoVerdict', () => {
+      // A bound the runner discards is a control that cannot run. This proves
+      // the opposite two ways: the call returns far inside the child's own
+      // lifetime, and the killed run is reported as no-verdict rather than as
+      // a failing exit code.
+      const started = Date.now();
+      const result = execCommandRunner(
+        process.execPath,
+        ['-e', 'setTimeout(() => {}, 30000)'],
+        { timeoutMs: 250 },
+      );
+      const elapsed = Date.now() - started;
+
+      expect(elapsed).toBeLessThan(15000);
+      expect(result.spawnError, 'a killed run was reported as an authoritative exit').toBeTruthy();
+    });
+
+    it('SpawnFailure_FromTheProductionRunner_DegradesTheWholeGate', () => {
+      // The composition end to end: the real adapter produces the field, the
+      // gate reads it, and the aggregate refuses to call the result a pass.
+      // Only the command NAME is substituted — nothing about the result is.
+      const repoRoot = createPackageJson({
+        lint: 'eslint .',
+        typecheck: 'tsc --noEmit',
+        'quality-check': 'echo quality',
+      });
+
+      const runner: RunCommandFn = vi.fn((_cmd, _args, options) =>
+        execCommandRunner(ABSENT_BINARY, [], options),
+      );
+
+      const result = runStaticAnalysis({ repoRoot, runCommand: runner, loadConfig: () => null });
+
+      expect(result.status).toBe('skip');
+      expect(result.skipReason).toBe('constituent-skipped');
+      expect(result.failCount).toBe(0);
+      expect(result.skipCount).toBe(3);
+      expect(result.output).toContain('ENOENT');
+      expect(result.output).not.toContain('Result: PASS');
+    });
+
+    it('ProductionRunner_IsWhatTheGateHandlerComposes', () => {
+      // The seam the two tests above exercise has to be the seam production
+      // uses. A second adapter in the handler would make every assertion here
+      // a statement about an unused function.
+      const handler = fs.readFileSync(
+        fileURLToPath(new URL('../../../../src/verbs/gates/static-analysis.ts', import.meta.url)),
+        'utf-8',
+      );
+
+      expect(handler).toContain("import { execCommandRunner, runStaticAnalysis } from '../pure/static-analysis.js'");
+      expect(handler).toContain('runCommand: execCommandRunner');
+      expect(handler, 'the handler declares a command runner of its own again').not.toMatch(
+        /const\s+\w*[rR]unner\w*\s*:\s*RunCommandFn/,
+      );
+    });
+  });
+
+  // ============================================================
+  // A GATE THAT RAN NOTHING IS NOT A GATE THAT PASSED
+  // ============================================================
+
+  describe('zero applicable checks', () => {
+    it('ToolchainWithNoRunnableCommand_Skips_RatherThanPassing', () => {
+      // `PASS (0/0 checks passed)` was reachable for any supported toolchain
+      // whose declarations dried up: the tally saw an empty list, found no
+      // failures and no skips, and rendered green. Zero legs is the strongest
+      // possible case of "a check that never ran is not evidence it would
+      // pass", so it lands on the same verdict.
+      const repoRoot = path.join(tmpDir, 'silent-go');
+      fs.mkdirSync(repoRoot, { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, 'go.mod'), 'module example.com/myapp', 'utf-8');
+
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: runner,
+        // A repository declaring `go` with no lint and no typecheck command is
+        // the live route to an empty leg set; the built-in registry reaches the
+        // same state the moment it stops declaring one.
+        loadConfig: () => configWithToolchains([
+          { id: 'go', projectType: 'Go', markers: ['go.mod'], commands: {} },
+        ]),
+      });
+
+      expect(result.status).toBe('skip');
+      expect(result.skipReason).toBe('constituent-skipped');
+      expect(result.passCount).toBe(0);
+      expect(result.failCount).toBe(0);
+      expect(result.skipCount).toBe(1);
+      expect(result.output).not.toContain('Result: PASS');
+      expect(result.output).toContain('no lint and no typecheck command');
+      // Nothing was spawned, which is exactly why nothing may be claimed.
+      expect((runner as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('OneRunnableCommand_StillReachesPass', () => {
+      // The kill-probe's other half: the skip above must come from the empty
+      // set, not from the config path being present at all.
+      const repoRoot = path.join(tmpDir, 'lint-only-go');
+      fs.mkdirSync(repoRoot, { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, 'go.mod'), 'module example.com/myapp', 'utf-8');
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: successRunner(),
+        loadConfig: () => configWithToolchains([
+          { id: 'go', projectType: 'Go', markers: ['go.mod'], commands: { lint: 'go vet ./...' } },
+        ]),
+      });
+
+      expect(result.status).toBe('pass');
+      expect(result.passCount).toBe(1);
+    });
+  });
+
+  // ============================================================
+  // THE `.exarchos.yml` TOOLCHAINS EXTENSION POINT
+  // ============================================================
+
+  describe('user-declared toolchains', () => {
+    function makeRepo(files: Record<string, string>): string {
+      const repoRoot = path.join(tmpDir, 'usr-' + Math.random().toString(36).slice(2));
+      fs.mkdirSync(repoRoot, { recursive: true });
+      for (const [name, content] of Object.entries(files)) {
+        fs.writeFileSync(path.join(repoRoot, name), content, 'utf-8');
+      }
+      return repoRoot;
+    }
+
+    function spawns(runner: RunCommandFn): Array<{ cmd: string; args: string[] }> {
+      return (runner as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => ({
+        cmd: c[0] as string,
+        args: [...(c[1] as string[])],
+      }));
+    }
+
+    it('DeclaredToolchain_OverridesTheBuiltInCommands', () => {
+      // The block is the sanctioned extension point and the test runtime
+      // already honours it. This gate ignored it entirely, so a repository
+      // could declare its linter, watch its tests use it, and have static
+      // analysis run something else.
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot: makeRepo({ 'Cargo.toml': '[package]\nname = "myapp"' }),
+        runCommand: runner,
+        loadConfig: () => configWithToolchains([
+          {
+            id: 'rust',
+            projectType: 'Rust',
+            markers: ['Cargo.toml'],
+            commands: { lint: 'cargo clippy --all-targets' },
+          },
+        ]),
+      });
+
+      expect(result.status).toBe('pass');
+      expect(spawns(runner)).toContainEqual({
+        cmd: 'cargo',
+        args: ['clippy', '--all-targets', '--', '-D', 'warnings'],
+      });
+    });
+
+    it('DeclaredLintFlags_AreNotSecondGuessed', () => {
+      // A declaration that already passes flags through to the compiler has
+      // chosen its lint levels. Appending a second `--` would corrupt the argv
+      // rather than harden it, so the promotion stands down.
+      const runner = successRunner();
+      runStaticAnalysis({
+        repoRoot: makeRepo({ 'Cargo.toml': '[package]\nname = "myapp"' }),
+        runCommand: runner,
+        loadConfig: () => configWithToolchains([
+          {
+            id: 'rust',
+            projectType: 'Rust',
+            markers: ['Cargo.toml'],
+            commands: { lint: 'cargo clippy -- -W clippy::pedantic' },
+          },
+        ]),
+      });
+
+      expect(spawns(runner)).toContainEqual({
+        cmd: 'cargo',
+        args: ['clippy', '--', '-W', 'clippy::pedantic'],
+      });
+    });
+
+    it('DeclaredToolchain_WithAnUnknownId_IsRun_NotRefused', () => {
+      // The gate's supported set exists to decide what a PARTIAL built-in
+      // declaration should mean. A repository that names the commands itself
+      // has already answered that, so refusing it would make the extension
+      // point advisory.
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot: makeRepo({ 'build.zig': 'pub fn build() void {}' }),
+        runCommand: runner,
+        loadConfig: () => configWithToolchains([
+          {
+            id: 'zig',
+            projectType: 'Zig',
+            markers: ['build.zig'],
+            commands: { lint: 'zig fmt --check .' },
+          },
+        ]),
+      });
+
+      expect(result.status).toBe('pass');
+      expect(result.projectType).toBe('Zig');
+      expect(spawns(runner)).toContainEqual({ cmd: 'zig', args: ['fmt', '--check', '.'] });
+    });
+
+    it('NodeScriptIndirection_SurvivesAPartialOverride', () => {
+      // Declaring node with only a test command must not cost the repository
+      // its lint and typecheck legs — nothing about that declaration says how
+      // to check it, so the script path still applies.
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot: createPackageJson({
+          lint: 'eslint .',
+          typecheck: 'tsc --noEmit',
+          'quality-check': 'echo quality',
+        }),
+        runCommand: runner,
+        loadConfig: () => configWithToolchains([
+          { id: 'node', projectType: 'Node.js', markers: ['package.json'], commands: { test: 'vitest run' } },
+        ]),
+      });
+
+      expect(result.status).toBe('pass');
+      expect(spawns(runner)).toContainEqual({ cmd: 'npm', args: ['run', 'lint'] });
+    });
+
+    it('UnreadableConfig_IsAnError_NotASilentlyIgnoredOne', () => {
+      // A `.exarchos.yml` that will not load is not an absent one. Continuing
+      // would mean running against a detection the operator did not ask for
+      // and reporting the result as though nothing were wrong.
+      const result = runStaticAnalysis({
+        repoRoot: makeRepo({ 'go.mod': 'module example.com/myapp' }),
+        runCommand: successRunner(),
+        loadConfig: () => {
+          throw new Error('Failed to parse .exarchos.yml at /repo/.exarchos.yml');
+        },
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('Failed to parse .exarchos.yml');
     });
   });
 
@@ -707,7 +1285,7 @@ describe('runStaticAnalysis', () => {
 
       // 30 distinct files, 2 lines each (60 lines total), so the head cap
       // engages AND the per-file breakdown would list all 30 without a cap —
-      // itself blowing the DR-7 budget the line cap protects.
+      // itself blowing the response budget the line cap protects.
       const fileCount = 30;
       const lines: string[] = [];
       for (let i = 1; i <= fileCount; i++) {

--- a/tests/unit/verbs/pure/static-analysis.test.ts
+++ b/tests/unit/verbs/pure/static-analysis.test.ts
@@ -761,7 +761,13 @@ describe('runStaticAnalysis', () => {
       });
 
       const calls = spawns(runner);
-      expect(calls.every((c) => c.cmd === 'npm')).toBe(true);
+      // Named rather than quantified: a failing `every` reports only `false`,
+      // and which command escaped the package manager is the whole finding.
+      expect(
+        calls.filter((c) => c.cmd !== 'npm').map((c) => c.cmd),
+        'a script was spawned outside the package manager',
+      ).toEqual([]);
+      expect(calls.length, 'nothing was spawned, so the check above is vacuous').toBeGreaterThan(0);
       expect(calls).toContainEqual({ cmd: 'npm', args: ['run', 'typecheck'] });
       expect(calls.some((c) => c.cmd === 'tsc')).toBe(false);
     });

--- a/tests/unit/verbs/team/post-delegation-check.test.ts
+++ b/tests/unit/verbs/team/post-delegation-check.test.ts
@@ -38,6 +38,15 @@ function makeIncompleteTask(id: string, status = 'in-progress') {
   return { id, status, branch: `branch-${id}` };
 }
 
+// The worktree test command is resolved from the worktree's own toolchain, so
+// a fixture worktree has to look like a repository the resolver recognizes.
+const NODE_MANIFEST = JSON.stringify({ scripts: { 'test:run': 'vitest run' } });
+
+/** `readFileSync` answering the manifest for package.json and the state otherwise. */
+function stateAndManifest(stateJson: string): (p: unknown) => string {
+  return (p: unknown) => (String(p).endsWith('package.json') ? NODE_MANIFEST : stateJson);
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('handlePostDelegationCheck', () => {
@@ -65,7 +74,7 @@ describe('handlePostDelegationCheck', () => {
       if (path === '/repo/wt-2/package.json') return true;
       return false;
     });
-    mockReadFileSync.mockReturnValue(stateJson);
+    mockReadFileSync.mockImplementation(stateAndManifest(stateJson));
     mockExecFileSync.mockReturnValue(Buffer.from(''));
 
     // Act
@@ -80,6 +89,135 @@ describe('handlePostDelegationCheck', () => {
     expect(data.passed).toBe(true);
     expect(data.checks.fail).toBe(0);
     expect(data.report).toContain('PASS');
+  });
+
+  // ─── Test 1b: the command comes from the resolver ─────────────────────
+
+  it('PostDelegation_UsesResolvedCommand', async () => {
+    const stateJson = makeState([makeCompleteTask('task-1', 'wt-1')]);
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p).replace(/^[A-Za-z]:/, '');
+      return (
+        path === '/tmp/state.json' ||
+        path === '/repo/wt-1' ||
+        path === '/repo/wt-1/package.json'
+      );
+    });
+    mockReadFileSync.mockImplementation(stateAndManifest(stateJson));
+    mockExecFileSync.mockReturnValue(Buffer.from(''));
+
+    const result = await handlePostDelegationCheck({
+      stateFile: '/tmp/state.json',
+      repoRoot: '/repo',
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    const [program, argv, options] = mockExecFileSync.mock.calls[0] as [
+      string,
+      readonly string[],
+      { cwd?: string },
+    ];
+    expect(program).toBe('npm');
+    expect(argv).toEqual(['run', 'test:run']);
+    expect(String(options.cwd).replace(/^[A-Za-z]:/, '')).toBe('/repo/wt-1');
+  });
+
+  // ─── Test 1c: a worktree with no resolvable runtime ───────────────────
+
+  it('NonNodeWorktree_IsIndeterminate_NotSkip', async () => {
+    // The worktree exists but nothing in it names a test runtime. The gate
+    // used to record a green SKIP here — a blocking gate reporting verified
+    // when it had verified nothing.
+    const stateJson = makeState([makeCompleteTask('task-1', 'wt-1')]);
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p).replace(/^[A-Za-z]:/, '');
+      return path === '/tmp/state.json' || path === '/repo/wt-1';
+    });
+    mockReadFileSync.mockReturnValue(stateJson);
+
+    const result = await handlePostDelegationCheck({
+      stateFile: '/tmp/state.json',
+      repoRoot: '/repo',
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      passed: boolean;
+      report: string;
+      checks: { pass: number; fail: number; skip: number; indeterminate: number };
+    };
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(data.checks.indeterminate).toBe(1);
+    // Unconcluded, and counted apart from both a waived SKIP and a real FAIL.
+    expect(data.checks.skip).toBe(0);
+    expect(data.checks.fail).toBe(0);
+    expect(data.passed).toBe(false);
+    expect(data.report).toContain('INDETERMINATE');
+  });
+
+  // ─── Test 1d: a runner that never started is not a failing worktree ───
+
+  it('PostDelegation_RunnerNeverStarts_IsIndeterminate_NotFail', async () => {
+    const stateJson = makeState([makeCompleteTask('task-1', 'wt-1')]);
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p).replace(/^[A-Za-z]:/, '');
+      return (
+        path === '/tmp/state.json' ||
+        path === '/repo/wt-1' ||
+        path === '/repo/wt-1/package.json'
+      );
+    });
+    mockReadFileSync.mockImplementation(stateAndManifest(stateJson));
+    mockExecFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('spawnSync npm ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = await handlePostDelegationCheck({
+      stateFile: '/tmp/state.json',
+      repoRoot: '/repo',
+    });
+
+    const data = result.data as {
+      passed: boolean;
+      report: string;
+      checks: { pass: number; fail: number; skip: number; indeterminate: number };
+    };
+    expect(data.checks.indeterminate).toBe(1);
+    expect(data.checks.fail).toBe(0);
+    expect(data.passed).toBe(false);
+    expect(data.report).toContain('ENOENT');
+  });
+
+  it('PostDelegation_RunnerNonZeroExit_IsStillAFailure', async () => {
+    // Discriminating twin: a process that RAN and exited non-zero is a real
+    // finding, and must not be softened into an unmeasured leg.
+    const stateJson = makeState([makeCompleteTask('task-1', 'wt-1')]);
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p).replace(/^[A-Za-z]:/, '');
+      return (
+        path === '/tmp/state.json' ||
+        path === '/repo/wt-1' ||
+        path === '/repo/wt-1/package.json'
+      );
+    });
+    mockReadFileSync.mockImplementation(stateAndManifest(stateJson));
+    mockExecFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('Command failed'), { status: 1 });
+    });
+
+    const result = await handlePostDelegationCheck({
+      stateFile: '/tmp/state.json',
+      repoRoot: '/repo',
+    });
+
+    const data = result.data as {
+      passed: boolean;
+      checks: { pass: number; fail: number; skip: number; indeterminate: number };
+    };
+    expect(data.checks.fail).toBe(1);
+    expect(data.checks.indeterminate).toBe(0);
+    expect(data.passed).toBe(false);
   });
 
   // ─── Test 2: State file not found → error ────────────────────────────

--- a/tests/unit/verbs/team/prepare-synthesis.test.ts
+++ b/tests/unit/verbs/team/prepare-synthesis.test.ts
@@ -112,6 +112,43 @@ function tasksToEvents(tasks: Record<string, { status: string }>): unknown[] {
   return events;
 }
 
+/**
+ * `execFileSync` behaviour for the two resolved command legs: the leg whose
+ * script name is in `failing` throws the way a non-zero exit does, everything
+ * else succeeds. The legs are told apart by argv, not by call order, so the
+ * assertion does not silently move when a leg is added or reordered.
+ */
+function legRunner(failing: Record<string, string> = {}) {
+  return ((_program: string, argv?: readonly string[]) => {
+    const script = (argv ?? []).join(' ');
+    for (const [name, output] of Object.entries(failing)) {
+      if (script.includes(name)) {
+        const err = new Error(`${name} failed`) as Error & { stdout: Buffer; status: number };
+        err.stdout = Buffer.from(output);
+        err.status = 1;
+        throw err;
+      }
+    }
+    return Buffer.from('Tests: 10 passed, 0 failed');
+  }) as unknown as typeof execFileSync;
+}
+
+/**
+ * `execSync` behaviour for the git legs, dispatched on the command rather than
+ * on call order. Resolving the toolchain adds its own `git rev-parse` probe, so
+ * an ordinal mock queue silently shifts under a leg that is not even the
+ * subject of the test.
+ */
+function gitRunner(defaultBranch: string, log: string) {
+  return ((command: string) => {
+    if (command.includes('symbolic-ref')) {
+      return `refs/remotes/origin/${defaultBranch}\n` as unknown as Buffer;
+    }
+    if (command.includes('git log')) return Buffer.from(log);
+    return Buffer.from('');
+  }) as unknown as typeof execSync;
+}
+
 function createMockEventStore(events: unknown[] = []) {
   return {
     query: vi.fn().mockResolvedValue(events),
@@ -131,6 +168,15 @@ describe('handlePrepareSynthesis', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prepare-synthesis-'));
+    // The tests and typecheck legs resolve their commands from the governed
+    // repository's toolchain, so the fixture tree has to be a repository the
+    // resolver recognizes. Without this the gate has nothing to run and says so
+    // — which is exactly what `UnresolvedRuntime_YieldsIndeterminate_NotFail`
+    // exercises, on a tree deliberately left bare.
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { 'test:run': 'vitest run', typecheck: 'tsc --noEmit' } }),
+    );
   });
 
   afterEach(async () => {
@@ -326,12 +372,12 @@ describe('handlePrepareSynthesis', () => {
     const mockMaterializer = createMockMaterializer(taskView);
     const mockStore = createMockEventStore();
     vi.mocked(getOrCreateMaterializer).mockReturnValue(mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>);
-    // Tests and typecheck pass, then detect default branch, then git log returns commit info
-    vi.mocked(execSync)
-      .mockReturnValueOnce(Buffer.from('Tests: 5 passed'))      // test suite
-      .mockReturnValueOnce(Buffer.from(''))                       // typecheck
-      .mockReturnValueOnce('refs/remotes/origin/main\n' as unknown as Buffer) // detectDefaultBranch
-      .mockReturnValueOnce(Buffer.from('* abc1234 feat: add feature\n* def5678 fix: bug fix')); // git log
+    // Tests and typecheck are resolved commands (execFileSync); the two legs
+    // still on execSync are the git ones.
+    vi.mocked(execFileSync).mockImplementation(legRunner());
+    vi.mocked(execSync).mockImplementation(
+      gitRunner('main', '* abc1234 feat: add feature\n* def5678 fix: bug fix'),
+    );
 
     // Act
     const result = await handlePrepareSynthesis({ featureId: 'test-feature', repoRoot: tmpDir }, tmpDir, mockStore as unknown as EventStore);
@@ -362,12 +408,9 @@ describe('handlePrepareSynthesis', () => {
     const mockMaterializer = createMockMaterializer(taskView);
     const mockStore = createMockEventStore();
     vi.mocked(getOrCreateMaterializer).mockReturnValue(mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>);
-    // Tests and typecheck pass, then detect default branch returns 'trunk', then git log
-    vi.mocked(execSync)
-      .mockReturnValueOnce(Buffer.from('Tests: 5 passed'))       // test suite
-      .mockReturnValueOnce(Buffer.from(''))                        // typecheck
-      .mockReturnValueOnce('refs/remotes/origin/trunk\n' as unknown as Buffer) // detectDefaultBranch → trunk
-      .mockReturnValueOnce(Buffer.from('* abc1234 feat: add feature')); // git log
+    // Detect default branch returns 'trunk', then git log
+    vi.mocked(execFileSync).mockImplementation(legRunner());
+    vi.mocked(execSync).mockImplementation(gitRunner('trunk', '* abc1234 feat: add feature'));
 
     // Act
     await handlePrepareSynthesis({ featureId: 'test-feature', repoRoot: tmpDir }, tmpDir, mockStore as unknown as EventStore);
@@ -394,11 +437,8 @@ describe('handlePrepareSynthesis', () => {
     const mockStore = createMockEventStore();
     vi.mocked(getOrCreateMaterializer).mockReturnValue(mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>);
     // Tests pass, typecheck passes, detect default branch, stack healthy
-    vi.mocked(execSync)
-      .mockReturnValueOnce(Buffer.from('Tests: 10 passed, 0 failed'))
-      .mockReturnValueOnce(Buffer.from(''))
-      .mockReturnValueOnce('refs/remotes/origin/main\n' as unknown as Buffer) // detectDefaultBranch
-      .mockReturnValueOnce(Buffer.from('main\n  feature-branch'));
+    vi.mocked(execFileSync).mockImplementation(legRunner());
+    vi.mocked(execSync).mockImplementation(gitRunner('main', 'main\n  feature-branch'));
 
     // Act
     const result = await handlePrepareSynthesis({ featureId: 'test-feature', repoRoot: tmpDir }, tmpDir, mockStore as unknown as EventStore);
@@ -509,24 +549,27 @@ describe('handlePrepareSynthesis', () => {
     const mockMaterializer = createMockMaterializer(taskView);
     const mockStore = createMockEventStore();
     vi.mocked(getOrCreateMaterializer).mockReturnValue(mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>);
-    // execSync throws on test failure (non-zero exit code)
-    const testError = new Error('Tests failed') as Error & { stdout: Buffer; status: number };
-    testError.stdout = Buffer.from('Tests: 3 passed, 2 failed');
-    testError.status = 1;
-    vi.mocked(execSync)
-      .mockImplementationOnce(() => { throw testError; })  // test suite fails
-      .mockReturnValueOnce(Buffer.from(''))                  // typecheck passes
-      .mockReturnValueOnce('refs/remotes/origin/main\n' as unknown as Buffer) // detectDefaultBranch
-      .mockReturnValueOnce(Buffer.from('main'));             // git log
+    // The resolved test command exits non-zero; typecheck still passes.
+    vi.mocked(execFileSync).mockImplementation(
+      legRunner({ 'test:run': 'Tests: 3 passed, 2 failed' }),
+    );
+    vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
 
     // Act
     const result = await handlePrepareSynthesis({ featureId: 'test-feature', repoRoot: tmpDir }, tmpDir, mockStore as unknown as EventStore);
 
     // Assert
     expect(result.success).toBe(true);
-    const data = result.data as { ready: boolean; tests: { passed: boolean } };
+    const data = result.data as {
+      ready: boolean;
+      tests: { passed: boolean; failCount?: number };
+      skipped?: true;
+    };
     expect(data.ready).toBe(false);
     expect(data.tests.passed).toBe(false);
+    // A failure is a measurement, not an absence of one.
+    expect(data.skipped).toBeUndefined();
+    expect(data.tests.failCount).toBe(2);
   });
 
   // ─── Test 11: Typecheck failure sets passed=false ─────────────────────────
@@ -539,14 +582,13 @@ describe('handlePrepareSynthesis', () => {
     const mockMaterializer = createMockMaterializer(taskView);
     const mockStore = createMockEventStore();
     vi.mocked(getOrCreateMaterializer).mockReturnValue(mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>);
-    const typecheckError = new Error('Typecheck failed') as Error & { stdout: Buffer; status: number };
-    typecheckError.stdout = Buffer.from('error TS2322: Type string not assignable\nerror TS2345: Argument mismatch');
-    typecheckError.status = 1;
-    vi.mocked(execSync)
-      .mockReturnValueOnce(Buffer.from('Tests: 5 passed'))     // test suite passes
-      .mockImplementationOnce(() => { throw typecheckError; })  // typecheck fails
-      .mockReturnValueOnce('refs/remotes/origin/main\n' as unknown as Buffer) // detectDefaultBranch
-      .mockReturnValueOnce(Buffer.from('main'));                // git log
+    vi.mocked(execFileSync).mockImplementation(
+      legRunner({
+        typecheck:
+          'error TS2322: Type string not assignable\nerror TS2345: Argument mismatch',
+      }),
+    );
+    vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
 
     // Act
     const result = await handlePrepareSynthesis({ featureId: 'test-feature', repoRoot: tmpDir }, tmpDir, mockStore as unknown as EventStore);
@@ -570,7 +612,13 @@ describe('handlePrepareSynthesis', () => {
     vi.mocked(getOrCreateMaterializer).mockReturnValue(
       mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>,
     );
-    vi.mocked(execSync).mockReturnValue(Buffer.from('src/registry.ts'));
+    vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+    // The changed-file leg is the `git diff` argv call; the command legs are
+    // the resolved test/typecheck ones and must not be answered with a diff.
+    vi.mocked(execFileSync).mockImplementation(((program: string) =>
+      program === 'git'
+        ? Buffer.from('src/registry.ts')
+        : Buffer.from('Tests: 1 passed, 0 failed')) as unknown as typeof execFileSync);
 
     // Act
     const result = await handlePrepareSynthesis(
@@ -608,7 +656,13 @@ describe('handlePrepareSynthesis', () => {
     vi.mocked(getOrCreateMaterializer).mockReturnValue(
       mockMaterializer as unknown as ReturnType<typeof getOrCreateMaterializer>,
     );
-    vi.mocked(execSync).mockReturnValue(Buffer.from('src/registry.ts'));
+    vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+    // The changed-file leg is the `git diff` argv call; the command legs are
+    // the resolved test/typecheck ones and must not be answered with a diff.
+    vi.mocked(execFileSync).mockImplementation(((program: string) =>
+      program === 'git'
+        ? Buffer.from('src/registry.ts')
+        : Buffer.from('Tests: 1 passed, 0 failed')) as unknown as typeof execFileSync);
 
     const result = await handlePrepareSynthesis(
       {
@@ -631,6 +685,266 @@ describe('handlePrepareSynthesis', () => {
     expect((docGate![1] as { data: { passed: boolean } }).data.passed).toBe(false);
     const data = result.data as { readiness: { documentReady: boolean } };
     expect(data.readiness.documentReady).toBe(true);
+  });
+
+  // ─── The two command legs come from the toolchain, not from a literal ────
+
+  it('TestsLeg_UsesResolvedCommand', async () => {
+    const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+    vi.mocked(getOrCreateMaterializer).mockReturnValue(
+      createMockMaterializer(
+        mockTaskDetailView({ t1: { status: 'completed' } }),
+      ) as unknown as ReturnType<typeof getOrCreateMaterializer>,
+    );
+    vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+    vi.mocked(execFileSync).mockImplementation(legRunner());
+
+    await handlePrepareSynthesis(
+      { featureId: 'test-feature', repoRoot: tmpDir },
+      tmpDir,
+      mockStore as unknown as EventStore,
+    );
+
+    const spawned = vi
+      .mocked(execFileSync)
+      .mock.calls.map((c) => [String(c[0]), ...((c[1] ?? []) as readonly string[])].join(' '));
+    // The resolver's npm profile for the fixture repo. No literal is spelled in
+    // the module: change the fixture's manifest and this command changes with it.
+    expect(spawned).toContain('npm run test:run');
+  });
+
+  it('TypecheckLeg_UsesResolvedCommand', async () => {
+    const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+    vi.mocked(getOrCreateMaterializer).mockReturnValue(
+      createMockMaterializer(
+        mockTaskDetailView({ t1: { status: 'completed' } }),
+      ) as unknown as ReturnType<typeof getOrCreateMaterializer>,
+    );
+    vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+    vi.mocked(execFileSync).mockImplementation(legRunner());
+
+    await handlePrepareSynthesis(
+      { featureId: 'test-feature', repoRoot: tmpDir },
+      tmpDir,
+      mockStore as unknown as EventStore,
+    );
+
+    const spawned = vi
+      .mocked(execFileSync)
+      .mock.calls.map((c) => [String(c[0]), ...((c[1] ?? []) as readonly string[])].join(' '));
+    expect(spawned).toContain('npm run typecheck');
+  });
+
+  it('ExitCodeOnlyCarrier_ReportsNoCounts_AndTypecheckIsUnmeasured', async () => {
+    // A Go worktree. Its runner resolves and its exit code is a complete
+    // verdict, but it prints no summary this parse understands — so the counts
+    // are absent rather than scraped out of another runner's grammar, even
+    // though the output here would satisfy the pattern.
+    //
+    // Go resolves NO typecheck command, and that is the resolver's own
+    // 'unresolved' answer, not the project withdrawing the obligation. So the
+    // leg is indeterminate: it does not pass, and it does not invent a command.
+    const goRepo = await fs.mkdtemp(path.join(os.tmpdir(), 'prepare-synthesis-go-'));
+    try {
+      await fs.writeFile(path.join(goRepo, 'go.mod'), 'module example.com/thing\n');
+      const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+      vi.mocked(getOrCreateMaterializer).mockReturnValue(
+        createMockMaterializer(
+          mockTaskDetailView({ t1: { status: 'completed' } }),
+        ) as unknown as ReturnType<typeof getOrCreateMaterializer>,
+      );
+      vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+      vi.mocked(execFileSync).mockImplementation(legRunner());
+
+      const result = await handlePrepareSynthesis(
+        { featureId: 'test-feature', repoRoot: goRepo },
+        goRepo,
+        mockStore as unknown as EventStore,
+      );
+
+      const data = result.data as {
+        skipped?: true;
+        reason?: string;
+        blockers?: string[];
+        tests: { passed: boolean; passCount?: number; failCount?: number };
+        typecheck: { passed: boolean; indeterminate?: true; reason?: string };
+        readiness: { typecheckPass: boolean };
+      };
+      const spawned = vi
+        .mocked(execFileSync)
+        .mock.calls.map((c) => [String(c[0]), ...((c[1] ?? []) as readonly string[])].join(' '));
+      expect(spawned).toContain('go test ./...');
+      expect(data.tests.passed).toBe(true);
+      expect(data.tests.passCount).toBeUndefined();
+      expect(data.tests.failCount).toBeUndefined();
+      // The leg the resolver could not answer for is unmeasured, NOT green.
+      expect(data.typecheck.indeterminate).toBe(true);
+      expect(data.typecheck.passed).toBe(false);
+      expect(data.readiness.typecheckPass).toBe(false);
+      expect(data.typecheck.reason).toContain('typecheck');
+      // Tests passed and nothing failed, so the whole carrier is unconcluded
+      // rather than reporting a failure nobody observed.
+      expect(data.skipped).toBe(true);
+      expect(data.reason).toContain('Typecheck');
+      expect(data.blockers?.some((b) => b.includes('Typecheck could not be run'))).toBe(true);
+      // No `go typecheck` was invented for a toolchain that has none.
+      expect(spawned.some((c) => c.includes('typecheck'))).toBe(false);
+    } finally {
+      await fs.rm(goRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('TypecheckLeg_ObservedFailureElsewhere_IsNotSoftenedToSkipped', async () => {
+    // Discriminating twin: the same Go worktree, but the suite genuinely
+    // FAILS. A gate that observed a failure has produced a finding, so it must
+    // not declare itself skipped — that would erase the one thing it measured.
+    const goRepo = await fs.mkdtemp(path.join(os.tmpdir(), 'prepare-synthesis-go-fail-'));
+    try {
+      await fs.writeFile(path.join(goRepo, 'go.mod'), 'module example.com/thing\n');
+      const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+      vi.mocked(getOrCreateMaterializer).mockReturnValue(
+        createMockMaterializer(
+          mockTaskDetailView({ t1: { status: 'completed' } }),
+        ) as unknown as ReturnType<typeof getOrCreateMaterializer>,
+      );
+      vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+      // `go test ./...` exits non-zero: a real, observed suite failure.
+      vi.mocked(execFileSync).mockImplementation(legRunner({ test: 'FAIL' }));
+
+      const result = await handlePrepareSynthesis(
+        { featureId: 'test-feature', repoRoot: goRepo },
+        goRepo,
+        mockStore as unknown as EventStore,
+      );
+
+      const data = result.data as {
+        skipped?: true;
+        tests: { passed: boolean; indeterminate?: true };
+        typecheck: { indeterminate?: true };
+      };
+      expect(data.tests.passed).toBe(false);
+      expect(data.tests.indeterminate).toBeUndefined();
+      expect(data.typecheck.indeterminate).toBe(true);
+      expect(data.skipped).toBeUndefined();
+    } finally {
+      await fs.rm(goRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('TestLeg_RunnerNeverStarts_IsIndeterminate_NotAFailingSuite', async () => {
+    // ENOENT carries no numeric exit status: nothing observed the suite. The
+    // leg is unmeasured rather than failing, and no counts are reported.
+    const goRepo = await fs.mkdtemp(path.join(os.tmpdir(), 'prepare-synthesis-enoent-'));
+    try {
+      await fs.writeFile(path.join(goRepo, 'go.mod'), 'module example.com/thing\n');
+      const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+      vi.mocked(getOrCreateMaterializer).mockReturnValue(
+        createMockMaterializer(
+          mockTaskDetailView({ t1: { status: 'completed' } }),
+        ) as unknown as ReturnType<typeof getOrCreateMaterializer>,
+      );
+      vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+      vi.mocked(execFileSync).mockImplementation(((program: string) => {
+        if (String(program) === 'go') {
+          // No numeric `status`: the process was never created.
+          throw Object.assign(new Error('spawnSync go ENOENT'), { code: 'ENOENT' });
+        }
+        return Buffer.from('');
+      }) as unknown as typeof execFileSync);
+
+      const result = await handlePrepareSynthesis(
+        { featureId: 'test-feature', repoRoot: goRepo },
+        goRepo,
+        mockStore as unknown as EventStore,
+      );
+
+      const data = result.data as {
+        skipped?: true;
+        reason?: string;
+        tests: { passed: boolean; indeterminate?: true; reason?: string; passCount?: number };
+      };
+      expect(data.tests.indeterminate).toBe(true);
+      expect(data.tests.passed).toBe(false);
+      expect(data.tests.reason).toContain('ENOENT');
+      expect(data.tests.passCount).toBeUndefined();
+      expect(data.skipped).toBe(true);
+      expect(data.reason).toContain('Test suite');
+    } finally {
+      await fs.rm(goRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('UnresolvedRuntime_YieldsIndeterminate_NotFail', async () => {
+    // A governed repository with no resolvable test runtime — the case a
+    // literal `npm run test:run` could only ever answer with a spurious red.
+    const bareRepo = await fs.mkdtemp(path.join(os.tmpdir(), 'prepare-synthesis-bare-'));
+    try {
+      const mockStore = createMockEventStore(tasksToEvents({ t1: { status: 'completed' } }));
+      vi.mocked(getOrCreateMaterializer).mockReturnValue(
+        createMockMaterializer(
+          mockTaskDetailView({ t1: { status: 'completed' } }),
+        ) as unknown as ReturnType<typeof getOrCreateMaterializer>,
+      );
+      vi.mocked(execSync).mockImplementation(gitRunner('main', 'main'));
+      vi.mocked(execFileSync).mockImplementation(legRunner());
+
+      const result = await handlePrepareSynthesis(
+        { featureId: 'test-feature', repoRoot: bareRepo },
+        bareRepo,
+        mockStore as unknown as EventStore,
+      );
+
+      const data = result.data as {
+        ready: boolean;
+        skipped?: true;
+        reason?: string;
+        blockers?: string[];
+        tests: { passed: boolean; indeterminate?: true; reason?: string };
+        typecheck: { passed: boolean; indeterminate?: true };
+      };
+      // Nothing was spawned against the bare tree.
+      const spawned = vi
+        .mocked(execFileSync)
+        .mock.calls.filter((c) => String(c[0]) !== 'git');
+      expect(spawned).toHaveLength(0);
+      // Neither a pass nor a failure: the carrier declares it could not run,
+      // which is what the shared verdict normalizer reads as indeterminate.
+      expect(data.skipped).toBe(true);
+      expect(data.reason).toBeTruthy();
+      expect(data.tests.indeterminate).toBe(true);
+      expect(data.typecheck.indeterminate).toBe(true);
+      expect(data.ready).toBe(false);
+      expect(data.blockers?.some((b) => b.includes('could not be run'))).toBe(true);
+
+      // The durable row says the same thing the carrier does.
+      const testGate = mockStore.append.mock.calls.find((call: unknown[]) => {
+        const e = call[1] as { type: string; data: { gateName: string } };
+        return e.type === 'gate.executed' && e.data.gateName === 'test-suite';
+      });
+      expect(
+        (testGate![1] as { data: { details?: Record<string, unknown> } }).data.details
+          ?.['indeterminate'],
+      ).toBe(true);
+    } finally {
+      await fs.rm(bareRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('NoNpmLiteral_RemainsInModule', async () => {
+    // The property, asserted on the source itself: a package-manager literal in
+    // this module is a command the governed repository never chose. The
+    // resolver is the only thing allowed to name one.
+    const source = await fs.readFile(
+      path.join(process.cwd(), 'src/verbs/team/prepare-synthesis.ts'),
+      'utf-8',
+    );
+    const code = source
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('//') && !line.trimStart().startsWith('*'))
+      .join('\n');
+    for (const literal of ['npm ', 'pnpm ', 'yarn ', 'npx ', 'bun ', 'test:run']) {
+      expect(code).not.toContain(literal);
+    }
   });
 
   // ─── DR-8 (#1756): repoRoot is threaded to every subprocess leg ───────────

--- a/tests/unit/verbs/team/setup-worktree.test.ts
+++ b/tests/unit/verbs/team/setup-worktree.test.ts
@@ -144,9 +144,18 @@ describe('handleSetupWorktree', () => {
     });
     vi.mocked(existsSync).mockImplementation((p: unknown) => {
       const path = String(p);
+      if (path === '/repo/.gitignore') return true;
       if (path === '/repo/.worktrees/task-001-setup') return false;
       if (path === '/repo/.worktrees/task-001-setup/package.json') return true;
       return false;
+    });
+    // Every step must be able to PASS for "all steps pass" to mean anything —
+    // the gitignore step only passes when the repo file already lists the entry.
+    vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path === '/repo/.gitignore') return '.worktrees/\n';
+      if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+      return '';
     });
 
     const result = await callSetup({
@@ -159,6 +168,7 @@ describe('handleSetupWorktree', () => {
     const data = result.data as { passed: boolean; checks: { pass: number; fail: number; skip: number } };
     expect(data.passed).toBe(true);
     expect(data.checks.fail).toBe(0);
+    expect(data.checks.skip).toBe(0);
     expect(data.checks.pass).toBe(5);
   });
 
@@ -232,101 +242,6 @@ describe('handleSetupWorktree', () => {
     const data = result.data as { passed: boolean; report: string };
     expect(data.passed).toBe(true);
     expect(data.report).toContain('already exists');
-  });
-
-  // ── Test 4: .worktrees not gitignored → adds to .gitignore ─────────────
-
-  it('WorktreesNotGitignored_AddsToGitignore', async () => {
-    let gitignoreCheckCallCount = 0;
-    vi.mocked(execFileSync).mockImplementation((cmd: unknown, args: unknown) => {
-      const cmdStr = String(cmd).replace(/\.cmd$/, '');
-      const argsArr = args as string[];
-      if (cmdStr === 'git' && argsArr.includes('check-ignore')) {
-        gitignoreCheckCallCount++;
-        if (gitignoreCheckCallCount === 1) {
-          const error = new Error('not ignored') as Error & { status: number };
-          error.status = 1;
-          throw error;
-        }
-        return '';
-      }
-      if (cmdStr === 'git' && argsArr.includes('show-ref')) return '';
-      if (cmdStr === 'git' && argsArr.includes('rev-parse')) return '.git';
-      if (cmdStr === 'npm' && argsArr.includes('install')) return '';
-      if (cmdStr === 'npm' && argsArr.includes('test:run')) return '';
-      return '';
-    });
-    vi.mocked(existsSync).mockImplementation((p: unknown) => {
-      const path = String(p);
-      if (path === '/repo/.gitignore') return true;
-      if (path === '/repo/.worktrees/task-004-api') return true;
-      if (path === '/repo/.worktrees/task-004-api/package.json') return true;
-      return false;
-    });
-    vi.mocked(readFileSync).mockImplementation((p: unknown) => {
-      const path = String(p);
-      if (path === '/repo/.gitignore') return 'node_modules/\n';
-      if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
-      return '';
-    });
-
-    const result = await callSetup({
-      repoRoot: '/repo',
-      taskId: 'task-004',
-      taskName: 'api',
-    });
-
-    expect(result.success).toBe(true);
-    expect(appendFileSync).toHaveBeenCalledWith(
-      '/repo/.gitignore',
-      '.worktrees/\n',
-    );
-  });
-
-  // ── #1213 / CodeRabbit #7: gitignore append must preserve line boundary ─
-
-  it('WorktreesNotGitignored_ExistingGitignoreNoTrailingNewline_PrependsNewline', async () => {
-    // Existing .gitignore lacks trailing newline (ends with "dist", no \n).
-    // A bare append would produce "dist.worktrees/\n" — a single
-    // concatenated line that no longer ignores either path. The fix
-    // prepends a newline so the final contents are "dist\n.worktrees/\n".
-    vi.mocked(execFileSync).mockImplementation((cmd: unknown, args: unknown) => {
-      const cmdStr = String(cmd).replace(/\.cmd$/, '');
-      const argsArr = args as string[];
-      if (cmdStr === 'git' && argsArr.includes('show-ref')) return '';
-      if (cmdStr === 'git' && argsArr.includes('rev-parse')) return '.git';
-      if (cmdStr === 'npm' && argsArr.includes('install')) return '';
-      if (cmdStr === 'npm' && argsArr.includes('test:run')) return '';
-      return '';
-    });
-    vi.mocked(existsSync).mockImplementation((p: unknown) => {
-      const path = String(p);
-      if (path === '/repo/.gitignore') return true;
-      if (path === '/repo/.worktrees/task-004b-newline') return true;
-      if (path === '/repo/.worktrees/task-004b-newline/package.json') return true;
-      return false;
-    });
-    vi.mocked(readFileSync).mockImplementation((p: unknown) => {
-      const path = String(p);
-      // Crucially: NO trailing newline here.
-      if (path === '/repo/.gitignore') return 'dist';
-      if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
-      return '';
-    });
-
-    const result = await callSetup({
-      repoRoot: '/repo',
-      taskId: 'task-004b',
-      taskName: 'newline',
-    });
-
-    expect(result.success).toBe(true);
-    // The append payload MUST start with \n so the final content is
-    // "dist\n.worktrees/\n", not "dist.worktrees/\n".
-    expect(appendFileSync).toHaveBeenCalledWith(
-      '/repo/.gitignore',
-      '\n.worktrees/\n',
-    );
   });
 
   // ── Test 5: install fails ───────────────────────────────────────────────
@@ -961,9 +876,9 @@ describe('handleSetupWorktree', () => {
     expect(pnpmCalls).toHaveLength(0);
   });
 
-  // ─── DR-1 (T-07, #1203): direct-read .gitignore, honest PASS message ──
+  // ─── The governed repo's .gitignore: read directly, never written ──────────
 
-  describe('ensureGitignored direct-read behavior', () => {
+  describe('checkGitignored reports the repo file and never writes it', () => {
     function setupBaseExecMocks() {
       // Generic happy-path mocks for show-ref / rev-parse / install / test.
       vi.mocked(execFileSync).mockImplementation((cmd: unknown, args: unknown) => {
@@ -979,7 +894,7 @@ describe('handleSetupWorktree', () => {
       });
     }
 
-    it('ensureGitignored_AlreadyPresent_ReportsAlreadyPresent', async () => {
+    it('checkGitignored_AlreadyPresent_ReportsAlreadyPresent', async () => {
       setupBaseExecMocks();
       vi.mocked(existsSync).mockImplementation((p: unknown) => {
         const path = String(p);
@@ -1005,64 +920,12 @@ describe('handleSetupWorktree', () => {
       expect(appendFileSync).not.toHaveBeenCalledWith('/repo/.gitignore', expect.anything());
     });
 
-    it('ensureGitignored_NotPresent_AppendsAndReportsAdded', async () => {
-      setupBaseExecMocks();
-      vi.mocked(existsSync).mockImplementation((p: unknown) => {
-        const path = String(p);
-        if (path === '/repo/.gitignore') return true;
-        if (path === '/repo/.worktrees/T-002-y') return true;
-        if (path === '/repo/.worktrees/T-002-y/package.json') return true;
-        return false;
-      });
-      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
-        const path = String(p);
-        if (path === '/repo/.gitignore') return 'node_modules/\n';
-        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
-        return '';
-      });
-
-      const result = await callSetup({
-        repoRoot: '/repo', taskId: 'T-002', taskName: 'y',
-      });
-
-      expect(result.success).toBe(true);
-      const data = result.data as { report: string };
-      expect(data.report).toMatch(/PASS.*\.worktrees is gitignored.*added/i);
-      expect(appendFileSync).toHaveBeenCalledWith('/repo/.gitignore', '.worktrees/\n');
-    });
-
-    it('ensureGitignored_FileMissing_CreatesWithEntry', async () => {
-      setupBaseExecMocks();
-      vi.mocked(existsSync).mockImplementation((p: unknown) => {
-        const path = String(p);
-        if (path === '/repo/.gitignore') return false;
-        if (path === '/repo/.worktrees/T-003-z') return true;
-        if (path === '/repo/.worktrees/T-003-z/package.json') return true;
-        return false;
-      });
-      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
-        const path = String(p);
-        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
-        return '';
-      });
-
-      const result = await callSetup({
-        repoRoot: '/repo', taskId: 'T-003', taskName: 'z',
-      });
-
-      expect(result.success).toBe(true);
-      const data = result.data as { report: string };
-      expect(data.report).toMatch(/PASS.*\.worktrees is gitignored.*created/i);
-      expect(appendFileSync).toHaveBeenCalledWith('/repo/.gitignore', '.worktrees/\n');
-    });
-
-    it('ensureGitignored_GlobalIgnoreOnlyMatch_StillReportsHonestlyAndUpdatesRepoGitignore', async () => {
-      // Critical regression coverage for #1203: a non-repo source (e.g.,
-      // global gitignore, .git/info/exclude) might tell `git check-ignore`
-      // the path is ignored. Repo `.gitignore` itself is empty of this entry
-      // and `git status` from a fresh clone would show .worktrees/ as
-      // untracked. The new contract: PASS message reflects the repo file
-      // state truthfully, and we always update the repo file when needed.
+    it('checkGitignored_GlobalIgnoreOnlyMatch_StillReportsTheRepoFileHonestly', async () => {
+      // A non-repo source (global gitignore, .git/info/exclude, a parent glob)
+      // might tell `git check-ignore` the path is ignored while the repo file
+      // itself lacks the entry — `git status` in a fresh clone would then show
+      // .worktrees/ as untracked. The contract: the report reflects the repo
+      // file, and `git check-ignore` is never consulted.
       setupBaseExecMocks();
       vi.mocked(existsSync).mockImplementation((p: unknown) => {
         const path = String(p);
@@ -1084,18 +947,17 @@ describe('handleSetupWorktree', () => {
 
       expect(result.success).toBe(true);
       const data = result.data as { report: string };
-      // Even if a global ignore would have matched, the repo file is
-      // missing — function must add and report 'added' truthfully.
-      expect(data.report).toMatch(/added/i);
-      expect(appendFileSync).toHaveBeenCalledWith('/repo/.gitignore', '.worktrees/\n');
-      // No git check-ignore call — function works directly off the repo file.
+      // Not PASS: whatever a global ignore would have said, the repo file is
+      // missing the entry, and that is what gets reported.
+      expect(data.report).toMatch(/SKIP.*\.worktrees is gitignored/i);
+      // No git check-ignore call — the step works directly off the repo file.
       const checkIgnoreCalls = vi.mocked(execFileSync).mock.calls.filter(
         (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('check-ignore'),
       );
       expect(checkIgnoreCalls).toHaveLength(0);
     });
 
-    it('ensureGitignored_AppendThrows_ReportsFail', async () => {
+    it('checkGitignored_ReadThrows_ReportsFail', async () => {
       setupBaseExecMocks();
       vi.mocked(existsSync).mockImplementation((p: unknown) => {
         const path = String(p);
@@ -1104,11 +966,8 @@ describe('handleSetupWorktree', () => {
       });
       vi.mocked(readFileSync).mockImplementation((p: unknown) => {
         const path = String(p);
-        if (path === '/repo/.gitignore') return 'node_modules/\n';
+        if (path === '/repo/.gitignore') throw new Error('EACCES: permission denied');
         return '';
-      });
-      vi.mocked(appendFileSync).mockImplementation(() => {
-        throw new Error('EACCES: permission denied');
       });
 
       const result = await callSetup({
@@ -1119,6 +978,80 @@ describe('handleSetupWorktree', () => {
       const data = result.data as { passed: boolean; report: string };
       expect(data.report).toMatch(/FAIL.*\.worktrees is gitignored.*EACCES/i);
       expect(data.passed).toBe(false);
+    });
+
+    it('GitignoreIsNeverWritten_MissingEntryOrMissingFile', async () => {
+      // The governed repository's .gitignore is that repository's to own, and
+      // there is no opt-in that changes that: setup_worktree must not edit it —
+      // not when the entry is merely missing, and not when the file is absent —
+      // and must say so both times.
+      setupBaseExecMocks();
+      for (const gitignoreExists of [true, false]) {
+        vi.mocked(appendFileSync).mockClear();
+        vi.mocked(existsSync).mockImplementation((p: unknown) => {
+          const path = String(p);
+          if (path === '/repo/.gitignore') return gitignoreExists;
+          if (path === '/repo/.worktrees/T-006-c') return true;
+          if (path === '/repo/.worktrees/T-006-c/package.json') return true;
+          return false;
+        });
+        vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+          const path = String(p);
+          if (path === '/repo/.gitignore') return 'node_modules/\n';
+          if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+          return '';
+        });
+
+        const result = await callSetup({
+          repoRoot: '/repo', taskId: 'T-006', taskName: 'c',
+        });
+
+        expect(result.success).toBe(true);
+        const data = result.data as { report: string };
+        expect(data.report).toMatch(/SKIP.*\.worktrees is gitignored/i);
+        expect(appendFileSync).not.toHaveBeenCalled();
+      }
+    });
+
+    it('MissingIgnoreEntry_IsReported_NotSilentlyWritten', async () => {
+      // A missing entry is a condition the operator is told about, naming the
+      // file and the line to add — not a silent repair, and not a setup failure.
+      setupBaseExecMocks();
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return true;
+        if (path === '/repo/.worktrees/T-007-d') return true;
+        if (path === '/repo/.worktrees/T-007-d/package.json') return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return 'node_modules/\n';
+        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+        return '';
+      });
+
+      const result = await callSetup({
+        repoRoot: '/repo', taskId: 'T-007', taskName: 'd',
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        passed: boolean;
+        report: string;
+        checks: { pass: number; fail: number; skip: number };
+      };
+      expect(data.report).toMatch(/SKIP.*\.worktrees is gitignored/i);
+      expect(data.report).toContain('/repo/.gitignore');
+      expect(data.report).toContain(".worktrees/' line");
+      expect(data.checks.skip).toBe(1);
+      // The skip must survive into the headline verdict. Counting only
+      // pass/fail there lets a repo that cannot pass this check read as a
+      // clean sweep of the checks that did run.
+      expect(data.report).toMatch(/\*\*Result: PASS\*\* \(\d+\/\d+ checks passed, 1 skipped\)/);
+      // Reported, not fatal.
+      expect(data.passed).toBe(true);
+      expect(appendFileSync).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/verbs/vcs/check-coderabbit.test.ts
+++ b/tests/unit/verbs/vcs/check-coderabbit.test.ts
@@ -4,8 +4,21 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { VcsProvider, ReviewStatus, ReviewerStatus } from '../../../../src/vcs/provider.js';
-import { handleCheckCoderabbit } from '../../../../src/verbs/vcs/check-coderabbit.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  handleCheckCoderabbit,
+  CODERABBIT_REVIEWER_ABSENT,
+} from '../../../../src/verbs/vcs/check-coderabbit.js';
 import type { PrReviewResult } from '../../../../src/verbs/vcs/check-coderabbit.js';
+
+/** The check's only documented consumer — synthesize step 4. */
+const CONSUMER_DOC = fileURLToPath(
+  new URL(
+    '../../../../content/synthesis/skills/synthesize/references/synthesis-steps.md',
+    import.meta.url,
+  ),
+);
 
 // ─── Mock VcsProvider Helper ────────────────────────────────────────────────
 
@@ -112,9 +125,13 @@ describe('handleCheckCoderabbit', () => {
     expect(data.results[0].verdict).toBe('fail');
   });
 
-  // ─── No CodeRabbit Review -> Pass (NONE) ────────────────────────────────
+  // ─── No CodeRabbit Review -> Indeterminate (NONE) ───────────────────────
 
-  it('handleCheckCoderabbit_NoReview_ReturnsPassedWithNone', async () => {
+  it('CodeRabbit_AbsentVendor_IsIndeterminate_NotPass', async () => {
+    // A human approval is not this reviewer's approval. The check exists to
+    // establish that CodeRabbit looked at the PR; nothing here establishes it,
+    // so the absence yields no verdict rather than the pass it used to mint —
+    // which read as coverage on every repository the reviewer does not watch.
     const provider = createMockProvider({
       1: makeReviewStatus([{ login: 'some-human', state: 'approved' }]),
     });
@@ -125,10 +142,45 @@ describe('handleCheckCoderabbit', () => {
     );
 
     expect(result.success).toBe(true);
-    const data = result.data as { passed: boolean; results: PrReviewResult[] };
-    expect(data.passed).toBe(true);
+    const data = result.data as {
+      passed: boolean;
+      skipped?: boolean;
+      discriminant?: string;
+      reason?: string;
+      report: string;
+      results: PrReviewResult[];
+    };
     expect(data.results[0].state).toBe('NONE');
-    expect(data.results[0].verdict).toBe('pass');
+    expect(data.results[0].verdict).toBe('indeterminate');
+    expect(data.passed).toBe(false);
+    // The skip descriptor is what makes the gate verdict `indeterminate` rather
+    // than a `fail` naming a disproof nobody observed.
+    expect(data.skipped).toBe(true);
+    expect(data.discriminant).toBe('coderabbit-reviewer-absent');
+    expect(data.reason).toContain('#1');
+    expect(data.report).toContain('INDETERMINATE');
+
+    const { normalizeGateVerdict } = await import('../../../../src/verbs/gates/gate-utils.js');
+    expect(normalizeGateVerdict(result)).toBe('indeterminate');
+  });
+
+  it('CodeRabbit_RealFailureAlongsideAnAbsence_StaysAFailure', async () => {
+    // A disproof is a conclusion. Stamping the carrier as skipped because some
+    // OTHER PR went unmeasured would hide it behind an inconclusive verdict.
+    const provider = createMockProvider({
+      1: makeReviewStatus([{ login: 'coderabbitai[bot]', state: 'changes_requested' }]),
+      2: makeReviewStatus([{ login: 'some-human', state: 'approved' }]),
+    });
+
+    const result = await handleCheckCoderabbit(
+      { owner: 'acme', repo: 'app', prNumbers: [1, 2] },
+      provider,
+    );
+
+    const data = result.data as { passed: boolean; skipped?: boolean; report: string };
+    expect(data.passed).toBe(false);
+    expect(data.skipped).toBeUndefined();
+    expect(data.report).toContain('FAIL');
   });
 
   // ─── API Error -> Fail ──────────────────────────────────────────────────
@@ -165,6 +217,8 @@ describe('handleCheckCoderabbit', () => {
   // ─── Invalid PR Number -> Skip ──────────────────────────────────────────
 
   it('handleCheckCoderabbit_InvalidPrNumber_ReturnsSkip', async () => {
+    // A `skip` is a WITHDRAWN subject — the number cannot name a PR, so there
+    // was never an obligation. It is not the same as an unmeasured one.
     const provider = createMockProvider({
       5: makeReviewStatus([{ login: 'coderabbitai[bot]', state: 'approved' }]),
     });
@@ -238,5 +292,30 @@ describe('handleCheckCoderabbit', () => {
     const data = result.data as { passed: boolean; results: PrReviewResult[] };
     expect(data.passed).toBe(false);
     expect(data.results[0].verdict).toBe('fail');
+  });
+
+  // ─── The verdict has a reader ────────────────────────────────────────────
+
+  it('TheConsumer_BranchesOnTheAbsentReviewer_RatherThanOnPassedAlone', async () => {
+    // Withholding the pass is only half the fix. The single documented consumer
+    // routes `passed: false` to the shepherd fix cycle — and no amount of
+    // shepherding summons a review from a reviewer that is not installed, so an
+    // unread indeterminate becomes an unfixable blocking failure on every
+    // governed repository that does not use this vendor. The step has to know
+    // the third outcome exists, and it has to name it by the discriminant the
+    // carrier actually stamps.
+    const doc = readFileSync(CONSUMER_DOC, 'utf-8');
+
+    expect(
+      doc.length,
+      'the consumer document was not read — an empty result proves nothing',
+    ).toBeGreaterThan(0);
+    expect(
+      doc,
+      'synthesize step 4 must name the discriminant the carrier stamps, so a ' +
+        'rename cannot leave the consumer reading a verdict that no longer exists',
+    ).toContain(CODERABBIT_REVIEWER_ABSENT);
+    // And it must say what to DO with it, which is not the fix cycle.
+    expect(doc).toMatch(/skipped/i);
   });
 });

--- a/tests/unit/verbs/vcs/validate-pr-stack.test.ts
+++ b/tests/unit/verbs/vcs/validate-pr-stack.test.ts
@@ -4,6 +4,21 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { VcsProvider, PrSummary, PrFilter } from '../../../../src/vcs/provider.js';
+import { UnsupportedOperationError } from '../../../../src/vcs/provider.js';
+
+// The composed router calls this handler with ONE argument, so the production
+// path resolves its own provider. Mocking the factory is what lets a test stand
+// where production stands.
+// The mock FORWARDS its argument: `createVcsProvider` resolves the configured
+// `vcs.provider` from it and only auto-detects when it is absent, so a stub that
+// swallowed the argument could not tell a threaded config from a dropped one.
+const mockCreateVcsProvider = vi.fn<(opts?: CreateVcsProviderOpts) => Promise<VcsProvider>>();
+vi.mock('../../../../src/vcs/factory.js', () => ({
+  createVcsProvider: (opts?: CreateVcsProviderOpts) => mockCreateVcsProvider(opts),
+}));
+
+import type { CreateVcsProviderOpts } from '../../../../src/vcs/factory.js';
+import type { ResolvedProjectConfig } from '../../../../src/config/resolve.js';
 import { handleValidatePrStack } from '../../../../src/verbs/vcs/validate-pr-stack.js';
 
 // ─── Mock VcsProvider Helper ────────────────────────────────────────────────
@@ -32,6 +47,7 @@ function createMockProvider(overrides: {
 describe('handleValidatePrStack', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    mockCreateVcsProvider.mockReset();
   });
 
   it('NoPRs_ReturnsPassedTrue', async () => {
@@ -150,5 +166,107 @@ describe('handleValidatePrStack', () => {
     await handleValidatePrStack({ baseBranch: 'main' }, provider);
 
     expect(provider.listPrs).toHaveBeenCalledWith({ state: 'open' });
+  });
+
+  // ─── Host capability ─────────────────────────────────────────────────────
+
+  it('NonGitHubProvider_YieldsADeclaredSkip_NotGhCliError', async () => {
+    // GitLab and Azure DevOps both throw `UnsupportedOperationError` from
+    // `listPrs`, which this handler converts into a hard `GH_CLI_ERROR`. Since
+    // the action is a BLOCKING synthesis gate, that turned "this obligation does
+    // not apply to your host" into "your synthesis failed".
+    const provider: VcsProvider = {
+      ...createMockProvider(),
+      name: 'gitlab',
+      listPrs: vi.fn().mockRejectedValue(new UnsupportedOperationError('gitlab', 'listPrs')),
+    };
+
+    const result = await handleValidatePrStack({ baseBranch: 'main' }, provider);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { skipped?: boolean; provider?: string; operation?: string };
+    expect(data.skipped).toBe(true);
+    expect(data.provider).toBe('gitlab');
+    expect(data.operation).toBe('validate_pr_stack');
+    // The skip happens BEFORE the unsupported call, so nothing throws.
+    expect(provider.listPrs).not.toHaveBeenCalled();
+  });
+
+  it('SkipBranch_IsReachableInProduction', async () => {
+    // Called the way the router calls it: args only. The guard used to read the
+    // absent `provider` parameter, which it treats as "unconfigured, GitHub is
+    // implicit" — so on a real GitLab repository the skip was unreachable and
+    // the handler fell through to a hard failure. Resolving first is what makes
+    // the declared control run.
+    mockCreateVcsProvider.mockResolvedValue({
+      ...createMockProvider(),
+      name: 'azure-devops',
+    });
+
+    const result = await handleValidatePrStack({ baseBranch: 'main' });
+
+    expect(mockCreateVcsProvider).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.data as { skipped?: boolean }).toMatchObject({
+      skipped: true,
+      provider: 'azure-devops',
+    });
+
+    // A blocking gate must still carry a verdict. The skip descriptor makes it
+    // inconclusive, which fails closed at the phase boundary — it is not the
+    // vacuous pass that would let an unrunnable control read as coverage.
+    const { normalizeGateVerdict } = await import('../../../../src/verbs/gates/gate-utils.js');
+    expect(normalizeGateVerdict(result)).toBe('indeterminate');
+  });
+
+  it('GitHubProvider_ResolvedByTheFactory_StillRuns', async () => {
+    // The guard must not turn into a blanket skip: a resolved GitHub provider
+    // is exactly the case the gate exists for.
+    mockCreateVcsProvider.mockResolvedValue(createMockProvider({ listPrs: [] }));
+
+    const result = await handleValidatePrStack({ baseBranch: 'main' });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { passed: boolean }).passed).toBe(true);
+  });
+
+  it('MissingBaseBranch_IsRejectedBeforeAnyProviderIsResolved', async () => {
+    const result = await handleValidatePrStack({ baseBranch: '' });
+
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(mockCreateVcsProvider).not.toHaveBeenCalled();
+  });
+
+  // ─── Provider resolution reads the project's declaration ─────────────────
+
+  it('ConfiguredProvider_ReachesTheFactory_RatherThanHostnameDetection', async () => {
+    // `createVcsProvider` prefers `config.vcs.provider` and only falls back to
+    // parsing the remote's HOSTNAME. Calling it bare demotes an explicit
+    // declaration to a guess — and the guess misses every self-hosted or
+    // enterprise host, landing on the GitHub default for a repository that
+    // said it was something else.
+    mockCreateVcsProvider.mockResolvedValue({ ...createMockProvider(), name: 'gitlab' });
+    const projectConfig = { vcs: { provider: 'gitlab' } } as unknown as ResolvedProjectConfig;
+
+    await handleValidatePrStack({ baseBranch: 'main', projectConfig });
+
+    expect(mockCreateVcsProvider).toHaveBeenCalledWith({ config: projectConfig });
+  });
+
+  it('Router_InjectsTheDispatchConfig_SoTheArgIsNotADeadCarrier', async () => {
+    // The handler reads `args.projectConfig`; nothing would ever write it unless
+    // the composite adapter does. Asserting only the handler would leave a
+    // parameter no caller fills — the config would still be dropped, just one
+    // layer further out.
+    mockCreateVcsProvider.mockResolvedValue({ ...createMockProvider(), name: 'gitlab' });
+    const projectConfig = { vcs: { provider: 'gitlab' } } as unknown as ResolvedProjectConfig;
+
+    const { handleOrchestrate } = await import('../../../../src/verbs/composite.js');
+    await handleOrchestrate(
+      { action: 'validate_pr_stack', baseBranch: 'main' },
+      { stateDir: '/tmp/validate-pr-stack-router', projectConfig, enableTelemetry: false } as never,
+    );
+
+    expect(mockCreateVcsProvider).toHaveBeenCalledWith({ config: projectConfig });
   });
 });

--- a/tests/unit/verbs/verification-ladder-routing.test.ts
+++ b/tests/unit/verbs/verification-ladder-routing.test.ts
@@ -157,6 +157,9 @@ describe('verification-ladder self-routing (FIX-1)', () => {
         featureId: 'feat-low',
         taskId: 'T-low',
         repoRoot: '/fake/repo',
+        // Explicit: `/fake/repo` is not a repository, so nothing could DETECT a
+        // base — and these cases are about policy routing, not base resolution.
+        baseBranch: 'main',
         riskTier: 'low',
         boundaryTouching: false,
       },
@@ -183,6 +186,9 @@ describe('verification-ladder self-routing (FIX-1)', () => {
         featureId: 'feat-nb',
         taskId: 'T-nb',
         repoRoot: '/fake/repo',
+        // Explicit: `/fake/repo` is not a repository, so nothing could DETECT a
+        // base — and these cases are about policy routing, not base resolution.
+        baseBranch: 'main',
         riskTier: 'medium',
         boundaryTouching: false,
       },
@@ -208,6 +214,9 @@ describe('verification-ladder self-routing (FIX-1)', () => {
         featureId: 'feat-lb',
         taskId: 'T-lb',
         repoRoot: '/fake/repo',
+        // Explicit: `/fake/repo` is not a repository, so nothing could DETECT a
+        // base — and these cases are about policy routing, not base resolution.
+        baseBranch: 'main',
         riskTier: 'low',
         boundaryTouching: true,
       },
@@ -234,6 +243,9 @@ describe('verification-ladder self-routing (FIX-1)', () => {
         featureId: 'feat-lb2',
         taskId: 'T-lb2',
         repoRoot: '/fake/repo',
+        // Explicit: `/fake/repo` is not a repository, so nothing could DETECT a
+        // base — and these cases are about policy routing, not base resolution.
+        baseBranch: 'main',
         riskTier: 'low',
         boundaryTouching: true,
       },
@@ -255,6 +267,9 @@ describe('verification-ladder self-routing (FIX-1)', () => {
         featureId: 'feat-med',
         taskId: 'T-med',
         repoRoot: '/fake/repo',
+        // Explicit: `/fake/repo` is not a repository, so nothing could DETECT a
+        // base — and these cases are about policy routing, not base resolution.
+        baseBranch: 'main',
         riskTier: 'medium',
         boundaryTouching: false,
       },
@@ -278,6 +293,9 @@ describe('verification-ladder self-routing (FIX-1)', () => {
         featureId: 'feat-legacy',
         taskId: 'T-legacy',
         repoRoot: '/fake/repo',
+        // Explicit: `/fake/repo` is not a repository, so nothing could DETECT a
+        // base — and these cases are about policy routing, not base resolution.
+        baseBranch: 'main',
       },
       ctx,
     );

--- a/tools/audit/gates/check-gate-runner-ownership.mjs
+++ b/tools/audit/gates/check-gate-runner-ownership.mjs
@@ -31,6 +31,9 @@ const OWNER_CATEGORIES = new Set([
   'legacy-v3-reservation',
 ]);
 
+const unscopedRationale =
+  'Two observations, not two authorities. The second is the unscoped-run row: these three actions declare gate.executed with condition always, so a handler that returns success without appending one has drifted from its own registration and the post-dispatch emission verifier reports it. Returning early because no diff base could be detected is still a completed run with a verdict, and the row carries skipped + the discriminant so the log can tell "could not be scoped" from "never invoked". It is fail-closed (passed:false) and, like its sibling, produces no admission evidence.';
+
 const diagnosticRationale =
   'Compatibility gate.executed observation only; it is not v2.12 admission evidence or an enforcement authority.';
 const mergedRationale =
@@ -106,10 +109,10 @@ const DISPOSITIONS = Object.freeze([
     ['src/verbs/gates/check-event-emissions.ts', 1, 'orchestrate/check-event-emissions'],
     ['src/verbs/gates/check-exploration-depth.ts', 2, 'orchestrate/check-exploration-depth'],
     ['src/verbs/gates/check-invariant-conformance.ts', 1, 'orchestrate/check-invariant-conformance'],
-    ['src/verbs/gates/context-economy.ts', 1, 'orchestrate/context-economy'],
+    ['src/verbs/gates/context-economy.ts', 2, 'orchestrate/context-economy', unscopedRationale],
     ['src/verbs/gates/gate-utils.ts', 1, 'orchestrate/gate-utils'],
     ['src/verbs/gates/mutation-adequacy.ts', 3, 'orchestrate/mutation-adequacy'],
-    ['src/verbs/gates/operational-resilience.ts', 1, 'orchestrate/operational-resilience'],
+    ['src/verbs/gates/operational-resilience.ts', 2, 'orchestrate/operational-resilience', unscopedRationale],
     ['src/verbs/gates/plan-coverage.ts', 1, 'orchestrate/plan-coverage'],
     ['src/verbs/gates/post-merge.ts', 1, 'orchestrate/post-merge'],
     ['src/verbs/team/prepare-delegation.ts', 1, 'orchestrate/prepare-delegation'],
@@ -118,13 +121,13 @@ const DISPOSITIONS = Object.freeze([
     ['src/verbs/review/review-verdict.ts', 3, 'orchestrate/review-verdict'],
     ['src/verbs/gates/security-scan.ts', 1, 'orchestrate/security-scan'],
     ['src/verbs/tasks/task-decomposition.ts', 1, 'orchestrate/task-decomposition'],
-    ['src/verbs/gates/workflow-determinism.ts', 1, 'orchestrate/workflow-determinism'],
-  ].map(([file, count, owner]) => ({
+    ['src/verbs/gates/workflow-determinism.ts', 2, 'orchestrate/workflow-determinism', unscopedRationale],
+  ].map(([file, count, owner, rationale]) => ({
     file,
     kind: 'direct-gate-emitter',
     count,
     owner,
-    rationale: diagnosticRationale,
+    rationale: rationale ?? diagnosticRationale,
     category: 'diagnostic-observation',
   })),
   { file: 'src/verbs/vcs/assess-stack.ts', kind: 'manual-gate-event', count: 1, owner: 'orchestrate/assess-stack', rationale: 'Mirrors external CI check status for diagnostics; it does not produce admission evidence.', category: 'diagnostic-observation' },

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,11 +4,11 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1202,
-    "parsedFiles": 1157,
+    "testFiles": 1208,
+    "parsedFiles": 1163,
     "shellFiles": 45,
-    "cases": 13362,
-    "dynamicTitles": 144,
+    "cases": 13520,
+    "dynamicTitles": 149,
     "unparseableFiles": 0
   },
   "unparseable": [],
@@ -4629,6 +4629,137 @@
         }
       ]
     },
+    "tests/acceptance/ladder-off-node.test.ts": {
+      "file": "tests/acceptance/ladder-off-node.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "every declared toolchain composes only its own reporter flag",
+          "name": "TheRegistryIsANonEmptyDenominator",
+          "dynamic": false
+        },
+        {
+          "suite": "every declared toolchain composes only its own reporter flag",
+          "name": "BuiltinToolchain_ReceivesNoForeignReporterFlag [%s]",
+          "dynamic": false
+        },
+        {
+          "suite": "every declared toolchain composes only its own reporter flag",
+          "name": "<dynamic-case-1>",
+          "dynamic": true
+        },
+        {
+          "suite": "every declared toolchain composes only its own reporter flag",
+          "name": "CargoTest_DoesNotReceiveReporterJson",
+          "dynamic": false
+        },
+        {
+          "suite": "every declared toolchain composes only its own reporter flag",
+          "name": "DotnetTest_DoesNotReceiveReporterJson",
+          "dynamic": false
+        },
+        {
+          "suite": "a command from a higher resolver layer keeps its own carrier",
+          "name": "ConfigDeclaredPytest_AtANodeRepo_GetsNoReporterFlag",
+          "dynamic": false
+        },
+        {
+          "suite": "a command from a higher resolver layer keeps its own carrier",
+          "name": "TaskRunnerCommand_GetsNoReporterFlag",
+          "dynamic": false
+        },
+        {
+          "suite": "a command from a higher resolver layer keeps its own carrier",
+          "name": "NonNpmNodeCommand_IsSpawnedAsResolved_AndStillRead [%s]",
+          "dynamic": false
+        },
+        {
+          "suite": "a command from a higher resolver layer keeps its own carrier",
+          "name": "<dynamic-case-2>",
+          "dynamic": true
+        },
+        {
+          "suite": "an exit-code runner produces a complete verdict",
+          "name": "ExitCodeToolchain_ZeroExit_ClearsTheRung",
+          "dynamic": false
+        },
+        {
+          "suite": "an exit-code runner produces a complete verdict",
+          "name": "ExitCodeToolchain_NonZeroExit_FailsTheRung",
+          "dynamic": false
+        },
+        {
+          "suite": "an exit-code runner produces a complete verdict",
+          "name": "ExitCodeToolchain_ReportsNoCountsItCouldNotMeasure",
+          "dynamic": false
+        },
+        {
+          "suite": "the blocking ladder gate clears on a Rust repository",
+          "name": "RustRepo_GreenSuite_MintsProof",
+          "dynamic": false
+        },
+        {
+          "suite": "the blocking ladder gate clears on a Rust repository",
+          "name": "RustRepo_RedSuite_ReportsTheFailure",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot run says so",
+          "name": "NoToolchain_IsIndeterminate_NotNpmFallback",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot run says so",
+          "name": "NoTestCommand_IsIndeterminate_AndCarriesTheResolverSGuidance",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot run says so",
+          "name": "IndeterminateReport_SaysTheRungIsNotCleared",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot run says so",
+          "name": "ProjectDeclaredRunner_IsRunAndReadByItsExitCode_NotShutOut",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot run says so",
+          "name": "SpawnFailure_IsIndeterminate_OnBothCarriers",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot run says so",
+          "name": "MissingBinary_ThroughTheProductionRunner_IsIndeterminate",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot run says so",
+          "name": "HungRunner_YieldsIndeterminate",
+          "dynamic": false
+        },
+        {
+          "suite": "VitestRepo_BehaviourUnchanged",
+          "name": "ThisRepo_StillResolvesTheVitestJsonCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "VitestRepo_BehaviourUnchanged",
+          "name": "ThisRepo_GreenRun_StillParsesToPass",
+          "dynamic": false
+        },
+        {
+          "suite": "VitestRepo_BehaviourUnchanged",
+          "name": "ThisRepo_LoadCascade_StillFoldsIntoTheFailureCount",
+          "dynamic": false
+        },
+        {
+          "suite": "VitestRepo_BehaviourUnchanged",
+          "name": "ThisRepo_UnparseableOutput_StillFailsClosed",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/architecture/agent-instructions.test.ts": {
       "file": "tests/architecture/agent-instructions.test.ts",
       "runner": "vitest:root",
@@ -5206,6 +5337,57 @@
         }
       ]
     },
+    "tests/architecture/gate-toolchain-coverage.test.ts": {
+      "file": "tests/architecture/gate-toolchain-coverage.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "GateToolchainCoverage_Denominator_IsNonEmptyOnBothSides",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "GateToolchainCoverage_EveryRunner_NamesARegistryToolchain",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "SupportedToolchains_ShortfallIsAsserted",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "SupportedToolchains_CoverageAndShortfall_PartitionTheRegistry",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "SupportedToolchains_EveryShortfallEntry_CarriesAReason",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "SupportedToolchains_NoTwoEntries_ShareAReason",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "FillerReason_RedensTheGuard",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "NewToolchain_WithoutARunner_RedensTheGuard",
+          "dynamic": false
+        },
+        {
+          "suite": "static-analysis toolchain coverage",
+          "name": "RetiredRunner_AlsoRedensTheGuard",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/architecture/guard-liveness.test.ts": {
       "file": "tests/architecture/guard-liveness.test.ts",
       "runner": "vitest:root",
@@ -5442,6 +5624,27 @@
         {
           "suite": "locality",
           "name": "Locality_SeededOverflow_IsRejected",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/architecture/no-literal-base-branch.test.ts": {
+      "file": "tests/architecture/no-literal-base-branch.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "Base-branch resolution: the gate surface never invents a branch",
+          "name": "NoGateModule_ContainsALiteralMainFallback",
+          "dynamic": false
+        },
+        {
+          "suite": "Base-branch resolution: the gate surface never invents a branch",
+          "name": "SeededLiteralFallback_IsDetected",
+          "dynamic": false
+        },
+        {
+          "suite": "Base-branch resolution: the gate surface never invents a branch",
+          "name": "MentioningTheBranchName_IsNotAViolation",
           "dynamic": false
         }
       ]
@@ -41655,6 +41858,11 @@
         },
         {
           "suite": "Runbook parameter shape (DR-3 / T-05): delegation stamp threading",
+          "name": "SynthesisFlow_UsesCreatePrAction_NotBashGh",
+          "dynamic": false
+        },
+        {
+          "suite": "Runbook parameter shape (DR-3 / T-05): delegation stamp threading",
           "name": "CheckStaticAnalysis_NeverBindsTheStamp_T04Exclusion",
           "dynamic": false
         },
@@ -48320,6 +48528,61 @@
           "suite": "resolveBaseBranch",
           "name": "EmptyProviderDefaultBranch_FallsThrough",
           "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "NoOriginHead_TheRemoteIsAskedDirectly",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "RemoteWithNoHead_IsNotABranchNamedUnknown",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "LocalRefWins_AndTheNetworkIsNeverTouched",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "InferredDefault_IsAcceptedOnlyAfterTheBranchIsSeenToExist",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "InferredDefault_NamingAMissingBranch_IsNoAnswer",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "UnresolvedReason_NamesEverySignalAndItsTrustClass",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveDiffBase",
+          "name": "ExplicitRefWins_AndNeverAsksGit",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveDiffBase",
+          "name": "BlankExplicitRef_IsNoAnswer_NotABranch",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveDiffBase",
+          "name": "AbsentExplicitRef_FallsThroughToDetection",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveDiffBase",
+          "name": "DiscriminantText_LivesInExactlyOnePlace",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveDiffBase",
+          "name": "SeededCopyOfTheDiscriminant_IsDetected",
+          "dynamic": false
         }
       ]
     },
@@ -49780,7 +50043,7 @@
         },
         {
           "suite": "check_integration_suite command resolution (#1537, DR-15)",
-          "name": "checkIntegrationSuite_RunnerSpawnFailure_DistinctFromJsonShapeMismatch",
+          "name": "checkIntegrationSuite_RunnerNeverStarted_IsNotTheSameAsRanAndGarbled",
           "dynamic": false
         },
         {
@@ -49908,7 +50171,12 @@
         },
         {
           "suite": "Check Polish Scope",
-          "name": "default baseBranch is \"main\"",
+          "name": "DetectsTheDefaultBranch_RatherThanAssumingMain",
+          "dynamic": false
+        },
+        {
+          "suite": "Check Polish Scope",
+          "name": "UnresolvedBase_ReportsIt_AndNeverDiffsAgainstMain",
           "dynamic": false
         }
       ]
@@ -49956,6 +50224,16 @@
           "suite": "handleContextEconomy > telemetry integration",
           "name": "handleContextEconomy_WithoutTelemetryData_ReturnsZeroMetrics",
           "dynamic": false
+        },
+        {
+          "suite": "handleContextEconomy > base branch",
+          "name": "handleContextEconomy_UnresolvedBase_IsInconclusive_NotPass",
+          "dynamic": false
+        },
+        {
+          "suite": "handleContextEconomy > base branch",
+          "name": "handleContextEconomy_ExplicitBase_IsUsedVerbatim",
+          "dynamic": false
         }
       ]
     },
@@ -49976,6 +50254,11 @@
         {
           "suite": "check_contract_drift registration + dispatch + steer",
           "name": "NextActions_OnPass_CarriesOneSemanticTestSteer",
+          "dynamic": false
+        },
+        {
+          "suite": "check_contract_drift registration + dispatch + steer",
+          "name": "UnresolvedBase_IsInconclusive_NotAPassAndNotADriftFinding",
           "dynamic": false
         }
       ]
@@ -50751,6 +51034,11 @@
           "suite": "check_mock_boundary registration + dispatch + steer",
           "name": "SteerForFinding_UnclassifiedDependency_FallsBackToGenericMenu",
           "dynamic": false
+        },
+        {
+          "suite": "check_mock_boundary registration + dispatch + steer",
+          "name": "UnresolvedBase_IsInconclusive_NotACleanBoundaryReport",
+          "dynamic": false
         }
       ]
     },
@@ -51325,13 +51613,23 @@
           "dynamic": false
         },
         {
-          "suite": "handleNeedsSchemaSync > default baseBranch",
-          "name": "defaults baseBranch to \"main\"",
+          "suite": "handleNeedsSchemaSync > base branch",
+          "name": "DetectsTheDefaultBranch_RatherThanAssumingMain",
           "dynamic": false
         },
         {
-          "suite": "handleNeedsSchemaSync > default baseBranch",
+          "suite": "handleNeedsSchemaSync > base branch",
           "name": "uses custom baseBranch when provided",
+          "dynamic": false
+        },
+        {
+          "suite": "handleNeedsSchemaSync > base branch",
+          "name": "UnresolvedBase_ReportsIt_AndNeverDiffsAgainstMain",
+          "dynamic": false
+        },
+        {
+          "suite": "handleNeedsSchemaSync > base branch",
+          "name": "SuppliedDiffFile_NeedsNoBaseAtAll",
           "dynamic": false
         },
         {
@@ -51368,6 +51666,11 @@
         {
           "suite": "handleOperationalResilience > git diff failure",
           "name": "handleOperationalResilience_GitDiffFails_ReturnsError",
+          "dynamic": false
+        },
+        {
+          "suite": "handleOperationalResilience > base branch",
+          "name": "handleOperationalResilience_UnresolvedBase_IsInconclusive_NotPass",
           "dynamic": false
         }
       ]
@@ -51751,6 +52054,16 @@
         {
           "suite": "handlePostMerge",
           "name": "handlePostMerge_PassesRunCommandAdapter",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePostMerge",
+          "name": "handlePostMerge_ThreadsRepoRootIntoTheCheck_NotOnlyIntoTheRunner",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePostMerge",
+          "name": "handlePostMerge_IndeterminateCheck_IsNotCollapsedToAFailure",
           "dynamic": false
         }
       ]
@@ -52136,6 +52449,31 @@
         },
         {
           "suite": "handleSpecCoverageCheck",
+          "name": "SpecCoverage_DoesNotSpawnNpxVitest",
+          "dynamic": false
+        },
+        {
+          "suite": "handleSpecCoverageCheck",
+          "name": "SpecCoverage_DeclaredPathIsNotAppendedToTheResolvedCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "handleSpecCoverageCheck",
+          "name": "SpecCoverage_UnresolvedRuntime_IsIndeterminate_NotGreen",
+          "dynamic": false
+        },
+        {
+          "suite": "handleSpecCoverageCheck",
+          "name": "SpecCoverage_RunnerNeverStarts_IsIndeterminate_NotAFailingTest",
+          "dynamic": false
+        },
+        {
+          "suite": "handleSpecCoverageCheck",
+          "name": "SpecCoverage_RunnerTimesOut_IsIndeterminate_NotAFailingTest",
+          "dynamic": false
+        },
+        {
+          "suite": "handleSpecCoverageCheck",
           "name": "planFileNotFound_returnsError",
           "dynamic": false
         },
@@ -52512,6 +52850,16 @@
           "suite": "check_test_adequacy routing + idempotency (task 014)",
           "name": "GateEvent_MigratedPath_DoesNotEmitLegacyGateEvent",
           "dynamic": false
+        },
+        {
+          "suite": "check_test_adequacy routing + idempotency (task 014)",
+          "name": "CheckTestAdequacy_UnresolvedBase_IsDiffFailed_AndNeverProbes",
+          "dynamic": false
+        },
+        {
+          "suite": "check_test_adequacy routing + idempotency (task 014)",
+          "name": "CheckTestAdequacy_UnresolvedBase_BlocksEvenAtTheLowestTier",
+          "dynamic": false
         }
       ]
     },
@@ -52700,6 +53048,37 @@
         }
       ]
     },
+    "tests/unit/verbs/gates/unscoped-gate-emission.test.ts": {
+      "file": "tests/unit/verbs/gates/unscoped-gate-emission.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "a gate that cannot scope itself still records the verdict",
+          "name": "UnscopedRun_StillAppendsGateExecuted [%s]",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot scope itself still records the verdict",
+          "name": "<dynamic-case-1>",
+          "dynamic": true
+        },
+        {
+          "suite": "a gate that cannot scope itself still records the verdict",
+          "name": "UnscopedRun_NeverMintsProof [%s]",
+          "dynamic": false
+        },
+        {
+          "suite": "a gate that cannot scope itself still records the verdict",
+          "name": "<dynamic-case-2>",
+          "dynamic": true
+        },
+        {
+          "suite": "a gate that cannot scope itself still records the verdict",
+          "name": "TheRowSaysWhy_SoAnUnscopedRunIsNotAnOrdinaryFailure",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/unit/verbs/gates/verify-doc-links.test.ts": {
       "file": "tests/unit/verbs/gates/verify-doc-links.test.ts",
       "runner": "vitest:root",
@@ -52834,6 +53213,26 @@
           "suite": "handleVerifyWorktreeBaseline",
           "name": "detectProjectType_PnpmProject_ReturnsPnpmTest",
           "dynamic": false
+        },
+        {
+          "suite": "handleVerifyWorktreeBaseline",
+          "name": "WorktreeBaseline_LabelComesFromTheRegistry_NotStringEquality",
+          "dynamic": false
+        },
+        {
+          "suite": "handleVerifyWorktreeBaseline",
+          "name": "WorktreeBaseline_UnknownProjectMessage_NamesEveryRegistryMarker",
+          "dynamic": false
+        },
+        {
+          "suite": "handleVerifyWorktreeBaseline",
+          "name": "WorktreeBaseline_RunnerNeverStarts_IsIndeterminate_NotFail",
+          "dynamic": false
+        },
+        {
+          "suite": "handleVerifyWorktreeBaseline",
+          "name": "WorktreeBaseline_RunnerNonZeroExit_IsStillAFailingBaseline",
+          "dynamic": false
         }
       ]
     },
@@ -52910,6 +53309,11 @@
         {
           "suite": "handleWorkflowDeterminism > git diff failure",
           "name": "handleWorkflowDeterminism_GitDiffFails_ReturnsError",
+          "dynamic": false
+        },
+        {
+          "suite": "handleWorkflowDeterminism > base branch",
+          "name": "handleWorkflowDeterminism_UnresolvedBase_IsInconclusive_NotPass",
           "dynamic": false
         }
       ]
@@ -54164,6 +54568,11 @@
         },
         {
           "suite": "migrated ladder gate durable evidence",
+          "name": "IntegrationSuite_CannotResolveACommand_RecordsIndeterminateNotPass",
+          "dynamic": false
+        },
+        {
+          "suite": "migrated ladder gate durable evidence",
           "name": "LadderGate_SameOperationIsIdempotent_NewOperationSupersedes",
           "dynamic": false
         },
@@ -55003,6 +55412,72 @@
         }
       ]
     },
+    "tests/unit/verbs/pure/command-outcome.test.ts": {
+      "file": "tests/unit/verbs/pure/command-outcome.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "classifyCommandFailure",
+          "name": "NumericStatus_IsAVerdict",
+          "dynamic": false
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "NumericStatus_WinsOverAnErrno",
+          "dynamic": false
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "SpawnErrno_%s_IsNotAVerdict",
+          "dynamic": false
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "<dynamic-case-1>",
+          "dynamic": true
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "Timeout_IsItsOwnArm_NotASpawnFailure",
+          "dynamic": false
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "OutputCeilingKill_StaysAVerdict_NotASpawnFailure",
+          "dynamic": false
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "CapturesBothStreams_IncludingBuffers",
+          "dynamic": false
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "DetailKeepsOnlyTheFirstMessageLine",
+          "dynamic": false
+        },
+        {
+          "suite": "classifyCommandFailure",
+          "name": "NonObjectThrow_LandsOnTheVerdictArm",
+          "dynamic": false
+        },
+        {
+          "suite": "inconclusiveReason",
+          "name": "ExitFailure_HasNoReason",
+          "dynamic": false
+        },
+        {
+          "suite": "inconclusiveReason",
+          "name": "SpawnFailure_NamesTheCommandAndTheCause",
+          "dynamic": false
+        },
+        {
+          "suite": "inconclusiveReason",
+          "name": "Timeout_SaysItWasKilled_NotThatItFailed",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/unit/verbs/pure/context-economy.parity.test.ts": {
       "file": "tests/unit/verbs/pure/context-economy.parity.test.ts",
       "runner": "vitest:root",
@@ -55510,6 +55985,127 @@
         }
       ]
     },
+    "tests/unit/verbs/pure/integration-suite.test.ts": {
+      "file": "tests/unit/verbs/pure/integration-suite.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "ExplicitScript_TakesPrecedenceAndKeepsTheReporterFlag",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "ScriptRunner_PutsTheReporterFlagAfterThePassthrough",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "NonPackageManagerCommand_AtANodeRepo_IsSpawnedUnaltered",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "ExitCodeToolchain_IsSpawnedExactlyAsDeclared",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "NoToolchain_IsUnrunnable_NotAnNpmFallback",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "ProjectWithNoResolvedTestCommand_IsUnrunnable",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "ResolverRemediation_IsTheReason_NotARestatementOfTheId",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "AThrowingResolver_IsUnrunnable_NotACrash",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationCommand",
+          "name": "UnknownToolchainId_IsRunnable_OnTheExitCodeCarrier",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationRuntime (the shipped seam)",
+          "name": "PnpmRepo_ResolvesPnpm_NotTheRegistrySNpmBaseline",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationRuntime (the shipped seam)",
+          "name": "ConfigDeclaredCommand_OutranksTheRegistryRow",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationRuntime (the shipped seam)",
+          "name": "NodeRepoWithNoTestScript_ProducesTheNoTestCommandArm",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveIntegrationRuntime (the shipped seam)",
+          "name": "UnrecognizedDirectory_ResolvesNothing_AndNamesNoCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "runIntegrationSuite carriers",
+          "name": "UnrunnableCommand_NeverSpawnsAnything",
+          "dynamic": false
+        },
+        {
+          "suite": "runIntegrationSuite carriers",
+          "name": "ExitCodeCarrier_SpawnFailure_IsIndeterminate_NotAFailedSuite",
+          "dynamic": false
+        },
+        {
+          "suite": "runIntegrationSuite carriers",
+          "name": "VitestCarrier_SpawnFailure_IsIndeterminateToo_NotAFailedSuite",
+          "dynamic": false
+        },
+        {
+          "suite": "runIntegrationSuite carriers",
+          "name": "VitestCarrier_RanButGarbled_StillFailsClosed",
+          "dynamic": false
+        },
+        {
+          "suite": "runIntegrationSuite carriers",
+          "name": "VitestCarrier_GreenJson_ParsesTheCounts",
+          "dynamic": false
+        },
+        {
+          "suite": "runIntegrationSuite carriers",
+          "name": "ExitCodeCarrier_DoesNotParseStdout",
+          "dynamic": false
+        },
+        {
+          "suite": "a runner that never finishes",
+          "name": "TimedOutRunner_IsIndeterminate_OnTheExitCodeCarrier",
+          "dynamic": false
+        },
+        {
+          "suite": "a runner that never finishes",
+          "name": "TimedOutRunner_IsIndeterminate_OnTheVitestCarrier",
+          "dynamic": false
+        },
+        {
+          "suite": "a runner that never finishes",
+          "name": "TimeoutIsDeclared_NotDefaulted",
+          "dynamic": false
+        },
+        {
+          "suite": "a runner that never finishes",
+          "name": "TimeoutClassification_SeparatesAKillFromAnExitAndFromAMissingCommand",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/unit/verbs/pure/merge-preflight.test.ts": {
       "file": "tests/unit/verbs/pure/merge-preflight.test.ts",
       "runner": "vitest:root",
@@ -55872,6 +56468,26 @@
           "suite": "checkPostMerge",
           "name": "empty checks from provider returns pass for CI",
           "dynamic": false
+        },
+        {
+          "suite": "checkPostMerge",
+          "name": "PostMerge_UsesResolvedCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "checkPostMerge",
+          "name": "PostMerge_UnresolvedRuntime_IsIndeterminate_NotPass",
+          "dynamic": false
+        },
+        {
+          "suite": "checkPostMerge",
+          "name": "PostMerge_RunnerNeverStarts_IsIndeterminate_NotARegression",
+          "dynamic": false
+        },
+        {
+          "suite": "checkPostMerge",
+          "name": "PostMerge_RunnerTimesOut_IsIndeterminate_NotARegression",
+          "dynamic": false
         }
       ]
     },
@@ -56190,6 +56806,121 @@
         {
           "suite": "runStaticAnalysis > platform detection",
           "name": "Node.js takes priority over other project files",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > registry-sourced commands",
+          "name": "Commands_ComeFromTheRegistry_NotAPerLanguageSwitch",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > registry-sourced commands",
+          "name": "ClippyLeg_IsPromotedSoAFindingCanFailIt",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > registry-sourced commands",
+          "name": "GoVetLeg_IsNotPromoted_BecauseItAlreadyFails",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > registry-sourced commands",
+          "name": "SupplementedLeg_SurvivesWhereTheRegistryDeclaresNothing",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > registry-sourced commands",
+          "name": "NodeLegs_StayScriptIndirections_NotTheRegistryCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > registry-sourced commands",
+          "name": "PythonRepo_IsNotToldNoProjectType",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > registry-sourced commands",
+          "name": "NothingDetected_EnumeratesEveryMarkerTheRegistryKnows",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > command timeout",
+          "name": "TimeoutIsDeclared_NotDefaulted",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > command timeout",
+          "name": "HungCommand_YieldsIndeterminate_NotAHang",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > command timeout",
+          "name": "UnspawnableTool_Degrades_RatherThanReadingAsAFailure",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > production command runner",
+          "name": "ProductionRunner_ReportsARealExitCode_WithoutASpawnError",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > production command runner",
+          "name": "ProductionRunner_CapturesStdout_OnSuccess",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > production command runner",
+          "name": "ProductionRunner_SetsSpawnError_WhenTheBinaryDoesNotExist",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > production command runner",
+          "name": "ProductionRunner_HonoursTimeoutMs_AndReportsTheKillAsNoVerdict",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > production command runner",
+          "name": "SpawnFailure_FromTheProductionRunner_DegradesTheWholeGate",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > production command runner",
+          "name": "ProductionRunner_IsWhatTheGateHandlerComposes",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > zero applicable checks",
+          "name": "ToolchainWithNoRunnableCommand_Skips_RatherThanPassing",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > zero applicable checks",
+          "name": "OneRunnableCommand_StillReachesPass",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > user-declared toolchains",
+          "name": "DeclaredToolchain_OverridesTheBuiltInCommands",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > user-declared toolchains",
+          "name": "DeclaredLintFlags_AreNotSecondGuessed",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > user-declared toolchains",
+          "name": "DeclaredToolchain_WithAnUnknownId_IsRun_NotRefused",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > user-declared toolchains",
+          "name": "NodeScriptIndirection_SurvivesAPartialOverride",
+          "dynamic": false
+        },
+        {
+          "suite": "runStaticAnalysis > user-declared toolchains",
+          "name": "UnreadableConfig_IsAnError_NotASilentlyIgnoredOne",
           "dynamic": false
         },
         {
@@ -58348,6 +59079,26 @@
         },
         {
           "suite": "handlePostDelegationCheck",
+          "name": "PostDelegation_UsesResolvedCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePostDelegationCheck",
+          "name": "NonNodeWorktree_IsIndeterminate_NotSkip",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePostDelegationCheck",
+          "name": "PostDelegation_RunnerNeverStarts_IsIndeterminate_NotFail",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePostDelegationCheck",
+          "name": "PostDelegation_RunnerNonZeroExit_IsStillAFailure",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePostDelegationCheck",
           "name": "stateFileNotFound_returnsError",
           "dynamic": false
         },
@@ -59334,6 +60085,41 @@
         {
           "suite": "handlePrepareSynthesis",
           "name": "PrepareSynthesis_AdvisoryUncoveredDoc_EmitsGateButDoesNotBlock",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePrepareSynthesis",
+          "name": "TestsLeg_UsesResolvedCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePrepareSynthesis",
+          "name": "TypecheckLeg_UsesResolvedCommand",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePrepareSynthesis",
+          "name": "ExitCodeOnlyCarrier_ReportsNoCounts_AndTypecheckIsUnmeasured",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePrepareSynthesis",
+          "name": "TypecheckLeg_ObservedFailureElsewhere_IsNotSoftenedToSkipped",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePrepareSynthesis",
+          "name": "TestLeg_RunnerNeverStarts_IsIndeterminate_NotAFailingSuite",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePrepareSynthesis",
+          "name": "UnresolvedRuntime_YieldsIndeterminate_NotFail",
+          "dynamic": false
+        },
+        {
+          "suite": "handlePrepareSynthesis",
+          "name": "NoNpmLiteral_RemainsInModule",
           "dynamic": false
         },
         {
@@ -60567,7 +61353,12 @@
         },
         {
           "suite": "handleCheckCoderabbit",
-          "name": "handleCheckCoderabbit_NoReview_ReturnsPassedWithNone",
+          "name": "CodeRabbit_AbsentVendor_IsIndeterminate_NotPass",
+          "dynamic": false
+        },
+        {
+          "suite": "handleCheckCoderabbit",
+          "name": "CodeRabbit_RealFailureAlongsideAnAbsence_StaysAFailure",
           "dynamic": false
         },
         {
@@ -60598,6 +61389,11 @@
         {
           "suite": "handleCheckCoderabbit",
           "name": "handleCheckCoderabbit_PendingReview_ReturnsFailed",
+          "dynamic": false
+        },
+        {
+          "suite": "handleCheckCoderabbit",
+          "name": "TheConsumer_BranchesOnTheAbsentReviewer_RatherThanOnPassedAlone",
           "dynamic": false
         }
       ]
@@ -61241,6 +62037,36 @@
         {
           "suite": "handleValidatePrStack",
           "name": "UsesProviderListPrs_WithStateOpenFilter",
+          "dynamic": false
+        },
+        {
+          "suite": "handleValidatePrStack",
+          "name": "NonGitHubProvider_YieldsADeclaredSkip_NotGhCliError",
+          "dynamic": false
+        },
+        {
+          "suite": "handleValidatePrStack",
+          "name": "SkipBranch_IsReachableInProduction",
+          "dynamic": false
+        },
+        {
+          "suite": "handleValidatePrStack",
+          "name": "GitHubProvider_ResolvedByTheFactory_StillRuns",
+          "dynamic": false
+        },
+        {
+          "suite": "handleValidatePrStack",
+          "name": "MissingBaseBranch_IsRejectedBeforeAnyProviderIsResolved",
+          "dynamic": false
+        },
+        {
+          "suite": "handleValidatePrStack",
+          "name": "ConfiguredProvider_ReachesTheFactory_RatherThanHostnameDetection",
+          "dynamic": false
+        },
+        {
+          "suite": "handleValidatePrStack",
+          "name": "Router_InjectsTheDispatchConfig_SoTheArgIsNotADeadCarrier",
           "dynamic": false
         }
       ]

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,10 +4,10 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1199,
-    "parsedFiles": 1154,
+    "testFiles": 1202,
+    "parsedFiles": 1157,
     "shellFiles": 45,
-    "cases": 13345,
+    "cases": 13362,
     "dynamicTitles": 144,
     "unparseableFiles": 0
   },
@@ -8548,6 +8548,32 @@
         }
       ]
     },
+    "tests/integration/worktree-membership.test.ts": {
+      "file": "tests/integration/worktree-membership.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "verify_worktree against a real repository",
+          "name": "ClaudeWorktreesLayout_IsRecognized",
+          "dynamic": false
+        },
+        {
+          "suite": "verify_worktree against a real repository",
+          "name": "MainCheckout_IsNotAWorktree",
+          "dynamic": false
+        },
+        {
+          "suite": "verify_worktree against a real repository",
+          "name": "MembershipComesFromGit_NotASubstring",
+          "dynamic": false
+        },
+        {
+          "suite": "verify_worktree against a real repository",
+          "name": "DirectoryOutsideAnyRepository_IsNotAWorktree",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/migration/batch-migration.test.ts": {
       "file": "tests/migration/batch-migration.test.ts",
       "runner": "vitest:root",
@@ -16808,6 +16834,32 @@
         {
           "suite": "resolveTaskRunner — kind candidates & priority",
           "name": "no runner files → undefined",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/unit/config/test-report-format.test.ts": {
+      "file": "tests/unit/config/test-report-format.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "resolveTestReportFormat (per-runner result carrier)",
+          "name": "EveryBuiltinToolchain_HasAReportFormat",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveTestReportFormat (per-runner result carrier)",
+          "name": "UnknownToolchain_ResolvesUnknownArm",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveTestReportFormat (per-runner result carrier)",
+          "name": "Descriptor_CarriesItsOwnReporterFlag",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveTestReportFormat (per-runner result carrier)",
+          "name": "MissingEntry_IsACompileError",
           "dynamic": false
         }
       ]
@@ -48225,6 +48277,52 @@
         }
       ]
     },
+    "tests/unit/vcs/resolve-base-branch.test.ts": {
+      "file": "tests/unit/vcs/resolve-base-branch.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "resolveBaseBranch",
+          "name": "PrefersProviderDefaultBranch",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "FallsBackToSymbolicRef",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "Unresolved_IsTyped_NotMain",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "UnsupportedProviderOperation_IsNotACrash",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "RefNameFailingTheSanitizer_IsNotTrusted",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "HostedNonAsciiBranchName_IsNotDiscarded",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "RefOutsideTheOriginPrefix_IsNotLaundered",
+          "dynamic": false
+        },
+        {
+          "suite": "resolveBaseBranch",
+          "name": "EmptyProviderDefaultBranch_FallsThrough",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/unit/vcs/worktree-provisioner.test.ts": {
       "file": "tests/unit/vcs/worktree-provisioner.test.ts",
       "runner": "vitest:root",
@@ -52745,12 +52843,27 @@
       "cases": [
         {
           "suite": "handleVerifyWorktree",
-          "name": "returns passed when path is inside a worktree",
+          "name": "ClaudeWorktreesLayout_IsRecognized",
           "dynamic": false
         },
         {
           "suite": "handleVerifyWorktree",
-          "name": "returns failed when path is not in a worktree",
+          "name": "MainCheckout_IsNotAWorktree",
+          "dynamic": false
+        },
+        {
+          "suite": "handleVerifyWorktree",
+          "name": "MembershipComesFromGit_NotASubstring",
+          "dynamic": false
+        },
+        {
+          "suite": "handleVerifyWorktree",
+          "name": "returns failed with the git reason when the directory is not in a repository",
+          "dynamic": false
+        },
+        {
+          "suite": "handleVerifyWorktree",
+          "name": "returns failed inside a bare repository",
           "dynamic": false
         },
         {
@@ -59665,16 +59778,6 @@
         },
         {
           "suite": "handleSetupWorktree",
-          "name": "WorktreesNotGitignored_AddsToGitignore",
-          "dynamic": false
-        },
-        {
-          "suite": "handleSetupWorktree",
-          "name": "WorktreesNotGitignored_ExistingGitignoreNoTrailingNewline_PrependsNewline",
-          "dynamic": false
-        },
-        {
-          "suite": "handleSetupWorktree",
           "name": "NpmInstallFails_Step4Fails",
           "dynamic": false
         },
@@ -59769,28 +59872,28 @@
           "dynamic": false
         },
         {
-          "suite": "handleSetupWorktree > ensureGitignored direct-read behavior",
-          "name": "ensureGitignored_AlreadyPresent_ReportsAlreadyPresent",
+          "suite": "handleSetupWorktree > checkGitignored reports the repo file and never writes it",
+          "name": "checkGitignored_AlreadyPresent_ReportsAlreadyPresent",
           "dynamic": false
         },
         {
-          "suite": "handleSetupWorktree > ensureGitignored direct-read behavior",
-          "name": "ensureGitignored_NotPresent_AppendsAndReportsAdded",
+          "suite": "handleSetupWorktree > checkGitignored reports the repo file and never writes it",
+          "name": "checkGitignored_GlobalIgnoreOnlyMatch_StillReportsTheRepoFileHonestly",
           "dynamic": false
         },
         {
-          "suite": "handleSetupWorktree > ensureGitignored direct-read behavior",
-          "name": "ensureGitignored_FileMissing_CreatesWithEntry",
+          "suite": "handleSetupWorktree > checkGitignored reports the repo file and never writes it",
+          "name": "checkGitignored_ReadThrows_ReportsFail",
           "dynamic": false
         },
         {
-          "suite": "handleSetupWorktree > ensureGitignored direct-read behavior",
-          "name": "ensureGitignored_GlobalIgnoreOnlyMatch_StillReportsHonestlyAndUpdatesRepoGitignore",
+          "suite": "handleSetupWorktree > checkGitignored reports the repo file and never writes it",
+          "name": "GitignoreIsNeverWritten_MissingEntryOrMissingFile",
           "dynamic": false
         },
         {
-          "suite": "handleSetupWorktree > ensureGitignored direct-read behavior",
-          "name": "ensureGitignored_AppendThrows_ReportsFail",
+          "suite": "handleSetupWorktree > checkGitignored reports the repo file and never writes it",
+          "name": "MissingIgnoreEntry_IsReported_NotSilentlyWritten",
           "dynamic": false
         },
         {


### PR DESCRIPTION
## Summary

Exarchos governs *other* repositories, but a measurable part of the gate surface was written for this one. The toolchain registry is properly polyglot — 12 toolchains, each declaring its own test/typecheck/lint/mutation commands — and the **command** axis mostly routed through it. The **result** axis had no seam at all, so gates that resolved a command correctly then read its output as if every repo were this one.

Stacked on #1862. Spec: [`2026-08-22-phase-gate-agnosticism.md`](https://github.com/lvlup-sw/docs/blob/main/exarchos/docs/specs/2026-08-22-phase-gate-agnosticism.md) · study: #1849

### Measured at `529348175`

- `check_integration_suite` — the **blocking** high-tier ladder gate — appended vitest's `--reporter=json` to whatever the registry returned, on **all 12 of 12** toolchains (`cargo test --reporter=json`, `pytest --reporter=json`), parsed vitest JSON only, and failed **closed** on any other shape. No-toolchain fallback: `npm run test:run` — this repository's own script name, not a convention. **The top ladder rung was unsatisfiable on 11 of 12 declared toolchains.**
- **10 of 40** gate modules defaulted the diff base to the literal `'main'`; **zero** detected the repository's default branch, though the provider seam exposes it and two near-verbatim private detectors already existed, both unexported.
- `check_static_analysis` — first rung of all 8 ladder cells — re-derived commands in a hard-coded 4-arm switch; `SUPPORTED_TOOLCHAINS` covered 4 of 12 and had **zero references outside its own module**.
- `verify_worktree` decided membership with a `.worktrees/` path substring — **false for the harness-native `.claude/worktrees/` layout**, so it aborted inside the very worktree this was written in.
- Verified by seeding a violation: **no guard anywhere** failed when a gate hard-coded a toolchain command.

## Changes

**The carrier seam.** `TEST_REPORT_FORMAT` mirrors the `MUTATION_DIFF_SCOPE` table beside it: keyed by toolchain id, returning a tagged descriptor so consumers branch on a kind and never on an identity, with `satisfies Record<ToolchainId, …>` making an unmapped toolchain a compile error. **Three arms only** — no `junit-xml`/`tap`, because nothing parses them. `exit-code-only` is the majority answer and a complete one.

**Wired, not just built.** `check_integration_suite` resolves through the *layered* resolver, so `.exarchos.yml` overrides, package-manager detection and the task-runner tier all participate. The reporter flag is appended only when the identified toolchain reports vitest JSON **and** the command's head is a Node package manager — keying on identity alone would have re-created `pytest --reporter=json` at any Node tree whose config says `test: pytest`.

**A process that never started no longer mints a verdict.** The spawn-failure guard missed `EINVAL` — how a Windows `.cmd` shim fails since CVE-2024-27980 — and the check now runs above the carrier switch, so both carriers report indeterminate rather than a failed suite.

**Base branch is detected.** All ten `'main'` literals gone; multi-rung detection with a typed unresolved arm, and an unresolved base yields the gate's own inconclusive verdict rather than a diff against a branch that may not exist.

**Coverage asserted.** `SUPPORTED_TOOLCHAINS`'s shortfall against the registry is now measured, so a thirteenth toolchain reddens a guard instead of silently falling outside.

## Test Plan

- [x] `npm run typecheck` clean (root + conformance + tests)
- [x] Gate-runner ownership census clean **on this branch alone**
- [x] `tests/architecture` 242/244 · affected `core` suites green · `npm run render:guard` clean
- [x] **End-to-end proof:** a real Cargo tree through `handleCheckIntegrationSuite` → argv exactly `['cargo','test']`, verdict `pass`
- [x] **Kill probe:** re-appending `--reporter=json` on the exit-code arm reddens 14 acceptance tests
- [x] Acceptance property derives its denominator from a **live** `BUILTIN_TOOLCHAINS` import with a non-empty floor, so it cannot go vacuous
- [x] Merge-suite failure **sets** diffed: 26 ≡ 26, zero new, zero vanished — the documented fresh-install baseline

**Known environmental (both named in #1849):** `published-contract` (`dist/` unbuilt in a worktree) and `worktree-inventory` (accumulation).

### Stated limitation

An indeterminate ladder verdict is **not** converted into a stop by anything downstream: the evidence fold is audit-visibility only, no admission requirement claims these rows, and the runbook step's failure policy is advisory (see #1862). The carrier says so in its report rather than resting on a guarantee that is not there. Closing it needs an admission requirement claiming `verification-ladder:<gateClass>` — a later wave.

### Scope

The one remaining `npm run test:run` literal is in `debug_review_gate`, which the triage wave deletes. Instrumenting a gate scheduled for removal is work the plan is ordered to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
