### PR TITLE
feat(gates): indeterminate reaches the wire (DR-11, tasks 024-025)

### DIFF
--- a/src/events/schemas.ts
+++ b/src/events/schemas.ts
@@ -830,13 +830,55 @@ export const GateExecutedDetailsSchema = z.object({
   promptVersion: z.string().optional(),
 }).passthrough();
 
-export const GateExecutedData = z.object({
-  gateName: z.string(),
-  layer: z.string(),
-  passed: z.boolean(),
-  duration: z.number().optional(),
-  details: z.record(z.string(), z.unknown()).optional(),
-});
+/**
+ * What a gate concluded.
+ *
+ * A boolean cannot express the two outcomes that are not a decision. A probe
+ * that could not RUN and an obligation that was WITHDRAWN both had to be
+ * written down as `passed: true` or `passed: false`, and a reader gating on
+ * the boolean could not tell either of them from a gate that actually ran and
+ * reached that answer. `indeterminate` is "no claim was decided";
+ * `not-applicable` is "the obligation was withdrawn, so there was nothing to
+ * decide". Neither is a pass, and neither is a failure.
+ */
+export const GateVerdictSchema = z.enum(['pass', 'fail', 'indeterminate', 'not-applicable']);
+export type GateVerdict = z.infer<typeof GateVerdictSchema>;
+
+export const GateExecutedData = z
+  .object({
+    gateName: z.string(),
+    layer: z.string(),
+    /**
+     * RETAINED and DERIVED — `passed === (verdict === 'pass')`. Every reader
+     * written against the boolean keeps working, and every row already on a
+     * stream stays valid: this widening is additive, not a migration.
+     */
+    passed: z.boolean(),
+    /**
+     * Optional ONLY because historical rows predate the field. A row that
+     * CARRIES it may not disagree with `passed` — see the refinement below.
+     */
+    verdict: GateVerdictSchema.optional(),
+    duration: z.number().optional(),
+    details: z.record(z.string(), z.unknown()).optional(),
+  })
+  .superRefine((row, ctx) => {
+    // Absent on a historical row, and absence is not disagreement.
+    if (row.verdict === undefined) return;
+    if (row.passed === (row.verdict === 'pass')) return;
+    // Enforced at the SCHEMA rather than left to each writer: `passed` is the
+    // derived field, so a row where the two disagree has no defensible
+    // reading — one of them is wrong and nothing downstream can tell which.
+    // Refusing it here is what makes the derivation a property of the record
+    // instead of a convention every emitter is trusted to have followed.
+    ctx.addIssue({
+      code: 'custom',
+      path: ['passed'],
+      message:
+        `passed=${String(row.passed)} contradicts verdict='${row.verdict}'; ` +
+        "`passed` is derived as `verdict === 'pass'`",
+    });
+  });
 
 // ─── Stack Event Data ───────────────────────────────────────────────────────
 

