### PR TITLE
feat(events): derived governance/telemetry partition map + differential-fold and raw-reader oracles (#1876 slice 3)

### DIFF
--- a/src/events/partition/authority.ts
+++ b/src/events/partition/authority.ts
@@ -1,0 +1,166 @@
+/**
+ * The governance/telemetry partition over the event catalog, DERIVED.
+ *
+ * ── The question this answers ───────────────────────────────────────────────
+ *
+ * An event is a GOVERNANCE event when something depends on it being there: the
+ * canonical projection folds it, or a correctness-bearing reader outside the
+ * fold re-reads it raw (a fence, an idempotency check, an HSM guard). Every
+ * other event is TELEMETRY — it records that something happened and nothing
+ * decides anything from it.
+ *
+ * Before this module the catalog answered a different question. `EventTier`
+ * says what an emission is welded to and `EventEmissionSource` says who
+ * appends it; neither says whether anything reads it back. So "may this event
+ * be dropped, re-ordered, or re-sourced" had no derivable answer, and the
+ * absence read as permission.
+ *
+ * ── Tier, not lifecycle ─────────────────────────────────────────────────────
+ *
+ * The classifier consults `EMISSION_SOURCE_BY_TIER[registration.tier]`, NOT
+ * `resolveEmissionSource`. That function composes lifecycle first, which would
+ * mask ownership in both directions: a `retired` type can still sit in a
+ * historical stream the fold replays, and a `planned` type has an ownership
+ * answer before its first append is ever written. Authority is a property of
+ * what the event is welded to, and lifecycle does not change that.
+ *
+ * ── Promotion only, never demotion ──────────────────────────────────────────
+ *
+ * A type whose tier derives `auto` is governance and stays governance, even
+ * when nothing here is known to fold or read it. Only the other direction is
+ * open: a witness may promote a non-`auto` type.
+ *
+ * The reason is about what the instruments can prove. A demotion asserts
+ * "nothing depends on this event" — a universal claim. The fold measurement and
+ * the raw-reader census are sufficient to justify a PROMOTION, because a single
+ * observed fold or reader is a witness; their completeness is not yet proved,
+ * and a static scanner has an acknowledged blind spot (a bare fold whose type
+ * comparison happens in another module). So a gap in either instrument can only
+ * make this map over-retain, never silently demote. Types that plainly look
+ * like telemetry and derive `auto` — the tool and turn families among them —
+ * are the demotion backlog, and closing it needs a stronger instrument than
+ * this one.
+ *
+ * ── Fail-closed, and by name ────────────────────────────────────────────────
+ *
+ * Built like `deriveEmissionRegistry`: a pure function over an injected
+ * population and an injected lookup, so a probe can derive over a seeded
+ * catalog without touching the live tables, and every refusal NAMES its
+ * offenders rather than reporting a count.
+ */
+
+import type { EmissionSource } from '../event-registration.js';
+
+/** Whether anything depends on the event being present. */
+export type EventAuthority = 'governance' | 'telemetry';
+
+/** How a promotion is proved. */
+export type AuthorityArm = 'projection-fold' | 'raw-reader' | 'charter-pin';
+
+/**
+ * Why a type whose tier does not make it governance is governance anyway.
+ *
+ * The witness is the whole basis for the promotion, so it carries its evidence
+ * rather than asserting the conclusion: `projection-fold` and `raw-reader`
+ * evidence are module paths an oracle re-measures against the tree, and
+ * `charter-pin` evidence is the ratified decision's citation.
+ */
+export interface AuthorityWitness {
+  readonly arm: AuthorityArm;
+  /** Module paths (repo-relative, forward-slashed), or the charter's citation. */
+  readonly evidence: readonly [string, ...string[]];
+  readonly because: string;
+}
+
+/**
+ * Partition a population of event types into governance and telemetry.
+ *
+ * The rule is one line and total: a type is `governance` iff its tier derives
+ * `auto` OR it carries a witness; otherwise it is `telemetry`.
+ *
+ * Four refusals, each because the alternative is a map that reads clean while
+ * saying nothing:
+ *
+ *   • **Empty population.** An empty map reads to every consumer as "no event
+ *     has an authority", which is exactly what a moved or renamed catalog
+ *     produces.
+ *   • **Unannotated type.** No tier, no derivable authority. Defaulting it
+ *     would be the guess this derivation exists to remove.
+ *   • **Witness for a type outside the population.** A renamed or deleted event
+ *     leaves its witness behind, still asserting a promotion for nothing.
+ *   • **Witness on a type the tier already makes governance.** Dead cover: the
+ *     declaration changes no answer, so it cannot be checked by anything, and a
+ *     later re-tiering would silently start relying on it.
+ */
+export function deriveEventAuthority(
+  eventTypes: Iterable<string>,
+  tierSourceOf: (eventType: string) => EmissionSource | undefined,
+  witnesses: Readonly<Record<string, AuthorityWitness>>,
+): Record<string, EventAuthority> {
+  const derived: Record<string, EventAuthority> = {};
+  const unannotated: string[] = [];
+  const deadCover: string[] = [];
+  let population = 0;
+
+  for (const eventType of eventTypes) {
+    population += 1;
+    const tierSource = tierSourceOf(eventType);
+    if (tierSource === undefined) {
+      unannotated.push(eventType);
+      continue;
+    }
+    const witness = witnesses[eventType];
+    if (tierSource === 'auto') {
+      if (witness !== undefined) deadCover.push(eventType);
+      derived[eventType] = 'governance';
+      continue;
+    }
+    derived[eventType] = witness === undefined ? 'telemetry' : 'governance';
+  }
+
+  if (population === 0) {
+    throw new Error(
+      'deriveEventAuthority: refusing to partition an empty event-type population. An empty ' +
+        'map reads to every consumer as "no event has an authority", so a moved or renamed ' +
+        'catalog must fail here rather than pass clean.',
+    );
+  }
+  if (unannotated.length > 0) {
+    throw new Error(
+      `deriveEventAuthority: ${unannotated.length} event type(s) carry no registration, so no ` +
+        `tier and therefore no authority can be derived for them: ${unannotated.sort().join(', ')}. ` +
+        'Annotate the type rather than defaulting its authority.',
+    );
+  }
+
+  const stale = Object.keys(witnesses).filter((eventType) => derived[eventType] === undefined);
+  if (stale.length > 0) {
+    throw new Error(
+      `deriveEventAuthority: ${stale.length} governance witness(es) name an event type that is ` +
+        `not in the population: ${stale.sort().join(', ')}. A witness for a renamed or deleted ` +
+        'type promotes nothing and must be removed with the type.',
+    );
+  }
+  if (deadCover.length > 0) {
+    throw new Error(
+      `deriveEventAuthority: ${deadCover.length} governance witness(es) cover a type whose tier ` +
+        `already derives governance: ${deadCover.sort().join(', ')}. The declaration changes no ` +
+        'answer, so nothing can check it — delete it, or re-tier the event if the tier is wrong.',
+    );
+  }
+
+  return derived;
+}
+
+/** Split a derived map into its two sides. Never authored, never a literal list. */
+export function partitionByAuthority(
+  authority: Readonly<Record<string, EventAuthority>>,
+): { readonly governance: ReadonlySet<string>; readonly telemetry: ReadonlySet<string> } {
+  const governance = new Set<string>();
+  const telemetry = new Set<string>();
+  for (const [eventType, value] of Object.entries(authority)) {
+    if (value === 'governance') governance.add(eventType);
+    else telemetry.add(eventType);
+  }
+  return Object.freeze({ governance, telemetry });
+}

--- a/src/events/partition/authority.ts
+++ b/src/events/partition/authority.ts
@@ -36,10 +36,32 @@
  * observed fold or reader is a witness; their completeness is not yet proved,
  * and a static scanner has an acknowledged blind spot (a bare fold whose type
  * comparison happens in another module). So a gap in either instrument can only
- * make this map over-retain, never silently demote. Types that plainly look
- * like telemetry and derive `auto` — the tool and turn families among them —
- * are the demotion backlog, and closing it needs a stronger instrument than
- * this one.
+ * make this map over-retain, never silently demote.
+ *
+ * ── The map disagrees with the charter's telemetry examples, on purpose ──────
+ *
+ * The ratified decision lists example telemetry types — the tool and turn
+ * families, the team family, `shepherd.iteration`, `stack.submitted`,
+ * `subagent.tokens_used`, `launch.executing_started`. Most of them classify
+ * GOVERNANCE here. Two distinct reasons, and neither is an oversight:
+ *
+ *   • several carry a live fold-external reader today, so demoting them would
+ *     be a false statement — the charter itself sequences each flip as its own
+ *     change that retires the reader and deletes the expectation row with it;
+ *   • the rest derive `auto` from a substrate tier, and the promotion-only rule
+ *     refuses to override that with an instrument that cannot prove absence.
+ *
+ * That disagreement is a BACKLOG, not a footnote, so it is counted rather than
+ * described: the partition's own test pins the exact set of charter-named
+ * telemetry examples still classified governance, a list that may only shrink.
+ *
+ * ── One more bound worth stating ────────────────────────────────────────────
+ *
+ * "The projection folds it" means the CANONICAL workflow-state fold. A secondary
+ * view can still derive a decision from a telemetry-classified event — the
+ * synthesis-readiness view computes its blockers from test and typecheck
+ * results — so a consumer that drops telemetry is safe for the canonical state
+ * and not yet proved safe for every view.
  *
  * ── Fail-closed, and by name ────────────────────────────────────────────────
  *
@@ -54,8 +76,21 @@ import type { EmissionSource } from '../event-registration.js';
 /** Whether anything depends on the event being present. */
 export type EventAuthority = 'governance' | 'telemetry';
 
-/** How a promotion is proved. */
-export type AuthorityArm = 'projection-fold' | 'raw-reader' | 'charter-pin';
+/**
+ * How a promotion is proved.
+ *
+ * `gate-expectation` is separate from `raw-reader` because the read it names is
+ * indirect: the gate iterates a DECLARED expectation table and asks a set built
+ * from the stream whether each listed type is present. No comparison against a
+ * literal appears anywhere, so a source scan cannot see it; the table is the
+ * evidence, and the oracle that re-measures this arm reads the table rather than
+ * the tree.
+ */
+export type AuthorityArm =
+  | 'projection-fold'
+  | 'raw-reader'
+  | 'gate-expectation'
+  | 'charter-pin';
 
 /**
  * Why a type whose tier does not make it governance is governance anyway.

--- a/src/events/partition/event-authority.ts
+++ b/src/events/partition/event-authority.ts
@@ -1,0 +1,64 @@
+// RESERVED(issue: #1876, owner: exarchos, expires: 2027-03-31) — production code
+// with no production importer YET. The partition is the map every later consumer
+// reads: the doctor check that reports a demotion candidate, the retention policy
+// that may drop a telemetry event, and the append path that will refuse to accept
+// a governance event on a telemetry channel. None of those exist, and wiring one
+// on the strength of a map whose oracles were written in the same change would be
+// asserting the map is settled before anything has tried to use it. It is
+// deliberately NOT claimed as test infrastructure: this is the shipped
+// classification, not gate machinery, and misfiling it would buy a permanent
+// exemption for a module that is supposed to become load-bearing.
+
+/**
+ * The live governance/telemetry partition over the shipped event catalog.
+ *
+ * Built EAGERLY at module scope, the way `EVENT_EMISSION_REGISTRY` is, so a
+ * population that cannot be partitioned fails at load rather than at whichever
+ * consumer happens to ask first. The two sets are derived from the map by
+ * partition — neither is authored, so neither can drift from it.
+ */
+
+import { EventTypes, type EventType } from '../schemas.js';
+import { ANNOTATED_EVENTS } from '../event-annotations.js';
+import { EMISSION_SOURCE_BY_TIER, type EmissionSource } from '../event-registration.js';
+import { deriveEventAuthority, partitionByAuthority, type EventAuthority } from './authority.js';
+import { GOVERNANCE_WITNESSES } from './witnesses.js';
+
+/**
+ * The tier's emission source for an event type, with lifecycle deliberately
+ * NOT composed in — see `authority.ts` for why authority reads the weld rather
+ * than whether the event is currently emitted.
+ */
+export function tierEmissionSourceOf(eventType: string): EmissionSource | undefined {
+  const registration = ANNOTATED_EVENTS.registrationOf(eventType);
+  return registration === undefined ? undefined : EMISSION_SOURCE_BY_TIER[registration.tier];
+}
+
+const DERIVED: Record<string, EventAuthority> = deriveEventAuthority(
+  EventTypes,
+  tierEmissionSourceOf,
+  GOVERNANCE_WITNESSES,
+);
+
+/**
+ * Total over the catalog by construction: built FROM `EventTypes`, so its key
+ * set cannot differ from the catalog's.
+ */
+export const EVENT_AUTHORITY: Record<EventType, EventAuthority> = DERIVED;
+
+const PARTITION = partitionByAuthority(DERIVED);
+
+/** Events something depends on: the fold consumes them, or a raw reader does. */
+export const GOVERNANCE_EVENTS: ReadonlySet<string> = PARTITION.governance;
+
+/** Events that record what happened and that nothing decides anything from. */
+export const TELEMETRY_EVENTS: ReadonlySet<string> = PARTITION.telemetry;
+
+/**
+ * The authority of one event type, or `undefined` for a type outside the
+ * catalog — a runtime-registered custom type has no tier here, and answering
+ * `'telemetry'` for it would be a guess dressed as a derivation.
+ */
+export function classifyEventAuthority(eventType: string): EventAuthority | undefined {
+  return DERIVED[eventType];
+}

--- a/src/events/partition/reader-census.ts
+++ b/src/events/partition/reader-census.ts
@@ -1,0 +1,315 @@
+/**
+ * Which event types are read RAW outside the canonical fold, measured from the
+ * source tree.
+ *
+ * ── Why the measurement, and not a table ────────────────────────────────────
+ *
+ * Half the correctness-bearing dependencies on an event never touch a
+ * projection. A fence checks whether a request was already executed, an
+ * idempotency guard looks for a prior operation, an HSM guard scans the
+ * hydrated event tail for one type. None of that is visible in a projection's
+ * reducer, so a type can be droppable by the fold and undroppable by the tree.
+ * A hand-maintained list of those readers would drift the moment a reader
+ * moved, and would drift silently, because the only instrument that could
+ * detect the drift is the measurement it replaced.
+ *
+ * ── The scanner is a port ───────────────────────────────────────────────────
+ *
+ * Resolving what a discriminant MEANS is a question about bindings, and the
+ * only instrument that cannot disagree with the compiler about bindings is the
+ * compiler. `typescript` is a devDependency, and a shipped module importing it
+ * would make the compiler a runtime dependency of a tree whose shipped artifact
+ * resolves only `dependencies`. So the policy lives here and the parser is
+ * injected, the same split the append-site census states for itself.
+ *
+ * ── Three buckets, and why the third is not a subset of the other two ───────
+ *
+ * A resolved discriminant is a reader. A discriminant that does not reduce to a
+ * string is UNRESOLVED and is reported, never dropped — "the census could not
+ * read this" and "this module reads nothing" are different answers.
+ *
+ * A query with no type discriminant at all is neither. It is an UNSCOPED FOLD,
+ * and it gets its own bucket: merging it into unresolved would flag a working
+ * scan as broken, and merging it into "resolved: nothing" would hide a reader
+ * that depends on the entire type universe. This bucket is also the census's
+ * acknowledged blind spot — a bare fold whose `.type` comparison happens in
+ * another module, behind a helper or across a call boundary, is invisible to a
+ * per-module scan. That is the second reason the partition promotes but never
+ * demotes: an under-report here can only leave a type classified governance.
+ *
+ * ── Only known event types count ────────────────────────────────────────────
+ *
+ * A resolved literal is admitted only when it is a member of the catalog the
+ * caller supplies. That single filter is what keeps an unrelated
+ * `finding.type === 'style'` comparison out of the census without anyone
+ * maintaining an exclusion list.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+import type { AuthorityWitness, EventAuthority } from './authority.js';
+
+/** What kind of read a site is. */
+export type EventReaderKind =
+  /** A `.query(stream, { type: X })` or `.queryByType(X, …)` discriminant. */
+  | 'query-discriminant'
+  /** An `event.type === 'x'` / `!== 'x'` comparison. */
+  | 'type-comparison'
+  /** A `case 'x':` arm on a switch whose discriminant is an event type. */
+  | 'switch-case'
+  /** A query call carrying no type discriminant at all. */
+  | 'unscoped-query';
+
+/** One read site the scanner found. */
+export interface EventReaderSite {
+  /** 1-based line of the read in the scanned source. */
+  readonly line: number;
+  readonly kind: EventReaderKind;
+  /** The resolved event-type string, or `undefined` when it did not reduce. */
+  readonly discriminant: string | undefined;
+}
+
+/** Inputs a scanner needs beyond the source text. */
+export interface EventReaderScanOptions {
+  /** Reported in parse diagnostics only; never affects the answer. */
+  readonly fileName?: string;
+  /**
+   * Dotted access paths (`ADMISSION_EVENT_TYPES.EVIDENCE_RECORDED`) mapped to
+   * their compile-time value, so a discriminant written as the exported
+   * constant resolves to the same answer as the raw literal.
+   */
+  readonly knownConstants: ReadonlyMap<string, string>;
+}
+
+/** The reader scanner port. The implementation is compiler-backed, under `tools/`. */
+export type EventReaderScanner = (
+  source: string,
+  options: EventReaderScanOptions,
+) => readonly EventReaderSite[];
+
+/** A read site referenced by where it is, for a diagnostic that can be acted on. */
+export interface EventReaderSiteRef {
+  /** Source module, relative to the scan root, forward-slashed. */
+  readonly module: string;
+  readonly line: number;
+  readonly kind: EventReaderKind;
+}
+
+/** Every fold-external reader, plus the two buckets that are not readers. */
+export interface EventReaderCensus {
+  /** Event type → the modules that read it raw, sorted and de-duplicated. */
+  readonly modulesByEvent: ReadonlyMap<string, readonly string[]>;
+  /** Reads whose discriminant is a runtime value. */
+  readonly unresolved: readonly EventReaderSiteRef[];
+  /** Queries with no type discriminant — the whole-universe dependencies. */
+  readonly unscopedFolds: readonly EventReaderSiteRef[];
+  /**
+   * Every module the scan read, sorted. Carried in full rather than only
+   * counted, because a consumer needs to tell "scanned and reads nothing" from
+   * "never in scope" — collapsing those turns an unanswered question into a
+   * refutation.
+   */
+  readonly scannedModules: readonly string[];
+  /** Modules scanned — the DENOMINATOR, so a shrunken scan cannot read as clean. */
+  readonly scannedModuleCount: number;
+}
+
+/**
+ * Every non-test TypeScript module under `sourceDir`, sorted.
+ *
+ * The suffix filter is a BUILD property, not a named subtree: a file the build
+ * never emits cannot host a shipped reader. `excludeDirs` carries the one
+ * deliberate subtree exclusion — the projections themselves, whose whole job is
+ * to fold every event including telemetry, so scanning them would report the
+ * fold as a violation of a rule about readers OUTSIDE it.
+ */
+async function collectSources(
+  sourceDir: string,
+  excludeDirs: readonly string[],
+): Promise<string[]> {
+  const files: string[] = [];
+  const excluded = new Set(excludeDirs);
+  const walk = async (dir: string): Promise<void> => {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules') continue;
+        if (excluded.has(full)) continue;
+        await walk(full);
+        continue;
+      }
+      if (
+        entry.isFile() &&
+        entry.name.endsWith('.ts') &&
+        !entry.name.endsWith('.test.ts') &&
+        !entry.name.endsWith('.bench.ts') &&
+        !entry.name.endsWith('.d.ts')
+      ) {
+        files.push(full);
+      }
+    }
+  };
+  await walk(sourceDir);
+  return files.sort();
+}
+
+/** Where the walk starts and what it refuses to descend into. */
+export interface EventReaderScanScope {
+  /** Directory the walk starts from, absolute. */
+  readonly sourceDir: string;
+  /** Absolute directories the walk does not descend into. */
+  readonly excludeDirs: readonly string[];
+}
+
+/**
+ * Scan a source tree and group every resolved fold-external read by the event
+ * it names.
+ *
+ * Pure with respect to its inputs beyond the read: the same tree and the same
+ * scanner produce the same census, and nothing here decides whether a site is a
+ * fault.
+ *
+ * Module paths are reported relative to `root`, so a census taken from the
+ * repository root names modules the way a witness declaration and a reviewer
+ * both write them.
+ */
+export async function scanEventReaders(
+  root: string,
+  scope: EventReaderScanScope,
+  scan: EventReaderScanner,
+  knownEventTypes: ReadonlySet<string>,
+  knownConstants: ReadonlyMap<string, string>,
+): Promise<EventReaderCensus> {
+  const files = await collectSources(scope.sourceDir, scope.excludeDirs);
+  const byEvent = new Map<string, Set<string>>();
+  const unresolved: EventReaderSiteRef[] = [];
+  const unscopedFolds: EventReaderSiteRef[] = [];
+  const scannedModules: string[] = [];
+
+  for (const file of files) {
+    const source = await readFile(file, 'utf8');
+    const module = relative(root, file).replaceAll('\\', '/');
+    scannedModules.push(module);
+    for (const site of scan(source, { fileName: module, knownConstants })) {
+      const ref: EventReaderSiteRef = { module, line: site.line, kind: site.kind };
+      if (site.kind === 'unscoped-query') {
+        unscopedFolds.push(ref);
+        continue;
+      }
+      if (site.discriminant === undefined) {
+        unresolved.push(ref);
+        continue;
+      }
+      // A literal that is not a catalog member is not a read of an event.
+      if (!knownEventTypes.has(site.discriminant)) continue;
+      const modules = byEvent.get(site.discriminant) ?? new Set<string>();
+      modules.add(module);
+      byEvent.set(site.discriminant, modules);
+    }
+  }
+
+  const modulesByEvent = new Map<string, readonly string[]>();
+  for (const [event, modules] of byEvent) {
+    modulesByEvent.set(event, Object.freeze([...modules].sort()));
+  }
+  const bySite = (a: EventReaderSiteRef, b: EventReaderSiteRef): number =>
+    a.module.localeCompare(b.module) || a.line - b.line;
+  return Object.freeze({
+    modulesByEvent,
+    unresolved: Object.freeze(unresolved.sort(bySite)),
+    unscopedFolds: Object.freeze(unscopedFolds.sort(bySite)),
+    scannedModules: Object.freeze(scannedModules.sort()),
+    scannedModuleCount: files.length,
+  });
+}
+
+/** A fold-external reader that names an event classified as telemetry. */
+export interface TelemetryReadViolation {
+  readonly module: string;
+  readonly eventType: string;
+  readonly message: string;
+}
+
+/** A declared raw-reader witness whose module no longer reads the type it cites. */
+export interface StaleReaderWitness {
+  readonly eventType: string;
+  readonly module: string;
+  readonly message: string;
+}
+
+/** Both directions of the census check. */
+export interface EventReaderAudit {
+  readonly violations: readonly TelemetryReadViolation[];
+  readonly staleWitnesses: readonly StaleReaderWitness[];
+}
+
+/**
+ * Reconcile a census against a classification, in both directions.
+ *
+ * Forward: a module that reads a telemetry-classified type raw is a violation —
+ * the read is a dependency, and the classification says there is none.
+ *
+ * Reverse: every module a `raw-reader` witness declares must still appear in the
+ * census for the type it cites. A witness whose reader was deleted or moved
+ * keeps asserting a promotion nothing supports, so it is NAMED rather than left
+ * to rot.
+ *
+ * A read of a GOVERNANCE type needs no witness. Requiring a declaration for
+ * every one of them would be a tax paid by ~80 sites for no additional check —
+ * the classification already says those events are depended upon.
+ *
+ * Pure: the census is a value, so a probe can hand it a fabricated one.
+ */
+export function auditEventReaders(
+  census: EventReaderCensus,
+  classification: Readonly<Record<string, EventAuthority>>,
+  witnesses: Readonly<Record<string, AuthorityWitness>>,
+): EventReaderAudit {
+  const violations: TelemetryReadViolation[] = [];
+  for (const [eventType, modules] of census.modulesByEvent) {
+    if (classification[eventType] !== 'telemetry') continue;
+    for (const module of modules) {
+      violations.push({
+        module,
+        eventType,
+        message:
+          `${module} reads "${eventType}" raw, outside the canonical fold, but the partition ` +
+          'classifies that type as telemetry — a type nothing depends on. Either the read is ' +
+          'not correctness-bearing and should stop naming the type, or the type is governance ' +
+          'and needs a raw-reader witness naming this module.',
+      });
+    }
+  }
+
+  const staleWitnesses: StaleReaderWitness[] = [];
+  for (const [eventType, witness] of Object.entries(witnesses)) {
+    if (witness.arm !== 'raw-reader') continue;
+    const readers = census.modulesByEvent.get(eventType) ?? [];
+    for (const module of witness.evidence) {
+      if (readers.includes(module)) continue;
+      staleWitnesses.push({
+        eventType,
+        module,
+        message:
+          `The raw-reader witness for "${eventType}" cites ${module}, but the census finds no ` +
+          `read of that type there. Readers found: ${readers.length === 0 ? '(none)' : readers.join(', ')}. ` +
+          'The declaration outlived the code it names — repoint it or retire the promotion.',
+      });
+    }
+  }
+
+  return Object.freeze({
+    violations: Object.freeze(
+      violations.sort(
+        (a, b) => a.eventType.localeCompare(b.eventType) || a.module.localeCompare(b.module),
+      ),
+    ),
+    staleWitnesses: Object.freeze(
+      staleWitnesses.sort(
+        (a, b) => a.eventType.localeCompare(b.eventType) || a.module.localeCompare(b.module),
+      ),
+    ),
+  });
+}