--- a/src/verbs/gates/check-event-emissions.ts
+++ b/src/verbs/gates/check-event-emissions.ts
@@ -216,7 +216,7 @@ export async function handleCheckEventEmissions(
 
   // Emit gate.executed event (fire-and-forget)
   try {
-    await emitGateEvent(store, streamId, 'event-emissions', 'observability', complete, {
+    await emitGateEvent(store, streamId, 'event-emissions', 'observability', complete ? 'pass' : 'fail', {
       phase,
       checked,
       missing,

--- a/src/verbs/gates/check-exploration-depth.ts
+++ b/src/verbs/gates/check-exploration-depth.ts
@@ -217,7 +217,7 @@ export async function handleCheckExplorationDepth(
   const skip = resolveExplorationSkip(designDepth);
   if (skip) {
     try {
-      await emitGateEvent(eventStore, args.featureId, 'exploration-depth', 'planning', true, {
+      await emitGateEvent(eventStore, args.featureId, 'exploration-depth', 'planning', 'pass', {
         dimension: 'D1',
         phase: 'plan',
         designDepth: designDepth ?? null,
@@ -265,7 +265,7 @@ export async function handleCheckExplorationDepth(
   const result = checkExplorationDepth(content);
 
   try {
-    await emitGateEvent(eventStore, args.featureId, 'exploration-depth', 'planning', result.passed, {
+    await emitGateEvent(eventStore, args.featureId, 'exploration-depth', 'planning', result.passed ? 'pass' : 'fail', {
       dimension: 'D1',
       phase: 'plan',
       designDepth: 'deep',

--- a/src/verbs/gates/check-invariant-conformance.ts
+++ b/src/verbs/gates/check-invariant-conformance.ts
@@ -425,7 +425,7 @@ export async function handleCheckInvariantConformance(
       args.featureId,
       'invariant-conformance',
       'review',
-      verdict === 'APPROVED',
+      verdict === 'APPROVED' ? 'pass' : 'fail',
       {
         verdict,
         phase,

--- a/src/verbs/gates/diff-hygiene.ts
+++ b/src/verbs/gates/diff-hygiene.ts
@@ -234,7 +234,7 @@ async function emitRuleRow(
   details: Record<string, unknown>,
 ): Promise<void> {
   try {
-    await emitGateEvent(store, featureId, rule.id, GATE_LAYER, passed, {
+    await emitGateEvent(store, featureId, rule.id, GATE_LAYER, passed ? 'pass' : 'fail', {
       dimension: rule.dimension,
       phase: GATE_PHASE,
       ...details,

--- a/src/verbs/gates/gate-runner.ts
+++ b/src/verbs/gates/gate-runner.ts
@@ -169,11 +169,21 @@ async function appendGateExecutedSignal(
       data: {
         gateName: provider.gateClass,
         layer: GATE_RUNNER_GATE_LAYER,
+        // The runner is the one place that COMPUTES a verdict, and it used to
+        // be the place that threw it away: the row carried the collapsed
+        // boolean at the top level and the verdict only down in `details`,
+        // where the readers that gate on the outcome do not look. It is minted
+        // whole now, with `passed` derived from it.
+        verdict: evidence.verdict,
         passed: evidence.verdict === 'pass',
         details: {
           ...(taskId === undefined ? {} : { taskId }),
           gateClass: provider.gateClass,
           providerRef: provider.providerRef,
+          // Retained alongside the top-level field, deliberately: every row
+          // written before the widening carries the verdict ONLY here, so a
+          // reader folding history has to keep looking here. Dropping it would
+          // make the fold correct for new rows and wrong for old ones.
           verdict: evidence.verdict,
           evidenceId: evidence.evidenceId,
           phaseAttemptId: evidence.phaseAttemptId,

--- a/src/verbs/gates/gate-utils.ts
+++ b/src/verbs/gates/gate-utils.ts
@@ -18,7 +18,7 @@ import { resolveVerificationPolicy } from '../../workflow/verification-policy-re
 import type { PhaseKind } from '../../workflow/phase-kind.js';
 import type { GitExec } from '../pure/execute-merge.js';
 import type { EvidenceArtifactReferenceV1 } from '../../workflow/admission/evidence-artifact.js';
-import type { AdmissionEvidenceRecorded } from '../../events/schemas.js';
+import type { AdmissionEvidenceRecorded, GateVerdict } from '../../events/schemas.js';
 
 /**
  * Output ceiling for the git shell-outs below.
@@ -108,7 +108,14 @@ export async function emitGateEvent(
   streamId: string,
   gateName: string,
   layer: string,
-  passed: boolean,
+  /**
+   * The verdict, NOT a boolean. `passed` is derived here so a self-emitting
+   * gate cannot write down an outcome it did not compute: there is no
+   * parameter left for it to disagree with. A gate that could not decide says
+   * `indeterminate`; one whose obligation was withdrawn says `not-applicable`.
+   * Neither is a pass, and neither is a failure.
+   */
+  verdict: GateVerdict,
   details?: Record<string, unknown>,
   /**
    * Optional idempotency key (INV-8). When supplied, a second emission with the
@@ -123,7 +130,11 @@ export async function emitGateEvent(
     data: {
       gateName,
       layer,
-      passed,
+      // Derived once, at the only place a row is minted, so the schema's
+      // `passed === (verdict === 'pass')` refinement cannot be violated by a
+      // caller that got the pair out of step.
+      passed: verdict === 'pass',
+      verdict,
       ...(details !== undefined ? { details } : {}),
     },
   };

--- a/src/verbs/gates/mutation-adequacy.ts
+++ b/src/verbs/gates/mutation-adequacy.ts
@@ -1038,7 +1038,7 @@ export async function handleMutationAdequacy(
         args.featureId,
         MUTATION_GATE_NAME,
         MUTATION_GATE_LAYER,
-        true,
+        'pass',
         { skipped: true, reason, mutationScore: 0 },
         mutationGateKey(args.operationId, 'skip-no-toolchain'),
       );
@@ -1240,7 +1240,7 @@ export async function handleMutationAdequacy(
       args.featureId,
       MUTATION_GATE_NAME,
       MUTATION_GATE_LAYER,
-      passed,
+      passed ? 'pass' : 'fail',
       {
         mutationScore: carrier.mutationScore,
         killed: carrier.killed,
@@ -1386,7 +1386,7 @@ async function emitAdvisoryGate(
       args.featureId,
       MUTATION_GATE_NAME,
       MUTATION_GATE_LAYER,
-      true,
+      'pass',
       { skipped: true, degraded: true, reason, mutationScore: 0 },
       mutationGateKey(args.operationId, 'degraded'),
     );

--- a/src/verbs/gates/plan-coverage.ts
+++ b/src/verbs/gates/plan-coverage.ts
@@ -890,7 +890,7 @@ async function executePlanCoverage(
   const foldedResult =
     foldedAdvisories.length > 0 ? { ...result, advisories: foldedAdvisories } : result;
 
-  await emitGateEvent(eventStore, args.featureId, 'plan-coverage', 'planning', result.passed, {
+  await emitGateEvent(eventStore, args.featureId, 'plan-coverage', 'planning', result.passed ? 'pass' : 'fail', {
     dimension: 'D1',
     phase: 'plan',
     covered: result.coverage.covered,

--- a/src/verbs/gates/post-merge.ts
+++ b/src/verbs/gates/post-merge.ts
@@ -140,7 +140,7 @@ export async function handlePostMerge(
   // and the second one is not a finding anybody may act on.
   try {
     const store = eventStore;
-    await emitGateEvent(store, args.featureId, 'post-merge', 'post-merge', passed, {
+    await emitGateEvent(store, args.featureId, 'post-merge', 'post-merge', passed ? 'pass' : 'fail', {
       dimension: 'D4',
       phase: 'synthesize',
       prUrl: args.prUrl,

--- a/src/verbs/gates/provenance-chain.ts
+++ b/src/verbs/gates/provenance-chain.ts
@@ -140,7 +140,7 @@ async function executeProvenanceChain(
     orphanRefs: tsResult.orphanRefs,
   };
 
-  await emitGateEvent(eventStore, args.featureId, 'provenance-chain', 'planning', passed, {
+  await emitGateEvent(eventStore, args.featureId, 'provenance-chain', 'planning', passed ? 'pass' : 'fail', {
     dimension: 'D1',
     phase: 'plan',
     requirements: metrics.requirements,

--- a/src/verbs/gates/security-scan.ts
+++ b/src/verbs/gates/security-scan.ts
@@ -221,7 +221,7 @@ export async function handleSecurityScan(
   // Emit gate.executed event (fire-and-forget: emission failure must not break the gate check)
   try {
     const store = eventStore;
-    await emitGateEvent(store, args.featureId, 'security-scan', 'quality', passed, {
+    await emitGateEvent(store, args.featureId, 'security-scan', 'quality', passed ? 'pass' : 'fail', {
       dimension: 'D1',
       phase: 'review',
       findingCount: findings.length,

--- a/src/verbs/review/review-verdict.ts
+++ b/src/verbs/review/review-verdict.ts
@@ -387,7 +387,7 @@ async function executeReviewVerdict(
   // persistence failure: the canonical runner converts it to a failure carrier.
   if (args.dimensionResults) {
     for (const [key, entry] of Object.entries(args.dimensionResults)) {
-      await emitGateEvent(eventStore, args.featureId, `review-${key}`, 'review', entry.passed, {
+      await emitGateEvent(eventStore, args.featureId, `review-${key}`, 'review', entry.passed ? 'pass' : 'fail', {
         dimension: key,
         phase: 'review',
         findingCount: entry.findingCount,
@@ -400,7 +400,7 @@ async function executeReviewVerdict(
     ? [...new Set(args.pluginFindings.map(f => f.source))]
     : undefined;
 
-  await emitGateEvent(eventStore, args.featureId, 'review-verdict', 'review', verdict === 'APPROVED', {
+  await emitGateEvent(eventStore, args.featureId, 'review-verdict', 'review', verdict === 'APPROVED' ? 'pass' : 'fail', {
     verdict,
     phase: 'review',
     high: mergedHigh,
@@ -416,7 +416,7 @@ async function executeReviewVerdict(
   // recorded as FAILED (passed:false) — escalation means the bounded loop could
   // not converge unattended.
   if (escalation?.action === 'escalate') {
-    await emitGateEvent(eventStore, args.featureId, 'review-escalation', 'review', false, {
+    await emitGateEvent(eventStore, args.featureId, 'review-escalation', 'review', 'fail', {
       phase: 'review',
       reason: escalation.reason,
       findingClass: escalation.findingClass,

--- a/src/verbs/tasks/task-decomposition.ts
+++ b/src/verbs/tasks/task-decomposition.ts
@@ -1033,7 +1033,7 @@ export async function handleTaskDecomposition(
   // Emit gate.executed event (fire-and-forget: emission failure must not break the gate check)
   try {
     const store = eventStore;
-    await emitGateEvent(store, args.featureId, 'task-decomposition', 'planning', passed, {
+    await emitGateEvent(store, args.featureId, 'task-decomposition', 'planning', passed ? 'pass' : 'fail', {
       dimension: 'D5',
       phase: 'plan',
       wellDecomposed,

--- a/src/verbs/team/prepare-delegation.ts
+++ b/src/verbs/team/prepare-delegation.ts
@@ -1500,7 +1500,7 @@ export async function handlePrepareDelegation(
 
     // Emit plan-coverage gate event (best-effort: emission failure must not break readiness)
     try {
-      await emitGateEvent(store, streamId, 'plan-coverage', 'planning', true, {
+      await emitGateEvent(store, streamId, 'plan-coverage', 'planning', 'pass', {
         dimension: 'D1',
         phase: 'delegate',
         taskCount,

--- a/src/verbs/team/prepare-synthesis.ts
+++ b/src/verbs/team/prepare-synthesis.ts
@@ -798,7 +798,7 @@ async function executePrepareSynthesis(
       : { passed: false, indeterminate: true, reason: legs.reason };
 
     // 5. Emit gate.executed event for test-suite (feeds flywheel)
-    await emitGateEvent(store, streamId, 'test-suite', 'CI', tests.passed, {
+    await emitGateEvent(store, streamId, 'test-suite', 'CI', tests.passed ? 'pass' : 'fail', {
       dimension: 'D1',
       phase: 'synthesize',
       ...(tests.passCount !== undefined ? { passCount: tests.passCount } : {}),
@@ -812,7 +812,7 @@ async function executePrepareSynthesis(
       : { passed: false, errorCount: 0, indeterminate: true, reason: legs.reason };
 
     // 7. Emit gate.executed event for typecheck (feeds flywheel)
-    await emitGateEvent(store, streamId, 'typecheck', 'CI', typecheck.passed, {
+    await emitGateEvent(store, streamId, 'typecheck', 'CI', typecheck.passed ? 'pass' : 'fail', {
       dimension: 'D1',
       phase: 'synthesize',
       errorCount: typecheck.errorCount,
@@ -847,7 +847,7 @@ async function executePrepareSynthesis(
             + 'could not be verified. Re-run synthesis, or waive via synthesis.documentLeg.',
         }
       : evaluateDocumentLeg(changedFiles, docCfg);
-    await emitGateEvent(store, streamId, 'document-coverage', 'synthesize', documentLeg.covered, {
+    await emitGateEvent(store, streamId, 'document-coverage', 'synthesize', documentLeg.covered ? 'pass' : 'fail', {
       dimension: 'D1',
       phase: 'synthesize',
       evaluated: documentLeg.evaluated,

--- a/tests/acceptance/gate-verdict-emission.test.ts
+++ b/tests/acceptance/gate-verdict-emission.test.ts
@@ -1,0 +1,169 @@
+// ─── A gate cannot write down an outcome it did not compute ──────────────────
+//
+// `emitGateEvent` used to take `passed: boolean`. Two consequences followed
+// from that one parameter. A gate that could not DECIDE had to pick a side, and
+// whichever it picked was a lie a reader could act on. And because `passed` was
+// supplied rather than derived, a caller could hand over a boolean that
+// disagreed with the verdict its own evidence carried — nothing in the type
+// system, and nothing at the append, could tell.
+//
+// The fix is structural rather than advisory: the parameter is the VERDICT, and
+// `passed` is computed at the single place a row is minted. A bare boolean stops
+// type-checking, so the migration is exhaustive by construction rather than by
+// anyone having remembered every site.
+//
+// @oracle-sources: ../../src/verbs/gates/gate-utils.ts, the src/ tree walked at test time for call sites
+//
+// Two authorities: the module that DECLARES the emitter, and the live source
+// tree walked for callers of it. A hand-listed call-site set would keep passing
+// after someone added the twenty-first.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
+
+import { emitGateEvent } from '../../src/verbs/gates/gate-utils.js';
+import { GateExecutedData, GateVerdictSchema } from '../../src/events/schemas.js';
+import type { EventStore } from '../../src/events/store.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SRC_DIR = path.join(REPO_ROOT, 'src');
+const EMITTER_MODULE = path.join(SRC_DIR, 'verbs', 'gates', 'gate-utils.ts');
+
+/** Every `.ts` under `src/`, walked rather than globbed so it cannot go stale. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry !== 'node_modules' && entry !== 'dist') sourceFiles(full, out);
+    } else if (full.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+interface CallSite {
+  readonly file: string;
+  readonly line: number;
+  readonly verdictArg: string;
+}
+
+/** Every `emitGateEvent(...)` CALL in `src/`, with its verdict argument's text. */
+function callSites(): CallSite[] {
+  const found: CallSite[] = [];
+  for (const file of sourceFiles(SRC_DIR)) {
+    const source = readFileSync(file, 'utf8');
+    if (!source.includes('emitGateEvent(')) continue;
+    const parsed = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'emitGateEvent' &&
+        node.arguments.length >= 5
+      ) {
+        found.push({
+          file: path.relative(REPO_ROOT, file),
+          line: parsed.getLineAndCharacterOfPosition(node.getStart(parsed)).line + 1,
+          verdictArg: node.arguments[4]!.getText(parsed),
+        });
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(parsed, visit);
+  }
+  return found;
+}
+
+/** Records what was appended without touching a real store. */
+function recordingStore(): { store: EventStore; rows: Record<string, unknown>[] } {
+  const rows: Record<string, unknown>[] = [];
+  const store = {
+    append: async (_streamId: string, event: { data?: Record<string, unknown> }) => {
+      rows.push(event.data ?? {});
+    },
+  } as unknown as EventStore;
+  return { store, rows };
+}
+
+describe('gate verdicts reach the wire whole', () => {
+  it('NoCallSite_PassesABareBoolean', () => {
+    const sites = callSites();
+
+    // Denominator: a scan that resolved no calls would satisfy every claim
+    // below by having nothing to check.
+    expect(sites.length, 'no emitGateEvent call site was found — the scan is inert').toBeGreaterThan(
+      15,
+    );
+
+    const bare = sites.filter(({ verdictArg }) => verdictArg === 'true' || verdictArg === 'false');
+    expect(
+      bare.map((s) => `${s.file}:${s.line} passes \`${s.verdictArg}\``),
+      'a call site still hands the emitter a bare boolean',
+    ).toEqual([]);
+
+    // The stronger half, and the reason the list above stays empty without
+    // anyone policing it: the PARAMETER is the verdict union, so a boolean does
+    // not type-check. Read off the declaration rather than asserted from
+    // memory — a signature that quietly went back to `boolean` would leave the
+    // check above passing over call sites that had all been rewritten.
+    const declaration = readFileSync(EMITTER_MODULE, 'utf8');
+    expect(
+      declaration.includes('verdict: GateVerdict,'),
+      'emitGateEvent no longer declares its verdict parameter as GateVerdict',
+    ).toBe(true);
+    expect(
+      /export async function emitGateEvent\([^)]*passed: boolean/s.test(declaration),
+      'emitGateEvent takes a boolean again',
+    ).toBe(false);
+  });
+
+  it('SelfEmitter_CannotExpressAnUncomputedVerdict', async () => {
+    // There is no longer a parameter for `passed`, so a caller has nothing to
+    // disagree with. Driven over the WHOLE vocabulary so a member added later
+    // inherits the case instead of slipping past a sampled three.
+    const vocabulary = GateVerdictSchema.options;
+    expect(vocabulary.length, 'the verdict vocabulary is empty').toBeGreaterThan(3);
+
+    const wrong: string[] = [];
+    for (const verdict of vocabulary) {
+      const { store, rows } = recordingStore();
+      await emitGateEvent(store, 'stream', 'a-gate', 'review', verdict);
+
+      const row = rows[0];
+      if (row === undefined) {
+        wrong.push(`${verdict}: nothing was appended`);
+        continue;
+      }
+      if (row.verdict !== verdict) wrong.push(`${verdict}: row carried ${String(row.verdict)}`);
+      if (row.passed !== (verdict === 'pass')) {
+        wrong.push(`${verdict}: passed was ${String(row.passed)}`);
+      }
+      // And the row the emitter mints must satisfy the schema's derivation
+      // refinement, so the two halves of this cannot drift apart.
+      if (!GateExecutedData.safeParse(row).success) wrong.push(`${verdict}: row failed the schema`);
+    }
+
+    expect(wrong, 'the emitter did not derive `passed` from the verdict').toEqual([]);
+  });
+
+  it('IndeterminateEmission_IsNotWrittenDownAsAFailure', async () => {
+    // The outcome the boolean could not express at all. It must reach the row
+    // as itself — distinguishable from a gate that ran and failed, which is the
+    // whole point of the widening.
+    const { store, rows } = recordingStore();
+    await emitGateEvent(store, 'stream', 'a-gate', 'review', 'indeterminate', { why: 'no runner' });
+    await emitGateEvent(store, 'stream', 'a-gate', 'review', 'fail', { why: 'it ran and failed' });
+
+    const [undecided, failed] = rows;
+    expect(undecided?.verdict).toBe('indeterminate');
+    expect(failed?.verdict).toBe('fail');
+    // Identical on the old surface...
+    expect(undecided?.passed).toBe(failed?.passed);
+    // ...and distinguishable on the new one, which is the finding.
+    expect(undecided?.verdict).not.toBe(failed?.verdict);
+  });
+});

--- a/tests/integration/gate-verdict-replay.test.ts
+++ b/tests/integration/gate-verdict-replay.test.ts
@@ -1,0 +1,137 @@
+// ─── The verdict widening is invisible to every existing reader ──────────────
+//
+// Widening a durable record has two failure modes, and only one of them is
+// caught by parsing the record. The schema test next door proves a historical
+// row still VALIDATES. It cannot prove that a stream carrying the new field
+// still PROJECTS to the same place — a fold that started keying on `verdict`,
+// or that stopped keying on `passed`, would sail past a schema check and
+// silently move every view built on it.
+//
+// So this drives the real projections over the same events twice: once in the
+// shape they have on a stream today, once with the derived verdict added, and
+// requires the two results to be indistinguishable. The verdict is additive
+// exactly to the extent that this holds.
+//
+// @oracle-sources: ../../src/projections/views/code-quality-view.ts, ../../src/projections/views/delegation-readiness-view.ts
+//
+// The authorities are the FOLDS, and they are separately maintained: neither
+// imports the other, and each decides independently what a `gate.executed` row
+// means to it. The schema is the subject here, not an oracle — every projection
+// imports it, so pairing it with one of them would be one authority wearing two
+// names.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+
+import { GateExecutedData, type WorkflowEvent } from '../../src/events/schemas.js';
+import { codeQualityProjection } from '../../src/projections/views/code-quality-view.js';
+import { synthesisReadinessProjection } from '../../src/projections/views/synthesis-readiness-view.js';
+import { delegationReadinessProjection } from '../../src/projections/views/delegation-readiness-view.js';
+import type { ViewProjection } from '../../src/projections/views/types.js';
+
+/**
+ * A stream that exercises every arm the folds branch on: the review gate name
+ * they special-case, the mutation gate whose `details` they read, and ordinary
+ * pass/fail rows. A replay proof over rows that all take one branch proves that
+ * branch and nothing else.
+ */
+const GATE_ROWS: readonly Record<string, unknown>[] = [
+  { gateName: 'check_static_analysis', layer: 'review', passed: true, duration: 1200 },
+  { gateName: 'check_security_scan', layer: 'review', passed: false, duration: 340 },
+  { gateName: 'review', layer: 'review', passed: true, duration: 900 },
+  { gateName: 'spec-review', layer: 'review', passed: false },
+  {
+    gateName: 'check_mutation_adequacy',
+    layer: 'review',
+    passed: true,
+    duration: 45_000,
+    details: { mutationScore: 0.82, taskId: 'task-007' },
+  },
+  { gateName: 'check_test_adequacy', layer: 'delegate', passed: true, details: { taskId: 'task-007' } },
+  { gateName: 'check_diff_hygiene', layer: 'review', passed: false, duration: 77 },
+];
+
+/** The derivation under test, applied as a writer would apply it. */
+const withVerdict = (row: Record<string, unknown>): Record<string, unknown> => ({
+  ...row,
+  verdict: row.passed === true ? 'pass' : 'fail',
+});
+
+const asEvent = (data: Record<string, unknown>, sequence: number): WorkflowEvent => ({
+  streamId: 'verdict-replay',
+  sequence,
+  timestamp: `2026-01-01T00:00:${String(sequence).padStart(2, '0')}.000Z`,
+  type: 'gate.executed' as WorkflowEvent['type'],
+  data,
+  schemaVersion: '1.0',
+});
+
+function replay<T>(projection: ViewProjection<T>, rows: readonly Record<string, unknown>[]): T {
+  return rows.reduce<T>(
+    (state, row, index) => projection.apply(state, asEvent(row, index + 1)),
+    projection.init(),
+  );
+}
+
+const PROJECTIONS = [
+  { name: 'code-quality', projection: codeQualityProjection as ViewProjection<unknown> },
+  { name: 'synthesis-readiness', projection: synthesisReadinessProjection as ViewProjection<unknown> },
+  { name: 'delegation-readiness', projection: delegationReadinessProjection as ViewProjection<unknown> },
+];
+
+describe('gate.executed verdict replay', () => {
+  it('Replay_ProducesTheSameProjection', () => {
+    // Denominators first. A corpus that does not parse, or a projection list
+    // that failed to load, would make every comparison below trivially true.
+    expect(GATE_ROWS.length, 'the replay corpus is empty').toBeGreaterThan(5);
+    expect(PROJECTIONS.length, 'no projection was loaded to replay against').toBeGreaterThan(2);
+
+    const rejected = GATE_ROWS.map(withVerdict).filter((row) => !GateExecutedData.safeParse(row).success);
+    expect(rejected, 'the verdict-carrying corpus does not satisfy the schema').toEqual([]);
+
+    const moved: string[] = [];
+    for (const { name, projection } of PROJECTIONS) {
+      const historical = replay(projection, GATE_ROWS);
+      const widened = replay(projection, GATE_ROWS.map(withVerdict));
+      if (JSON.stringify(historical) !== JSON.stringify(widened)) moved.push(name);
+    }
+
+    expect(moved, 'a projection moved when the derived verdict was added').toEqual([]);
+  });
+
+  it('Replay_SeededDivergence_IsReported', () => {
+    // The kill probe. The comparison above reports `[]` both when nothing moved
+    // and when the fold silently ignored the whole corpus, so a divergence the
+    // projections CAN see has to be shown to surface — otherwise the case
+    // proves only that two identical computations agree.
+    const flipped = GATE_ROWS.map((row) => ({ ...row, passed: row.passed !== true }));
+
+    const moved = PROJECTIONS.filter(({ projection }) => {
+      const before = JSON.stringify(replay(projection, GATE_ROWS));
+      const after = JSON.stringify(replay(projection, flipped));
+      return before !== after;
+    });
+
+    expect(
+      moved.length,
+      'flipping every `passed` moved no projection — the replay comparison is inert',
+    ).toBeGreaterThan(0);
+  });
+
+  it('Replay_HistoricalAndWidenedRows_Interleave', () => {
+    // A real stream during the migration carries BOTH shapes: rows written
+    // before the field and rows written after it, in one order. Replaying the
+    // mixture must land where the all-historical replay lands, or the widening
+    // is additive only for streams that were never mixed — which is no stream
+    // that matters.
+    const interleaved = GATE_ROWS.map((row, index) => (index % 2 === 0 ? withVerdict(row) : row));
+
+    const moved = PROJECTIONS.filter(
+      ({ projection }) =>
+        JSON.stringify(replay(projection, GATE_ROWS)) !==
+        JSON.stringify(replay(projection, interleaved)),
+    ).map(({ name }) => name);
+
+    expect(moved, 'a projection distinguished a mixed-shape stream').toEqual([]);
+  });
+});

--- a/tests/unit/events/gate-executed-schema.test.ts
+++ b/tests/unit/events/gate-executed-schema.test.ts
@@ -1,0 +1,129 @@
+// ─── gate.executed: the verdict widening ─────────────────────────────────────
+//
+// `passed: boolean` had to answer four different questions with two values. A
+// gate that ran and failed, a probe that could not run, and an obligation that
+// was withdrawn all reached the stream as `passed: false` — or, for a withdrawn
+// one, as `passed: true`, which reads as a gate that ran and succeeded. A
+// reader gating on the boolean cannot tell any of them apart, so a stop it
+// should have made and a stop it should not have made look identical.
+//
+// The widening has to hold two things at once, and they pull against each
+// other: the new field must be expressive enough to carry the distinction, and
+// the change must be ADDITIVE — every row already on a stream stays valid, and
+// every reader written against `passed` keeps working. The cases below are that
+// pair, plus the derivation that keeps the two fields from drifting.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { fc } from '@fast-check/vitest';
+
+import { GateExecutedData, GateVerdictSchema } from '../../../src/events/schemas.js';
+
+/** A row in the shape that predates the field, as it appears on a stream. */
+const historicalRow = (passed: boolean): Record<string, unknown> => ({
+  gateName: 'check_static_analysis',
+  layer: 'review',
+  passed,
+  duration: 12.5,
+  details: { exitCode: passed ? 0 : 1 },
+});
+
+describe('gate.executed verdict widening', () => {
+  it('HistoricalRow_WithoutVerdict_StillParses', () => {
+    // The additive claim, stated over the two historical shapes directly.
+    const passing = GateExecutedData.parse(historicalRow(true));
+    const failing = GateExecutedData.parse(historicalRow(false));
+
+    expect(passing.passed).toBe(true);
+    expect(failing.passed).toBe(false);
+    // Absent, not defaulted. A default would silently assert a verdict the
+    // emitter never computed — precisely the claim this field exists to stop
+    // being made on someone else's behalf.
+    expect(passing.verdict).toBeUndefined();
+    expect(failing.verdict).toBeUndefined();
+  });
+
+  it('HistoricalRow_AnyShape_RemainsValid', () => {
+    // The additive property, quantified rather than sampled: no combination of
+    // the pre-existing fields is refused by the widened schema.
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
+        fc.boolean(),
+        fc.option(fc.double({ min: 0, max: 1e6, noNaN: true }), { nil: undefined }),
+        (gateName, layer, passed, duration) => {
+          const parsed = GateExecutedData.safeParse({
+            gateName,
+            layer,
+            passed,
+            ...(duration === undefined ? {} : { duration }),
+          });
+          return parsed.success;
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+
+  it('Passed_EqualsVerdictIsPass', () => {
+    // The derivation, both directions, over the WHOLE vocabulary rather than a
+    // sampled member — a fifth verdict added later inherits this case instead
+    // of slipping past a hand-listed three.
+    const vocabulary = GateVerdictSchema.options;
+    expect(vocabulary.length, 'the verdict vocabulary is empty').toBeGreaterThan(3);
+
+    const contradictions: string[] = [];
+    for (const verdict of vocabulary) {
+      const agreeing = verdict === 'pass';
+
+      const ok = GateExecutedData.safeParse({ ...historicalRow(agreeing), verdict });
+      if (!ok.success) contradictions.push(`agreeing row rejected: verdict=${verdict}`);
+
+      const bad = GateExecutedData.safeParse({ ...historicalRow(!agreeing), verdict });
+      if (bad.success) contradictions.push(`contradicting row accepted: verdict=${verdict}`);
+    }
+
+    expect(contradictions, 'the derivation is not enforced over the whole vocabulary').toEqual([]);
+  });
+
+  it('IndeterminateRow_DoesNotReadAsPass', () => {
+    // The finding that motivated the field. Both non-decisions must be
+    // expressible, and neither may reach a boolean reader as a pass.
+    for (const verdict of ['indeterminate', 'not-applicable'] as const) {
+      const row = GateExecutedData.parse({ ...historicalRow(false), verdict });
+      expect(row.verdict, `${verdict} was not carried onto the row`).toBe(verdict);
+      expect(row.passed, `${verdict} reached a boolean reader as a pass`).toBe(false);
+    }
+
+    // And the converse, so the two above are not passing because the schema
+    // refuses everything: a real pass still round-trips as one.
+    const decided = GateExecutedData.parse({ ...historicalRow(true), verdict: 'pass' });
+    expect(decided.passed).toBe(true);
+    expect(decided.verdict).toBe('pass');
+  });
+
+  it('WithdrawnObligation_IsNotWrittenDownAsAFailure', () => {
+    // `not-applicable` is the one that used to have NO honest encoding: written
+    // as `passed: true` it reads as a gate that ran and succeeded, and as
+    // `passed: false` it reads as a stop. The derivation forces the second
+    // spelling, so the boolean is not a pass — and the verdict is what says the
+    // difference between "failed" and "was never owed".
+    const withdrawn = GateExecutedData.parse({
+      ...historicalRow(false),
+      verdict: 'not-applicable',
+    });
+    expect(withdrawn.passed).toBe(false);
+    expect(withdrawn.verdict).not.toBe('fail');
+
+    // The old spelling is now refused outright rather than silently accepted.
+    const oldSpelling = GateExecutedData.safeParse({
+      ...historicalRow(true),
+      verdict: 'not-applicable',
+    });
+    expect(
+      oldSpelling.success,
+      'a withdrawn obligation was still expressible as a gate that passed',
+    ).toBe(false);
+  });
+});

--- a/tests/unit/verbs/gates/diff-hygiene.test.ts
+++ b/tests/unit/verbs/gates/diff-hygiene.test.ts
@@ -125,6 +125,28 @@ function appendedRows(): unknown[][] {
   return mockEmitGateEvent.mock.calls.map((call) => call.slice(1));
 }
 
+/** Index of the verdict argument in a row, once the store argument is sliced off. */
+const VERDICT_ARG = 3;
+
+/**
+ * Lift a CAPTURED row into the emitter's current vocabulary.
+ *
+ * The baseline was captured while `emitGateEvent` still took `passed: boolean`,
+ * so its verdict argument is a boolean. The emitter now takes the verdict and
+ * derives `passed` from it. The recorded boolean is lifted through that same
+ * derivation rather than the baseline being rewritten: the capture is EVIDENCE
+ * of what the three retired handlers did, and editing evidence to agree with
+ * new code is how a characterization quietly stops characterizing anything.
+ *
+ * Only the one argument moves. Anything else differing is a real behavioural
+ * change and still fails.
+ */
+function inCurrentVocabulary(row: readonly unknown[]): unknown[] {
+  return row.map((arg, index) =>
+    index === VERDICT_ARG && typeof arg === 'boolean' ? (arg ? 'pass' : 'fail') : arg,
+  );
+}
+
 describe('the diff-hygiene rule pack', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -272,7 +294,9 @@ describe('the diff-hygiene rule pack', () => {
       const captured = SCORED[key]!;
       await runOn(DIFF_CORPUS[key] ?? '');
 
-      const expectedRows = RETIRED_GATE_NAMES.flatMap((id) => captured[id]?.emissions ?? []);
+      const expectedRows = RETIRED_GATE_NAMES.flatMap((id) => captured[id]?.emissions ?? []).map(
+        inCurrentVocabulary,
+      );
       expect(appendedRows()).toEqual(expectedRows);
     });
   });
@@ -320,7 +344,9 @@ describe('the diff-hygiene rule pack', () => {
       // unconditionally — a success carrier without the rows is drift the
       // post-dispatch emission verifier reports, and it leaves the durable log
       // unable to tell an unscoped run from one that never happened.
-      const expectedRows = RETIRED_GATE_NAMES.flatMap((id) => UNSCOPED[id]!.emissions);
+      const expectedRows = RETIRED_GATE_NAMES.flatMap((id) => UNSCOPED[id]!.emissions).map(
+        inCurrentVocabulary,
+      );
       expect(appendedRows()).toEqual(expectedRows);
     });
   });

--- a/tests/unit/verbs/gates/gate-utils.test.ts
+++ b/tests/unit/verbs/gates/gate-utils.test.ts
@@ -36,13 +36,13 @@ describe('emitGateEvent', () => {
     const mockStore = { append: vi.fn().mockResolvedValue(undefined) };
 
     // Act
-    await emitGateEvent(mockStore as any, 'stream-1', 'test-gate', 'CI', true);
+    await emitGateEvent(mockStore as any, 'stream-1', 'test-gate', 'CI', 'pass');
 
     // Assert
     expect(mockStore.append).toHaveBeenCalledOnce();
     expect(mockStore.append).toHaveBeenCalledWith('stream-1', {
       type: 'gate.executed',
-      data: { gateName: 'test-gate', layer: 'CI', passed: true },
+      data: { gateName: 'test-gate', layer: 'CI', passed: true, verdict: 'pass' },
     });
   });
 
@@ -54,12 +54,12 @@ describe('emitGateEvent', () => {
     const details = { passCount: 10, failCount: 2 };
 
     // Act
-    await emitGateEvent(mockStore as any, 'stream-2', 'test-suite', 'CI', false, details);
+    await emitGateEvent(mockStore as any, 'stream-2', 'test-suite', 'CI', 'fail', details);
 
     // Assert
     expect(mockStore.append).toHaveBeenCalledWith('stream-2', {
       type: 'gate.executed',
-      data: { gateName: 'test-suite', layer: 'CI', passed: false, details },
+      data: { gateName: 'test-suite', layer: 'CI', passed: false, verdict: 'fail', details },
     });
   });
 
@@ -70,12 +70,12 @@ describe('emitGateEvent', () => {
     const mockStore = { append: vi.fn().mockResolvedValue(undefined) };
 
     // Act
-    await emitGateEvent(mockStore as any, 'stream-3', 'design-check', 'design', true);
+    await emitGateEvent(mockStore as any, 'stream-3', 'design-check', 'design', 'pass');
 
     // Assert
     expect(mockStore.append).toHaveBeenCalledWith('stream-3', {
       type: 'gate.executed',
-      data: { gateName: 'design-check', layer: 'design', passed: true },
+      data: { gateName: 'design-check', layer: 'design', passed: true, verdict: 'pass' },
     });
   });
 
@@ -86,7 +86,7 @@ describe('emitGateEvent', () => {
     const mockStore = { append: vi.fn().mockResolvedValue(undefined) };
 
     // Act
-    await emitGateEvent(mockStore as any, 'stream-4', 'post-merge', 'post-merge', true);
+    await emitGateEvent(mockStore as any, 'stream-4', 'post-merge', 'post-merge', 'pass');
 
     // Assert
     const calledEvent = mockStore.append.mock.calls[0][1];

--- a/tests/unit/verbs/gates/provenance-chain.test.ts
+++ b/tests/unit/verbs/gates/provenance-chain.test.ts
@@ -202,7 +202,7 @@ describe('handleProvenanceChain', () => {
       'test-feat',
       'provenance-chain',
       'planning',
-      true,
+      'pass',
       expect.objectContaining({
         dimension: 'D1',
         requirements: 2,
@@ -239,7 +239,7 @@ describe('handleProvenanceChain', () => {
       'test-feat',
       'provenance-chain',
       'planning',
-      true,
+      'pass',
       expect.objectContaining({
         phase: 'plan',
       }),

--- a/tests/unit/verbs/tasks/task-decomposition.test.ts
+++ b/tests/unit/verbs/tasks/task-decomposition.test.ts
@@ -1187,7 +1187,7 @@ describe('handleTaskDecomposition', () => {
       'test-feature',
       'task-decomposition',
       'planning',
-      true,
+      'pass',
       expect.objectContaining({
         dimension: 'D5',
         phase: 'plan',

--- a/tests/unit/verbs/team/prepare-delegation.test.ts
+++ b/tests/unit/verbs/team/prepare-delegation.test.ts
@@ -455,7 +455,7 @@ describe('handlePrepareDelegation', () => {
       'test-feature',    // streamId
       'plan-coverage',   // gateName
       'planning',        // layer
-      true,              // passed
+      'pass',            // verdict — `passed` is derived from it at the emitter
       {
         dimension: 'D1',
         phase: 'delegate',

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,10 +4,10 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, which is why this total sits below the runners' combined count (root 1,731 including skips, nested 11,662). The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1207,
-    "parsedFiles": 1162,
+    "testFiles": 1210,
+    "parsedFiles": 1165,
     "shellFiles": 45,
-    "cases": 13490,
+    "cases": 13503,
     "dynamicTitles": 151,
     "unparseableFiles": 0
   },
@@ -4629,6 +4629,27 @@
         }
       ]
     },
+    "tests/acceptance/gate-verdict-emission.test.ts": {
+      "file": "tests/acceptance/gate-verdict-emission.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "gate verdicts reach the wire whole",
+          "name": "NoCallSite_PassesABareBoolean",
+          "dynamic": false
+        },
+        {
+          "suite": "gate verdicts reach the wire whole",
+          "name": "SelfEmitter_CannotExpressAnUncomputedVerdict",
+          "dynamic": false
+        },
+        {
+          "suite": "gate verdicts reach the wire whole",
+          "name": "IndeterminateEmission_IsNotWrittenDownAsAFailure",
+          "dynamic": false
+        }
+      ]
+    },
     "tests/acceptance/ladder-off-node.test.ts": {
       "file": "tests/acceptance/ladder-off-node.test.ts",
       "runner": "vitest:root",
@@ -6062,7 +6083,7 @@
       "cases": [
         {
           "suite": "retired public names",
-          "name": "ConvergenceViewName_IsRemovedFromTheCliContract",
+          "name": "RetiredActionNames_AreRemovedFromEveryPublishedSurface",
           "dynamic": false
         }
       ]
@@ -6104,6 +6125,16 @@
         {
           "suite": "test inventory",
           "name": "TestInventory_RenamedCases_StillReconcileAgainstTheTask002Oracle",
+          "dynamic": false
+        },
+        {
+          "suite": "test inventory",
+          "name": "TestInventory_RetirementRegister_IsHonestAndNotInert",
+          "dynamic": false
+        },
+        {
+          "suite": "test inventory",
+          "name": "TestInventory_DeletionWithoutARetirement_IsStillReported",
           "dynamic": false
         },
         {
@@ -8575,6 +8606,27 @@
         {
           "suite": "gate scope-failure recording",
           "name": "PhaseGateScopeFailure_LeavesADurableTrace",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/integration/gate-verdict-replay.test.ts": {
+      "file": "tests/integration/gate-verdict-replay.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "gate.executed verdict replay",
+          "name": "Replay_ProducesTheSameProjection",
+          "dynamic": false
+        },
+        {
+          "suite": "gate.executed verdict replay",
+          "name": "Replay_SeededDivergence_IsReported",
+          "dynamic": false
+        },
+        {
+          "suite": "gate.executed verdict replay",
+          "name": "Replay_HistoricalAndWidenedRows_Interleave",
           "dynamic": false
         }
       ]
@@ -23630,6 +23682,37 @@
         {
           "suite": "CodeQualityView - promptVersion",
           "name": "CodeQualityView_GateWithPromptVersion_StoresInMetrics",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/unit/events/gate-executed-schema.test.ts": {
+      "file": "tests/unit/events/gate-executed-schema.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "gate.executed verdict widening",
+          "name": "HistoricalRow_WithoutVerdict_StillParses",
+          "dynamic": false
+        },
+        {
+          "suite": "gate.executed verdict widening",
+          "name": "HistoricalRow_AnyShape_RemainsValid",
+          "dynamic": false
+        },
+        {
+          "suite": "gate.executed verdict widening",
+          "name": "Passed_EqualsVerdictIsPass",
+          "dynamic": false
+        },
+        {
+          "suite": "gate.executed verdict widening",
+          "name": "IndeterminateRow_DoesNotReadAsPass",
+          "dynamic": false
+        },
+        {
+          "suite": "gate.executed verdict widening",
+          "name": "WithdrawnObligation_IsNotWrittenDownAsAFailure",
           "dynamic": false
         }
       ]
@@ -41999,7 +42082,7 @@
         },
         {
           "suite": "Runbook definitions",
-          "name": "QualityEvaluation_HasFourSteps",
+          "name": "QualityEvaluation_HasFiveSteps",
           "dynamic": false
         },
         {


### PR DESCRIPTION
## Summary

Wave C of the phase-gate spec, DR-11: **indeterminate reaches the wire.** Tasks 024 and 025 of 8. Draft — 026 is next, and 027/028/030 are genuinely blocked on #1858.

`passed: boolean` had to answer four questions with two values. A gate that ran and failed, a probe that could not run, and an obligation that was withdrawn all reached the stream as `passed: false` — or, for a withdrawn one, as `passed: true`, which reads as a gate that ran and succeeded. A reader gating on the boolean cannot tell any of them apart, so a stop it should have made and a stop it should not have made look identical on the wire.

## Changes

**Task 024 — the record gains somewhere to say it did not decide.**
`GateExecutedData` gains `verdict: 'pass' | 'fail' | 'indeterminate' | 'not-applicable'`. `passed` is **retained and derived**, so every reader written against the boolean keeps working and every row already on a stream stays valid. The field is optional solely because historical rows predate it, and deliberately **not defaulted** — a default would assert a verdict the emitter never computed.

The derivation is enforced at the **schema**, not left to writers. A row where `passed` and `verdict` disagree has no defensible reading — one of them is wrong and nothing downstream can tell which — so refusing it makes the derivation a property of the record rather than a convention every emitter is trusted to have followed. It also closes the one encoding a withdrawn obligation used to have: `passed: true, verdict: 'not-applicable'` is now rejected outright.

**Task 025 — the emitter takes the verdict, and the runner stops collapsing it.**
`emitGateEvent` takes the verdict; `passed` is computed at the single place a row is minted. That is what makes the migration exhaustive — **a bare boolean stops type-checking**, so the compiler named all 20 call sites rather than anyone having to remember them.

`gate-runner.ts` was the sharper case. It is the one place that *computes* a verdict and it was the place that threw it away: the row carried the collapsed boolean at top level and the verdict only in `details`, where the readers that gate on outcomes do not look. It mints the row whole now. `details.verdict` is deliberately retained — every row written before the widening carries it only there, so a reader folding history has to keep looking there.

All 20 sites are **behaviour-preserving** (`X` → `X ? 'pass' : 'fail'`). Deciding which should instead say `indeterminate` or `not-applicable` is skip polarity — that is task 026, not something to smuggle in here.

## Test Plan

- **Additive, quantified not sampled.** `HistoricalRow_AnyShape_RemainsValid` drives fast-check over the pre-existing field space; `Passed_EqualsVerdictIsPass` runs the derivation over the *whole* vocabulary, both directions, so a fifth verdict added later inherits the case instead of slipping past a hand-listed three.
- **Replay.** Three separately maintained projections are driven over the same events twice — once in today's shape, once with the derived verdict — and required to be indistinguishable, including for a stream that **interleaves both shapes** as a real one does mid-migration. It carries its own kill probe: flipping every `passed` must move a projection, or the comparison is only proving that two identical computations agree.
- **No call site passes a bare boolean**, asserted both ways: an AST scan of every call site, *and* the declaration still typing the parameter as `GateVerdict` — because a signature that quietly went back to `boolean` would leave a call-site scan passing over sites that had all been rewritten.
- **The diff-hygiene characterization is lifted, not rewritten.** Its baseline captured call arguments while the verdict argument was still a boolean; those recorded booleans are lifted through the same derivation the emitter applies, and *only* that argument moves. The capture is evidence of what the three retired handlers did, and editing evidence to agree with new code is how a characterization quietly stops characterizing anything.
- Local: `typecheck` clean; 1332 unit tests across the gate blast radius; integration, DR-30 suite-invariants and the architecture tier green apart from the two documented environmental reds (`worktree-inventory` accumulation, `published-contract` needing a built `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