--- a/src/events/partition/reader-census.ts
+++ b/src/events/partition/reader-census.ts
@@ -37,6 +37,17 @@
  * per-module scan. That is the second reason the partition promotes but never
  * demotes: an under-report here can only leave a type classified governance.
  *
+ * ── A read is not always a comparison ───────────────────────────────────────
+ *
+ * Equality and `case` arms are the obvious spellings and they were once the only
+ * ones this census could see. They are not the only ones in the tree: a fence
+ * asks a set whether it holds the type, a saga verifier filters a stream by a
+ * family prefix and decides on what survives. A census blind to those reports
+ * zero violations over modules whose verdict is a function of the event it
+ * cannot see — the failure mode that motivated the grammar rather than a
+ * hypothetical one. So membership tests and family prefixes are first-class read
+ * shapes, and a family prefix expands to every catalog member it covers.
+ *
  * ── Only known event types count ────────────────────────────────────────────
  *
  * A resolved literal is admitted only when it is a member of the catalog the
@@ -58,6 +69,10 @@ export type EventReaderKind =
   | 'type-comparison'
   /** A `case 'x':` arm on a switch whose discriminant is an event type. */
   | 'switch-case'
+  /** A `SET.has(event.type)` / `ARRAY.includes(event.type)` membership test. */
+  | 'membership-test'
+  /** An `event.type.startsWith('family.')` filter over a whole family. */
+  | 'prefix-filter'
   /** A query call carrying no type discriminant at all. */
   | 'unscoped-query';
 
@@ -66,7 +81,13 @@ export interface EventReaderSite {
   /** 1-based line of the read in the scanned source. */
   readonly line: number;
   readonly kind: EventReaderKind;
-  /** The resolved event-type string, or `undefined` when it did not reduce. */
+  /**
+   * The resolved event-type string, or `undefined` when it did not reduce.
+   *
+   * For a `prefix-filter` this is the PREFIX, not a type: the site names a whole
+   * family and only the catalog can say which members that is, so the expansion
+   * happens where the catalog is known rather than in the parser.
+   */
   readonly discriminant: string | undefined;
 }
 
@@ -187,6 +208,11 @@ export async function scanEventReaders(
   const unresolved: EventReaderSiteRef[] = [];
   const unscopedFolds: EventReaderSiteRef[] = [];
   const scannedModules: string[] = [];
+  const record = (eventType: string, module: string): void => {
+    const modules = byEvent.get(eventType) ?? new Set<string>();
+    modules.add(module);
+    byEvent.set(eventType, modules);
+  };
 
   for (const file of files) {
     const source = await readFile(file, 'utf8');
@@ -202,11 +228,21 @@ export async function scanEventReaders(
         unresolved.push(ref);
         continue;
       }
+      if (site.kind === 'prefix-filter') {
+        // A family filter reads every member of the family. Expanding it here,
+        // against the catalog the caller supplied, is what stops a reader
+        // spelled `startsWith('team.')` from looking like a module that names no
+        // event — the under-report that hides a whole family's dependency. A
+        // prefix matching nothing in the catalog is not a read of an event.
+        for (const eventType of knownEventTypes) {
+          if (!eventType.startsWith(site.discriminant)) continue;
+          record(eventType, module);
+        }
+        continue;
+      }
       // A literal that is not a catalog member is not a read of an event.
       if (!knownEventTypes.has(site.discriminant)) continue;
-      const modules = byEvent.get(site.discriminant) ?? new Set<string>();
-      modules.add(module);
-      byEvent.set(site.discriminant, modules);
+      record(site.discriminant, module);
     }
   }
 

--- a/src/events/partition/witnesses.ts
+++ b/src/events/partition/witnesses.ts
@@ -7,17 +7,25 @@
  * list of places where a human judgment overrides a derivation, which is what
  * makes it reviewable.
  *
- * Two of the three arms are re-measured by oracles rather than trusted:
+ * EVERY arm is re-measured by an oracle. The arm is self-declared, so an arm
+ * nothing checks would let a mislabel buy a permanent exemption — and that is
+ * not hypothetical: `task.assigned` was filed here as a charter pin claiming no
+ * fold named it while the canonical projection had a mutating arm for it, and
+ * neither of the two loops that re-measure the table looked at charter-pin rows.
  *
  *   • `projection-fold` — the differential fold proves the promotion is load
  *     bearing: dropping it makes the governance-filtered fold diverge.
  *   • `raw-reader` — the fold-external reader census proves the named module
  *     still reads the named type. A witness whose module stopped reading it is
  *     reported as stale, so this table cannot outlive the code it cites.
+ *   • `gate-expectation` — the emission gate's expectation table still lists the
+ *     type, measured from the table itself.
  *   • `charter-pin` — the ratified authority decision pins a whole family
  *     governance, and these rows are the family members whose tier disagrees.
- *     No reader and no fold names them today; the family pin IS the basis, and
- *     saying so here is what keeps it from looking like measured evidence.
+ *     The claim such a row makes is NEGATIVE — no fold, no reader, no
+ *     expectation row — and that claim is measured too: a charter-pin row that
+ *     acquires real evidence is named and has to move to the arm that now
+ *     carries it.
  *
  * Adding a row for a type whose tier already derives `auto` is refused at load:
  * a witness that changes no answer is cover nothing can check.
@@ -64,6 +72,24 @@ export const GOVERNANCE_WITNESSES: Readonly<Record<string, AuthorityWitness>> = 
       'The delegation saga verifier folds planned against dispatched and assigned to decide ' +
       'whether every planned task was actually handed to a teammate.',
   },
+  'team.task.completed': {
+    arm: 'raw-reader',
+    evidence: ['src/events/schemas.ts', 'src/verbs/team/verify-delegation-saga.ts'],
+    because:
+      'Two live readers, neither of them a comparison. The saga verifier filters the raw stream ' +
+      'by the team family and its catch-all arm turns any member appearing after the team was ' +
+      'disbanded into a violation, so its pass/fail is a function of this type; and the agent- ' +
+      'event validator asks a literal table whether the type is one that must carry an agent id, ' +
+      'refusing the append when it does not.',
+  },
+  'team.task.failed': {
+    arm: 'raw-reader',
+    evidence: ['src/events/schemas.ts', 'src/verbs/team/verify-delegation-saga.ts'],
+    because:
+      'The same two readers as its sibling: the saga verifier decides on it through the family ' +
+      'filter and the post-disband rule, and the agent-event validator requires an agent id on ' +
+      'it before the append is accepted.',
+  },
   'worktree.created': {
     arm: 'raw-reader',
     evidence: ['src/verbs/gates/gate-utils.ts'],
@@ -82,19 +108,32 @@ export const GOVERNANCE_WITNESSES: Readonly<Record<string, AuthorityWitness>> = 
       'an escalation bound from it, so the reader must be retired or re-sourced first.',
   },
 
-  'task.assigned': {
-    arm: 'charter-pin',
-    evidence: [CHARTER],
+  'stack.submitted': {
+    arm: 'gate-expectation',
+    evidence: ['src/verbs/gates/check-event-emissions.ts'],
     because:
-      'The task family is pinned governance as a family. No fold and no fold-external reader ' +
-      'names this member today, so the family pin is the entire basis for the promotion.',
+      'The emission gate lists this type among the events the synthesize phase must have ' +
+      'produced, and its complete/incomplete verdict is exactly whether the raw stream contains ' +
+      'it. The charter names the type among its telemetry examples and requires the expectation ' +
+      'row and its description to be deleted in the same commit as the demotion; neither has ' +
+      'happened, so the type is still depended upon and stays governance until that flip lands.',
+  },
+
+  'task.assigned': {
+    arm: 'projection-fold',
+    evidence: ['src/projections/views/workflow-state-projection.ts'],
+    because:
+      'The canonical workflow-state fold appends a task row for it, so a stream replayed without ' +
+      'it produces a different task list. The task family is pinned governance by charter too, ' +
+      'but that pin is not the basis here — the fold is, and it is measured.',
   },
   'task.progressed': {
-    arm: 'charter-pin',
-    evidence: [CHARTER],
+    arm: 'raw-reader',
+    evidence: ['src/events/schemas.ts'],
     because:
-      'The task family is pinned governance as a family. No fold and no fold-external reader ' +
-      'names this member today, so the family pin is the entire basis for the promotion.',
+      'The agent-event validator names this type in the table of events that must carry an agent ' +
+      'id and a source, and refuses the append when they are missing. The task family is pinned ' +
+      'governance by charter as well, but a live reader is the stronger basis.',
   },
   'merge.requested': {
     arm: 'charter-pin',

--- a/src/events/partition/witnesses.ts
+++ b/src/events/partition/witnesses.ts
@@ -1,0 +1,113 @@
+/**
+ * Every promotion of a non-`auto` event type to governance, with its evidence.
+ *
+ * A row here says: the tier alone would file this event as telemetry, and that
+ * is wrong, for THIS reason. Nothing else in the partition is hand-written —
+ * the predicate carries the whole `auto` side — so this table is the complete
+ * list of places where a human judgment overrides a derivation, which is what
+ * makes it reviewable.
+ *
+ * Two of the three arms are re-measured by oracles rather than trusted:
+ *
+ *   • `projection-fold` — the differential fold proves the promotion is load
+ *     bearing: dropping it makes the governance-filtered fold diverge.
+ *   • `raw-reader` — the fold-external reader census proves the named module
+ *     still reads the named type. A witness whose module stopped reading it is
+ *     reported as stale, so this table cannot outlive the code it cites.
+ *   • `charter-pin` — the ratified authority decision pins a whole family
+ *     governance, and these rows are the family members whose tier disagrees.
+ *     No reader and no fold names them today; the family pin IS the basis, and
+ *     saying so here is what keeps it from looking like measured evidence.
+ *
+ * Adding a row for a type whose tier already derives `auto` is refused at load:
+ * a witness that changes no answer is cover nothing can check.
+ */
+
+import type { AuthorityWitness } from './authority.js';
+
+const CHARTER = 'lvlup-sw/exarchos#1876 ratified event-authority decision record';
+
+export const GOVERNANCE_WITNESSES: Readonly<Record<string, AuthorityWitness>> = Object.freeze({
+  'team.spawned': {
+    arm: 'projection-fold',
+    evidence: ['src/projections/views/workflow-state-projection.ts'],
+    because:
+      'The canonical workflow-state fold consumes it — replaying a stream without it produces a ' +
+      'different state, so it is not droppable.',
+  },
+  'team.disbanded': {
+    arm: 'projection-fold',
+    evidence: ['src/projections/views/workflow-state-projection.ts'],
+    because:
+      'The canonical workflow-state fold consumes it, and the team-disbanded HSM guard reads the ' +
+      'folded result — dropping it changes both the state and the transition it gates.',
+  },
+
+  'team.task.assigned': {
+    arm: 'raw-reader',
+    evidence: ['src/lifecycle/subagent-stop.ts'],
+    because:
+      'The subagent stop hook queries this type raw to resolve which teammate a stop belongs to, ' +
+      'matching on worktree path. Without the event the hook attributes the stop to nobody.',
+  },
+  'team.teammate.dispatched': {
+    arm: 'raw-reader',
+    evidence: ['src/lifecycle/subagent-stop.ts', 'src/verbs/team/verify-delegation-saga.ts'],
+    because:
+      'Read raw by the stop hook for teammate attribution and by the delegation saga verifier, ' +
+      'which folds dispatch against completion to decide whether the saga is closed.',
+  },
+  'team.task.planned': {
+    arm: 'raw-reader',
+    evidence: ['src/verbs/team/verify-delegation-saga.ts'],
+    because:
+      'The delegation saga verifier folds planned against dispatched and assigned to decide ' +
+      'whether every planned task was actually handed to a teammate.',
+  },
+  'worktree.created': {
+    arm: 'raw-reader',
+    evidence: ['src/verbs/gates/gate-utils.ts'],
+    because:
+      'Gate execution resolves its repository root by reading this event raw. Drop it and a gate ' +
+      'runs against the wrong tree, or against none.',
+  },
+  'shepherd.iteration': {
+    arm: 'raw-reader',
+    evidence: ['src/verbs/review/escalation-policy.ts', 'src/verbs/vcs/assess-stack.ts'],
+    because:
+      'The escalation policy counts these events raw and calls itself the single event-sourced ' +
+      'iteration-count authority; the bound it enforces is therefore a function of the event ' +
+      'stream. This is in direct tension with the ratified charter, which lists the type among ' +
+      'its telemetry examples: the demotion cannot land while a live fold-external reader derives ' +
+      'an escalation bound from it, so the reader must be retired or re-sourced first.',
+  },
+
+  'task.assigned': {
+    arm: 'charter-pin',
+    evidence: [CHARTER],
+    because:
+      'The task family is pinned governance as a family. No fold and no fold-external reader ' +
+      'names this member today, so the family pin is the entire basis for the promotion.',
+  },
+  'task.progressed': {
+    arm: 'charter-pin',
+    evidence: [CHARTER],
+    because:
+      'The task family is pinned governance as a family. No fold and no fold-external reader ' +
+      'names this member today, so the family pin is the entire basis for the promotion.',
+  },
+  'merge.requested': {
+    arm: 'charter-pin',
+    evidence: [CHARTER],
+    because:
+      'The merge family is pinned governance as a family. Only append sites exist for this ' +
+      'member — no fold and no reader names it — so the family pin is the entire basis.',
+  },
+  'workflow.handoff_summarized': {
+    arm: 'charter-pin',
+    evidence: [CHARTER],
+    because:
+      'The workflow family is pinned governance as a family. No fold and no fold-external reader ' +
+      'names this member today, so the family pin is the entire basis for the promotion.',
+  },
+});

--- a/src/registry/action-contract.ts
+++ b/src/registry/action-contract.ts
@@ -719,3 +719,26 @@ export function contractEmissionsOf(action: object): readonly ActionEmission[] {
     return [];
   }
 }
+
+/**
+ * Every event name an action's contract ENSURES by append, or empty when the
+ * block is absent, unreadable, or reasons that it ensures nothing.
+ *
+ * The `durable-evidence` arm of a postcondition names an evidence type, not an
+ * event, so it is filtered out here rather than at each caller — re-deriving
+ * that narrowing at every consumer is how two consumers end up disagreeing
+ * about what an `ensures` entry names.
+ */
+export function contractEnsuredEventsOf(action: object): readonly string[] {
+  const raw = Reflect.get(action, 'actionContract');
+  if (raw === undefined) return [];
+  try {
+    const contract = normalizeActionContract(raw);
+    if (contract.ensures.kind !== 'declared') return [];
+    return contract.ensures.values
+      .filter((postcondition) => postcondition.source === 'event-append')
+      .map((postcondition) => postcondition.event);
+  } catch {
+    return [];
+  }
+}

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -103,6 +103,7 @@ export {
   HOST_OBLIGATIONS,
   actionContractCanonicalBytes,
   contractEmissionsOf,
+  contractEnsuredEventsOf,
   declared,
   none,
   normalizeActionContract,

--- a/tests/architecture/event-authority-contracts.test.ts
+++ b/tests/architecture/event-authority-contracts.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Every event an action contract names must be a governance event.
+ *
+ * @oracle-sources: ../../src/registry/**, ../../src/events/partition/**
+ *
+ * An `emissions` entry and an `event-append` postcondition are both promises
+ * the dispatcher is held to: the emission is verified to have landed, the
+ * postcondition is checked by re-reading the stream. A contract that named a
+ * telemetry event would be promising something the partition says nothing
+ * depends on — either the promise is enforced, in which case the event is
+ * depended upon and the classification is wrong, or the classification is right
+ * and the contract is declaring a promise nothing needs.
+ *
+ * This is an INDEPENDENT check rather than a restatement of the partition. The
+ * whole declared population is `auto` by tier today, so it is green under the
+ * tier map alone with no witness involved; what the conjunct rules out is a
+ * future contract naming a type the tier does not cover.
+ *
+ * Both arms carry the declaring `tool.action`, so a failure names the
+ * declaration site rather than only the event — a bare event name would leave a
+ * reader grepping the whole registry for it.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  TOOL_REGISTRY,
+  contractEmissionsOf,
+  contractEnsuredEventsOf,
+} from '../../src/registry.js';
+import { EventTypes } from '../../src/events/schemas.js';
+import {
+  EVENT_AUTHORITY,
+  TELEMETRY_EVENTS,
+  classifyEventAuthority,
+} from '../../src/events/partition/event-authority.js';
+import type { EventAuthority } from '../../src/events/partition/authority.js';
+
+/** One event name a contract declares, with the declaration site that named it. */
+interface DeclaredEventName {
+  readonly site: string;
+  readonly arm: 'emissions' | 'ensures';
+  readonly event: string;
+}
+
+/**
+ * Every event name declared by any live built-in action, in registry order.
+ *
+ * Built by walking `TOOL_REGISTRY` rather than a snapshot, so an action added
+ * without a snapshot refresh is still in the population.
+ */
+const DECLARED: readonly DeclaredEventName[] = TOOL_REGISTRY.flatMap((tool) =>
+  tool.actions.flatMap((action) => [
+    ...contractEmissionsOf(action).map((emission) => ({
+      site: `${tool.name}.${action.name}`,
+      arm: 'emissions' as const,
+      event: emission.event,
+    })),
+    ...contractEnsuredEventsOf(action).map((event) => ({
+      site: `${tool.name}.${action.name}`,
+      arm: 'ensures' as const,
+      event,
+    })),
+  ]),
+);
+
+/**
+ * The conjunct itself, as a pure function over a declared population and a
+ * classification — so the seeded probe below is judged by the same auditor that
+ * reads the live registry, not by a parallel branch that could drift from it.
+ */
+function auditDeclaredEventNames(
+  declared: readonly DeclaredEventName[],
+  classification: Readonly<Record<string, EventAuthority>>,
+): readonly string[] {
+  return declared
+    .filter((row) => classification[row.event] !== 'governance')
+    .map(
+      (row) =>
+        `${row.site} declares ${row.arm} event "${row.event}", which the partition classifies ` +
+        `as ${classification[row.event] ?? 'unknown'} — a contract may only promise a governance event.`,
+    );
+}
+
+describe('ActionContractConjunct — a declared event is a governance event', () => {
+  it('ActionContractConjunct_DeclaredEventPopulation_IsNonEmpty', () => {
+    // A floor, never the number: pinning the count would turn every new action
+    // into a failure of this oracle instead of a check by it.
+    expect(DECLARED.length).toBeGreaterThan(0);
+    expect(new Set(DECLARED.map((row) => row.event)).size).toBeGreaterThan(10);
+    expect(DECLARED.filter((row) => row.arm === 'emissions').length).toBeGreaterThan(0);
+    expect(DECLARED.every((row) => row.site.includes('.'))).toBe(true);
+  });
+
+  it('ActionContractConjunct_EveryDeclaredEventName_IsAKnownEventType', () => {
+    const known = new Set<string>(EventTypes);
+    const unknown = DECLARED.filter((row) => !known.has(row.event)).map(
+      (row) => `${row.site} (${row.arm}) → ${row.event}`,
+    );
+    expect(unknown).toEqual([]);
+  });
+
+  it('ActionContractConjunct_EveryDeclaredEventName_ResolvesToAGovernanceEvent', () => {
+    const unclassified = DECLARED.filter(
+      (row) => classifyEventAuthority(row.event) === undefined,
+    ).map((row) => `${row.site} (${row.arm}) → ${row.event}`);
+    expect(unclassified).toEqual([]);
+
+    expect(auditDeclaredEventNames(DECLARED, EVENT_AUTHORITY)).toEqual([]);
+  });
+
+  it('ActionContractConjunct_SeededContractNamingATelemetryType_IsNamedInTheFailure', () => {
+    const [telemetryType] = [...TELEMETRY_EVENTS].sort();
+    expect(telemetryType).toBeDefined();
+
+    const seededSite = 'exarchos_seeded.seeded_action';
+    const seeded: readonly DeclaredEventName[] = [
+      ...DECLARED,
+      { site: seededSite, arm: 'emissions', event: telemetryType ?? '' },
+    ];
+
+    const findings = auditDeclaredEventNames(seeded, EVENT_AUTHORITY);
+    expect(findings.length).toBe(1);
+    expect(findings.join('\n')).toContain(seededSite);
+    expect(findings.join('\n')).toContain(telemetryType ?? '');
+  });
+});

--- a/tests/architecture/event-authority-contracts.test.ts
+++ b/tests/architecture/event-authority-contracts.test.ts
@@ -1,7 +1,8 @@
 /**
- * Every event an action contract names must be a governance event.
+ * Every event a live DECLARATION names must be a governance event.
  *
- * @oracle-sources: ../../src/registry/**, ../../src/events/partition/**
+ * @oracle-sources: ../../src/registry/**, ../../src/events/partition/**,
+ * ../../src/verbs/gates/check-event-emissions.ts
  *
  * An `emissions` entry and an `event-append` postcondition are both promises
  * the dispatcher is held to: the emission is verified to have landed, the
@@ -11,14 +12,22 @@
  * depended upon and the classification is wrong, or the classification is right
  * and the contract is declaring a promise nothing needs.
  *
- * This is an INDEPENDENT check rather than a restatement of the partition. The
- * whole declared population is `auto` by tier today, so it is green under the
- * tier map alone with no witness involved; what the conjunct rules out is a
- * future contract naming a type the tier does not cover.
+ * The emission gate's phase-expectation table is the third declaration of the
+ * same shape, and it is the one that bites. The gate iterates that table and
+ * asks a set built from the raw stream whether each listed type is present, so
+ * its complete/incomplete verdict is a function of exactly those types — yet no
+ * literal comparison appears anywhere in the module, which means the source-scan
+ * census structurally cannot see it. This is where `stack.submitted` was
+ * classified telemetry while a shipped gate derived a verdict from its presence.
  *
- * Both arms carry the declaring `tool.action`, so a failure names the
- * declaration site rather than only the event — a bare event name would leave a
- * reader grepping the whole registry for it.
+ * This is an INDEPENDENT check rather than a restatement of the partition. Most
+ * of the declared population is `auto` by tier, so it is green under the tier
+ * map alone with no witness involved; what the conjunct rules out is a
+ * declaration naming a type the tier does not cover.
+ *
+ * Every arm carries its declaration site, so a failure names where the promise
+ * was made rather than only the event — a bare event name would leave a reader
+ * grepping the whole registry for it.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -29,40 +38,53 @@ import {
   contractEnsuredEventsOf,
 } from '../../src/registry.js';
 import { EventTypes } from '../../src/events/schemas.js';
+import { PHASE_EXPECTED_EVENTS } from '../../src/verbs/gates/check-event-emissions.js';
 import {
   EVENT_AUTHORITY,
   TELEMETRY_EVENTS,
   classifyEventAuthority,
 } from '../../src/events/partition/event-authority.js';
+import { GOVERNANCE_WITNESSES } from '../../src/events/partition/witnesses.js';
 import type { EventAuthority } from '../../src/events/partition/authority.js';
 
-/** One event name a contract declares, with the declaration site that named it. */
+/** One event name a declaration names, with the site that named it. */
 interface DeclaredEventName {
   readonly site: string;
-  readonly arm: 'emissions' | 'ensures';
+  readonly arm: 'emissions' | 'ensures' | 'phase-expectation';
   readonly event: string;
 }
 
 /**
- * Every event name declared by any live built-in action, in registry order.
+ * Every event name declared by any live built-in action, in registry order,
+ * plus every event the emission gate expects a phase to have produced.
  *
- * Built by walking `TOOL_REGISTRY` rather than a snapshot, so an action added
- * without a snapshot refresh is still in the population.
+ * Built by walking `TOOL_REGISTRY` and the live expectation table rather than a
+ * snapshot, so a declaration added without a snapshot refresh is still in the
+ * population.
  */
-const DECLARED: readonly DeclaredEventName[] = TOOL_REGISTRY.flatMap((tool) =>
-  tool.actions.flatMap((action) => [
-    ...contractEmissionsOf(action).map((emission) => ({
-      site: `${tool.name}.${action.name}`,
-      arm: 'emissions' as const,
-      event: emission.event,
-    })),
-    ...contractEnsuredEventsOf(action).map((event) => ({
-      site: `${tool.name}.${action.name}`,
-      arm: 'ensures' as const,
+const DECLARED: readonly DeclaredEventName[] = [
+  ...TOOL_REGISTRY.flatMap((tool) =>
+    tool.actions.flatMap((action) => [
+      ...contractEmissionsOf(action).map((emission) => ({
+        site: `${tool.name}.${action.name}`,
+        arm: 'emissions' as const,
+        event: emission.event,
+      })),
+      ...contractEnsuredEventsOf(action).map((event) => ({
+        site: `${tool.name}.${action.name}`,
+        arm: 'ensures' as const,
+        event,
+      })),
+    ]),
+  ),
+  ...Object.entries(PHASE_EXPECTED_EVENTS).flatMap(([phase, expected]) =>
+    expected.map((event) => ({
+      site: `check-event-emissions.PHASE_EXPECTED_EVENTS.${phase}`,
+      arm: 'phase-expectation' as const,
       event,
     })),
-  ]),
-);
+  ),
+];
 
 /**
  * The conjunct itself, as a pure function over a declared population and a
@@ -83,13 +105,44 @@ function auditDeclaredEventNames(
 }
 
 describe('ActionContractConjunct — a declared event is a governance event', () => {
-  it('ActionContractConjunct_DeclaredEventPopulation_IsNonEmpty', () => {
+  it('ActionContractConjunct_DeclaredEventPopulation_IsNonEmptyOnEveryArm', () => {
     // A floor, never the number: pinning the count would turn every new action
     // into a failure of this oracle instead of a check by it.
     expect(DECLARED.length).toBeGreaterThan(0);
     expect(new Set(DECLARED.map((row) => row.event)).size).toBeGreaterThan(10);
-    expect(DECLARED.filter((row) => row.arm === 'emissions').length).toBeGreaterThan(0);
     expect(DECLARED.every((row) => row.site.includes('.'))).toBe(true);
+
+    // PER ARM, because the arms are read by different accessors and each can
+    // fail to nothing on its own. `contractEnsuredEventsOf` in particular
+    // swallows every failure and answers `[]`, and its events are a subset of
+    // the emissions arm's — so a total collapse of that reader changed no result
+    // anywhere until this floor existed.
+    for (const arm of ['emissions', 'ensures', 'phase-expectation'] as const) {
+      const rows = DECLARED.filter((row) => row.arm === arm);
+      expect(rows.length, `the ${arm} arm resolved no declaration at all`).toBeGreaterThan(0);
+      expect(new Set(rows.map((row) => row.event)).size).toBeGreaterThan(0);
+    }
+  });
+
+  it('ActionContractConjunct_GateExpectationWitness_IsNamedByTheLiveExpectationTable', () => {
+    // The one witness arm no source scan can re-measure: the gate's read is an
+    // iteration of a table, not a comparison against a literal. So it is
+    // re-measured HERE, against the table itself — a witness whose expectation
+    // row was deleted stops being evidence the moment the row goes.
+    const declared = Object.entries(GOVERNANCE_WITNESSES)
+      .filter(([, witness]) => witness.arm === 'gate-expectation')
+      .map(([type]) => type);
+    expect(declared.length).toBeGreaterThan(0);
+
+    const expected = new Set<string>(Object.values(PHASE_EXPECTED_EVENTS).flat());
+    expect(expected.size).toBeGreaterThan(0);
+
+    const unsupported = declared.filter((type) => !expected.has(type));
+    expect(
+      unsupported,
+      'A gate-expectation witness promotes a type the expectation table no longer lists. The ' +
+        'declaration outlived the row it cites — retire the promotion, or repoint it.',
+    ).toEqual([]);
   });
 
   it('ActionContractConjunct_EveryDeclaredEventName_IsAKnownEventType', () => {
@@ -114,14 +167,17 @@ describe('ActionContractConjunct — a declared event is a governance event', ()
     expect(telemetryType).toBeDefined();
 
     const seededSite = 'exarchos_seeded.seeded_action';
+    const seededPhase = 'check-event-emissions.PHASE_EXPECTED_EVENTS.seeded_phase';
     const seeded: readonly DeclaredEventName[] = [
       ...DECLARED,
       { site: seededSite, arm: 'emissions', event: telemetryType ?? '' },
+      { site: seededPhase, arm: 'phase-expectation', event: telemetryType ?? '' },
     ];
 
     const findings = auditDeclaredEventNames(seeded, EVENT_AUTHORITY);
-    expect(findings.length).toBe(1);
+    expect(findings.length).toBe(2);
     expect(findings.join('\n')).toContain(seededSite);
+    expect(findings.join('\n')).toContain(seededPhase);
     expect(findings.join('\n')).toContain(telemetryType ?? '');
   });
 });

--- a/tests/architecture/event-authority-raw-readers.test.ts
+++ b/tests/architecture/event-authority-raw-readers.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Nothing outside the canonical fold may depend on an event the partition calls
+ * telemetry.
+ *
+ * @oracle-sources: ../../src/** minus ../../src/projections/**,
+ * ../../src/events/partition/witnesses.ts
+ *
+ * The partition's claim about a telemetry event is that dropping it changes no
+ * answer. The differential fold proves that for the projection. It proves
+ * nothing about the other half of the system: fences, idempotency checks and
+ * HSM guards read the event log raw, outside any reducer, and a type that is
+ * droppable by the fold can be undroppable by one of those.
+ *
+ * So this walks the shipped tree, resolves every read of an event type it can,
+ * and requires that none of them names a telemetry-classified type. The
+ * projections are excluded on purpose — their job is to fold everything,
+ * telemetry included, so scanning them would report the fold as a violation of
+ * a rule about readers outside it.
+ *
+ * ## Why the vacuity assertions carry weight
+ *
+ * A census fails open. A walk that finds nothing reports no violations and
+ * looks clean, which is the defect this repository keeps re-encountering. Four
+ * assertions stand against that:
+ *
+ *   1. the scanned population is corroborated against `git ls-files`, so a
+ *      shrunken walk shows up as a shrunken denominator;
+ *   2. the resolved reader map is non-empty — a scanner that stopped resolving
+ *      discriminants would otherwise pass silently;
+ *   3. unscoped folds are non-empty, because this tree has many, and a zero
+ *      there means the scan stopped seeing query calls at all;
+ *   4. a seeded reader naming a telemetry type must be NAMED in the failure,
+ *      by the same auditor that reads the real census.
+ *
+ * The reverse direction is checked too: every module a raw-reader witness cites
+ * must still be found reading the type it was promoted for. A witness whose
+ * reader moved away keeps asserting a promotion nothing supports.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { EventTypes } from '../../src/events/schemas.js';
+import { ADMISSION_EVENT_TYPES } from '../../src/workflow/admission/types.js';
+import {
+  auditEventReaders,
+  scanEventReaders,
+  type EventReaderCensus,
+} from '../../src/events/partition/reader-census.js';
+import {
+  EVENT_AUTHORITY,
+  TELEMETRY_EVENTS,
+} from '../../src/events/partition/event-authority.js';
+import { GOVERNANCE_WITNESSES } from '../../src/events/partition/witnesses.js';
+import { scanEventReaders as compilerBackedScanner } from '../../tools/test-helpers/event-reader-scanner.js';
+import { listTrackedFiles } from '../../tools/test-helpers/tracked-population.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SOURCE_DIR = path.join(REPO_ROOT, 'src');
+const EXCLUDED_DIR = path.join(SOURCE_DIR, 'projections');
+
+/**
+ * The discriminant vocabulary the scanner may need, DERIVED from the live
+ * constant table rather than transcribed — admission readers spell the type as
+ * the exported constant, not as a literal.
+ */
+const KNOWN_CONSTANTS: ReadonlyMap<string, string> = new Map(
+  Object.entries(ADMISSION_EVENT_TYPES).map(
+    ([member, value]) => [`ADMISSION_EVENT_TYPES.${member}`, value] as const,
+  ),
+);
+
+const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set<string>(EventTypes);
+
+const censusPromise: Promise<EventReaderCensus> = scanEventReaders(
+  REPO_ROOT,
+  { sourceDir: SOURCE_DIR, excludeDirs: [EXCLUDED_DIR] },
+  compilerBackedScanner,
+  KNOWN_EVENT_TYPES,
+  KNOWN_CONSTANTS,
+);
+
+function describeUnread(census: EventReaderCensus): string {
+  const unresolved = census.unresolved
+    .slice(0, 20)
+    .map((site) => `${site.module}:${site.line} (${site.kind})`)
+    .join(', ');
+  return (
+    `scanned ${census.scannedModuleCount} module(s); ` +
+    `${census.unresolved.length} unresolved discriminant(s)` +
+    `${unresolved === '' ? '' : `: ${unresolved}`}; ` +
+    `${census.unscopedFolds.length} unscoped fold(s)`
+  );
+}
+
+describe('RawReaderCensus — no fold-external reader depends on a telemetry event', () => {
+  it('RawReaderCensus_ScannedPopulation_IsNonEmptyAndCorroboratedByGit', async () => {
+    const census = await censusPromise;
+    expect(census.scannedModuleCount).toBeGreaterThan(0);
+
+    const tracked = listTrackedFiles(REPO_ROOT, {
+      exclude: (file) =>
+        !file.startsWith('src/') ||
+        file.startsWith('src/projections/') ||
+        file.endsWith('.test.ts') ||
+        file.endsWith('.bench.ts') ||
+        file.endsWith('.d.ts'),
+    });
+    expect(tracked.length).toBeGreaterThan(0);
+
+    const walked = new Set(census.scannedModules);
+    const missed = tracked.filter((file) => !walked.has(file));
+    expect(missed).toEqual([]);
+  });
+
+  it('RawReaderCensus_EveryFoldExternalReader_NamesNoTelemetryClassifiedEventType', async () => {
+    const census = await censusPromise;
+    // The denominator: a scan that resolved no reader at all would report no
+    // violations and read as a clean tree.
+    expect(census.modulesByEvent.size).toBeGreaterThan(0);
+    expect(TELEMETRY_EVENTS.size).toBeGreaterThan(0);
+
+    const audit = auditEventReaders(census, EVENT_AUTHORITY, GOVERNANCE_WITNESSES);
+    expect(
+      audit.violations.map((violation) => violation.message),
+      describeUnread(census),
+    ).toEqual([]);
+  });
+
+  it('RawReaderCensus_SeededReaderNamingATelemetryType_IsNamedInTheFailure', async () => {
+    const census = await censusPromise;
+    const [telemetryType] = [...TELEMETRY_EVENTS].sort();
+    expect(telemetryType).toBeDefined();
+
+    const seededModule = 'src/__seeded_reader__.ts';
+    const seeded: EventReaderCensus = {
+      ...census,
+      modulesByEvent: new Map([
+        ...census.modulesByEvent,
+        [telemetryType ?? '', [seededModule]],
+      ]),
+    };
+
+    const audit = auditEventReaders(seeded, EVENT_AUTHORITY, GOVERNANCE_WITNESSES);
+    const messages = audit.violations.map((violation) => violation.message).join('\n');
+    expect(audit.violations.length).toBe(1);
+    expect(messages).toContain(seededModule);
+    expect(messages).toContain(telemetryType ?? '');
+  });
+
+  it('RawReaderCensus_DeclaredRawReaderWitness_IsNamedByALiveReader', async () => {
+    const census = await censusPromise;
+    const declared = Object.entries(GOVERNANCE_WITNESSES).filter(
+      ([, witness]) => witness.arm === 'raw-reader',
+    );
+    // A table with no raw-reader arm would make the reverse check vacuous.
+    expect(declared.length).toBeGreaterThan(0);
+
+    const audit = auditEventReaders(census, EVENT_AUTHORITY, GOVERNANCE_WITNESSES);
+    expect(
+      audit.staleWitnesses.map((stale) => stale.message),
+      describeUnread(census),
+    ).toEqual([]);
+  });
+
+  it('RawReaderCensus_UnscopedFoldsAndUnresolvedDiscriminants_AreReportedNotDropped', async () => {
+    const census = await censusPromise;
+    // A bare fold depends on the whole type universe. Reporting it as "reads
+    // nothing" would hide a dependency; reporting it as unresolved would flag a
+    // working scan as broken. It gets its own bucket, and this tree has many.
+    expect(census.unscopedFolds.length).toBeGreaterThan(0);
+
+    const buckets = new Set(census.unscopedFolds.map((site) => site.kind));
+    expect([...buckets]).toEqual(['unscoped-query']);
+
+    const misfiled = census.unresolved.filter((site) => site.kind === 'unscoped-query');
+    expect(misfiled).toEqual([]);
+
+    for (const site of [...census.unscopedFolds, ...census.unresolved]) {
+      expect(site.module).not.toBe('');
+      expect(site.line).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/architecture/event-authority-raw-readers.test.ts
+++ b/tests/architecture/event-authority-raw-readers.test.ts
@@ -20,7 +20,7 @@
  * ## Why the vacuity assertions carry weight
  *
  * A census fails open. A walk that finds nothing reports no violations and
- * looks clean, which is the defect this repository keeps re-encountering. Four
+ * looks clean, which is the defect this repository keeps re-encountering. Five
  * assertions stand against that:
  *
  *   1. the scanned population is corroborated against `git ls-files`, so a
@@ -30,13 +30,23 @@
  *   3. unscoped folds are non-empty, because this tree has many, and a zero
  *      there means the scan stopped seeing query calls at all;
  *   4. a seeded reader naming a telemetry type must be NAMED in the failure,
- *      by the same auditor that reads the real census.
+ *      and the seed is a MODULE ON DISK walked by the real scanner, not a row
+ *      spliced into the census value. That distinction is the whole point: a
+ *      seed injected into the value exercises the auditor and nothing else, so
+ *      it stayed green through a grammar gap that made four shipped readers
+ *      invisible;
+ *   5. every read SPELLING the grammar claims to cover is proved to resolve, so
+ *      a silently narrowed grammar shows up as a spelling that stopped
+ *      resolving rather than as a clean tree.
  *
  * The reverse direction is checked too: every module a raw-reader witness cites
- * must still be found reading the type it was promoted for. A witness whose
- * reader moved away keeps asserting a promotion nothing supports.
+ * must still be found reading the type it was promoted for, and every
+ * charter-pin witness — whose claim is that NO reader names its type — is held
+ * to that claim against the same census.
  */
 
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -129,25 +139,82 @@ describe('RawReaderCensus — no fold-external reader depends on a telemetry eve
     ).toEqual([]);
   });
 
-  it('RawReaderCensus_SeededReaderNamingATelemetryType_IsNamedInTheFailure', async () => {
-    const census = await censusPromise;
+  it('RawReaderCensus_SeededReaderModuleOnDisk_IsWalkedResolvedAndNamed', async () => {
     const [telemetryType] = [...TELEMETRY_EVENTS].sort();
     expect(telemetryType).toBeDefined();
 
-    const seededModule = 'src/__seeded_reader__.ts';
-    const seeded: EventReaderCensus = {
-      ...census,
-      modulesByEvent: new Map([
-        ...census.modulesByEvent,
-        [telemetryType ?? '', [seededModule]],
-      ]),
-    };
+    // A module on disk, walked by the real scanner — not a row spliced into a
+    // census value. The spelling is the membership test, because that is the
+    // spelling a value-level seed could never have caught.
+    const root = await mkdtemp(path.join(os.tmpdir(), 'exarchos-reader-census-'));
+    try {
+      const sourceDir = path.join(root, 'src');
+      await mkdir(sourceDir, { recursive: true });
+      await writeFile(
+        path.join(sourceDir, 'seeded-reader.ts'),
+        [
+          `const WATCHED: readonly string[] = ['${telemetryType ?? ''}'];`,
+          'export function isWatched(event: { type: string }): boolean {',
+          '  return WATCHED.includes(event.type);',
+          '}',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
 
-    const audit = auditEventReaders(seeded, EVENT_AUTHORITY, GOVERNANCE_WITNESSES);
-    const messages = audit.violations.map((violation) => violation.message).join('\n');
-    expect(audit.violations.length).toBe(1);
-    expect(messages).toContain(seededModule);
-    expect(messages).toContain(telemetryType ?? '');
+      const seeded = await scanEventReaders(
+        root,
+        { sourceDir, excludeDirs: [] },
+        compilerBackedScanner,
+        KNOWN_EVENT_TYPES,
+        KNOWN_CONSTANTS,
+      );
+      expect(seeded.scannedModuleCount).toBe(1);
+      expect(seeded.modulesByEvent.get(telemetryType ?? '')).toEqual(['src/seeded-reader.ts']);
+
+      const audit = auditEventReaders(seeded, EVENT_AUTHORITY, GOVERNANCE_WITNESSES);
+      const messages = audit.violations.map((violation) => violation.message).join('\n');
+      expect(audit.violations.length).toBe(1);
+      expect(messages).toContain('src/seeded-reader.ts');
+      expect(messages).toContain(telemetryType ?? '');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('RawReaderCensus_EverySupportedReadSpelling_ResolvesToItsEventType', () => {
+    // The grammar's own denominator. Each entry is a spelling that is LIVE in
+    // this tree; a scanner that quietly stopped covering one would otherwise
+    // report the modules using it as depending on no event, and the census would
+    // read clean over exactly the readers it had gone blind to.
+    const [governanceType] = [...EventTypes].sort();
+    expect(governanceType).toBeDefined();
+    const target = governanceType ?? '';
+    const family = `${target.split('.')[0] ?? ''}.`;
+
+    const spellings: ReadonlyMap<string, string> = new Map([
+      ['comparison', `export const f = (e: { type: string }) => e.type === '${target}';`],
+      ['switch-case', `export function f(e: { type: string }) { switch (e.type) { case '${target}': return 1; default: return 0; } }`],
+      ['query-filter', `export const f = (s: { query: Function }) => s.query('id', { type: '${target}' });`],
+      ['array-membership', `const T = ['${target}']; export const f = (e: { type: string }) => T.includes(e.type);`],
+      ['set-membership', `const T = new Set(['${target}']); export const f = (e: { type: string }) => T.has(e.type);`],
+      ['prefix-filter', `export const f = (e: { type: string }) => e.type.startsWith('${family}');`],
+    ]);
+
+    const blind: string[] = [];
+    for (const [name, source] of spellings) {
+      const sites = compilerBackedScanner(source, {
+        fileName: `${name}.ts`,
+        knownConstants: KNOWN_CONSTANTS,
+      });
+      const named = sites.some(
+        (site) =>
+          site.discriminant === target ||
+          (site.kind === 'prefix-filter' && site.discriminant === family),
+      );
+      if (!named) blind.push(name);
+    }
+    expect(blind, `the scanner no longer resolves these read spellings`).toEqual([]);
   });
 
   it('RawReaderCensus_DeclaredRawReaderWitness_IsNamedByALiveReader', async () => {
@@ -163,6 +230,31 @@ describe('RawReaderCensus — no fold-external reader depends on a telemetry eve
       audit.staleWitnesses.map((stale) => stale.message),
       describeUnread(census),
     ).toEqual([]);
+  });
+
+  it('RawReaderCensus_CharterPinWitness_IsNamedByNoLiveReader', async () => {
+    const census = await censusPromise;
+    expect(census.modulesByEvent.size).toBeGreaterThan(0);
+
+    // A charter pin says the promotion rests on the ratified family decision
+    // ALONE — no fold, no reader. Left unmeasured, that arm is where a promotion
+    // with real evidence goes to escape every oracle, so the negative half is
+    // held to the census: a pinned type a module actually reads has to move to
+    // the raw-reader arm, which names its module and is re-measured.
+    const pinned = Object.entries(GOVERNANCE_WITNESSES)
+      .filter(([, witness]) => witness.arm === 'charter-pin')
+      .map(([type]) => type);
+    expect(pinned.length).toBeGreaterThan(0);
+
+    const contradicted = pinned
+      .map((type) => ({ type, readers: census.modulesByEvent.get(type) ?? [] }))
+      .filter((row) => row.readers.length > 0)
+      .map(
+        (row) =>
+          `The charter-pin witness for "${row.type}" claims no fold-external reader names it, ` +
+          `but the census finds ${row.readers.join(', ')}. Move it to the raw-reader arm.`,
+      );
+    expect(contradicted, describeUnread(census)).toEqual([]);
   });
 
   it('RawReaderCensus_UnscopedFoldsAndUnresolvedDiscriminants_AreReportedNotDropped', async () => {

--- a/tests/unit/events/event-authority-partition.test.ts
+++ b/tests/unit/events/event-authority-partition.test.ts
@@ -90,6 +90,19 @@ const UNSCHEMATIZED_PAYLOADS: Readonly<Record<string, Record<string, unknown>>> 
 
 const SCHEMAS: Readonly<Record<string, z.ZodType | undefined>> = EVENT_DATA_SCHEMAS;
 
+/**
+ * Constraints a schema states as a refinement, which JSON Schema cannot carry
+ * and the sampler therefore cannot see: a workflow type must be a registered
+ * name, and a migration source path must be state-dir relative. These are
+ * merged over the sampled payload; the validity assertion below is what keeps
+ * this table honest, because a refinement the sampler can suddenly satisfy
+ * makes its row here dead cover that the next reader should delete.
+ */
+const REFINEMENT_OVERRIDES: Readonly<Record<string, Record<string, unknown>>> = {
+  'workflow.started': { workflowType: 'feature' },
+  'migration.legacy_jsonl_imported': { sourcePath: 'legacy/events.jsonl' },
+};
+
 /** The payload the corpus uses for a type, and where it came from. */
 interface CorpusPayload {
   readonly data: Record<string, unknown>;
@@ -99,7 +112,7 @@ interface CorpusPayload {
 function payloadFor(eventType: string): CorpusPayload {
   const sampled = sampleEventData(SCHEMAS[eventType]);
   if (sampled !== undefined && Object.keys(sampled).length > 0) {
-    return { data: sampled, source: 'schema' };
+    return { data: { ...sampled, ...REFINEMENT_OVERRIDES[eventType] }, source: 'schema' };
   }
   const supplied = UNSCHEMATIZED_PAYLOADS[eventType];
   if (supplied !== undefined) return { data: supplied, source: 'unschematized' };
@@ -249,6 +262,34 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     const filtered = CORPUS.filter((event) => !TELEMETRY_EVENTS.has(event.type));
     // The filter must actually remove something, and exactly the telemetry side.
     expect(CORPUS.length - filtered.length).toBe(TELEMETRY_EVENTS.size);
+  });
+
+  it('DifferentialFold_CorpusPayloads_ValidateUnderTheirOwnSchemas', () => {
+    // The fold is fed schema-generated payloads so that every arm has a real
+    // event to run on. A payload the type's own schema rejects — one item
+    // where two are required, a bare string where a timestamp is — is not
+    // that: the arm it was meant to exercise may guard on exactly the
+    // constraint the sample broke, and the corpus would then report the arm
+    // inert while the sampler was the thing at fault. Validity is asserted
+    // here for the whole catalog, so a sampler regression names its types.
+    const rejected: string[] = [];
+    let validated = 0;
+    for (const [type, payload] of PAYLOADS) {
+      if (payload.source !== 'schema') continue;
+      const schema = SCHEMAS[type];
+      if (schema === undefined) continue;
+      const result = schema.safeParse(payload.data);
+      validated += 1;
+      if (!result.success) {
+        const issues = result.error.issues
+          .slice(0, 2)
+          .map((issue) => `${issue.path.map(String).join('.')}: ${issue.message}`)
+          .join('; ');
+        rejected.push(`${type} — ${issues}`);
+      }
+    }
+    expect(validated, 'no schema-sourced payload reached validation').toBeGreaterThan(100);
+    expect(rejected, 'schema-generated payloads the schema itself rejects').toEqual([]);
   });
 
   it('DifferentialFold_CorpusDiscriminatingPower_IsAssertedNotAssumed', () => {

--- a/tests/unit/events/event-authority-partition.test.ts
+++ b/tests/unit/events/event-authority-partition.test.ts
@@ -12,21 +12,44 @@
 //
 // The second is what the partition MEANS. "Telemetry" is only a real claim if
 // dropping every telemetry event leaves the canonical fold's answer unchanged.
-// So the differential folds one event of every catalog type through the
-// workflow-state projection twice — once whole, once with the telemetry side
-// removed — and requires the two states to be identical. The filter has to
-// actually remove something, which is asserted against the derived telemetry
-// set rather than a number, and a deliberate misclassification of a folded type
-// has to make the two diverge, which is what stops the equality from being
-// satisfiable by an empty filter.
+//
+// ## Why the corpus payloads are generated, not empty
+//
+// The corpus once carried `data: {}` for every type, and that made the second
+// claim nearly unfalsifiable: a reducer arm that reads a field before it mutates
+// cannot fire on an empty bag, so 168 of 178 catalog types folded to a no-op for
+// a reason that had nothing to do with their classification. A mutating arm
+// added for a telemetry-classified type would have been invisible.
+//
+// So each corpus event carries the richest payload its own data schema admits,
+// generated from that schema rather than transcribed. The handful of types that
+// declare no schema carry an explicit payload here, and the coverage is asserted
+// BOTH ways: a type with neither is named, and a hand-written payload for a type
+// whose schema already produces one is named as dead cover.
+//
+// ## What the differential actually asserts
+//
+//   • per telemetry type, that its arm is IDENTITY — applied to a fresh state
+//     and to a realistic folded state, it changes nothing. This is the claim,
+//     stated one type at a time so a failure names the type;
+//   • that the whole governance-filtered corpus folds to the full corpus's state;
+//   • that misclassifying ANY type the corpus can discriminate makes the two
+//     folds diverge — the discriminating set is measured, not a pair of
+//     hand-picked witnesses, and its size is asserted so a corpus that went inert
+//     again cannot pass.
 //
 // The fold is `workflowStateProjection.init()`/`.apply()` directly, never
 // through the materializer, whose cache would skip the fold. It is deliberately
 // this ONE fold: view projections such as the telemetry view exist precisely to
 // consume telemetry, so a differential over every view would be red by design
-// and would say nothing about governance.
+// and would say nothing about governance. That scoping has a KNOWN limit worth
+// stating: a secondary view can derive a verdict from a telemetry event without
+// the canonical fold noticing — the synthesis-readiness view computes its
+// blockers from test and typecheck results — so this differential bounds what a
+// retention policy may drop from the canonical state, not from every view.
 
 import { describe, it, expect } from 'vitest';
+import type { z } from 'zod';
 import {
   deriveEventAuthority,
   type AuthorityWitness,
@@ -40,9 +63,54 @@ import {
   classifyEventAuthority,
   tierEmissionSourceOf,
 } from '../../../src/events/partition/event-authority.js';
-import { EventTypes, type WorkflowEvent } from '../../../src/events/schemas.js';
+import {
+  EVENT_DATA_SCHEMAS,
+  EventTypes,
+  type WorkflowEvent,
+} from '../../../src/events/schemas.js';
 import { buildEvent } from '../../../src/events/event-factory.js';
 import { workflowStateProjection } from '../../../src/projections/views/workflow-state-projection.js';
+import { sampleEventData } from '../../../tools/test-helpers/event-payload-sample.js';
+
+/**
+ * Payloads for the catalog types that declare no data schema, so the corpus has
+ * no empty-bag holes for a fold arm to hide behind. `state.patched` is the one
+ * that matters — its patch bag is hash-unrecoverable by construction, which is
+ * exactly why it has no schema and exactly why it must not fold as a no-op.
+ */
+const UNSCHEMATIZED_PAYLOADS: Readonly<Record<string, Record<string, unknown>>> = {
+  'state.patched': { patch: { 'oneshot.synthesisPolicy': 'always' } },
+  'pr.created': { prNumber: 1, url: 'https://example.invalid/pr/1' },
+  'pr.merged': { prNumber: 1, mergedAt: '2026-01-01T00:00:00.000Z' },
+  'pr.commented': { prNumber: 1, body: 'sample comment' },
+  'issue.created': { issueNumber: 1, url: 'https://example.invalid/issue/1' },
+  'checkpoint.enforced': { reason: 'sample reason' },
+  'checkpoint.state_missing': { featureId: 'feat-authority-corpus' },
+  'preflight.executed': { check: 'sample check', passed: true },
+  'preflight.blocked': { check: 'sample check', reason: 'sample reason' },
+};
+
+const SCHEMAS: Readonly<Record<string, z.ZodType | undefined>> = EVENT_DATA_SCHEMAS;
+
+/** The payload the corpus uses for a type, and where it came from. */
+interface CorpusPayload {
+  readonly data: Record<string, unknown>;
+  readonly source: 'schema' | 'unschematized' | 'none';
+}
+
+function payloadFor(eventType: string): CorpusPayload {
+  const sampled = sampleEventData(SCHEMAS[eventType]);
+  if (sampled !== undefined && Object.keys(sampled).length > 0) {
+    return { data: sampled, source: 'schema' };
+  }
+  const supplied = UNSCHEMATIZED_PAYLOADS[eventType];
+  if (supplied !== undefined) return { data: supplied, source: 'unschematized' };
+  return { data: {}, source: 'none' };
+}
+
+const PAYLOADS: ReadonlyMap<string, CorpusPayload> = new Map(
+  EventTypes.map((type) => [type, payloadFor(type)] as const),
+);
 
 /**
  * One event of every catalog type, in catalog order. Total over the catalog by
@@ -55,7 +123,7 @@ import { workflowStateProjection } from '../../../src/projections/views/workflow
 const CORPUS: readonly WorkflowEvent[] = EventTypes.map((type, index) =>
   buildEvent('feat-authority-corpus', index + 1, {
     type,
-    data: {},
+    data: PAYLOADS.get(type)?.data ?? {},
     timestamp: '2026-01-01T00:00:00.000Z',
   }),
 );
@@ -70,6 +138,21 @@ function fold(events: readonly WorkflowEvent[]): unknown {
 function foldExcluding(excluded: ReadonlySet<string>): unknown {
   return fold(CORPUS.filter((event) => !excluded.has(event.type)));
 }
+
+const FULL_FOLD = JSON.stringify(fold(CORPUS));
+
+/**
+ * The types this corpus can actually SEE: dropping one changes the folded
+ * state. Measured, never listed — it is the honest denominator of every claim
+ * the differential makes, and asserting its size is what stops a corpus that
+ * quietly went inert from passing.
+ */
+const DISCRIMINATING: readonly string[] = EventTypes.filter(
+  (type) => JSON.stringify(foldExcluding(new Set([type]))) !== FULL_FOLD,
+);
+
+/** The state a realistic stream reaches, for folding one more event onto. */
+const GOVERNANCE_STATE = foldExcluding(TELEMETRY_EVENTS);
 
 const A_GOVERNANCE_WITNESS: AuthorityWitness = {
   arm: 'charter-pin',
@@ -139,8 +222,27 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     expect(misfiledGovernance).toEqual([]);
   });
 
-  it('DifferentialFold_Corpus_CarriesOneEventOfEveryTelemetryType', () => {
+  it('DifferentialFold_Corpus_CarriesARealisticPayloadForEveryCatalogType', () => {
     expect(CORPUS.length).toBe(EventTypes.length);
+
+    const empty = EventTypes.filter((type) => PAYLOADS.get(type)?.source === 'none');
+    expect(
+      empty,
+      'A type whose corpus event carries an empty payload cannot exercise a fold arm that reads ' +
+        'a field, so its inertness in this corpus proves nothing. Give it a data schema, or a ' +
+        'payload in UNSCHEMATIZED_PAYLOADS.',
+    ).toEqual([]);
+
+    const deadCover = Object.keys(UNSCHEMATIZED_PAYLOADS).filter(
+      (type) => PAYLOADS.get(type)?.source !== 'unschematized',
+    );
+    expect(
+      deadCover,
+      'A hand-written payload for a type whose schema already generates one changes nothing and ' +
+        'so is checked by nothing — delete it.',
+    ).toEqual([]);
+
+    // The corpus is total over the catalog, telemetry side included.
     const missing = [...TELEMETRY_EVENTS].filter(
       (type) => !CORPUS.some((event) => event.type === type),
     );
@@ -151,21 +253,61 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     expect(CORPUS.length - filtered.length).toBe(TELEMETRY_EVENTS.size);
   });
 
+  it('DifferentialFold_CorpusDiscriminatingPower_IsAssertedNotAssumed', () => {
+    // Dropping any one of these changes the folded state, so an equality over
+    // this corpus is a claim about something. The floor is a floor, never the
+    // number: pinning the count would make every new folded event type a failure
+    // of this oracle rather than a check by it.
+    expect(
+      DISCRIMINATING.length,
+      'The corpus can no longer tell any event from a no-op, so every fold comparison below is ' +
+        'satisfiable by an empty projection.',
+    ).toBeGreaterThan(10);
+    expect(DISCRIMINATING.every((type) => classifyEventAuthority(type) === 'governance')).toBe(
+      true,
+    );
+  });
+
+  it('DifferentialFold_EveryTelemetryType_FoldsToIdentity', () => {
+    expect(TELEMETRY_EVENTS.size).toBeGreaterThan(0);
+
+    const initial = JSON.stringify(workflowStateProjection.init());
+    const governance = JSON.stringify(GOVERNANCE_STATE);
+    const mutating: string[] = [];
+    for (const type of [...TELEMETRY_EVENTS].sort()) {
+      const event = CORPUS.find((candidate) => candidate.type === type);
+      expect(event).toBeDefined();
+      if (event === undefined) continue;
+      const ontoInit = JSON.stringify(
+        workflowStateProjection.apply(workflowStateProjection.init(), event),
+      );
+      const ontoGovernance = JSON.stringify(
+        workflowStateProjection.apply(GOVERNANCE_STATE, event),
+      );
+      if (ontoInit !== initial) mutating.push(`${type} (on a fresh state)`);
+      if (ontoGovernance !== governance) mutating.push(`${type} (on a folded state)`);
+    }
+    expect(
+      mutating,
+      'A telemetry-classified event changed the canonical fold. Either the arm is wrong or the ' +
+        'classification is — the partition says nothing depends on these events.',
+    ).toEqual([]);
+  });
+
   it('DifferentialFold_GovernanceFilteredCorpus_FoldsIdenticallyToTheFullCorpus', () => {
     expect(TELEMETRY_EVENTS.size).toBeGreaterThan(0);
     expect(foldExcluding(TELEMETRY_EVENTS)).toEqual(fold(CORPUS));
   });
 
-  it('DifferentialFold_TelemetryMisclassifyingAFoldedType_DivergesFromTheFullFold', () => {
-    const foldedTypes = Object.entries(GOVERNANCE_WITNESSES)
-      .filter(([, witness]) => witness.arm === 'projection-fold')
-      .map(([type]) => type);
-    expect(foldedTypes.length).toBeGreaterThan(0);
+  it('DifferentialFold_MisclassifyingAnyDiscriminatingType_DivergesFromTheFullFold', () => {
+    expect(DISCRIMINATING.length).toBeGreaterThan(10);
 
-    for (const type of foldedTypes) {
+    const undetected: string[] = [];
+    for (const type of DISCRIMINATING) {
       const misclassified = new Set([...TELEMETRY_EVENTS, type]);
-      expect(foldExcluding(misclassified)).not.toEqual(fold(CORPUS));
+      if (JSON.stringify(foldExcluding(misclassified)) === FULL_FOLD) undetected.push(type);
     }
+    expect(undetected).toEqual([]);
   });
 
   it('GovernanceWitnesses_ProjectionFoldArm_ChangesTheCanonicalFoldState', () => {
@@ -190,5 +332,80 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     }
     expect(inert).toEqual([]);
     expect(notGovernance).toEqual([]);
+  });
+
+  it('CharterTension_TelemetryExamplesStillClassifiedGovernance_AreThePinnedBacklog', () => {
+    // The ratified charter names a bucket of types as telemetry EXAMPLES. The
+    // derivation disagrees with it for most of them, and for two different
+    // reasons: some carry a live fold-external reader (a demotion would be
+    // false), and most derive `auto` from a substrate tier, which the
+    // promotion-only rule refuses to override with an instrument that cannot
+    // prove a universal absence.
+    //
+    // Neither reason is an argument for leaving the disagreement in a comment.
+    // The charter schedules those flips as later, independently-landable work,
+    // and each one has to delete its expectation row in the same commit — so the
+    // gap is a BACKLOG, and a backlog is a thing you count. Pinning the exact
+    // set makes every flip a visible shrink and makes a new disagreement
+    // impossible to add silently.
+    const namedByCharter = (type: string): boolean =>
+      type.startsWith('tool.') ||
+      type.startsWith('team.') ||
+      type === 'turn.completed' ||
+      type === 'subagent.tokens_used' ||
+      type === 'launch.executing_started' ||
+      type === 'shepherd.iteration' ||
+      type === 'stack.submitted';
+
+    const charterExamples = EventTypes.filter(namedByCharter);
+    expect(charterExamples.length).toBeGreaterThan(10);
+
+    const stillGovernance = charterExamples
+      .filter((type) => classifyEventAuthority(type) === 'governance')
+      .sort();
+
+    expect(
+      stillGovernance,
+      'The charter calls these telemetry and the derivation still calls them governance. Each ' +
+        'flip is its own change — it deletes the expectation row and the description row with ' +
+        'the demotion — so this list may only SHRINK, and a new entry means a type was promoted ' +
+        'against the charter without saying so.',
+    ).toEqual([
+      'launch.executing_started',
+      'shepherd.iteration',
+      'stack.submitted',
+      'subagent.tokens_used',
+      'team.disbanded',
+      'team.spawned',
+      'team.task.assigned',
+      'team.task.completed',
+      'team.task.failed',
+      'team.task.planned',
+      'team.teammate.dispatched',
+      'tool.action_errored',
+      'tool.completed',
+      'tool.errored',
+      'tool.invoked',
+      'turn.completed',
+    ]);
+  });
+
+  it('GovernanceWitnesses_CharterPinArm_ClaimsNoEvidenceItActuallyHas', () => {
+    // A charter pin says: no fold names this, and no reader does. That is a
+    // NEGATIVE claim, and an unchecked negative claim is how a promotion with
+    // real evidence ends up filed under the one arm no oracle re-measures. The
+    // fold half is measurable right here; the reader half is measured by the
+    // raw-reader census, which checks the same table.
+    const pinned = Object.entries(GOVERNANCE_WITNESSES)
+      .filter(([, witness]) => witness.arm === 'charter-pin')
+      .map(([type]) => type);
+    expect(pinned.length).toBeGreaterThan(0);
+
+    const contradicted = pinned.filter((type) => DISCRIMINATING.includes(type));
+    expect(
+      contradicted,
+      'A charter-pin row claims the canonical fold does not name its type, but dropping the type ' +
+        'changes the fold. Move the row to the projection-fold arm, which is measured.',
+    ).toEqual([]);
   });
 });

--- a/tests/unit/events/event-authority-partition.test.ts
+++ b/tests/unit/events/event-authority-partition.test.ts
@@ -1,0 +1,194 @@
+// ─── The governance/telemetry partition, and the fold it has to survive ──────
+//
+// @oracle-sources: ../../../src/events/partition/authority.ts,
+// ../../../src/events/partition/witnesses.ts,
+// ../../../src/projections/views/workflow-state-projection.ts
+//
+// Two claims, and neither is checkable without the other.
+//
+// The first is that the partition is DERIVED: rebuild it from the catalog, the
+// annotations and the witness table and you get exactly the shipped map, and a
+// population it cannot partition fails by name rather than defaulting.
+//
+// The second is what the partition MEANS. "Telemetry" is only a real claim if
+// dropping every telemetry event leaves the canonical fold's answer unchanged.
+// So the differential folds one event of every catalog type through the
+// workflow-state projection twice — once whole, once with the telemetry side
+// removed — and requires the two states to be identical. The filter has to
+// actually remove something, which is asserted against the derived telemetry
+// set rather than a number, and a deliberate misclassification of a folded type
+// has to make the two diverge, which is what stops the equality from being
+// satisfiable by an empty filter.
+//
+// The fold is `workflowStateProjection.init()`/`.apply()` directly, never
+// through the materializer, whose cache would skip the fold. It is deliberately
+// this ONE fold: view projections such as the telemetry view exist precisely to
+// consume telemetry, so a differential over every view would be red by design
+// and would say nothing about governance.
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveEventAuthority,
+  type AuthorityWitness,
+  type EventAuthority,
+} from '../../../src/events/partition/authority.js';
+import { GOVERNANCE_WITNESSES } from '../../../src/events/partition/witnesses.js';
+import {
+  EVENT_AUTHORITY,
+  GOVERNANCE_EVENTS,
+  TELEMETRY_EVENTS,
+  classifyEventAuthority,
+  tierEmissionSourceOf,
+} from '../../../src/events/partition/event-authority.js';
+import { EventTypes, type WorkflowEvent } from '../../../src/events/schemas.js';
+import { buildEvent } from '../../../src/events/event-factory.js';
+import { workflowStateProjection } from '../../../src/projections/views/workflow-state-projection.js';
+
+/**
+ * One event of every catalog type, in catalog order. Total over the catalog by
+ * construction, so it cannot go vacuous when a type is added — a new event type
+ * joins the corpus without anyone editing this file.
+ *
+ * The timestamp is fixed so the two folds compare a state whose time fields
+ * came from the events rather than from the clock.
+ */
+const CORPUS: readonly WorkflowEvent[] = EventTypes.map((type, index) =>
+  buildEvent('feat-authority-corpus', index + 1, {
+    type,
+    data: {},
+    timestamp: '2026-01-01T00:00:00.000Z',
+  }),
+);
+
+function fold(events: readonly WorkflowEvent[]): unknown {
+  return events.reduce(
+    (state, event) => workflowStateProjection.apply(state, event),
+    workflowStateProjection.init(),
+  );
+}
+
+function foldExcluding(excluded: ReadonlySet<string>): unknown {
+  return fold(CORPUS.filter((event) => !excluded.has(event.type)));
+}
+
+const A_GOVERNANCE_WITNESS: AuthorityWitness = {
+  arm: 'charter-pin',
+  evidence: ['lvlup-sw/exarchos#1876 ratified event-authority decision record'],
+  because: 'A seeded witness, standing in for a real promotion.',
+};
+
+describe('EventAuthority — the partition is derived, and telemetry means droppable', () => {
+  it('EventAuthority_LiveMap_IsTheDerivationOfEveryAnnotationAndWitness', () => {
+    const rebuilt = deriveEventAuthority(
+      EventTypes,
+      tierEmissionSourceOf,
+      GOVERNANCE_WITNESSES,
+    );
+
+    // The denominator first: an empty rebuild would make every comparison below
+    // vacuously true.
+    expect(Object.keys(rebuilt).length).toBe(EventTypes.length);
+    expect(Object.keys(rebuilt).length).toBeGreaterThan(0);
+
+    const disagreements = EventTypes.filter(
+      (type) => rebuilt[type] !== EVENT_AUTHORITY[type],
+    ).map((type) => `${type}: shipped=${EVENT_AUTHORITY[type]} derived=${rebuilt[type]}`);
+    expect(disagreements).toEqual([]);
+  });
+
+  it('EventAuthority_EmptyPopulation_Throws', () => {
+    expect(() => deriveEventAuthority([], () => 'auto', {})).toThrow(
+      /empty event-type population/,
+    );
+  });
+
+  it('EventAuthority_UnannotatedType_IsNamedInTheThrow', () => {
+    expect(() =>
+      deriveEventAuthority(['ghost.unannotated', 'other.unannotated'], () => undefined, {}),
+    ).toThrow(/ghost\.unannotated, other\.unannotated/);
+  });
+
+  it('EventAuthority_WitnessForAnUnknownEventType_IsNamedInTheThrow', () => {
+    expect(() =>
+      deriveEventAuthority(['live.telemetry'], () => 'model', {
+        'renamed.away': A_GOVERNANCE_WITNESS,
+      }),
+    ).toThrow(/renamed\.away/);
+  });
+
+  it('EventAuthority_WitnessOnATypeAlreadyGovernanceByTier_IsNamedAsDeadCover', () => {
+    expect(() =>
+      deriveEventAuthority(['already.governance'], () => 'auto', {
+        'already.governance': A_GOVERNANCE_WITNESS,
+      }),
+    ).toThrow(/already\.governance/);
+  });
+
+  it('EventAuthority_TelemetrySet_IsNonEmptyAndDerivedFromTheMap', () => {
+    expect(TELEMETRY_EVENTS.size).toBeGreaterThan(0);
+    expect(GOVERNANCE_EVENTS.size).toBeGreaterThan(0);
+    expect(TELEMETRY_EVENTS.size + GOVERNANCE_EVENTS.size).toBe(EventTypes.length);
+
+    const misfiled = [...TELEMETRY_EVENTS].filter(
+      (type) => classifyEventAuthority(type) !== 'telemetry',
+    );
+    expect(misfiled).toEqual([]);
+    const misfiledGovernance = [...GOVERNANCE_EVENTS].filter(
+      (type) => classifyEventAuthority(type) !== 'governance',
+    );
+    expect(misfiledGovernance).toEqual([]);
+  });
+
+  it('DifferentialFold_Corpus_CarriesOneEventOfEveryTelemetryType', () => {
+    expect(CORPUS.length).toBe(EventTypes.length);
+    const missing = [...TELEMETRY_EVENTS].filter(
+      (type) => !CORPUS.some((event) => event.type === type),
+    );
+    expect(missing).toEqual([]);
+
+    const filtered = CORPUS.filter((event) => !TELEMETRY_EVENTS.has(event.type));
+    // The filter must actually remove something, and exactly the telemetry side.
+    expect(CORPUS.length - filtered.length).toBe(TELEMETRY_EVENTS.size);
+  });
+
+  it('DifferentialFold_GovernanceFilteredCorpus_FoldsIdenticallyToTheFullCorpus', () => {
+    expect(TELEMETRY_EVENTS.size).toBeGreaterThan(0);
+    expect(foldExcluding(TELEMETRY_EVENTS)).toEqual(fold(CORPUS));
+  });
+
+  it('DifferentialFold_TelemetryMisclassifyingAFoldedType_DivergesFromTheFullFold', () => {
+    const foldedTypes = Object.entries(GOVERNANCE_WITNESSES)
+      .filter(([, witness]) => witness.arm === 'projection-fold')
+      .map(([type]) => type);
+    expect(foldedTypes.length).toBeGreaterThan(0);
+
+    for (const type of foldedTypes) {
+      const misclassified = new Set([...TELEMETRY_EVENTS, type]);
+      expect(foldExcluding(misclassified)).not.toEqual(fold(CORPUS));
+    }
+  });
+
+  it('GovernanceWitnesses_ProjectionFoldArm_ChangesTheCanonicalFoldState', () => {
+    const declared = Object.entries(GOVERNANCE_WITNESSES).filter(
+      ([, witness]) => witness.arm === 'projection-fold',
+    );
+    expect(declared.length).toBeGreaterThan(0);
+
+    const inert: string[] = [];
+    const notGovernance: string[] = [];
+    for (const [type] of declared) {
+      const seeded = CORPUS.find((event) => event.type === type);
+      expect(seeded).toBeDefined();
+      const applied = seeded === undefined
+        ? workflowStateProjection.init()
+        : workflowStateProjection.apply(workflowStateProjection.init(), seeded);
+      if (JSON.stringify(applied) === JSON.stringify(workflowStateProjection.init())) {
+        inert.push(type);
+      }
+      const classification: EventAuthority | undefined = classifyEventAuthority(type);
+      if (classification !== 'governance') notGovernance.push(type);
+    }
+    expect(inert).toEqual([]);
+    expect(notGovernance).toEqual([]);
+  });
+});

--- a/tests/unit/events/event-authority-partition.test.ts
+++ b/tests/unit/events/event-authority-partition.test.ts
@@ -1,8 +1,6 @@
 // ─── The governance/telemetry partition, and the fold it has to survive ──────
 //
-// @oracle-sources: ../../../src/events/partition/authority.ts,
-// ../../../src/events/partition/witnesses.ts,
-// ../../../src/projections/views/workflow-state-projection.ts
+// @oracle-sources: ../../../src/events/partition/witnesses.ts, ../../../src/projections/views/workflow-state-projection.ts
 //
 // Two claims, and neither is checkable without the other.
 //

--- a/tools/audit/guard-liveness-baseline.json
+++ b/tools/audit/guard-liveness-baseline.json
@@ -1,10 +1,10 @@
 {
-  "capturedAt": "2026-08-23",
-  "trackedFiles": 3022,
+  "capturedAt": "2026-09-03",
+  "trackedFiles": 3076,
   "surfaces": {
     "depcruise:no-domain-core-to-io-adapters:from": {
       "kind": "module-set",
-      "matched": 110,
+      "matched": 118,
       "detail": {
         "pattern": "^src/(events|workflow)/"
       }
@@ -18,15 +18,15 @@
     },
     "codeowners:*": {
       "kind": "ownership",
-      "matched": 3022
+      "matched": 3076
     },
     "codeowners:src/": {
       "kind": "ownership",
-      "matched": 752
+      "matched": 768
     },
     "codeowners:tools/": {
       "kind": "ownership",
-      "matched": 326
+      "matched": 330
     },
     "codeowners:content/": {
       "kind": "ownership",
@@ -38,7 +38,7 @@
     },
     "codeowners:tests/": {
       "kind": "ownership",
-      "matched": 1474
+      "matched": 1505
     },
     "package.files:dist/bin": {
       "kind": "build-output",
@@ -107,7 +107,7 @@
     },
     "lint:eslint-cli-glob": {
       "kind": "lint-scope",
-      "matched": 915,
+      "matched": 933,
       "detail": {
         "glob": "src/**/*.ts tools/**/*.ts"
       }
@@ -128,7 +128,7 @@
     },
     "knip:workspace:.": {
       "kind": "dead-code",
-      "matched": 2532,
+      "matched": 2583,
       "detail": {
         "glob": "src/**/*.ts tests/**/*.ts !tests/evals/**/runs/** tools/audit/**/*.ts tools/conformance/src/**/*.ts tools/evals/**/*.ts tools/evals-pkg/**/*.ts tools/git-hooks/**/*.ts tools/release/**/*.ts tools/test-helpers/**/*.ts docs/.vitepress/**/*.ts"
       }

--- a/tools/audit/reference-census.json
+++ b/tools/audit/reference-census.json
@@ -1,7 +1,7 @@
 {
-  "capturedAt": "2026-08-23",
-  "trackedFiles": 3022,
-  "scannedFiles": 2917,
+  "capturedAt": "2026-09-03",
+  "trackedFiles": 3076,
+  "scannedFiles": 2971,
   "namedFilesIncluded": [
     ".github/CODEOWNERS",
     ".gitattributes",
@@ -12,16 +12,16 @@
     "docs/designs": {
       "disposition": "delete",
       "ownFiles": 0,
-      "externalReferrers": 111,
+      "externalReferrers": 112,
       "referrersByKind": {
         "code": 82,
         "config": 3,
         "snapshot": 1,
-        "markdownLive": 23,
+        "markdownLive": 24,
         "markdownArchival": 1,
         "other": 1
       },
-      "liveReferrers": 110,
+      "liveReferrers": 111,
       "sampleReferrers": [
         ".exarchos.yml",
         ".exarchos/invariants.md",
@@ -50,16 +50,16 @@
     "docs/plans": {
       "disposition": "delete",
       "ownFiles": 0,
-      "externalReferrers": 62,
+      "externalReferrers": 63,
       "referrersByKind": {
         "code": 40,
         "config": 3,
         "snapshot": 1,
-        "markdownLive": 17,
+        "markdownLive": 18,
         "markdownArchival": 0,
         "other": 1
       },
-      "liveReferrers": 62,
+      "liveReferrers": 63,
       "sampleReferrers": [
         ".claude-plugin/packaging-policy.json",
         "content/delivery/skills/delegate/references/worked-example.md",
@@ -418,21 +418,22 @@
     "docs/migrations": {
       "disposition": "delete",
       "ownFiles": 1,
-      "externalReferrers": 6,
+      "externalReferrers": 7,
       "referrersByKind": {
         "code": 5,
         "config": 0,
         "snapshot": 0,
-        "markdownLive": 1,
+        "markdownLive": 2,
         "markdownArchival": 0,
         "other": 0
       },
-      "liveReferrers": 6,
+      "liveReferrers": 7,
       "sampleReferrers": [
         "src/events/event-name.ts",
         "src/events/schemas.ts",
         "tests/scripts/migration-followups.test.ts",
         "tests/unit/events/event-name.test.ts",
+        "tools/audit/comment-quality/audit.md",
         "tools/audit/prose-manifest.ts",
         "tools/audit/test-fixtures/measured-premises/internal-mechanics-overhaul.md"
       ],

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,10 +4,10 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, so this total is not comparable to any runner's expanded count and no runner totals are pinned here — a pinned pair went stale the first time the tree grew. The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1257,
-    "parsedFiles": 1212,
+    "testFiles": 1260,
+    "parsedFiles": 1215,
     "shellFiles": 45,
-    "cases": 13827,
+    "cases": 13846,
     "dynamicTitles": 150,
     "unparseableFiles": 0
   },
@@ -5777,6 +5777,63 @@
         {
           "suite": "Documentation_EveryStatedRule_IsOneThatIsEnforced",
           "name": "the enforcement table is not empty",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/architecture/event-authority-contracts.test.ts": {
+      "file": "tests/architecture/event-authority-contracts.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "ActionContractConjunct — a declared event is a governance event",
+          "name": "ActionContractConjunct_DeclaredEventPopulation_IsNonEmpty",
+          "dynamic": false
+        },
+        {
+          "suite": "ActionContractConjunct — a declared event is a governance event",
+          "name": "ActionContractConjunct_EveryDeclaredEventName_IsAKnownEventType",
+          "dynamic": false
+        },
+        {
+          "suite": "ActionContractConjunct — a declared event is a governance event",
+          "name": "ActionContractConjunct_EveryDeclaredEventName_ResolvesToAGovernanceEvent",
+          "dynamic": false
+        },
+        {
+          "suite": "ActionContractConjunct — a declared event is a governance event",
+          "name": "ActionContractConjunct_SeededContractNamingATelemetryType_IsNamedInTheFailure",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/architecture/event-authority-raw-readers.test.ts": {
+      "file": "tests/architecture/event-authority-raw-readers.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "RawReaderCensus — no fold-external reader depends on a telemetry event",
+          "name": "RawReaderCensus_ScannedPopulation_IsNonEmptyAndCorroboratedByGit",
+          "dynamic": false
+        },
+        {
+          "suite": "RawReaderCensus — no fold-external reader depends on a telemetry event",
+          "name": "RawReaderCensus_EveryFoldExternalReader_NamesNoTelemetryClassifiedEventType",
+          "dynamic": false
+        },
+        {
+          "suite": "RawReaderCensus — no fold-external reader depends on a telemetry event",
+          "name": "RawReaderCensus_SeededReaderNamingATelemetryType_IsNamedInTheFailure",
+          "dynamic": false
+        },
+        {
+          "suite": "RawReaderCensus — no fold-external reader depends on a telemetry event",
+          "name": "RawReaderCensus_DeclaredRawReaderWitness_IsNamedByALiveReader",
+          "dynamic": false
+        },
+        {
+          "suite": "RawReaderCensus — no fold-external reader depends on a telemetry event",
+          "name": "RawReaderCensus_UnscopedFoldsAndUnresolvedDiscriminants_AreReportedNotDropped",
           "dynamic": false
         }
       ]
@@ -23850,6 +23907,62 @@
         {
           "suite": "EventAnnotations — the DR-2 tier and lifecycle assignment for the event catalog",
           "name": "EventAnnotations_ReportCoupledCount_IsDerivedAtIntroduction",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/unit/events/event-authority-partition.test.ts": {
+      "file": "tests/unit/events/event-authority-partition.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_LiveMap_IsTheDerivationOfEveryAnnotationAndWitness",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_EmptyPopulation_Throws",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_UnannotatedType_IsNamedInTheThrow",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_WitnessForAnUnknownEventType_IsNamedInTheThrow",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_WitnessOnATypeAlreadyGovernanceByTier_IsNamedAsDeadCover",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_TelemetrySet_IsNonEmptyAndDerivedFromTheMap",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "DifferentialFold_Corpus_CarriesOneEventOfEveryTelemetryType",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "DifferentialFold_GovernanceFilteredCorpus_FoldsIdenticallyToTheFullCorpus",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "DifferentialFold_TelemetryMisclassifyingAFoldedType_DivergesFromTheFullFold",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "GovernanceWitnesses_ProjectionFoldArm_ChangesTheCanonicalFoldState",
           "dynamic": false
         }
       ]

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -7,7 +7,7 @@
     "testFiles": 1260,
     "parsedFiles": 1215,
     "shellFiles": 45,
-    "cases": 13846,
+    "cases": 13851,
     "dynamicTitles": 150,
     "unparseableFiles": 0
   },
@@ -23947,7 +23947,22 @@
         },
         {
           "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
-          "name": "DifferentialFold_Corpus_CarriesOneEventOfEveryTelemetryType",
+          "name": "DifferentialFold_Corpus_CarriesARealisticPayloadForEveryCatalogType",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "DifferentialFold_CorpusPayloads_ValidateUnderTheirOwnSchemas",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "DifferentialFold_CorpusDiscriminatingPower_IsAssertedNotAssumed",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "DifferentialFold_EveryTelemetryType_FoldsToIdentity",
           "dynamic": false
         },
         {
@@ -23957,12 +23972,22 @@
         },
         {
           "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
-          "name": "DifferentialFold_TelemetryMisclassifyingAFoldedType_DivergesFromTheFullFold",
+          "name": "DifferentialFold_MisclassifyingAnyDiscriminatingType_DivergesFromTheFullFold",
           "dynamic": false
         },
         {
           "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
           "name": "GovernanceWitnesses_ProjectionFoldArm_ChangesTheCanonicalFoldState",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "CharterTension_TelemetryExamplesStillClassifiedGovernance_AreThePinnedBacklog",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "GovernanceWitnesses_CharterPinArm_ClaimsNoEvidenceItActuallyHas",
           "dynamic": false
         }
       ]

--- a/tools/test-helpers/event-payload-sample.ts
+++ b/tools/test-helpers/event-payload-sample.ts
@@ -63,6 +63,46 @@ function resolveRef(ref: string, root: Readonly<Record<string, unknown>>): Schem
 }
 
 /**
+ * A string the node's own constraints admit.
+ *
+ * The plain `sample-<name>` string satisfies a bare `type: string`, and nothing
+ * else: a timestamp field rejects it, a digest field rejects it, a URL field
+ * rejects it, and the fold arm behind any of those never runs. Formats come
+ * from the JSON Schema `format` keyword; the digest shape comes from its
+ * `pattern`; an absolute-path requirement is a refinement the JSON Schema
+ * cannot express, so it is read off the property name.
+ */
+function sampleString(node: Readonly<Record<string, unknown>>, propertyName: string): string {
+  const format = node['format'];
+  switch (format) {
+    case 'date-time':
+      return '2026-01-01T00:00:00.000Z';
+    case 'date':
+      return '2026-01-01';
+    case 'time':
+      return '00:00:00';
+    case 'uuid':
+      return '00000000-0000-4000-8000-000000000000';
+    case 'uri':
+    case 'url':
+      return `https://example.test/${propertyName}`;
+    case 'email':
+      return `${propertyName}@example.test`;
+    default:
+      break;
+  }
+  const pattern = node['pattern'];
+  if (typeof pattern === 'string') {
+    const hexRun = /^\^\[a-f0-9\]\{(\d+)\}\$$/.exec(pattern);
+    if (hexRun?.[1] !== undefined) return '0'.repeat(Number(hexRun[1]));
+  }
+  if (/(^|[a-z])(path|dir|directory|cwd|root)$/i.test(propertyName)) {
+    return `/sample/${propertyName}`;
+  }
+  return `sample-${propertyName}`;
+}
+
+/**
  * One deterministic value admitted by `node`.
  *
  * Deterministic on purpose: two runs of the same corpus must fold to the same
@@ -111,7 +151,7 @@ function sampleNode(
 
   switch (type) {
     case 'string':
-      return `sample-${propertyName}`;
+      return sampleString(node, propertyName);
     case 'integer':
     case 'number': {
       const minimum = asNumber(node['minimum']);
@@ -126,12 +166,30 @@ function sampleNode(
     case 'null':
       return null;
     case 'array': {
+      // A tuple names each position's schema; sample every position, because
+      // a two-element `lineRange` with one entry is not a line range.
+      const positions = asArray(node['prefixItems']);
+      if (positions !== undefined && positions.length > 0) {
+        return positions.map((position, index) => {
+          const positionNode = asRecord(position);
+          return positionNode === undefined
+            ? `sample-${propertyName}-${index + 1}`
+            : sampleNode(positionNode, root, `${propertyName}-${index + 1}`, depth + 1);
+        });
+      }
       const items = node['items'];
       if (items === undefined) return [];
       const itemNode = asRecord(items);
-      return itemNode === undefined
-        ? []
-        : [sampleNode(itemNode, root, `${propertyName}-item`, depth + 1)];
+      if (itemNode === undefined) return [];
+      // A schema that demands a floor gets the floor: one item under a
+      // `minItems: 2` is a payload the schema itself rejects, and a fold arm
+      // that only runs on a valid payload would stay inert under it. Each item
+      // carries its own ordinal so a uniqueness constraint is honored too.
+      const floor = asNumber(node['minItems']) ?? 1;
+      const count = Math.max(1, Math.trunc(floor));
+      return Array.from({ length: count }, (_, index) =>
+        sampleNode(itemNode, root, `${propertyName}-item-${index + 1}`, depth + 1),
+      );
     }
     case 'object':
     default:

--- a/tools/test-helpers/event-payload-sample.ts
+++ b/tools/test-helpers/event-payload-sample.ts
@@ -1,0 +1,189 @@
+// ─── Realistic event payloads, DERIVED from the shipped data schemas ─────────
+//
+// A differential fold whose corpus carries `data: {}` proves almost nothing. A
+// reducer arm that reads a field before it mutates cannot fire on an empty bag,
+// so "dropping this event changes no state" and "this event's arm never got a
+// chance to run" produce the same green. Measured on this tree, an empty-payload
+// corpus made 168 of 178 catalog types indistinguishable from a no-op, and the
+// eight types the canonical fold mutates on under a real payload — `state.patched`
+// and `task.assigned` among them — were among the invisible ones.
+//
+// So the corpus payload is GENERATED from each type's own `EVENT_DATA_SCHEMAS`
+// entry rather than hand-written. Two properties follow, and both matter:
+//
+//   • a new event type joins the corpus with a realistic payload and nobody
+//     edits a table, so the corpus cannot rot into emptiness one type at a time;
+//   • the payload cannot disagree with the schema, because it is a reading of
+//     the schema.
+//
+// Every property is filled, optional ones included: the goal is the RICHEST
+// admissible payload, since a field left out is a reducer arm left unexercised.
+//
+// `z.toJSONSchema` is the public projection of a zod schema. Walking
+// `_zod.def` directly would couple this helper to zod's internals for no gain —
+// JSON Schema already carries every discriminant the sampler needs.
+
+import { z } from 'zod';
+
+/** A JSON-Schema node, as far as the sampler reads one. */
+type SchemaNode = Readonly<Record<string, unknown>> | boolean;
+
+const MAX_DEPTH = 6;
+
+function isObjectNode(node: SchemaNode): node is Readonly<Record<string, unknown>> {
+  return typeof node === 'object' && node !== null;
+}
+
+function asRecord(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : undefined;
+}
+
+function asArray(value: unknown): readonly unknown[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/** Resolve a local `$ref` against the document root; unresolvable refs sample as a string. */
+function resolveRef(ref: string, root: Readonly<Record<string, unknown>>): SchemaNode | undefined {
+  if (!ref.startsWith('#/')) return undefined;
+  let current: unknown = root;
+  for (const rawSegment of ref.slice(2).split('/')) {
+    const segment = rawSegment.replaceAll('~1', '/').replaceAll('~0', '~');
+    const record = asRecord(current);
+    if (record === undefined) return undefined;
+    current = record[segment];
+  }
+  const resolved = asRecord(current);
+  return resolved;
+}
+
+/**
+ * One deterministic value admitted by `node`.
+ *
+ * Deterministic on purpose: two runs of the same corpus must fold to the same
+ * state, or every differential comparison becomes a coin flip.
+ */
+function sampleNode(
+  node: SchemaNode,
+  root: Readonly<Record<string, unknown>>,
+  propertyName: string,
+  depth: number,
+): unknown {
+  if (node === true || depth > MAX_DEPTH) return `sample-${propertyName}`;
+  if (node === false) return undefined;
+  if (!isObjectNode(node)) return `sample-${propertyName}`;
+
+  const ref = node['$ref'];
+  if (typeof ref === 'string') {
+    const target = resolveRef(ref, root);
+    return target === undefined
+      ? `sample-${propertyName}`
+      : sampleNode(target, root, propertyName, depth + 1);
+  }
+
+  if ('const' in node) return node['const'];
+
+  const enumValues = asArray(node['enum']);
+  if (enumValues !== undefined && enumValues.length > 0) return enumValues[0];
+
+  for (const branchKey of ['anyOf', 'oneOf', 'allOf'] as const) {
+    const branches = asArray(node[branchKey]);
+    if (branches === undefined || branches.length === 0) continue;
+    // The first non-null branch: a nullable field sampled as `null` exercises
+    // nothing, and the point of the corpus is to exercise arms.
+    for (const branch of branches) {
+      const candidate = asRecord(branch);
+      if (candidate === undefined) continue;
+      if (candidate['type'] === 'null') continue;
+      return sampleNode(candidate, root, propertyName, depth + 1);
+    }
+    const first = asRecord(branches[0]);
+    if (first !== undefined) return sampleNode(first, root, propertyName, depth + 1);
+  }
+
+  const declaredType = node['type'];
+  const type = Array.isArray(declaredType) ? declaredType[0] : declaredType;
+
+  switch (type) {
+    case 'string':
+      return `sample-${propertyName}`;
+    case 'integer':
+    case 'number': {
+      const minimum = asNumber(node['minimum']);
+      const maximum = asNumber(node['maximum']);
+      const candidate = minimum ?? 1;
+      // A schema-wide `maximum` of `Number.MAX_SAFE_INTEGER` is zod's encoding of
+      // "a JS number", not a real bound, so clamping is enough — no scaling.
+      return maximum !== undefined && candidate > maximum ? maximum : candidate;
+    }
+    case 'boolean':
+      return true;
+    case 'null':
+      return null;
+    case 'array': {
+      const items = node['items'];
+      if (items === undefined) return [];
+      const itemNode = asRecord(items);
+      return itemNode === undefined
+        ? []
+        : [sampleNode(itemNode, root, `${propertyName}-item`, depth + 1)];
+    }
+    case 'object':
+    default:
+      break;
+  }
+
+  const properties = asRecord(node['properties']);
+  if (properties !== undefined) {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(properties)) {
+      const childNode = asRecord(child);
+      if (childNode === undefined) continue;
+      const value = sampleNode(childNode, root, key, depth + 1);
+      if (value !== undefined) out[key] = value;
+    }
+    return out;
+  }
+
+  const additional = asRecord(node['additionalProperties']);
+  if (additional !== undefined) {
+    return { [`${propertyName}Key`]: sampleNode(additional, root, propertyName, depth + 1) };
+  }
+  if (node['type'] === 'object') return {};
+
+  return `sample-${propertyName}`;
+}
+
+/**
+ * The richest payload the schema admits, or `undefined` when the type declares
+ * no data schema.
+ *
+ * `undefined` is deliberately distinguishable from `{}`: "this type has no
+ * schema to sample" and "this type's schema admits an empty bag" are different
+ * facts, and a caller asserting corpus richness has to be able to tell them
+ * apart.
+ */
+export function sampleEventData(
+  schema: z.ZodType | undefined,
+): Record<string, unknown> | undefined {
+  if (schema === undefined) return undefined;
+  let jsonSchema: Readonly<Record<string, unknown>>;
+  try {
+    const produced: unknown = z.toJSONSchema(schema, { io: 'input', unrepresentable: 'any' });
+    const record = asRecord(produced);
+    if (record === undefined) return undefined;
+    jsonSchema = record;
+  } catch {
+    // A schema JSON Schema cannot express samples as nothing rather than as an
+    // empty bag, so the caller's richness assertion names the type.
+    return undefined;
+  }
+  const sampled = sampleNode(jsonSchema, jsonSchema, 'value', 0);
+  const record = asRecord(sampled);
+  return record === undefined ? undefined : { ...record };
+}

--- a/tools/test-helpers/event-reader-scanner.ts
+++ b/tools/test-helpers/event-reader-scanner.ts
@@ -1,0 +1,342 @@
+// ─── The real resolver behind the fold-external event-reader census ──────────
+//
+// `src/events/partition/reader-census.ts` decides WHAT a fold-external read of
+// an event means for the governance/telemetry partition. It does not, and must
+// not, decide what a piece of TypeScript MEANS — whether `{ type: X }` names an
+// event type is a question about bindings, and the only instrument that cannot
+// disagree with the compiler about bindings is the compiler.
+//
+// ── Why this module is HERE and not next to the policy it serves ─────────────
+// The same reasoning the evidence-emission scanner states for itself:
+// `typescript` is a devDependency, so a shipped `src/` module importing it makes
+// the compiler a runtime dependency of a tree whose shipped artifact resolves
+// only `dependencies`, and the effect ledger enforces exactly that against
+// itself.
+//
+// ── Why three forms and not one ─────────────────────────────────────────────
+// A scoped query is the minority spelling. Most correctness-bearing readers in
+// this tree fold a stream unfiltered and compare `.type` downstream, inside a
+// guard or a saga; several switch on it. A census that only read
+// `filters.type` would miss precisely the guard-layer literals that are the
+// clearest dependencies in the tree, and would look complete while doing so.
+//
+//   • `store.query(id, { type: X })` / `store.queryByType(X, …)`;
+//   • `event.type === 'x'`, `e.type !== 'x'`, and the bare `type` / `eventType`
+//     identifiers the same comparison is written with elsewhere;
+//   • `case 'x':` on a switch whose discriminant is one of those shapes.
+//
+// A query call carrying no type filter is reported as an UNSCOPED read rather
+// than as nothing: it depends on the whole type universe, and calling that
+// "reads no event" is the under-report the census refuses.
+//
+// The AST helpers below are deliberately local rather than shared with the
+// evidence scanner: that port answers "what does this module APPEND", this one
+// answers "what does this module READ", and folding them into one traversal
+// would make a change made for one census silently change the other's answer.
+
+import ts from 'typescript';
+import type {
+  EventReaderScanOptions,
+  EventReaderScanner,
+  EventReaderSite,
+} from '../../src/events/partition/reader-census.js';
+
+/**
+ * `parseDiagnostics` is off the public `ts.SourceFile` surface but is the only
+ * way to tell a CLEAN parse from a RECOVERED one. A narrowing predicate rather
+ * than an assertion, because the cast ratchet scans this directory.
+ */
+function isDiagnosticArray(value: unknown): value is readonly ts.Diagnostic[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Parse one module, refusing a RECOVERED parse.
+ *
+ * `ts.createSourceFile` never throws: handed broken input it returns a partial
+ * tree with nodes silently missing. A reader whose comparison vanished reads as
+ * a module that depends on nothing, which is the direction this census must not
+ * fail in.
+ */
+function parseOrThrow(source: string, fileName: string): ts.SourceFile {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TS,
+  );
+  const raw: unknown = Reflect.get(sourceFile, 'parseDiagnostics');
+  const diagnostics: readonly ts.Diagnostic[] = isDiagnosticArray(raw) ? raw : [];
+  const first = diagnostics[0];
+  if (first !== undefined) {
+    const detail = ts.flattenDiagnosticMessageText(first.messageText, ' ');
+    throw new Error(
+      `event-reader-scanner: ${fileName} did not parse cleanly ` +
+        `(${diagnostics.length} syntax error(s); first: ${detail}). Refusing to report a reader ` +
+        `census derived from a recovered parse, which would under-report readers and read as a ` +
+        `module that depends on no event.`,
+    );
+  }
+  return sourceFile;
+}
+
+/** Strip `as const`, `satisfies T`, `<T>x`, `x!` and parentheses to the value beneath. */
+function unwrap(node: ts.Expression): ts.Expression {
+  let current = node;
+  for (;;) {
+    if (
+      ts.isAsExpression(current) ||
+      ts.isSatisfiesExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isParenthesizedExpression(current) ||
+      ts.isNonNullExpression(current)
+    ) {
+      current = current.expression;
+      continue;
+    }
+    return current;
+  }
+}
+
+/**
+ * Local name → the name it was imported under, for every named import in the
+ * file, so an aliased constant table still resolves against canonical paths.
+ */
+function collectImportAliases(sourceFile: ts.SourceFile): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings === undefined || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      aliases.set(element.name.text, (element.propertyName ?? element.name).text);
+    }
+  }
+  return aliases;
+}
+
+/**
+ * Every `const NAME = <expression>` in the file, at any nesting depth.
+ *
+ * Deliberately flat rather than scope-accurate: an over-broad binding table can
+ * only make a read MORE resolvable, and a same-named shadow resolving to a
+ * different type surfaces as a reader to examine — the fail-loud direction.
+ */
+function collectConstBindings(sourceFile: ts.SourceFile): Map<string, ts.Expression> {
+  const bindings = new Map<string, ts.Expression>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined &&
+      !bindings.has(node.name.text)
+    ) {
+      bindings.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return bindings;
+}
+
+interface ResolutionContext {
+  readonly aliases: ReadonlyMap<string, string>;
+  readonly bindings: ReadonlyMap<string, ts.Expression>;
+  readonly knownConstants: ReadonlyMap<string, string>;
+}
+
+/** The string an expression evaluates to, or `undefined` when undecidable. */
+function resolveString(
+  node: ts.Expression,
+  ctx: ResolutionContext,
+  seen: ReadonlySet<string> = new Set(),
+): string | undefined {
+  const expr = unwrap(node);
+
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) {
+    return expr.text;
+  }
+
+  // `TABLE.MEMBER` — an exported constant table the census supplied, reached
+  // under whatever local name this file imported it as.
+  if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.expression)) {
+    const local = expr.expression.text;
+    const canonical = ctx.aliases.get(local) ?? local;
+    const viaKnown = ctx.knownConstants.get(`${canonical}.${expr.name.text}`);
+    if (viaKnown !== undefined) return viaKnown;
+    const declared = ctx.bindings.get(local);
+    if (declared !== undefined && !seen.has(local)) {
+      const object = unwrap(declared);
+      if (ts.isObjectLiteralExpression(object)) {
+        const member = ownProperty(object, expr.name.text);
+        if (member !== undefined) {
+          return resolveString(member, ctx, new Set([...seen, local]));
+        }
+      }
+    }
+    return undefined;
+  }
+
+  // A plain identifier bound to a literal (or to another identifier that is).
+  if (ts.isIdentifier(expr) && !seen.has(expr.text)) {
+    const bound = ctx.bindings.get(expr.text);
+    if (bound !== undefined) {
+      return resolveString(bound, ctx, new Set([...seen, expr.text]));
+    }
+  }
+
+  return undefined;
+}
+
+/** The last own-property initializer for `name`, ignoring spreads. */
+function ownProperty(
+  object: ts.ObjectLiteralExpression,
+  name: string,
+): ts.Expression | undefined {
+  let found: ts.Expression | undefined;
+  for (const property of object.properties) {
+    if (
+      ts.isPropertyAssignment(property) &&
+      (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) &&
+      property.name.text === name
+    ) {
+      found = property.initializer;
+    } else if (ts.isShorthandPropertyAssignment(property) && property.name.text === name) {
+      found = property.name;
+    }
+  }
+  return found;
+}
+
+/** The object literal an argument denotes, inline or hoisted into a `const`. */
+function asObjectLiteral(
+  node: ts.Expression,
+  ctx: ResolutionContext,
+): ts.ObjectLiteralExpression | undefined {
+  const expr = unwrap(node);
+  if (ts.isObjectLiteralExpression(expr)) return expr;
+  if (ts.isIdentifier(expr)) {
+    const bound = ctx.bindings.get(expr.text);
+    if (bound !== undefined) {
+      const inner = unwrap(bound);
+      if (ts.isObjectLiteralExpression(inner)) return inner;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether an expression is the kind of thing an event-type discriminant is read
+ * from: `something.type`, or a bare `type` / `eventType` binding — the last
+ * spelling being live in this tree's own event tool surface.
+ */
+function isEventTypeReference(node: ts.Expression): boolean {
+  const expr = unwrap(node);
+  if (ts.isPropertyAccessExpression(expr)) return expr.name.text === 'type';
+  if (ts.isElementAccessExpression(expr)) {
+    const argument = unwrap(expr.argumentExpression);
+    return ts.isStringLiteral(argument) && argument.text === 'type';
+  }
+  if (ts.isIdentifier(expr)) return expr.text === 'type' || expr.text === 'eventType';
+  return false;
+}
+
+const COMPARISON_TOKENS: ReadonlySet<ts.SyntaxKind> = new Set([
+  ts.SyntaxKind.EqualsEqualsEqualsToken,
+  ts.SyntaxKind.ExclamationEqualsEqualsToken,
+  ts.SyntaxKind.EqualsEqualsToken,
+  ts.SyntaxKind.ExclamationEqualsToken,
+]);
+
+function lineOf(sourceFile: ts.SourceFile, node: ts.Node): number {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+/**
+ * Every fold-external read of an event type in one module.
+ *
+ * `.append` is deliberately NOT inspected: an append is a write, and a census
+ * that counted it would report every emitter as a dependency on its own event.
+ */
+export const scanEventReaders: EventReaderScanner = (
+  source: string,
+  options: EventReaderScanOptions,
+): readonly EventReaderSite[] => {
+  const fileName = options.fileName ?? 'module.ts';
+  const sourceFile = parseOrThrow(source, fileName);
+  const ctx: ResolutionContext = {
+    aliases: collectImportAliases(sourceFile),
+    bindings: collectConstBindings(sourceFile),
+    knownConstants: options.knownConstants,
+  };
+
+  const sites: EventReaderSite[] = [];
+
+  const visitQuery = (node: ts.CallExpression, method: string): void => {
+    const line = lineOf(sourceFile, node);
+    if (method === 'queryByType') {
+      const first = node.arguments[0];
+      sites.push({
+        line,
+        kind: 'query-discriminant',
+        discriminant: first === undefined ? undefined : resolveString(first, ctx),
+      });
+      return;
+    }
+    // `.query(streamId, filters?)` — the filter bag is the second argument.
+    const filters = node.arguments[1];
+    if (filters === undefined) {
+      sites.push({ line, kind: 'unscoped-query', discriminant: undefined });
+      return;
+    }
+    const object = asObjectLiteral(filters, ctx);
+    const typeProperty = object === undefined ? undefined : ownProperty(object, 'type');
+    if (object !== undefined && typeProperty === undefined) {
+      // A readable filter bag that narrows by anything except type still reads
+      // the whole type universe.
+      sites.push({ line, kind: 'unscoped-query', discriminant: undefined });
+      return;
+    }
+    sites.push({
+      line,
+      kind: 'query-discriminant',
+      discriminant: typeProperty === undefined ? undefined : resolveString(typeProperty, ctx),
+    });
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const method = node.expression.name.text;
+      if (method === 'query' || method === 'queryByType') visitQuery(node, method);
+    }
+
+    if (ts.isBinaryExpression(node) && COMPARISON_TOKENS.has(node.operatorToken.kind)) {
+      const left = unwrap(node.left);
+      const right = unwrap(node.right);
+      const subject = isEventTypeReference(left) ? right : isEventTypeReference(right) ? left : undefined;
+      if (subject !== undefined) {
+        sites.push({
+          line: lineOf(sourceFile, node),
+          kind: 'type-comparison',
+          discriminant: resolveString(subject, ctx),
+        });
+      }
+    }
+
+    if (ts.isSwitchStatement(node) && isEventTypeReference(node.expression)) {
+      for (const clause of node.caseBlock.clauses) {
+        if (!ts.isCaseClause(clause)) continue;
+        sites.push({
+          line: lineOf(sourceFile, clause),
+          kind: 'switch-case',
+          discriminant: resolveString(clause.expression, ctx),
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return sites;
+};

--- a/tools/test-helpers/event-reader-scanner.ts
+++ b/tools/test-helpers/event-reader-scanner.ts
@@ -23,7 +23,16 @@
 //   • `store.query(id, { type: X })` / `store.queryByType(X, …)`;
 //   • `event.type === 'x'`, `e.type !== 'x'`, and the bare `type` / `eventType`
 //     identifiers the same comparison is written with elsewhere;
-//   • `case 'x':` on a switch whose discriminant is one of those shapes.
+//   • `case 'x':` on a switch whose discriminant is one of those shapes;
+//   • `SET.has(event.type)` / `ARRAY.includes(event.type)` — a membership test
+//     against a collection of type literals reads every literal in it;
+//   • `event.type.startsWith('family.')` — a family filter reads the whole
+//     family, and the census expands the prefix against the catalog.
+//
+// The last two are not decoration. Four shipped modules spell their read that
+// way, including a gate whose verdict and a saga verifier whose pass/fail are
+// functions of the types they name; a grammar covering only comparisons reported
+// them as depending on no event at all, which is the fail-open direction.
 //
 // A query call carrying no type filter is reported as an UNSCOPED read rather
 // than as nothing: it depends on the whole type universe, and calling that
@@ -209,6 +218,41 @@ function ownProperty(
   return found;
 }
 
+/**
+ * The list of strings a collection expression denotes, or `undefined` when the
+ * collection is a runtime value.
+ *
+ * `undefined` and `[]` are deliberately different answers: an unresolvable
+ * receiver is reported as an unresolved read, while a receiver that genuinely
+ * holds no literal reads nothing. Handles an array literal, a `new Set([…])`,
+ * and either of those reached through a `const` binding.
+ */
+function resolveStringList(
+  node: ts.Expression,
+  ctx: ResolutionContext,
+  seen: ReadonlySet<string> = new Set(),
+): readonly (string | undefined)[] | undefined {
+  const expr = unwrap(node);
+
+  if (ts.isArrayLiteralExpression(expr)) {
+    return expr.elements.map((element) => resolveString(element, ctx, seen));
+  }
+
+  if (ts.isNewExpression(expr) && ts.isIdentifier(expr.expression) && expr.expression.text === 'Set') {
+    const first = expr.arguments?.[0];
+    return first === undefined ? [] : resolveStringList(first, ctx, seen);
+  }
+
+  if (ts.isIdentifier(expr) && !seen.has(expr.text)) {
+    const bound = ctx.bindings.get(expr.text);
+    if (bound !== undefined) {
+      return resolveStringList(bound, ctx, new Set([...seen, expr.text]));
+    }
+  }
+
+  return undefined;
+}
+
 /** The object literal an argument denotes, inline or hoisted into a `const`. */
 function asObjectLiteral(
   node: ts.Expression,
@@ -305,10 +349,43 @@ export const scanEventReaders: EventReaderScanner = (
     });
   };
 
+  /**
+   * `RECEIVER.has(event.type)` / `RECEIVER.includes(event.type)` — the receiver
+   * is the vocabulary, so every literal in it is read at this site. An
+   * unresolvable receiver yields ONE unresolved site rather than nothing: a
+   * runtime-built set is a read the census could not decode, not an absence.
+   */
+  const visitMembership = (node: ts.CallExpression, receiver: ts.Expression): void => {
+    const argument = node.arguments[0];
+    if (argument === undefined || !isEventTypeReference(argument)) return;
+    const line = lineOf(sourceFile, node);
+    const members = resolveStringList(receiver, ctx);
+    if (members === undefined) {
+      sites.push({ line, kind: 'membership-test', discriminant: undefined });
+      return;
+    }
+    for (const member of members) {
+      sites.push({ line, kind: 'membership-test', discriminant: member });
+    }
+  };
+
   const visit = (node: ts.Node): void => {
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
       const method = node.expression.name.text;
       if (method === 'query' || method === 'queryByType') visitQuery(node, method);
+      if (method === 'has' || method === 'includes') {
+        visitMembership(node, node.expression.expression);
+      }
+      if (method === 'startsWith' && isEventTypeReference(node.expression.expression)) {
+        const argument = node.arguments[0];
+        const prefix = argument === undefined ? undefined : resolveString(argument, ctx);
+        sites.push({
+          line: lineOf(sourceFile, node),
+          kind: 'prefix-filter',
+          // The census owns the expansion — only it knows the catalog.
+          discriminant: prefix === undefined || prefix === '' ? undefined : prefix,
+        });
+      }
     }
 
     if (ts.isBinaryExpression(node) && COMPARISON_TOKENS.has(node.operatorToken.kind)) {


### PR DESCRIPTION
## Summary

Third slice of the #1876 event-authority decision: the explicit, derived **governance / telemetry partition** over the 178-type event catalog, plus the standing oracles the decision names as its acceptance criterion (differential fold, fold-external raw-reader census, action-contract conjunct). Green against today's tree. No event type is added or retired, no fact moves to bundle custody, and nothing in production reads the map yet.

Classification predicate, as ratified: an event is **governance** iff the projection folds it OR a fold-external correctness-bearing reader re-reads it raw. The derivation starts from the emission tier (`auto` → governance) and is **promotion-only**: a witness can lift a `model`/`hook` event to governance on named evidence, never demote an `auto` one. A scanner gap can therefore only over-retain, never silently drop a load-bearing event.

Refs #1876 · #1856 · #1875. Slice 1 was #1883, slice 2 was #1885.

## Changes

- `src/events/partition/` (new subdirectory — `src/events` sits at the locality cap)
  - `authority.ts` — `deriveEventAuthority` / `partitionByAuthority`, fail-closed like `deriveEmissionRegistry`: empty population, unannotated type, stale witness key and dead-cover witness (witnessing an already-`auto` type) all throw at load.
  - `witnesses.ts` — the declaration table: one row per promoted type with its arm (`projection-fold`, `raw-reader`, `gate-expectation`, `charter-pin`) and file evidence. **Every arm is re-measured by a test**; the charter-pin arm's negative claim (no fold, no reader, no expectation row) is checked in both directions.
  - `event-authority.ts` — the live eager binding: `EVENT_AUTHORITY`, `GOVERNANCE_EVENTS`, `TELEMETRY_EVENTS`, `classifyEventAuthority`. Carries a `RESERVED` header because no production importer exists yet, by design.
  - `reader-census.ts` — census policy over the fold-external readers.
- `tools/test-helpers/event-reader-scanner.ts` — TypeScript-compiler scan of every module outside `src/projections` that reads `state._events` or queries the store, extracting the event names it depends on. Grammar covers equality, `switch` cases, query `type` filters, **membership tests** (`Set.has`, `includes`) and **family prefixes** (`startsWith('team.')`, expanded against the catalog).
- `tools/test-helpers/event-payload-sample.ts` — per-type payload generation from each event's data schema (array floors, tuple positions, string formats, digest patterns), so the differential-fold corpus exercises every mutating fold arm instead of `data: {}`. Every schema-sourced payload is validated under its own schema by `DifferentialFold_CorpusPayloads_ValidateUnderTheirOwnSchemas`; refinement-only constraints are overridden explicitly.
- `src/registry/action-contract.ts` — `contractEnsuredEventsOf` (event names an `ensures` block cites), re-exported.
- Tests (19 cases, spliced in place into `tools/audit/test-inventory-baseline.json`):
  - `tests/unit/events/event-authority-partition.test.ts` — differential fold (governance-filtered fold ≡ full fold; telemetry set non-empty and derived; corpus discriminating power asserted), the four fail-closed throws, and the **pinned shrink-only charter backlog** (below).
  - `tests/architecture/event-authority-raw-readers.test.ts` — census with a git-corroborated denominator (631 modules scanned, 65 event reads resolved), separate `unresolved` / `unscopedFolds` buckets, and a seeded violation that is a **module on disk** walked by the real scanner, so a grammar gap reddens rather than passing.
  - `tests/architecture/event-authority-contracts.test.ts` — every event an `ActionContract` `ensures`/`emissions` block or the `PHASE_EXPECTED_EVENTS` table names is governance; per-arm non-empty floors (an arm collapsing to `[]` is a named failure).
- `tools/audit/guard-liveness-baseline.json`, `tools/audit/reference-census.json` — re-measured with the new modules; monotone diffs.

### What the oracles found on the live tree (folded into the classification)

- `stack.submitted`, `team.task.completed`, `team.task.failed` were telemetry by tier while shipped code decides on them (`check-event-emissions.ts` derives a gate verdict from the expectation table; `verify-delegation-saga.ts` rules on team events after disband). Promoted with evidence.
- `task.assigned` is folded by the canonical projection (a task row is appended), so its row is `projection-fold`, not a charter pin.

### Disclosed divergence from the decision record's telemetry examples

The record names `tool.*`, `turn.completed`, `subagent.tokens_used`, `launch.executing_started`, `team.*`, `shepherd.iteration`, `stack.submitted` as telemetry examples. The derivation classifies 16 of them governance today: some carry a live fold-external reader (a demotion would be false), the rest derive `auto` from a substrate tier that the promotion-only rule will not override. The record schedules those flips as later, independently-landable per-event work, each deleting its expectation/description rows in the same commit. That gap is pinned as an exact list (`CharterTension_TelemetryExamplesStillClassifiedGovernance_AreThePinnedBacklog`), so each flip edits the pin as a visible shrink and any new disagreement is a named failure.

Known limit, stated and not closed: "the projection folds it" means the canonical workflow-state fold. A secondary view can still derive a verdict from a telemetry-classified event (e.g. `synthesis-readiness-view` on `test.result`). Widening the fold arm to secondary views is follow-up work.

## Test Plan

- [x] `npm run typecheck` (root, conformance, tests) green
- [x] `npx vitest run --project core tests/unit/events` — 1028 passed
- [x] `npx vitest run --project unit tests/architecture` — 267 passed; the one failure (`worktree-inventory`) is the author-machine live-worktree count and `skipIf`s in CI; untouched by this diff
- [x] Kill probes, each observed red then restored: delete a raw-reader witness → named; repoint a witness → named; break the membership-read grammar → on-disk seeded module named; empty the payload sampler → discriminating-power assertion red; `contractEnsuredEventsOf` → `[]` → per-arm floor red; relabel `task.assigned` as charter-pin → arm re-measurement red
- [x] Built by workflow: 3 recon → design → implement → 3 adversarial verifiers (vacuity / decision conformance / guards) → fixer → independent re-verification of the fix commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
