### PR TITLE
feat(events): first charter-backed event-authority flips — demotion arm, six runtime-telemetry rows, stack.submitted leaves the emission gate (#1888 item 6)

### DIFF
--- a/content/synthesis/skills/synthesize/SKILL.md
+++ b/content/synthesis/skills/synthesize/SKILL.md
@@ -163,9 +163,9 @@ For merge ordering strategy, see `references/merge-ordering.md`.
 - **'feedback'** -- Route to `shepherd [PR_URL]` to address comments, then return here
 - **'no'** -- Pause workflow; resume later with `rehydrate`
 
-### Event Emissions (REQUIRED)
+### Event Emissions
 
-After PRs are created and auto-merge is enabled, emit the `stack.submitted` event:
+After PRs are created and auto-merge is enabled, record the submission with a `stack.submitted` event. This is a telemetry record of what went up — nothing decides anything from it, and `check-event-emissions` does not ask for it:
 
 ```typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -177,7 +177,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-During shepherd iterations (CI monitoring loop), emit after each assessment:
+During shepherd iterations (CI monitoring loop), emit after each assessment (REQUIRED — the escalation policy counts these events to bound the loop):
 
 ```typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -191,7 +191,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-These events are checked by `check-event-emissions` during workflow validation. Missing emissions will trigger warnings.
+`shepherd.iteration`, together with `team.spawned` and `team.disbanded`, is checked by `check-event-emissions` during workflow validation. A missing one triggers a warning; `stack.submitted` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/content/synthesis/skills/synthesize/SKILL.md
+++ b/content/synthesis/skills/synthesize/SKILL.md
@@ -191,7 +191,9 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-`shepherd.iteration`, together with `team.spawned` and `team.disbanded`, is checked by `check-event-emissions` during workflow validation. A missing one triggers a warning; `stack.submitted` is not checked.
+Checked by `check-event-emissions` in this phase: `team.spawned`, `team.disbanded`, `shepherd.iteration`.
+
+A missing one comes back as a hint with `complete: false` — on the explicit gate call, and on the `_eventHints` field the telemetry middleware adds to tool results while hints are outstanding. `stack.submitted` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/rendered/skills/standard/synthesize/SKILL.md
+++ b/rendered/skills/standard/synthesize/SKILL.md
@@ -163,9 +163,9 @@ For merge ordering strategy, see `references/merge-ordering.md`.
 - **'feedback'** -- Route to `shepherd [PR_URL]` to address comments, then return here
 - **'no'** -- Pause workflow; resume later with `rehydrate`
 
-### Event Emissions (REQUIRED)
+### Event Emissions
 
-After PRs are created and auto-merge is enabled, emit the `stack.submitted` event:
+After PRs are created and auto-merge is enabled, record the submission with a `stack.submitted` event. This is a telemetry record of what went up — nothing decides anything from it, and `check-event-emissions` does not ask for it:
 
 ```typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -177,7 +177,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-During shepherd iterations (CI monitoring loop), emit after each assessment:
+During shepherd iterations (CI monitoring loop), emit after each assessment (REQUIRED — the escalation policy counts these events to bound the loop):
 
 ```typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -191,7 +191,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-These events are checked by `check-event-emissions` during workflow validation. Missing emissions will trigger warnings.
+`shepherd.iteration`, together with `team.spawned` and `team.disbanded`, is checked by `check-event-emissions` during workflow validation. A missing one triggers a warning; `stack.submitted` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/rendered/skills/standard/synthesize/SKILL.md
+++ b/rendered/skills/standard/synthesize/SKILL.md
@@ -191,7 +191,9 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-`shepherd.iteration`, together with `team.spawned` and `team.disbanded`, is checked by `check-event-emissions` during workflow validation. A missing one triggers a warning; `stack.submitted` is not checked.
+Checked by `check-event-emissions` in this phase: `team.spawned`, `team.disbanded`, `shepherd.iteration`.
+
+A missing one comes back as a hint with `complete: false` — on the explicit gate call, and on the `_eventHints` field the telemetry middleware adds to tool results while hints are outstanding. `stack.submitted` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/src/events/partition/authority.ts
+++ b/src/events/partition/authority.ts
@@ -49,10 +49,17 @@
  * over-retains; it never demotes anything by itself.
  *
  * The judgment has to be made against the tree, not the charter text. The
- * decision record listed `launch.executing_started` beside the hook-tier
- * self-reports; on the tree it is the START claim of the launch liveness pair,
- * which `ps` and the phantom-launch heal pair against through the operations
- * fold — a dependency the reader census cannot see. It stays governance.
+ * decision record listed `launch.executing_started` beside
+ * `subagent.tokens_used` as `hook`-tier self-reports. On the tree neither is
+ * `hook` tier — the one tier that derives `hook` has no members, and both are
+ * `capability`, so `auto` — which is the only reason the token self-report's
+ * demotion row is admissible at all. And the launch START claim is not a
+ * self-report: the launch liveness descriptor pairs it with its terminal, and
+ * the `worktrees@v1` reducer reads it raw for `ps` and the phantom-launch heal.
+ * The reader census names that reducer and the declaration conjunct's liveness
+ * arm names the descriptor, so a demotion row for it would be red twice. It
+ * stays governance; the token self-report, which neither instrument names, is
+ * demoted.
  *
  * ── The map still disagrees with the charter's telemetry examples ───────────
  *
@@ -125,17 +132,33 @@ export interface AuthorityWitness {
 }
 
 /**
+ * A comment on the roadmap issue — the only place a charter act is made. The
+ * issue number is part of the type: a comment anywhere else is not an act, and
+ * an anchor that is not a comment id is not a citation.
+ */
+export type CharterActUrl =
+  `https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-${number}`;
+
+/** A comment on the event-authority decision issue, where the record was ratified. */
+export type DecisionRecordCitation =
+  `https://github.com/lvlup-sw/exarchos/issues/1876#issuecomment-${number}`;
+
+/**
  * Why a type whose tier makes it governance is telemetry anyway.
  *
  * There is no arm to choose: a demotion has exactly one basis, the charter act
- * that ordered the flip, executing the ratified decision. The evidence names
- * both. The `because` states what was read on the tree to make the judgment —
- * which views fold the type, and that nothing outside them does — so a reviewer
- * can re-read the same places rather than trust the row.
+ * that ordered the flip, executing the ratified decision. Both citations are
+ * typed rather than free strings, so a row cannot point at a placeholder or at
+ * the wrong issue and still compile. The `because` states what was read on the
+ * tree to make the judgment — which views fold the type, and that nothing
+ * outside them does — so a reviewer can re-read the same places rather than
+ * trust the row.
  */
 export interface CharterDemotion {
-  /** The charter act on the roadmap, then the decision record it executes. */
-  readonly evidence: readonly [string, ...string[]];
+  /** The charter act on the roadmap that ordered THIS flip. */
+  readonly act: CharterActUrl;
+  /** The ratified decision the act executes. */
+  readonly record: DecisionRecordCitation;
   readonly because: string;
 }
 
@@ -154,9 +177,10 @@ export interface CharterDemotion {
  *     produces.
  *   • **Unannotated type.** No tier, no derivable authority. Defaulting it
  *     would be the guess this derivation exists to remove.
- *   • **Witness or demotion for a type outside the population.** A renamed or
- *     deleted event leaves its row behind, still asserting an override for
- *     nothing.
+ *   • **Witness for a type outside the population.** A renamed or deleted
+ *     event leaves its row behind, still asserting a promotion of nothing.
+ *   • **Demotion for a type outside the population.** The same stale row in
+ *     the other table, still citing a charter act for a type that is gone.
  *   • **Witness AND demotion on one type.** The two tables contradict each
  *     other, and picking either silently would hide a flip that a new reader
  *     has since overtaken — or a reader that a flip has since orphaned.

--- a/src/events/partition/authority.ts
+++ b/src/events/partition/authority.ts
@@ -24,32 +24,49 @@
  * answer before its first append is ever written. Authority is a property of
  * what the event is welded to, and lifecycle does not change that.
  *
- * ── Promotion only, never demotion ──────────────────────────────────────────
+ * ── Promotion by witness; demotion by charter act only ──────────────────────
  *
- * A type whose tier derives `auto` is governance and stays governance, even
- * when nothing here is known to fold or read it. Only the other direction is
- * open: a witness may promote a non-`auto` type.
+ * The tier gives a starting answer — `auto` is governance, anything else is
+ * telemetry — and two hand-written tables override it in opposite directions.
+ * Neither direction is open to an instrument on its own.
  *
- * The reason is about what the instruments can prove. A demotion asserts
- * "nothing depends on this event" — a universal claim. The fold measurement and
- * the raw-reader census are sufficient to justify a PROMOTION, because a single
- * observed fold or reader is a witness; their completeness is not yet proved,
- * and a static scanner has an acknowledged blind spot (a bare fold whose type
- * comparison happens in another module). So a gap in either instrument can only
- * make this map over-retain, never silently demote.
+ * A WITNESS promotes a non-`auto` type. A single observed fold arm or raw
+ * reader is sufficient evidence for that, so a witness carries the module it
+ * cites and an oracle re-measures it against the tree.
  *
- * ── The map disagrees with the charter's telemetry examples, on purpose ──────
+ * A DEMOTION files an `auto` type as telemetry. That asserts "nothing depends
+ * on this event" — a universal claim no instrument here can prove: the fold
+ * measurement covers one projection, and the reader census has an acknowledged
+ * blind spot (a table entry such as a liveness descriptor, or a bare fold whose
+ * type comparison happens in another module). So a demotion is never derived
+ * from a measurement. It is a JUDGMENT made by reading the tree, ordered by the
+ * ratified charter and recorded as a charter act on the roadmap, and every row
+ * carries that citation. What the instruments CAN do is re-measure the judgment
+ * in the direction they are good at: once a type is telemetry, a fold arm that
+ * mutates, a raw reader the census sees, a contract that promises it, an
+ * expectation or description row that names it, or a liveness descriptor that
+ * pairs on it is a named failure. A gap in an instrument therefore still only
+ * over-retains; it never demotes anything by itself.
+ *
+ * The judgment has to be made against the tree, not the charter text. The
+ * decision record listed `launch.executing_started` beside the hook-tier
+ * self-reports; on the tree it is the START claim of the launch liveness pair,
+ * which `ps` and the phantom-launch heal pair against through the operations
+ * fold — a dependency the reader census cannot see. It stays governance.
+ *
+ * ── The map still disagrees with the charter's telemetry examples ───────────
  *
  * The ratified decision lists example telemetry types — the tool and turn
  * families, the team family, `shepherd.iteration`, `stack.submitted`,
- * `subagent.tokens_used`, `launch.executing_started`. Most of them classify
- * GOVERNANCE here. Two distinct reasons, and neither is an oversight:
+ * `subagent.tokens_used`, `launch.executing_started`. The per-tool and turn
+ * records and the token self-report are demoted; `stack.submitted` left the
+ * emission gate's expectation table and is telemetry by tier. The rest still
+ * classify GOVERNANCE here, each for a measured reason:
  *
- *   • several carry a live fold-external reader today, so demoting them would
- *     be a false statement — the charter itself sequences each flip as its own
- *     change that retires the reader and deletes the expectation row with it;
- *   • the rest derive `auto` from a substrate tier, and the promotion-only rule
- *     refuses to override that with an instrument that cannot prove absence.
+ *   • the team family, `shepherd.iteration` and `launch.executing_started`
+ *     carry a live fold arm, raw reader or liveness pairing today, so demoting
+ *     them would be a false statement — the charter sequences each flip as its
+ *     own change that retires the reader first.
  *
  * That disagreement is a BACKLOG, not a footnote, so it is counted rather than
  * described: the partition's own test pins the exact set of charter-named
@@ -66,9 +83,9 @@
  * ── Fail-closed, and by name ────────────────────────────────────────────────
  *
  * Built like `deriveEmissionRegistry`: a pure function over an injected
- * population and an injected lookup, so a probe can derive over a seeded
- * catalog without touching the live tables, and every refusal NAMES its
- * offenders rather than reporting a count.
+ * population and injected tables, so a probe can derive over a seeded catalog
+ * without touching the live tables, and every refusal NAMES its offenders
+ * rather than reporting a count.
  */
 
 import type { EmissionSource } from '../event-registration.js';
@@ -108,12 +125,28 @@ export interface AuthorityWitness {
 }
 
 /**
+ * Why a type whose tier makes it governance is telemetry anyway.
+ *
+ * There is no arm to choose: a demotion has exactly one basis, the charter act
+ * that ordered the flip, executing the ratified decision. The evidence names
+ * both. The `because` states what was read on the tree to make the judgment —
+ * which views fold the type, and that nothing outside them does — so a reviewer
+ * can re-read the same places rather than trust the row.
+ */
+export interface CharterDemotion {
+  /** The charter act on the roadmap, then the decision record it executes. */
+  readonly evidence: readonly [string, ...string[]];
+  readonly because: string;
+}
+
+/**
  * Partition a population of event types into governance and telemetry.
  *
- * The rule is one line and total: a type is `governance` iff its tier derives
- * `auto` OR it carries a witness; otherwise it is `telemetry`.
+ * The rule is one line and total: a type is `governance` iff it carries a
+ * witness, OR its tier derives `auto` and it carries no demotion; otherwise it
+ * is `telemetry`.
  *
- * Four refusals, each because the alternative is a map that reads clean while
+ * Seven refusals, each because the alternative is a map that reads clean while
  * saying nothing:
  *
  *   • **Empty population.** An empty map reads to every consumer as "no event
@@ -121,20 +154,30 @@ export interface AuthorityWitness {
  *     produces.
  *   • **Unannotated type.** No tier, no derivable authority. Defaulting it
  *     would be the guess this derivation exists to remove.
- *   • **Witness for a type outside the population.** A renamed or deleted event
- *     leaves its witness behind, still asserting a promotion for nothing.
+ *   • **Witness or demotion for a type outside the population.** A renamed or
+ *     deleted event leaves its row behind, still asserting an override for
+ *     nothing.
+ *   • **Witness AND demotion on one type.** The two tables contradict each
+ *     other, and picking either silently would hide a flip that a new reader
+ *     has since overtaken — or a reader that a flip has since orphaned.
  *   • **Witness on a type the tier already makes governance.** Dead cover: the
  *     declaration changes no answer, so it cannot be checked by anything, and a
  *     later re-tiering would silently start relying on it.
+ *   • **Demotion on a type the tier already makes telemetry.** The same dead
+ *     cover in the other direction — the tier answers telemetry with or without
+ *     the row, so the row is a charter citation nothing exercises.
  */
 export function deriveEventAuthority(
   eventTypes: Iterable<string>,
   tierSourceOf: (eventType: string) => EmissionSource | undefined,
   witnesses: Readonly<Record<string, AuthorityWitness>>,
+  demotions: Readonly<Record<string, CharterDemotion>> = {},
 ): Record<string, EventAuthority> {
   const derived: Record<string, EventAuthority> = {};
   const unannotated: string[] = [];
-  const deadCover: string[] = [];
+  const contradicted: string[] = [];
+  const deadCoverWitnesses: string[] = [];
+  const deadCoverDemotions: string[] = [];
   let population = 0;
 
   for (const eventType of eventTypes) {
@@ -145,11 +188,17 @@ export function deriveEventAuthority(
       continue;
     }
     const witness = witnesses[eventType];
-    if (tierSource === 'auto') {
-      if (witness !== undefined) deadCover.push(eventType);
-      derived[eventType] = 'governance';
+    const demotion = demotions[eventType];
+    if (witness !== undefined && demotion !== undefined) {
+      contradicted.push(eventType);
       continue;
     }
+    if (tierSource === 'auto') {
+      if (witness !== undefined) deadCoverWitnesses.push(eventType);
+      derived[eventType] = demotion === undefined ? 'governance' : 'telemetry';
+      continue;
+    }
+    if (demotion !== undefined) deadCoverDemotions.push(eventType);
     derived[eventType] = witness === undefined ? 'telemetry' : 'governance';
   }
 
@@ -168,19 +217,47 @@ export function deriveEventAuthority(
     );
   }
 
-  const stale = Object.keys(witnesses).filter((eventType) => derived[eventType] === undefined);
-  if (stale.length > 0) {
+  const inPopulation = (eventType: string): boolean =>
+    derived[eventType] !== undefined || contradicted.includes(eventType);
+  const staleWitnesses = Object.keys(witnesses).filter((eventType) => !inPopulation(eventType));
+  if (staleWitnesses.length > 0) {
     throw new Error(
-      `deriveEventAuthority: ${stale.length} governance witness(es) name an event type that is ` +
-        `not in the population: ${stale.sort().join(', ')}. A witness for a renamed or deleted ` +
-        'type promotes nothing and must be removed with the type.',
+      `deriveEventAuthority: ${staleWitnesses.length} governance witness(es) name an event type ` +
+        `that is not in the population: ${staleWitnesses.sort().join(', ')}. A witness for a ` +
+        'renamed or deleted type promotes nothing and must be removed with the type.',
     );
   }
-  if (deadCover.length > 0) {
+  const staleDemotions = Object.keys(demotions).filter((eventType) => !inPopulation(eventType));
+  if (staleDemotions.length > 0) {
     throw new Error(
-      `deriveEventAuthority: ${deadCover.length} governance witness(es) cover a type whose tier ` +
-        `already derives governance: ${deadCover.sort().join(', ')}. The declaration changes no ` +
-        'answer, so nothing can check it — delete it, or re-tier the event if the tier is wrong.',
+      `deriveEventAuthority: ${staleDemotions.length} charter demotion(s) name an event type ` +
+        `that is not in the population: ${staleDemotions.sort().join(', ')}. A demotion for a ` +
+        'renamed or deleted type demotes nothing and must be removed with the type.',
+    );
+  }
+  if (contradicted.length > 0) {
+    throw new Error(
+      `deriveEventAuthority: ${contradicted.length} event type(s) carry BOTH a governance ` +
+        `witness and a charter demotion: ${contradicted.sort().join(', ')}. The tables ` +
+        'contradict each other — either the flip was overtaken by a new reader, in which case ' +
+        'the demotion is false and must go, or the reader the witness cites was retired for the ' +
+        'flip, in which case the witness must go. Neither is decided here.',
+    );
+  }
+  if (deadCoverWitnesses.length > 0) {
+    throw new Error(
+      `deriveEventAuthority: ${deadCoverWitnesses.length} governance witness(es) cover a type ` +
+        `whose tier already derives governance: ${deadCoverWitnesses.sort().join(', ')}. The ` +
+        'declaration changes no answer, so nothing can check it — delete it, or re-tier the ' +
+        'event if the tier is wrong.',
+    );
+  }
+  if (deadCoverDemotions.length > 0) {
+    throw new Error(
+      `deriveEventAuthority: ${deadCoverDemotions.length} charter demotion(s) cover a type ` +
+        `whose tier already derives telemetry: ${deadCoverDemotions.sort().join(', ')}. The ` +
+        'row changes no answer, so nothing can check it — delete it; a type that is telemetry ' +
+        'by tier needs no charter act to stay so.',
     );
   }
 

--- a/src/events/partition/demotions.ts
+++ b/src/events/partition/demotions.ts
@@ -1,0 +1,91 @@
+/**
+ * Every demotion of an `auto`-tier event type to telemetry, with the charter
+ * act that ordered it.
+ *
+ * A row here says: the tier alone would file this event as governance, and
+ * that is wrong, because nothing decides anything from it — and a charter act
+ * on the roadmap has said so. This is the mirror of the witness table, and it
+ * is the ONLY place a type leaves governance: the derivation never demotes on
+ * the strength of a measurement, because no instrument here can prove that
+ * nothing reads an event (see the module header in `authority.ts`).
+ *
+ * What a row is held to, once it is here:
+ *
+ *   • the differential fold proves the canonical arm is identity — a demoted
+ *     type that changed the folded state is named;
+ *   • the raw-reader census proves no fold-external module names it — a reader
+ *     that appears later is a violation, not a re-classification;
+ *   • the declaration conjunct proves no contract promises it, no expectation
+ *     or description row instructs the model to emit it, and no liveness
+ *     descriptor pairs on it;
+ *   • the derivation refuses a row for a type outside the catalog, for a type
+ *     whose tier is already telemetry, and for a type that also carries a
+ *     witness — the last is the shape a flip takes when a new reader overtakes
+ *     it, and it is a load-time throw rather than a silent winner.
+ *
+ * None of those proves the demotion right. Each proves that a way of being
+ * wrong would be named. The judgment itself was made by reading the tree, and
+ * `because` records what was read so the next reader can re-read it.
+ *
+ * Every row cites the charter act first and the decision record second: the
+ * act is what made THIS flip land, the record is the standing decision it
+ * executes. A demotion of a type the charter never named would be a new
+ * decision, not a flip, and the partition's test refuses it by name.
+ */
+
+import type { CharterDemotion } from './authority.js';
+
+const DECISION_RECORD = 'lvlup-sw/exarchos#1876 ratified event-authority decision record';
+
+/**
+ * The roadmap comment that ordered these flips. The tracker (#1888, item 6)
+ * requires the charter act to precede the PR that lands the flip, so the
+ * citation is to the act, not to the PR.
+ */
+const CHARTER_ACT =
+  'lvlup-sw/exarchos#1599 charter act 2026-09-05 — first event-authority flips (#1888 item 6): ' +
+  'https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-CHARTER_ACT_COMMENT_ID';
+
+const TOOL_RECORD =
+  'Appended once per dispatched call by the telemetry wrapper (projections/telemetry/middleware.ts) ' +
+  'and folded only by the `telemetry` view, which turns the family into per-tool latency, size ' +
+  'and error metrics. The canonical workflow-state arm is identity, no module outside the ' +
+  'projections names the type, and no contract, expectation row or liveness descriptor does. ' +
+  'The charter files per-tool records as runtime telemetry.';
+
+export const CHARTER_DEMOTIONS: Readonly<Record<string, CharterDemotion>> = Object.freeze({
+  'tool.invoked': {
+    evidence: [CHARTER_ACT, DECISION_RECORD],
+    because: TOOL_RECORD,
+  },
+  'tool.completed': {
+    evidence: [CHARTER_ACT, DECISION_RECORD],
+    because: TOOL_RECORD,
+  },
+  'tool.errored': {
+    evidence: [CHARTER_ACT, DECISION_RECORD],
+    because: TOOL_RECORD,
+  },
+  'tool.action_errored': {
+    evidence: [CHARTER_ACT, DECISION_RECORD],
+    because: TOOL_RECORD,
+  },
+  'turn.completed': {
+    evidence: [CHARTER_ACT, DECISION_RECORD],
+    because:
+      'A per-turn output-token aggregate the `telemetry` view folds into `view.turns` for the ' +
+      'quality-hint generators. Its lifecycle is `planned` — no producer exists yet — so nothing ' +
+      'can have come to depend on it; the canonical arm is identity and no reader names it. The ' +
+      'charter files turn records beside per-tool records as runtime telemetry.',
+  },
+  'subagent.tokens_used': {
+    evidence: [CHARTER_ACT, DECISION_RECORD],
+    because:
+      'Appended by the SubagentStop hook (lifecycle/subagent-stop.ts) after the subagent has ' +
+      'terminated, and folded by the delegation-timeline and team-performance views to attribute ' +
+      'output tokens to a task. The canonical arm is identity, no fold-external module reads it, ' +
+      'and the hook that appends it resolves the teammate from `team.task.assigned` and ' +
+      '`team.teammate.dispatched` — never from this type. The charter names it among the ' +
+      'worker-interior self-reports.',
+  },
+});

--- a/src/events/partition/demotions.ts
+++ b/src/events/partition/demotions.ts
@@ -95,7 +95,9 @@ const DECISION_RECORD_SHAPE =
  * seeded row carrying the placeholder can reach it from a test.
  */
 export function assertCharterCitations(
-  demotions: Readonly<Record<string, { readonly act: string; readonly record: string }>>,
+  demotions: Readonly<
+    Record<string, { readonly act: string; readonly record: string; readonly because?: string }>
+  >,
 ): void {
   const malformed = Object.entries(demotions)
     .filter(([, row]) => !CHARTER_ACT_SHAPE.test(row.act) || !DECISION_RECORD_SHAPE.test(row.record))

--- a/src/events/partition/demotions.ts
+++ b/src/events/partition/demotions.ts
@@ -13,15 +13,21 @@
  *
  *   • the differential fold proves the canonical arm is identity — a demoted
  *     type that changed the folded state is named;
- *   • the raw-reader census proves no fold-external module names it — a reader
- *     that appears later is a violation, not a re-classification;
+ *   • the raw-reader census proves no module under `src/` outside
+ *     `src/projections/` names it — a reader that appears later is a
+ *     violation, not a re-classification;
  *   • the declaration conjunct proves no contract promises it, no expectation
  *     or description row instructs the model to emit it, and no liveness
  *     descriptor pairs on it;
  *   • the derivation refuses a row for a type outside the catalog, for a type
  *     whose tier is already telemetry, and for a type that also carries a
  *     witness — the last is the shape a flip takes when a new reader overtakes
- *     it, and it is a load-time throw rather than a silent winner.
+ *     it, and it is a load-time throw rather than a silent winner;
+ *   • the citations are typed and re-checked at load: a row must point at a
+ *     comment on the roadmap and at a comment on the decision issue, so a
+ *     placeholder or a citation to the wrong issue fails to compile, and the
+ *     same shape is checked on the values in case a cast got a literal past
+ *     the compiler.
  *
  * None of those proves the demotion right. Each proves that a way of being
  * wrong would be named. The judgment itself was made by reading the tree, and
@@ -33,59 +39,121 @@
  * decision, not a flip, and the partition's test refuses it by name.
  */
 
-import type { CharterDemotion } from './authority.js';
-
-const DECISION_RECORD = 'lvlup-sw/exarchos#1876 ratified event-authority decision record';
+import type { EventType } from '../schemas.js';
+import type { CharterActUrl, CharterDemotion, DecisionRecordCitation } from './authority.js';
 
 /**
- * The roadmap comment that ordered these flips. The tracker (#1888, item 6)
- * requires the charter act to precede the PR that lands the flip, so the
- * citation is to the act, not to the PR.
+ * The roadmap comment that ordered these flips — the tracker requires the act
+ * to precede the PR that lands the flip, so the citation is to the act, not to
+ * the PR. Written as ONE literal so the compiler checks it against
+ * `CharterActUrl`: a concatenation widens to `string` and a placeholder anchor
+ * is not a comment id, and both fail to compile.
  */
-const CHARTER_ACT =
-  'lvlup-sw/exarchos#1599 charter act 2026-09-05 — first event-authority flips (#1888 item 6): ' +
-  'https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-CHARTER_ACT_COMMENT_ID';
+const CHARTER_ACT: CharterActUrl =
+  'https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-5555387087';
+
+/** The ratified event-authority decision record the act executes. */
+const DECISION_RECORD: DecisionRecordCitation =
+  'https://github.com/lvlup-sw/exarchos/issues/1876#issuecomment-5465417502';
+
+// ─── Compile-time self-tests ─────────────────────────────────────────────────
+//
+// Sited in a non-test source file deliberately: `tests/tsconfig.json` excludes
+// `tests/unit/**`, so a `@ts-expect-error` in the partition's own suite would be
+// checked by nothing. Same idiom as `registry/type-assertions.ts`.
+type ExpectTrue<T extends true> = T;
+type NotAssignableTo<A, B> = A extends B ? false : true;
+/** The placeholder anchor the first draft carried is not an act. @proof */
+export type _CharterActPlaceholderAnchorDoesNotCompile = ExpectTrue<
+  NotAssignableTo<
+    'https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-CHARTER_ACT_COMMENT_ID',
+    CharterActUrl
+  >
+>;
+/** A comment on any issue but the roadmap is not a charter act. @proof */
+export type _CharterActOnAnotherIssueDoesNotCompile = ExpectTrue<
+  NotAssignableTo<
+    'https://github.com/lvlup-sw/exarchos/issues/1888#issuecomment-5555387087',
+    CharterActUrl
+  >
+>;
+/** A bare issue reference is not the ratified record — the record is a comment. @proof */
+export type _DecisionRecordWithoutAnAnchorDoesNotCompile = ExpectTrue<
+  NotAssignableTo<'https://github.com/lvlup-sw/exarchos/issues/1876', DecisionRecordCitation>
+>;
+
+const CHARTER_ACT_SHAPE = /^https:\/\/github\.com\/lvlup-sw\/exarchos\/issues\/1599#issuecomment-\d+$/;
+const DECISION_RECORD_SHAPE =
+  /^https:\/\/github\.com\/lvlup-sw\/exarchos\/issues\/1876#issuecomment-\d+$/;
+
+/**
+ * Every row's two citations resolve to a comment on the issue the type names.
+ * The template-literal types prove that for every literal the compiler sees; a
+ * single `as` on a constant would get past them, and the repository's cast
+ * ratchet has room for one. So the same shape is checked once more at load, on
+ * the VALUES, and a row that fails names itself. Loosely typed on purpose so a
+ * seeded row carrying the placeholder can reach it from a test.
+ */
+export function assertCharterCitations(
+  demotions: Readonly<Record<string, { readonly act: string; readonly record: string }>>,
+): void {
+  const malformed = Object.entries(demotions)
+    .filter(([, row]) => !CHARTER_ACT_SHAPE.test(row.act) || !DECISION_RECORD_SHAPE.test(row.record))
+    .map(([type, row]) => `${type} (act: ${row.act}; record: ${row.record})`)
+    .sort();
+  if (malformed.length > 0) {
+    throw new Error(
+      `CHARTER_DEMOTIONS: ${malformed.length} row(s) cite something other than a comment on the ` +
+        `roadmap (#1599) and a comment on the decision issue (#1876): ${malformed.join('; ')}. ` +
+        'A flip with no act to point at is a judgment with no paper trail.',
+    );
+  }
+}
 
 const TOOL_RECORD =
   'Appended once per dispatched call by the telemetry wrapper (projections/telemetry/middleware.ts) ' +
   'and folded only by the `telemetry` view, which turns the family into per-tool latency, size ' +
-  'and error metrics. The canonical workflow-state arm is identity, no module outside the ' +
-  'projections names the type, and no contract, expectation row or liveness descriptor does. ' +
-  'The charter files per-tool records as runtime telemetry.';
+  'and error metrics. The canonical workflow-state arm is identity; no module under `src/` ' +
+  'outside `src/projections/` names the type (the offline eval harness under `tools/evals/` reads ' +
+  '`tool.errored` as a dataset heuristic, and is outside the shipped tree); and no contract, ' +
+  'expectation row or liveness descriptor does. The charter files per-tool records as runtime ' +
+  'telemetry.';
 
+/**
+ * Keyed by `EventType` at the literal (`satisfies`) so a row for a renamed or
+ * misspelled type fails to compile, while the exported type stays the string
+ * map the derivation and its oracles iterate. The `satisfies` is load-bearing:
+ * a plain freeze assigned to the annotation skips the excess-key check once
+ * one key overlaps.
+ */
 export const CHARTER_DEMOTIONS: Readonly<Record<string, CharterDemotion>> = Object.freeze({
-  'tool.invoked': {
-    evidence: [CHARTER_ACT, DECISION_RECORD],
-    because: TOOL_RECORD,
-  },
-  'tool.completed': {
-    evidence: [CHARTER_ACT, DECISION_RECORD],
-    because: TOOL_RECORD,
-  },
-  'tool.errored': {
-    evidence: [CHARTER_ACT, DECISION_RECORD],
-    because: TOOL_RECORD,
-  },
-  'tool.action_errored': {
-    evidence: [CHARTER_ACT, DECISION_RECORD],
-    because: TOOL_RECORD,
-  },
+  'tool.invoked': { act: CHARTER_ACT, record: DECISION_RECORD, because: TOOL_RECORD },
+  'tool.completed': { act: CHARTER_ACT, record: DECISION_RECORD, because: TOOL_RECORD },
+  'tool.errored': { act: CHARTER_ACT, record: DECISION_RECORD, because: TOOL_RECORD },
+  'tool.action_errored': { act: CHARTER_ACT, record: DECISION_RECORD, because: TOOL_RECORD },
   'turn.completed': {
-    evidence: [CHARTER_ACT, DECISION_RECORD],
+    act: CHARTER_ACT,
+    record: DECISION_RECORD,
     because:
       'A per-turn output-token aggregate the `telemetry` view folds into `view.turns` for the ' +
       'quality-hint generators. Its lifecycle is `planned` — no producer exists yet — so nothing ' +
-      'can have come to depend on it; the canonical arm is identity and no reader names it. The ' +
-      'charter files turn records beside per-tool records as runtime telemetry.',
+      'can have come to depend on it; the canonical arm is identity and no module under `src/` ' +
+      'outside `src/projections/` names it. The charter files turn records beside per-tool ' +
+      'records as runtime telemetry.',
   },
   'subagent.tokens_used': {
-    evidence: [CHARTER_ACT, DECISION_RECORD],
+    act: CHARTER_ACT,
+    record: DECISION_RECORD,
     because:
-      'Appended by the SubagentStop hook (lifecycle/subagent-stop.ts) after the subagent has ' +
-      'terminated, and folded by the delegation-timeline and team-performance views to attribute ' +
-      'output tokens to a task. The canonical arm is identity, no fold-external module reads it, ' +
-      'and the hook that appends it resolves the teammate from `team.task.assigned` and ' +
-      '`team.teammate.dispatched` — never from this type. The charter names it among the ' +
-      'worker-interior self-reports.',
+      'Appended by exarchos code on the SubagentStop trigger (lifecycle/subagent-stop.ts) after ' +
+      'the subagent has terminated — `capability` tier, so `auto`, whatever the decision record ' +
+      'called it — and folded by the delegation-timeline and team-performance views to attribute ' +
+      'output tokens to a task. The canonical arm is identity, no module under `src/` outside ' +
+      '`src/projections/` reads it, and the code that appends it resolves the teammate from ' +
+      '`team.task.assigned` and `team.teammate.dispatched` — never from this type. It rides the ' +
+      'FEATURE stream: telemetry is a fold fact, not a stream placement. The charter names it ' +
+      'among the worker-interior self-reports.',
   },
-});
+} satisfies Partial<Record<EventType, CharterDemotion>>);
+
+assertCharterCitations(CHARTER_DEMOTIONS);

--- a/src/events/partition/event-authority.ts
+++ b/src/events/partition/event-authority.ts
@@ -18,7 +18,7 @@
 // no partition change is the telemetry middleware's argument-rewriting path
 // (`projections/telemetry/middleware.ts`, `autoCorrectionOptions`), dormant
 // today because every dispatcher call passes three arguments; the view-level
-// differential the tracker's item 9 asks for should name it.
+// differential still owed over that middleware should name it.
 
 /**
  * The live governance/telemetry partition over the shipped event catalog.

--- a/src/events/partition/event-authority.ts
+++ b/src/events/partition/event-authority.ts
@@ -14,7 +14,9 @@
  *
  * Built EAGERLY at module scope, the way `EVENT_EMISSION_REGISTRY` is, so a
  * population that cannot be partitioned fails at load rather than at whichever
- * consumer happens to ask first. The two sets are derived from the map by
+ * consumer happens to ask first — a witness or demotion that contradicts the
+ * other table, or names a type the catalog no longer has, is a load failure
+ * here, not a quiet winner. The two sets are derived from the map by
  * partition — neither is authored, so neither can drift from it.
  */
 
@@ -22,6 +24,7 @@ import { EventTypes, type EventType } from '../schemas.js';
 import { ANNOTATED_EVENTS } from '../event-annotations.js';
 import { EMISSION_SOURCE_BY_TIER, type EmissionSource } from '../event-registration.js';
 import { deriveEventAuthority, partitionByAuthority, type EventAuthority } from './authority.js';
+import { CHARTER_DEMOTIONS } from './demotions.js';
 import { GOVERNANCE_WITNESSES } from './witnesses.js';
 
 /**
@@ -38,6 +41,7 @@ const DERIVED: Record<string, EventAuthority> = deriveEventAuthority(
   EventTypes,
   tierEmissionSourceOf,
   GOVERNANCE_WITNESSES,
+  CHARTER_DEMOTIONS,
 );
 
 /**

--- a/src/events/partition/event-authority.ts
+++ b/src/events/partition/event-authority.ts
@@ -8,6 +8,17 @@
 // deliberately NOT claimed as test infrastructure: this is the shipped
 // classification, not gate machinery, and misfiling it would buy a permanent
 // exemption for a module that is supposed to become load-bearing.
+//
+// Two facts the first consumer has to carry, recorded here because no other
+// module holds them. (1) Telemetry is a FOLD fact, not a stream placement:
+// `subagent.tokens_used` and `stack.submitted` ride feature streams beside
+// governance rows, and the SubagentStop append keys its idempotency per stream,
+// so a retention policy that drops telemetry is a row filter, never a stream
+// drop. (2) The one in-tree reader that would become correctness-bearing with
+// no partition change is the telemetry middleware's argument-rewriting path
+// (`projections/telemetry/middleware.ts`, `autoCorrectionOptions`), dormant
+// today because every dispatcher call passes three arguments; the view-level
+// differential the tracker's item 9 asks for should name it.
 
 /**
  * The live governance/telemetry partition over the shipped event catalog.

--- a/src/events/partition/witnesses.ts
+++ b/src/events/partition/witnesses.ts
@@ -2,10 +2,11 @@
  * Every promotion of a non-`auto` event type to governance, with its evidence.
  *
  * A row here says: the tier alone would file this event as telemetry, and that
- * is wrong, for THIS reason. Nothing else in the partition is hand-written —
- * the predicate carries the whole `auto` side — so this table is the complete
- * list of places where a human judgment overrides a derivation, which is what
- * makes it reviewable.
+ * is wrong, for THIS reason. The only other hand-written input to the partition
+ * is the demotion table beside this one (`demotions.ts`), which overrides the
+ * tier in the opposite direction and only on a charter act — so the two tables
+ * together are the complete list of places where a human judgment overrides a
+ * derivation, which is what makes them reviewable.
  *
  * EVERY arm is re-measured by an oracle. The arm is self-declared, so an arm
  * nothing checks would let a mislabel buy a permanent exemption — and that is
@@ -19,7 +20,11 @@
  *     still reads the named type. A witness whose module stopped reading it is
  *     reported as stale, so this table cannot outlive the code it cites.
  *   • `gate-expectation` — the emission gate's expectation table still lists the
- *     type, measured from the table itself.
+ *     type, measured from the table itself. No live row uses this arm today:
+ *     `stack.submitted` was its one member until the charter flip deleted the
+ *     expectation and description rows that were its whole basis. The arm
+ *     stays because the read shape it names is real and invisible to a source
+ *     scan, and its oracle is kept non-vacuous from a seeded stale row.
  *   • `charter-pin` — the ratified authority decision pins a whole family
  *     governance, and these rows are the family members whose tier disagrees.
  *     The claim such a row makes is NEGATIVE — no fold, no reader, no
@@ -106,17 +111,6 @@ export const GOVERNANCE_WITNESSES: Readonly<Record<string, AuthorityWitness>> = 
       'stream. This is in direct tension with the ratified charter, which lists the type among ' +
       'its telemetry examples: the demotion cannot land while a live fold-external reader derives ' +
       'an escalation bound from it, so the reader must be retired or re-sourced first.',
-  },
-
-  'stack.submitted': {
-    arm: 'gate-expectation',
-    evidence: ['src/verbs/gates/check-event-emissions.ts'],
-    because:
-      'The emission gate lists this type among the events the synthesize phase must have ' +
-      'produced, and its complete/incomplete verdict is exactly whether the raw stream contains ' +
-      'it. The charter names the type among its telemetry examples and requires the expectation ' +
-      'row and its description to be deleted in the same commit as the demotion; neither has ' +
-      'happened, so the type is still depended upon and stays governance until that flip lands.',
   },
 
   'task.assigned': {

--- a/src/events/partition/witnesses.ts
+++ b/src/events/partition/witnesses.ts
@@ -36,10 +36,18 @@
  * a witness that changes no answer is cover nothing can check.
  */
 
+import type { EventType } from '../schemas.js';
 import type { AuthorityWitness } from './authority.js';
 
 const CHARTER = 'lvlup-sw/exarchos#1876 ratified event-authority decision record';
 
+/**
+ * Keyed by `EventType` at the literal (`satisfies`) so a row for a renamed or
+ * misspelled type fails to compile, while the exported type stays the string
+ * map the derivation and its oracles iterate. The `satisfies` is load-bearing:
+ * a plain freeze assigned to the annotation skips the excess-key check once
+ * one key overlaps.
+ */
 export const GOVERNANCE_WITNESSES: Readonly<Record<string, AuthorityWitness>> = Object.freeze({
   'team.spawned': {
     arm: 'projection-fold',
@@ -143,4 +151,4 @@ export const GOVERNANCE_WITNESSES: Readonly<Record<string, AuthorityWitness>> = 
       'The workflow family is pinned governance as a family. No fold and no fold-external reader ' +
       'names this member today, so the family pin is the entire basis for the promotion.',
   },
-});
+} satisfies Partial<Record<EventType, AuthorityWitness>>);

--- a/src/verbs/gates/check-event-emissions.ts
+++ b/src/verbs/gates/check-event-emissions.ts
@@ -142,12 +142,12 @@ assertExpectationsLive(PHASE_EXPECTED_EVENTS);
 
 /**
  * The hint the gate returns for a missing expected event. Every key is an
- * instruction to the model to emit the event, so a key no expectation row
- * reaches is a standing instruction for something the gate never asks about —
- * exported so the declaration conjunct can hold the table to that, alongside
- * the expectation rows it is keyed against.
+ * instruction to the model to emit the event, so the table and the expectation
+ * rows describe ONE population — asserted in both directions at load, below.
+ * Exported so the gate's tests can seed the assertion.
  */
 export const EVENT_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  'task.assigned': 'Emit task.assigned via exarchos_event for each planned task, before prepare_delegation',
   'team.spawned': 'Emit team.spawned via exarchos_event after creating the team',
   'team.task.planned': 'Emit team.task.planned via exarchos_event for each planned task',
   'team.teammate.dispatched': 'Emit team.teammate.dispatched via exarchos_event after dispatching subagents',
@@ -187,6 +187,60 @@ export function assertDescriptionsLive(
 }
 
 assertDescriptionsLive(EVENT_DESCRIPTIONS);
+
+/**
+ * Load-time assertion that the two tables describe the SAME population, in
+ * both directions. A description no expectation row reaches is a standing
+ * instruction to emit something the gate never asks about — the stale prose a
+ * flip is required to delete in the same commit as the row. An expectation no
+ * description covers would have fallen through to a generic hint that reads as
+ * complete while telling the model nothing; the delegate rows derive from the
+ * reducer, so a type added there arrives here with no row unless this throws.
+ * Exported with both tables injectable so each direction is provable from a
+ * seeded pair rather than trusted.
+ */
+export function assertDescriptionsCoverExpectations(
+  expectations: Readonly<Record<string, readonly EventType[]>>,
+  descriptions: Readonly<Record<string, string>>,
+): void {
+  const expected = new Set<string>(Object.values(expectations).flat());
+  const unreachable = Object.keys(descriptions)
+    .filter((eventType) => !expected.has(eventType))
+    .sort();
+  if (unreachable.length > 0) {
+    throw new Error(
+      `EVENT_DESCRIPTIONS instructs the model to emit ${unreachable.length} event(s) no phase ` +
+        `expects: ${unreachable.join(', ')}. The row outlived its expectation — delete it, or ` +
+        'restore the expectation it described.',
+    );
+  }
+  const undescribed = [...expected].filter((eventType) => descriptions[eventType] === undefined).sort();
+  if (undescribed.length > 0) {
+    throw new Error(
+      `PHASE_EXPECTED_EVENTS expects ${undescribed.length} event(s) EVENT_DESCRIPTIONS does not ` +
+        `describe: ${undescribed.join(', ')}. The gate would have nothing to say about a missing ` +
+        'one — add the row in the same change that added the expectation.',
+    );
+  }
+}
+
+assertDescriptionsCoverExpectations(PHASE_EXPECTED_EVENTS, EVENT_DESCRIPTIONS);
+
+/**
+ * Total over every expected event, by the load-time assertion above. A miss
+ * here means the tables changed after load; it is a bug, and it throws rather
+ * than substituting a generic hint that would read as a complete answer.
+ */
+function descriptionOf(eventType: EventType): string {
+  const description = EVENT_DESCRIPTIONS[eventType];
+  if (description === undefined) {
+    throw new Error(
+      `EVENT_DESCRIPTIONS has no row for expected event '${eventType}' — a state ` +
+        'assertDescriptionsCoverExpectations refuses at load.',
+    );
+  }
+  return description;
+}
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -301,7 +355,7 @@ export async function handleCheckEventEmissions(
       const requiredFields = extractRequiredFields(eventType);
       hints.push({
         eventType,
-        description: EVENT_DESCRIPTIONS[eventType] ?? `Missing expected event: ${eventType}`,
+        description: descriptionOf(eventType),
         ...(requiredFields && requiredFields.length > 0 ? { requiredFields } : {}),
       });
     }

--- a/src/verbs/gates/check-event-emissions.ts
+++ b/src/verbs/gates/check-event-emissions.ts
@@ -79,17 +79,26 @@ export function modelEmittedOnly(
 
 // RC2 (#1395): `review.routed` was removed from every phase entry below — it is
 // now auto-emitted by handleReviewTriage (review/tools.ts), so the model is no
-// longer nagged for it. The surviving team.* / stack.submitted / shepherd.*
-// entries stay model-emitted (Category C): their transition is a model-walked
-// runbook step bracketing a `native:` harness tool, so auto-emission needs a
+// longer nagged for it. The surviving team.* / shepherd.* entries stay
+// model-emitted (Category C): their transition is a model-walked runbook step
+// bracketing a `native:` harness tool, so auto-emission needs a
 // runbook-executor seam (deferred to v2.11 / #1258). Re-adding an `'auto'`
 // event here will trip the compile-time assertion immediately below.
+//
+// `stack.submitted` left the synthesize row with the first event-authority
+// flip (the charter act on #1599, executing the #1876 decision): this table
+// was the ONLY thing that depended on it — the gate's complete/incomplete
+// verdict was a function of its presence — and the charter files the type as
+// telemetry. The model may still emit it as a record of the submission; the
+// gate no longer demands it, and nothing else decides anything from it. A row
+// here is a dependency, so re-adding one is a re-promotion and needs a
+// gate-expectation witness in the partition to say so.
 export const PHASE_EXPECTED_EVENTS: Readonly<Record<string, readonly EventType[]>> = {
   'delegate': modelEmittedOnly(getRegisteredEventTypes('delegate')),
   'overhaul-delegate': modelEmittedOnly(getRegisteredEventTypes('overhaul-delegate')),
   'review': ['team.spawned', 'team.task.planned', 'team.teammate.dispatched', 'team.disbanded'],
   'overhaul-review': ['team.spawned', 'team.task.planned', 'team.teammate.dispatched', 'team.disbanded'],
-  'synthesize': ['team.spawned', 'team.disbanded', 'stack.submitted', 'shepherd.iteration'],
+  'synthesize': ['team.spawned', 'team.disbanded', 'shepherd.iteration'],
   'overhaul-update-docs': ['team.spawned', 'team.disbanded'],
 };
 
@@ -131,14 +140,22 @@ assertExpectationsLive(PHASE_EXPECTED_EVENTS);
 
 // ─── Human-Readable Descriptions for Event Types ────────────────────────────
 
-const EVENT_DESCRIPTIONS: Readonly<Record<string, string>> = {
+/**
+ * The hint the gate returns for a missing expected event. Every key is an
+ * instruction to the model to emit the event, so a key no expectation row
+ * reaches is a standing instruction for something the gate never asks about —
+ * exported so the declaration conjunct can hold the table to that, alongside
+ * the expectation rows it is keyed against.
+ */
+export const EVENT_DESCRIPTIONS: Readonly<Record<string, string>> = {
   'team.spawned': 'Emit team.spawned via exarchos_event after creating the team',
   'team.task.planned': 'Emit team.task.planned via exarchos_event for each planned task',
   'team.teammate.dispatched': 'Emit team.teammate.dispatched via exarchos_event after dispatching subagents',
   'team.disbanded': 'Emit team.disbanded via exarchos_event after all teammates complete',
   // review.routed description removed in RC2 (#1395): now auto-emitted, never a
   // model-emitted hint, so its description is dead. DIM-5 hygiene.
-  'stack.submitted': 'Emit stack.submitted via exarchos_event after submitting the PR stack',
+  // stack.submitted description removed with the first event-authority flip:
+  // its expectation row went, so the hint had nothing left to describe.
   'shepherd.iteration': 'Emit shepherd.iteration via exarchos_event after each shepherd loop iteration',
   'task.progressed': 'Emit task.progressed via exarchos_event after each TDD phase transition (red/green/refactor)',
 };

--- a/tests/architecture/event-authority-contracts.test.ts
+++ b/tests/architecture/event-authority-contracts.test.ts
@@ -2,6 +2,7 @@
  * Every event a live DECLARATION names must be a governance event.
  *
  * @oracle-sources: ../../src/registry/**, ../../src/events/partition/**,
+ * ../../src/events/liveness-registry.ts,
  * ../../src/verbs/gates/check-event-emissions.ts
  *
  * An `emissions` entry and an `event-append` postcondition are both promises
@@ -12,18 +13,27 @@
  * depended upon and the classification is wrong, or the classification is right
  * and the contract is declaring a promise nothing needs.
  *
- * The emission gate's phase-expectation table is the third declaration of the
- * same shape, and it is the one that bites. The gate iterates that table and
- * asks a set built from the raw stream whether each listed type is present, so
- * its complete/incomplete verdict is a function of exactly those types — yet no
- * literal comparison appears anywhere in the module, which means the source-scan
- * census structurally cannot see it. This is where `stack.submitted` was
- * classified telemetry while a shipped gate derived a verdict from its presence.
+ * Two more declaration tables have the same shape, and both are ones the
+ * source-scan census structurally cannot see, because the read they describe is
+ * an iteration of a table rather than a comparison against a literal:
+ *
+ *   • the emission gate's phase-expectation table. The gate iterates it and
+ *     asks a set built from the raw stream whether each listed type is present,
+ *     so its complete/incomplete verdict is a function of exactly those types.
+ *     This is where `stack.submitted` was classified telemetry while a shipped
+ *     gate derived a verdict from its presence — and, later, where its flip
+ *     landed by deleting the row that was its only reader;
+ *   • the liveness registry. Each descriptor names a START type and its
+ *     TERMINAL types, and `ps` and the phantom-launch heal pair them through the
+ *     operations fold to decide what is in flight. The decision record filed
+ *     `launch.executing_started` beside the hook-tier self-reports; this arm is
+ *     what would have named that demotion as false.
  *
  * This is an INDEPENDENT check rather than a restatement of the partition. Most
  * of the declared population is `auto` by tier, so it is green under the tier
  * map alone with no witness involved; what the conjunct rules out is a
- * declaration naming a type the tier does not cover.
+ * declaration naming a type the tier does not cover — or one a charter
+ * demotion has since removed from it.
  *
  * Every arm carries its declaration site, so a failure names where the promise
  * was made rather than only the event — a bare event name would leave a reader
@@ -38,29 +48,35 @@ import {
   contractEnsuredEventsOf,
 } from '../../src/registry.js';
 import { EventTypes } from '../../src/events/schemas.js';
-import { PHASE_EXPECTED_EVENTS } from '../../src/verbs/gates/check-event-emissions.js';
+import { LIVENESS_DESCRIPTORS } from '../../src/events/liveness-registry.js';
+import {
+  EVENT_DESCRIPTIONS,
+  PHASE_EXPECTED_EVENTS,
+} from '../../src/verbs/gates/check-event-emissions.js';
 import {
   EVENT_AUTHORITY,
   TELEMETRY_EVENTS,
   classifyEventAuthority,
 } from '../../src/events/partition/event-authority.js';
 import { GOVERNANCE_WITNESSES } from '../../src/events/partition/witnesses.js';
-import type { EventAuthority } from '../../src/events/partition/authority.js';
+import type { AuthorityWitness, EventAuthority } from '../../src/events/partition/authority.js';
 
 /** One event name a declaration names, with the site that named it. */
 interface DeclaredEventName {
   readonly site: string;
-  readonly arm: 'emissions' | 'ensures' | 'phase-expectation';
+  readonly arm: 'emissions' | 'ensures' | 'phase-expectation' | 'liveness-pair';
   readonly event: string;
 }
 
+const DECLARED_ARMS = ['emissions', 'ensures', 'phase-expectation', 'liveness-pair'] as const;
+
 /**
  * Every event name declared by any live built-in action, in registry order,
- * plus every event the emission gate expects a phase to have produced.
+ * plus every event the emission gate expects a phase to have produced, plus
+ * every START and TERMINAL type a liveness descriptor pairs on.
  *
- * Built by walking `TOOL_REGISTRY` and the live expectation table rather than a
- * snapshot, so a declaration added without a snapshot refresh is still in the
- * population.
+ * Built by walking `TOOL_REGISTRY` and the live tables rather than a snapshot,
+ * so a declaration added without a snapshot refresh is still in the population.
  */
 const DECLARED: readonly DeclaredEventName[] = [
   ...TOOL_REGISTRY.flatMap((tool) =>
@@ -84,6 +100,13 @@ const DECLARED: readonly DeclaredEventName[] = [
       event,
     })),
   ),
+  ...LIVENESS_DESCRIPTORS.flatMap((descriptor) =>
+    [descriptor.startType, ...descriptor.terminalTypes].map((event) => ({
+      site: `liveness-registry.${descriptor.surface}`,
+      arm: 'liveness-pair' as const,
+      event,
+    })),
+  ),
 ];
 
 /**
@@ -104,6 +127,48 @@ function auditDeclaredEventNames(
     );
 }
 
+/**
+ * The reverse of the gate-expectation arm: a witness that cites the expectation
+ * table is evidence only while the table still lists its type. Pure, so the
+ * live table and a seeded stale row go through the same auditor.
+ */
+function staleGateExpectationWitnesses(
+  witnesses: Readonly<Record<string, AuthorityWitness>>,
+  expected: ReadonlySet<string>,
+): readonly string[] {
+  return Object.entries(witnesses)
+    .filter(([type, witness]) => witness.arm === 'gate-expectation' && !expected.has(type))
+    .map(
+      ([type]) =>
+        `The gate-expectation witness for "${type}" promotes a type the expectation table no ` +
+        'longer lists. The declaration outlived the row it cites — retire the promotion, or repoint it.',
+    );
+}
+
+/**
+ * A description row is the hint the gate returns when an expected event is
+ * missing. A key no expectation row reaches is a standing instruction to the
+ * model to emit something the gate never asks about — exactly the stale prose
+ * a flip is required to delete in the same commit as the row. Pure, for the
+ * same reason as its siblings.
+ */
+function unreachableDescriptionRows(
+  descriptions: Readonly<Record<string, string>>,
+  expected: ReadonlySet<string>,
+): readonly string[] {
+  return Object.keys(descriptions)
+    .filter((type) => !expected.has(type))
+    .map(
+      (type) =>
+        `EVENT_DESCRIPTIONS["${type}"] instructs the model to emit an event no phase expects. ` +
+        'The row outlived its expectation — delete it, or restore the expectation it described.',
+    );
+}
+
+const EXPECTED_BY_SOME_PHASE: ReadonlySet<string> = new Set<string>(
+  Object.values(PHASE_EXPECTED_EVENTS).flat(),
+);
+
 describe('ActionContractConjunct — a declared event is a governance event', () => {
   it('ActionContractConjunct_DeclaredEventPopulation_IsNonEmptyOnEveryArm', () => {
     // A floor, never the number: pinning the count would turn every new action
@@ -117,11 +182,18 @@ describe('ActionContractConjunct — a declared event is a governance event', ()
     // swallows every failure and answers `[]`, and its events are a subset of
     // the emissions arm's — so a total collapse of that reader changed no result
     // anywhere until this floor existed.
-    for (const arm of ['emissions', 'ensures', 'phase-expectation'] as const) {
+    for (const arm of DECLARED_ARMS) {
       const rows = DECLARED.filter((row) => row.arm === arm);
       expect(rows.length, `the ${arm} arm resolved no declaration at all`).toBeGreaterThan(0);
       expect(new Set(rows.map((row) => row.event)).size).toBeGreaterThan(0);
     }
+
+    // The liveness arm has a known shape — four surfaces, each with one START
+    // and at least one TERMINAL — so its floor can be stated exactly enough to
+    // catch a descriptor whose terminal list emptied.
+    const liveness = DECLARED.filter((row) => row.arm === 'liveness-pair');
+    expect(liveness.filter((row) => row.event.endsWith('.executing_started')).length).toBe(4);
+    expect(liveness.length).toBeGreaterThanOrEqual(8);
   });
 
   it('ActionContractConjunct_GateExpectationWitness_IsNamedByTheLiveExpectationTable', () => {
@@ -129,20 +201,43 @@ describe('ActionContractConjunct — a declared event is a governance event', ()
     // iteration of a table, not a comparison against a literal. So it is
     // re-measured HERE, against the table itself — a witness whose expectation
     // row was deleted stops being evidence the moment the row goes.
-    const declared = Object.entries(GOVERNANCE_WITNESSES)
-      .filter(([, witness]) => witness.arm === 'gate-expectation')
-      .map(([type]) => type);
-    expect(declared.length).toBeGreaterThan(0);
+    //
+    // The arm may be EMPTY on the live table — it is, since `stack.submitted`
+    // flipped — so the live check alone would be vacuous. The seeded row is
+    // what keeps the auditor honest: a witness citing the arm for a type the
+    // table does not list must be named, through the same function.
+    expect(EXPECTED_BY_SOME_PHASE.size).toBeGreaterThan(0);
+    expect(staleGateExpectationWitnesses(GOVERNANCE_WITNESSES, EXPECTED_BY_SOME_PHASE)).toEqual([]);
 
-    const expected = new Set<string>(Object.values(PHASE_EXPECTED_EVENTS).flat());
-    expect(expected.size).toBeGreaterThan(0);
+    const seededType = 'seeded.never-expected';
+    expect(EXPECTED_BY_SOME_PHASE.has(seededType)).toBe(false);
+    const seeded: Readonly<Record<string, AuthorityWitness>> = {
+      ...GOVERNANCE_WITNESSES,
+      [seededType]: {
+        arm: 'gate-expectation',
+        evidence: ['src/verbs/gates/check-event-emissions.ts'],
+        because: 'A seeded witness whose row is gone.',
+      },
+    };
+    const stale = staleGateExpectationWitnesses(seeded, EXPECTED_BY_SOME_PHASE);
+    expect(stale.length).toBe(1);
+    expect(stale[0]).toContain(seededType);
+  });
 
-    const unsupported = declared.filter((type) => !expected.has(type));
-    expect(
-      unsupported,
-      'A gate-expectation witness promotes a type the expectation table no longer lists. The ' +
-        'declaration outlived the row it cites — retire the promotion, or repoint it.',
-    ).toEqual([]);
+  it('ActionContractConjunct_EveryDescriptionRow_IsReachedByAnExpectationRow', () => {
+    // The denominator: a description table with no rows would make the live
+    // check below true of nothing.
+    expect(Object.keys(EVENT_DESCRIPTIONS).length).toBeGreaterThan(0);
+    expect(unreachableDescriptionRows(EVENT_DESCRIPTIONS, EXPECTED_BY_SOME_PHASE)).toEqual([]);
+
+    const seededType = 'seeded.described-but-unexpected';
+    const seeded: Readonly<Record<string, string>> = {
+      ...EVENT_DESCRIPTIONS,
+      [seededType]: 'Emit seeded.described-but-unexpected via exarchos_event',
+    };
+    const stale = unreachableDescriptionRows(seeded, EXPECTED_BY_SOME_PHASE);
+    expect(stale.length).toBe(1);
+    expect(stale[0]).toContain(seededType);
   });
 
   it('ActionContractConjunct_EveryDeclaredEventName_IsAKnownEventType', () => {
@@ -168,16 +263,37 @@ describe('ActionContractConjunct — a declared event is a governance event', ()
 
     const seededSite = 'exarchos_seeded.seeded_action';
     const seededPhase = 'check-event-emissions.PHASE_EXPECTED_EVENTS.seeded_phase';
+    const seededSurface = 'liveness-registry.seeded';
     const seeded: readonly DeclaredEventName[] = [
       ...DECLARED,
       { site: seededSite, arm: 'emissions', event: telemetryType ?? '' },
       { site: seededPhase, arm: 'phase-expectation', event: telemetryType ?? '' },
+      { site: seededSurface, arm: 'liveness-pair', event: telemetryType ?? '' },
     ];
 
     const findings = auditDeclaredEventNames(seeded, EVENT_AUTHORITY);
-    expect(findings.length).toBe(2);
+    expect(findings.length).toBe(3);
     expect(findings.join('\n')).toContain(seededSite);
     expect(findings.join('\n')).toContain(seededPhase);
+    expect(findings.join('\n')).toContain(seededSurface);
     expect(findings.join('\n')).toContain(telemetryType ?? '');
+  });
+
+  it('ActionContractConjunct_ADemotedLivenessStart_WouldBeNamedBySite', () => {
+    // The specific false demotion the decision record invited: file the launch
+    // START claim as telemetry. It is governance on the live map; the probe
+    // shows that, had it flipped, this arm names the descriptor that pairs on
+    // it — the reader census cannot, because a descriptor is a table entry and
+    // not a comparison.
+    const launchStart = 'launch.executing_started';
+    expect(classifyEventAuthority(launchStart)).toBe('governance');
+
+    const flipped: Readonly<Record<string, EventAuthority>> = {
+      ...EVENT_AUTHORITY,
+      [launchStart]: 'telemetry',
+    };
+    const findings = auditDeclaredEventNames(DECLARED, flipped);
+    expect(findings.some((finding) => finding.includes('liveness-registry.launch'))).toBe(true);
+    expect(findings.every((finding) => finding.includes(launchStart))).toBe(true);
   });
 });

--- a/tests/architecture/event-authority-contracts.test.ts
+++ b/tests/architecture/event-authority-contracts.test.ts
@@ -25,9 +25,12 @@
  *     landed by deleting the row that was its only reader;
  *   • the liveness registry. Each descriptor names a START type and its
  *     TERMINAL types, and `ps` and the phantom-launch heal pair them through the
- *     operations fold to decide what is in flight. The decision record filed
- *     `launch.executing_started` beside the hook-tier self-reports; this arm is
- *     what would have named that demotion as false.
+ *     `worktrees@v1` fold to decide what is in flight. The decision record filed
+ *     `launch.executing_started` beside the hook-tier self-reports; the reader
+ *     census names that fold's reducer, and this arm names the descriptor, so a
+ *     demotion row for it would be red in both. For the merge and mutation START
+ *     claims the census finds no reader at all, and there this arm is the only
+ *     oracle.
  *
  * This is an INDEPENDENT check rather than a restatement of the partition. Most
  * of the declared population is `auto` by tier, so it is green under the tier
@@ -49,10 +52,7 @@ import {
 } from '../../src/registry.js';
 import { EventTypes } from '../../src/events/schemas.js';
 import { LIVENESS_DESCRIPTORS } from '../../src/events/liveness-registry.js';
-import {
-  EVENT_DESCRIPTIONS,
-  PHASE_EXPECTED_EVENTS,
-} from '../../src/verbs/gates/check-event-emissions.js';
+import { PHASE_EXPECTED_EVENTS } from '../../src/verbs/gates/check-event-emissions.js';
 import {
   EVENT_AUTHORITY,
   TELEMETRY_EVENTS,
@@ -145,26 +145,6 @@ function staleGateExpectationWitnesses(
     );
 }
 
-/**
- * A description row is the hint the gate returns when an expected event is
- * missing. A key no expectation row reaches is a standing instruction to the
- * model to emit something the gate never asks about — exactly the stale prose
- * a flip is required to delete in the same commit as the row. Pure, for the
- * same reason as its siblings.
- */
-function unreachableDescriptionRows(
-  descriptions: Readonly<Record<string, string>>,
-  expected: ReadonlySet<string>,
-): readonly string[] {
-  return Object.keys(descriptions)
-    .filter((type) => !expected.has(type))
-    .map(
-      (type) =>
-        `EVENT_DESCRIPTIONS["${type}"] instructs the model to emit an event no phase expects. ` +
-        'The row outlived its expectation — delete it, or restore the expectation it described.',
-    );
-}
-
 const EXPECTED_BY_SOME_PHASE: ReadonlySet<string> = new Set<string>(
   Object.values(PHASE_EXPECTED_EVENTS).flat(),
 );
@@ -188,12 +168,18 @@ describe('ActionContractConjunct — a declared event is a governance event', ()
       expect(new Set(rows.map((row) => row.event)).size).toBeGreaterThan(0);
     }
 
-    // The liveness arm has a known shape — four surfaces, each with one START
-    // and at least one TERMINAL — so its floor can be stated exactly enough to
-    // catch a descriptor whose terminal list emptied.
+    // The liveness arm's population is the registry's by construction — one
+    // START plus every TERMINAL per descriptor — so it is pinned to that sum
+    // rather than to a literal floor, which a descriptor whose terminal list
+    // emptied could have passed (the registry's own suite is what refuses an
+    // empty terminal list; this only holds the arm to reading all of it).
     const liveness = DECLARED.filter((row) => row.arm === 'liveness-pair');
-    expect(liveness.filter((row) => row.event.endsWith('.executing_started')).length).toBe(4);
-    expect(liveness.length).toBeGreaterThanOrEqual(8);
+    expect(liveness.filter((row) => row.event.endsWith('.executing_started')).length).toBe(
+      LIVENESS_DESCRIPTORS.length,
+    );
+    expect(liveness.length).toBe(
+      LIVENESS_DESCRIPTORS.reduce((rows, descriptor) => rows + 1 + descriptor.terminalTypes.length, 0),
+    );
   });
 
   it('ActionContractConjunct_GateExpectationWitness_IsNamedByTheLiveExpectationTable', () => {
@@ -220,22 +206,6 @@ describe('ActionContractConjunct — a declared event is a governance event', ()
       },
     };
     const stale = staleGateExpectationWitnesses(seeded, EXPECTED_BY_SOME_PHASE);
-    expect(stale.length).toBe(1);
-    expect(stale[0]).toContain(seededType);
-  });
-
-  it('ActionContractConjunct_EveryDescriptionRow_IsReachedByAnExpectationRow', () => {
-    // The denominator: a description table with no rows would make the live
-    // check below true of nothing.
-    expect(Object.keys(EVENT_DESCRIPTIONS).length).toBeGreaterThan(0);
-    expect(unreachableDescriptionRows(EVENT_DESCRIPTIONS, EXPECTED_BY_SOME_PHASE)).toEqual([]);
-
-    const seededType = 'seeded.described-but-unexpected';
-    const seeded: Readonly<Record<string, string>> = {
-      ...EVENT_DESCRIPTIONS,
-      [seededType]: 'Emit seeded.described-but-unexpected via exarchos_event',
-    };
-    const stale = unreachableDescriptionRows(seeded, EXPECTED_BY_SOME_PHASE);
     expect(stale.length).toBe(1);
     expect(stale[0]).toContain(seededType);
   });
@@ -283,8 +253,9 @@ describe('ActionContractConjunct — a declared event is a governance event', ()
     // The specific false demotion the decision record invited: file the launch
     // START claim as telemetry. It is governance on the live map; the probe
     // shows that, had it flipped, this arm names the descriptor that pairs on
-    // it — the reader census cannot, because a descriptor is a table entry and
-    // not a comparison.
+    // it. The reader census would name the `worktrees@v1` reducer as well; this
+    // arm is the one that also covers the merge and mutation START claims,
+    // which no module reads raw.
     const launchStart = 'launch.executing_started';
     expect(classifyEventAuthority(launchStart)).toBe('governance');
 

--- a/tests/architecture/event-emissions-gate-consumers.test.ts
+++ b/tests/architecture/event-emissions-gate-consumers.test.ts
@@ -1,0 +1,100 @@
+/**
+ * No shipped module decides anything from the emission gate's verdict.
+ *
+ * @oracle-sources: ../../src/verbs/gates/check-event-emissions.ts
+ *
+ * `check_event_emissions` appends a `gate.executed` row under the gate name
+ * `event-emissions` and returns hints. The first event-authority flip changed
+ * what that verdict is a function of — the synthesize row lost
+ * `stack.submitted` — and the claim that made this a small change, that the
+ * gate is advisory and nothing reads its verdict to decide, was hand-traced
+ * through every `gate.executed` reader. A hand trace is true on the day it is
+ * made. This reads the tree instead: the gate-name literal appears in exactly
+ * the modules allowed below, so a reader that starts discriminating on it is
+ * named.
+ *
+ * The scan is textual on purpose. `gate.executed` readers compare `gateName`
+ * against a literal (`=== 'review'`, `.includes('plan-coverage')`), and a
+ * literal is what a source scan sees. It does not prove that no reader folds
+ * every gate into a decision without naming this one — the convergence view
+ * drops rows without a `dimension`, which this gate never sets — and it does
+ * not claim to.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const SOURCE_ROOT = join(REPO_ROOT, 'src');
+
+/**
+ * The gate name as a string literal. An import path such as
+ * `./gates/check-event-emissions.js` contains the words and is not one: the
+ * character before them is a hyphen, not a quote.
+ */
+const GATE_NAME_LITERAL = /(['"`])event-emissions\1/;
+
+/** Modules allowed to name the gate: the gate itself, and nothing else. */
+const ALLOWED: readonly string[] = ['src/verbs/gates/check-event-emissions.ts'];
+
+function* sourceFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) yield* sourceFiles(path);
+    else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) yield path;
+  }
+}
+
+/** Pure over a path→source map, so the live tree and a seeded reader go through the same scan. */
+function modulesNamingTheGate(sources: ReadonlyMap<string, string>): readonly string[] {
+  return [...sources]
+    .filter(([, text]) => GATE_NAME_LITERAL.test(text))
+    .map(([path]) => path)
+    .sort();
+}
+
+function liveSources(): ReadonlyMap<string, string> {
+  const sources = new Map<string, string>();
+  for (const file of sourceFiles(SOURCE_ROOT)) {
+    sources.set(relative(REPO_ROOT, file).split('\\').join('/'), readFileSync(file, 'utf8'));
+  }
+  return sources;
+}
+
+describe('EventEmissionsGate — nothing shipped decides on its verdict', () => {
+  it(
+    'EventEmissionsGate_GateNameLiteral_AppearsOnlyInTheGateModule',
+    () => {
+      const sources = liveSources();
+      // The denominator: a scan that read nothing would find nothing, and the
+      // gate names itself, so the allowlist is also the floor.
+      expect(sources.size).toBeGreaterThan(100);
+      for (const allowed of ALLOWED) expect(sources.has(allowed), allowed).toBe(true);
+      expect(modulesNamingTheGate(sources)).toEqual([...ALLOWED].sort());
+    },
+    20_000,
+  );
+
+  it('EventEmissionsGate_SeededReaderDiscriminatingOnTheName_IsNamedAndAnImportIsNot', () => {
+    const seeded = new Map<string, string>([
+      [
+        'src/verbs/gates/check-event-emissions.ts',
+        "requireGateEvent(store, streamId, 'event-emissions', 'observability', complete, carrier)",
+      ],
+      [
+        'src/projections/views/seeded-readiness-view.ts',
+        "if (row.data.gateName === 'event-emissions' && !row.data.passed) blockers.push('emissions');",
+      ],
+      [
+        'src/verbs/composite.ts',
+        "import { handleCheckEventEmissions } from './gates/check-event-emissions.js';",
+      ],
+    ]);
+    expect(modulesNamingTheGate(seeded)).toEqual([
+      'src/projections/views/seeded-readiness-view.ts',
+      'src/verbs/gates/check-event-emissions.ts',
+    ]);
+  });
+});

--- a/tests/architecture/skill-prose-gate-row-agreement.test.ts
+++ b/tests/architecture/skill-prose-gate-row-agreement.test.ts
@@ -1,0 +1,141 @@
+/**
+ * A skill's "checked by `check-event-emissions`" sentence names exactly the
+ * gate's expectation row for its phase.
+ *
+ * @oracle-sources: ../../src/verbs/gates/check-event-emissions.ts, ../../content/synthesis/skills/synthesize/SKILL.md
+ *
+ * The prose is what the model reads; the row is what the gate checks. Nothing
+ * generates one from the other — the skills renderer lives in `src/install`,
+ * which may not import `src/verbs`, so a generator needs an intermediate this
+ * change does not add. Until it exists the two are joined HERE: the sentence is
+ * written in one machine-readable shape, on a line of its own, and this test
+ * reads it back and compares the set. The first event-authority flip
+ * hand-synchronised sentence and row in one commit; this is what notices the
+ * second flip forgetting to.
+ *
+ * Only the content source is read. `render:guard` pins `rendered/` to
+ * `content/`, so the source is the one place the sentence is authored.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { PHASE_EXPECTED_EVENTS } from '../../src/verbs/gates/check-event-emissions.js';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+interface ProseSite {
+  /** Content-source path of the skill, repo-relative. */
+  readonly skill: string;
+  /** The `PHASE_EXPECTED_EVENTS` key the sentence speaks for. */
+  readonly phase: string;
+}
+
+/**
+ * Every skill sentence that claims to name what the gate checks. One row
+ * today. The delegate skill's "checked by" table has the same claim in a
+ * different shape and does not agree with its derived row (it omits
+ * `team.disbanded` and `task.progressed`); it is recorded as residue rather
+ * than pinned here to a shape it does not yet have.
+ */
+const SITES: readonly ProseSite[] = [
+  { skill: 'content/synthesis/skills/synthesize/SKILL.md', phase: 'synthesize' },
+];
+
+/** The one shape the sentence may take — the whole line, so the list ends where the line does. */
+const CHECKED_LINE = /^Checked by `check-event-emissions` in this phase: (.*)$/;
+
+const BACKTICKED_EVENT = /`([a-z][a-z0-9_.]*)`/g;
+
+/** What the skill's checked line names, or why there is no answer. */
+function checkedTypesIn(
+  markdown: string,
+): { readonly types: readonly string[] } | { readonly problem: string } {
+  const lines = markdown
+    .split('\n')
+    .map((line) => CHECKED_LINE.exec(line))
+    .filter((match): match is RegExpExecArray => match !== null);
+  if (lines.length !== 1) {
+    return {
+      problem:
+        'expected exactly one "Checked by `check-event-emissions` in this phase:" line, ' +
+        `found ${lines.length}`,
+    };
+  }
+  const types = [...(lines[0]?.[1] ?? '').matchAll(BACKTICKED_EVENT)].map((match) => match[1] ?? '');
+  if (types.length === 0) return { problem: 'the checked line names no backticked event type' };
+  return { types };
+}
+
+/**
+ * Pure comparator, so the live sites and a seeded disagreement go through the
+ * same judge. Both directions are named: prose that over-claims and prose that
+ * under-claims are different defects.
+ */
+function disagreements(markdown: string, expected: readonly string[]): readonly string[] {
+  const read = checkedTypesIn(markdown);
+  if ('problem' in read) return [read.problem];
+  const named = new Set(read.types);
+  const row = new Set(expected);
+  return [
+    ...[...named]
+      .filter((type) => !row.has(type))
+      .map((type) => `prose names ${type}, which the gate row does not expect`),
+    ...[...row]
+      .filter((type) => !named.has(type))
+      .map((type) => `gate row expects ${type}, which the prose does not name`),
+  ].sort();
+}
+
+describe('SkillProse — the checked-by sentence names the gate row', () => {
+  it('SkillProse_EverySite_HasAnExpectationRowAndAContentFile', () => {
+    expect(SITES.length).toBeGreaterThan(0);
+    for (const site of SITES) {
+      expect(PHASE_EXPECTED_EVENTS[site.phase], `${site.phase} has no expectation row`).toBeDefined();
+      expect(() => readFileSync(join(REPO_ROOT, site.skill), 'utf8'), site.skill).not.toThrow();
+    }
+  });
+
+  it('SkillProse_CheckedLine_NamesExactlyTheGateRow', () => {
+    for (const site of SITES) {
+      const markdown = readFileSync(join(REPO_ROOT, site.skill), 'utf8');
+      const expected = PHASE_EXPECTED_EVENTS[site.phase] ?? [];
+      expect(expected.length, `${site.phase} expects nothing`).toBeGreaterThan(0);
+      expect(disagreements(markdown, expected), site.skill).toEqual([]);
+    }
+  });
+
+  it('SkillProse_SeededDisagreement_IsNamedInBothDirectionsAndOnAMissingLine', () => {
+    const [site] = SITES;
+    expect(site).toBeDefined();
+    if (site === undefined) return;
+    const markdown = readFileSync(join(REPO_ROOT, site.skill), 'utf8');
+    const expected = PHASE_EXPECTED_EVENTS[site.phase] ?? [];
+
+    // Prose names a type the row does not expect — the shape the flip removed.
+    const overClaiming = markdown.replace(
+      /^(Checked by `check-event-emissions` in this phase: .*)\.$/m,
+      '$1, `stack.submitted`.',
+    );
+    expect(overClaiming).not.toBe(markdown);
+    expect(disagreements(overClaiming, expected)).toEqual([
+      'prose names stack.submitted, which the gate row does not expect',
+    ]);
+
+    // The row expects a type the prose does not name.
+    expect(disagreements(markdown, [...expected, 'seeded.expected'])).toEqual([
+      'gate row expects seeded.expected, which the prose does not name',
+    ]);
+
+    // No checked line at all is a named problem, never a pass over an empty set.
+    const silent = markdown
+      .split('\n')
+      .filter((line) => !CHECKED_LINE.test(line))
+      .join('\n');
+    const findings = disagreements(silent, expected);
+    expect(findings.length).toBe(1);
+    expect(findings[0]).toContain('found 0');
+  });
+});

--- a/tests/core/packaged/containment.test.ts
+++ b/tests/core/packaged/containment.test.ts
@@ -192,12 +192,20 @@ function verifyPackedAgainstSource(packageDir: string): ContainmentResult {
   return verifyContainment({ required: sourceProjections, layers: [packed.layer] });
 }
 
+/**
+ * The hook below shells out to `npm pack` over the whole package and walks the
+ * ~1k-file projection tree: ~31s on ubuntu-latest, 47s to over 60s on
+ * windows-latest, which is the core tier's entire hook budget. The budget here
+ * is this hook's own, not the tier's; a genuine hang still fails, just later.
+ */
+const PACK_HOOK_TIMEOUT_MS = 180_000;
+
 beforeAll(() => {
   workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-t29-packed-'));
   const tarball = runNpmPack(REPO_ROOT, path.join(workDir, 'tgz'));
   pristinePackageDir = extractTarball(tarball, path.join(workDir, 'pristine'));
   sourceProjections = enumerateProjections(REPO_ROOT, npmFilesSpecs()).projections;
-});
+}, PACK_HOOK_TIMEOUT_MS);
 
 afterAll(() => {
   if (workDir !== '') fs.rmSync(workDir, { recursive: true, force: true });

--- a/tests/core/packaged/containment.test.ts
+++ b/tests/core/packaged/containment.test.ts
@@ -96,6 +96,18 @@ const REPO_ROOT = findRepoRoot(HERE);
  * `dist/**`, none of which is a projection, and running it would make this
  * suite depend on a compile rather than on the packaging manifest.
  */
+/**
+ * The setup hook shells out to `npm pack` over the whole package and walks the
+ * ~1k-file projection tree: ~31s on ubuntu-latest, 47s to over 60s on
+ * windows-latest, which is the core tier's entire hook budget. The budget here
+ * is this hook's own, not the tier's. Vitest's hook timer cannot interrupt a
+ * synchronous spawn, so each child carries its own bound and is killed when it
+ * exceeds it: a hung `npm pack` fails the hook instead of holding it.
+ */
+const PACK_CHILD_TIMEOUT_MS = 150_000;
+const EXTRACT_CHILD_TIMEOUT_MS = 20_000;
+const PACK_HOOK_TIMEOUT_MS = 180_000;
+
 function runNpmPack(repoRoot: string, destDir: string): string {
   fs.mkdirSync(destDir, { recursive: true });
   const useShell = needsWindowsShell('npm');
@@ -103,6 +115,8 @@ function runNpmPack(repoRoot: string, destDir: string): string {
     cwd: repoRoot,
     encoding: 'utf8',
     stdio: 'pipe',
+    timeout: PACK_CHILD_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
     ...(useShell ? { shell: true } : {}),
   });
   if (res.error !== undefined || res.status !== 0) {
@@ -136,6 +150,8 @@ function extractTarball(tarball: string, intoDir: string): string {
     cwd: intoDir,
     encoding: 'utf8',
     stdio: 'pipe',
+    timeout: EXTRACT_CHILD_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (res.error !== undefined || res.status !== 0) {
     throw new Error(
@@ -191,14 +207,6 @@ function verifyPackedAgainstSource(packageDir: string): ContainmentResult {
   const packed = readPackedProjectionLayer(packageDir);
   return verifyContainment({ required: sourceProjections, layers: [packed.layer] });
 }
-
-/**
- * The hook below shells out to `npm pack` over the whole package and walks the
- * ~1k-file projection tree: ~31s on ubuntu-latest, 47s to over 60s on
- * windows-latest, which is the core tier's entire hook budget. The budget here
- * is this hook's own, not the tier's; a genuine hang still fails, just later.
- */
-const PACK_HOOK_TIMEOUT_MS = 180_000;
 
 beforeAll(() => {
   workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-t29-packed-'));

--- a/tests/migration/__fixtures__/batch-baselines/synthesize.md
+++ b/tests/migration/__fixtures__/batch-baselines/synthesize.md
@@ -163,9 +163,9 @@ For merge ordering strategy, see `references/merge-ordering.md`.
 - **'feedback'** -- Route to `shepherd [PR_URL]` to address comments, then return here
 - **'no'** -- Pause workflow; resume later with `rehydrate`
 
-### Event Emissions (REQUIRED)
+### Event Emissions
 
-After PRs are created and auto-merge is enabled, emit the `stack.submitted` event:
+After PRs are created and auto-merge is enabled, record the submission with a `stack.submitted` event. This is a telemetry record of what went up — nothing decides anything from it, and `check-event-emissions` does not ask for it:
 
 ```typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -177,7 +177,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-During shepherd iterations (CI monitoring loop), emit after each assessment:
+During shepherd iterations (CI monitoring loop), emit after each assessment (REQUIRED — the escalation policy counts these events to bound the loop):
 
 ```typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -191,7 +191,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-These events are checked by `check-event-emissions` during workflow validation. Missing emissions will trigger warnings.
+`shepherd.iteration`, together with `team.spawned` and `team.disbanded`, is checked by `check-event-emissions` during workflow validation. A missing one triggers a warning; `stack.submitted` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/tests/migration/__fixtures__/batch-baselines/synthesize.md
+++ b/tests/migration/__fixtures__/batch-baselines/synthesize.md
@@ -191,7 +191,9 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 ```
 
-`shepherd.iteration`, together with `team.spawned` and `team.disbanded`, is checked by `check-event-emissions` during workflow validation. A missing one triggers a warning; `stack.submitted` is not checked.
+Checked by `check-event-emissions` in this phase: `team.spawned`, `team.disbanded`, `shepherd.iteration`.
+
+A missing one comes back as a hint with `complete: false` — on the explicit gate call, and on the `_eventHints` field the telemetry middleware adds to tool results while hints are outstanding. `stack.submitted` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/tests/migration/__snapshots__/snapshots.test.ts.snap
+++ b/tests/migration/__snapshots__/snapshots.test.ts.snap
@@ -9788,7 +9788,9 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 \`\`\`
 
-\`shepherd.iteration\`, together with \`team.spawned\` and \`team.disbanded\`, is checked by \`check-event-emissions\` during workflow validation. A missing one triggers a warning; \`stack.submitted\` is not checked.
+Checked by \`check-event-emissions\` in this phase: \`team.spawned\`, \`team.disbanded\`, \`shepherd.iteration\`.
+
+A missing one comes back as a hint with \`complete: false\` — on the explicit gate call, and on the \`_eventHints\` field the telemetry middleware adds to tool results while hints are outstanding. \`stack.submitted\` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/tests/migration/__snapshots__/snapshots.test.ts.snap
+++ b/tests/migration/__snapshots__/snapshots.test.ts.snap
@@ -9760,9 +9760,9 @@ For merge ordering strategy, see \`references/merge-ordering.md\`.
 - **'feedback'** -- Route to \`shepherd [PR_URL]\` to address comments, then return here
 - **'no'** -- Pause workflow; resume later with \`rehydrate\`
 
-### Event Emissions (REQUIRED)
+### Event Emissions
 
-After PRs are created and auto-merge is enabled, emit the \`stack.submitted\` event:
+After PRs are created and auto-merge is enabled, record the submission with a \`stack.submitted\` event. This is a telemetry record of what went up — nothing decides anything from it, and \`check-event-emissions\` does not ask for it:
 
 \`\`\`typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -9774,7 +9774,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 \`\`\`
 
-During shepherd iterations (CI monitoring loop), emit after each assessment:
+During shepherd iterations (CI monitoring loop), emit after each assessment (REQUIRED — the escalation policy counts these events to bound the loop):
 
 \`\`\`typescript
 exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
@@ -9788,7 +9788,7 @@ exarchos:exarchos_event({ action: "append", stream: "<featureId>", event: {
 }})
 \`\`\`
 
-These events are checked by \`check-event-emissions\` during workflow validation. Missing emissions will trigger warnings.
+\`shepherd.iteration\`, together with \`team.spawned\` and \`team.disbanded\`, is checked by \`check-event-emissions\` during workflow validation. A missing one triggers a warning; \`stack.submitted\` is not checked.
 
 ### Post-Merge Cleanup
 

--- a/tests/scripts/ci-topology.test.ts
+++ b/tests/scripts/ci-topology.test.ts
@@ -426,11 +426,23 @@ function npmRunInvocation(scriptName: string): RegExp {
 }
 
 /**
- * True iff `cmd` names the `core` vitest project. `--project core-extra`
- * must not count — `\b` after `core` still matches a hyphen.
+ * True iff `cmd` is a vitest invocation selecting exactly `project`. The
+ * option has to follow vitest's own invocation: `echo --project unit` names
+ * the option without running anything, and would otherwise satisfy a topology
+ * pin while the project it names is collected by nobody. `--project
+ * core-extra` must not count for `core` — `\b` after `core` still matches a
+ * hyphen.
  */
+function isVitestProjectCommand(cmd: string, project: string): boolean {
+  const invocation = /^(?:npx\s+)?vitest(?:\s+|$)/.exec(cmd.trim());
+  if (invocation === null) return false;
+  const args = cmd.trim().slice(invocation[0].length);
+  return new RegExp(`(?:^|\\s)--project ${escapeRegExp(project)}(?:\\s|$)`).test(args);
+}
+
+/** True iff `cmd` runs the `core` vitest project. */
 function isCoreProjectCommand(cmd: string): boolean {
-  return /(?:^|\s)--project core(?:\s|$)/.test(cmd);
+  return isVitestProjectCommand(cmd, 'core');
 }
 
 /**
@@ -470,7 +482,7 @@ function jobRunsCoreProjectScript(job: WorkflowJob | undefined, scriptName: stri
 function isUnitProjectScript(scripts: Record<string, string>, name: string, hops = 0): boolean {
   const cmd = scripts[name];
   if (cmd === undefined) return false;
-  if (/(?:^|\s)--project unit(?:\s|$)/.test(cmd)) return true;
+  if (isVitestProjectCommand(cmd, 'unit')) return true;
   const alias = /^npm run (\S+)\s*$/.exec(cmd.trim());
   return alias !== null && hops < 1 && isUnitProjectScript(scripts, alias[1] ?? '', hops + 1);
 }
@@ -585,6 +597,9 @@ describe('CI path-filter & guard coverage (DR-22)', () => {
     expect(isCoreProjectCommand('vitest --project core')).toBe(true);
     expect(isCoreProjectCommand('vitest --project core --run')).toBe(true);
     expect(isCoreProjectCommand('vitest --project core-extra')).toBe(false);
+    expect(isCoreProjectCommand('npx vitest run --project core')).toBe(true);
+    expect(isCoreProjectCommand('echo --project core')).toBe(false);
+    expect(isCoreProjectCommand("echo 'vitest run --project core'")).toBe(false);
   });
 
   it('LayerCensus_UnitProjectHostScripts_AreRunStepsOnBothPlatforms', () => {
@@ -626,12 +641,18 @@ describe('CI path-filter & guard coverage (DR-22)', () => {
       'test:deep': 'npm run test:run',
       'test:unit-extra': 'vitest run --project unit-extra',
       'test:echo': "echo 'npm run test:unit'",
+      'test:option-echo': 'echo --project unit',
+      'test:npx': 'npx vitest run --project unit',
     };
     expect(isUnitProjectScript(scripts, 'test:unit')).toBe(true);
     expect(isUnitProjectScript(scripts, 'test:run')).toBe(true);
     expect(isUnitProjectScript(scripts, 'test:deep'), 'two hops is a new shape').toBe(false);
     expect(isUnitProjectScript(scripts, 'test:unit-extra')).toBe(false);
     expect(isUnitProjectScript(scripts, 'test:echo')).toBe(false);
+    expect(isUnitProjectScript(scripts, 'test:option-echo'), 'the option alone runs nothing').toBe(
+      false,
+    );
+    expect(isUnitProjectScript(scripts, 'test:npx')).toBe(true);
     expect(isUnitProjectScript(scripts, 'test:absent')).toBe(false);
   });
 

--- a/tests/scripts/ci-topology.test.ts
+++ b/tests/scripts/ci-topology.test.ts
@@ -434,10 +434,13 @@ function npmRunInvocation(scriptName: string): RegExp {
  * must not count for `core` — `\b` after `core` still matches a hyphen.
  */
 function isVitestProjectCommand(cmd: string, project: string): boolean {
-  const invocation = /^(?:npx\s+)?vitest(?:\s+|$)/.exec(cmd.trim());
+  // Only the first shell command is vitest's: cut at `;`, either `|` form,
+  // either `&` form (a backgrounded vitest included), or a newline BEFORE
+  // matching the invocation, so `\s+` cannot swallow a newline boundary.
+  const head = cmd.trim().split(/[;|&\r\n]/, 1)[0] ?? '';
+  const invocation = /^(?:npx\s+)?vitest(?:\s+|$)/.exec(head);
   if (invocation === null) return false;
-  // Only up to the first shell separator is vitest's argument list.
-  const args = cmd.trim().slice(invocation[0].length).split(/\s*(?:&&|\|\||;|\|)\s*/, 1)[0] ?? '';
+  const args = head.slice(invocation[0].length);
   return new RegExp(`(?:^|\\s)--project ${escapeRegExp(project)}(?:\\s|$)`).test(args);
 }
 
@@ -604,6 +607,8 @@ describe('CI path-filter & guard coverage (DR-22)', () => {
     expect(isCoreProjectCommand('vitest && echo --project core')).toBe(false);
     expect(isCoreProjectCommand('vitest --project unit && echo --project core')).toBe(false);
     expect(isCoreProjectCommand('vitest --project core && echo done')).toBe(true);
+    expect(isCoreProjectCommand('vitest & echo --project core')).toBe(false);
+    expect(isCoreProjectCommand('vitest\necho --project core')).toBe(false);
   });
 
   it('LayerCensus_UnitProjectHostScripts_AreRunStepsOnBothPlatforms', () => {

--- a/tests/scripts/ci-topology.test.ts
+++ b/tests/scripts/ci-topology.test.ts
@@ -461,6 +461,20 @@ function jobRunsCoreProjectScript(job: WorkflowJob | undefined, scriptName: stri
   );
 }
 
+/**
+ * True iff `scripts[name]` runs `--project unit`, directly or through ONE hop
+ * of `npm run <alias>` — `test:run` is `npm run test:unit`, and CI invokes the
+ * alias. One hop is what the tree has; a deeper chain is a new shape to pin,
+ * not one to resolve silently.
+ */
+function isUnitProjectScript(scripts: Record<string, string>, name: string, hops = 0): boolean {
+  const cmd = scripts[name];
+  if (cmd === undefined) return false;
+  if (/(?:^|\s)--project unit(?:\s|$)/.test(cmd)) return true;
+  const alias = /^npm run (\S+)\s*$/.exec(cmd.trim());
+  return alias !== null && hops < 1 && isUnitProjectScript(scripts, alias[1] ?? '', hops + 1);
+}
+
 describe('CI path-filter & guard coverage (DR-22)', () => {
   it('Filters_RootFilter_IncludesProjectionRootGlobs', () => {
     const workflow = loadWorkflow(CI_WORKFLOW_PATH);
@@ -571,6 +585,54 @@ describe('CI path-filter & guard coverage (DR-22)', () => {
     expect(isCoreProjectCommand('vitest --project core')).toBe(true);
     expect(isCoreProjectCommand('vitest --project core --run')).toBe(true);
     expect(isCoreProjectCommand('vitest --project core-extra')).toBe(false);
+  });
+
+  it('LayerCensus_UnitProjectHostScripts_AreRunStepsOnBothPlatforms', () => {
+    // The architecture oracles — the event-authority declaration conjunct and
+    // the raw-reader census among them — are collected by the `unit` vitest
+    // project, which CI hosts as `npm run test:run`, an alias of `test:unit`.
+    // The core pin above says nothing about that lane, so a workflow edit that
+    // dropped the step would leave those oracles collected by nothing while
+    // every job stayed green. Same shape as the core pin, with the alias chain
+    // resolved through package.json rather than matched by name.
+    const workflow = loadWorkflow(CI_WORKFLOW_PATH);
+    const pkg: { scripts?: Record<string, string> } = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'),
+    );
+    const scripts = pkg.scripts ?? {};
+    const unitScripts = Object.keys(scripts).filter((name) => isUnitProjectScript(scripts, name));
+    expect(unitScripts, 'package.json declares no script expanding to --project unit').not.toEqual(
+      [],
+    );
+
+    const needs = new Set(needsList(workflow.jobs[AGGREGATOR_JOB]));
+    const hosts = Object.entries(workflow.jobs).filter(
+      ([name, job]) => needs.has(name) && unitScripts.some((s) => jobRunsCoreProjectScript(job, s)),
+    );
+    expect(
+      hosts.map(([name]) => name),
+      'no ci-gate dependency runs a script whose expansion is --project unit',
+    ).not.toEqual([]);
+
+    const runners = hosts.map(([, job]) => job['runs-on']);
+    expect(runners, 'Linux does not host the unit project').toContain('ubuntu-latest');
+    expect(runners, 'Windows does not host the unit project').toContain('windows-latest');
+  });
+
+  it('IsUnitProjectScript_ResolvesOneAliasHopAndNoMore', () => {
+    const scripts: Record<string, string> = {
+      'test:unit': 'vitest run --project unit',
+      'test:run': 'npm run test:unit',
+      'test:deep': 'npm run test:run',
+      'test:unit-extra': 'vitest run --project unit-extra',
+      'test:echo': "echo 'npm run test:unit'",
+    };
+    expect(isUnitProjectScript(scripts, 'test:unit')).toBe(true);
+    expect(isUnitProjectScript(scripts, 'test:run')).toBe(true);
+    expect(isUnitProjectScript(scripts, 'test:deep'), 'two hops is a new shape').toBe(false);
+    expect(isUnitProjectScript(scripts, 'test:unit-extra')).toBe(false);
+    expect(isUnitProjectScript(scripts, 'test:echo')).toBe(false);
+    expect(isUnitProjectScript(scripts, 'test:absent')).toBe(false);
   });
 
   it('Guards_HooksGuardRunsInCI_AndIsRootFiltered', () => {

--- a/tests/scripts/ci-topology.test.ts
+++ b/tests/scripts/ci-topology.test.ts
@@ -427,16 +427,17 @@ function npmRunInvocation(scriptName: string): RegExp {
 
 /**
  * True iff `cmd` is a vitest invocation selecting exactly `project`. The
- * option has to follow vitest's own invocation: `echo --project unit` names
- * the option without running anything, and would otherwise satisfy a topology
- * pin while the project it names is collected by nobody. `--project
- * core-extra` must not count for `core` — `\b` after `core` still matches a
- * hyphen.
+ * option has to be one of vitest's own arguments: `echo --project unit` names
+ * the option without running anything, and `vitest && echo --project unit`
+ * hands it to a later command — either would otherwise satisfy a topology pin
+ * while the project it names is collected by nobody. `--project core-extra`
+ * must not count for `core` — `\b` after `core` still matches a hyphen.
  */
 function isVitestProjectCommand(cmd: string, project: string): boolean {
   const invocation = /^(?:npx\s+)?vitest(?:\s+|$)/.exec(cmd.trim());
   if (invocation === null) return false;
-  const args = cmd.trim().slice(invocation[0].length);
+  // Only up to the first shell separator is vitest's argument list.
+  const args = cmd.trim().slice(invocation[0].length).split(/\s*(?:&&|\|\||;|\|)\s*/, 1)[0] ?? '';
   return new RegExp(`(?:^|\\s)--project ${escapeRegExp(project)}(?:\\s|$)`).test(args);
 }
 
@@ -600,6 +601,9 @@ describe('CI path-filter & guard coverage (DR-22)', () => {
     expect(isCoreProjectCommand('npx vitest run --project core')).toBe(true);
     expect(isCoreProjectCommand('echo --project core')).toBe(false);
     expect(isCoreProjectCommand("echo 'vitest run --project core'")).toBe(false);
+    expect(isCoreProjectCommand('vitest && echo --project core')).toBe(false);
+    expect(isCoreProjectCommand('vitest --project unit && echo --project core')).toBe(false);
+    expect(isCoreProjectCommand('vitest --project core && echo done')).toBe(true);
   });
 
   it('LayerCensus_UnitProjectHostScripts_AreRunStepsOnBothPlatforms', () => {
@@ -643,6 +647,7 @@ describe('CI path-filter & guard coverage (DR-22)', () => {
       'test:echo': "echo 'npm run test:unit'",
       'test:option-echo': 'echo --project unit',
       'test:npx': 'npx vitest run --project unit',
+      'test:chained': 'vitest run && echo --project unit',
     };
     expect(isUnitProjectScript(scripts, 'test:unit')).toBe(true);
     expect(isUnitProjectScript(scripts, 'test:run')).toBe(true);
@@ -653,6 +658,9 @@ describe('CI path-filter & guard coverage (DR-22)', () => {
       false,
     );
     expect(isUnitProjectScript(scripts, 'test:npx')).toBe(true);
+    expect(isUnitProjectScript(scripts, 'test:chained'), 'a later command is not vitest').toBe(
+      false,
+    );
     expect(isUnitProjectScript(scripts, 'test:absent')).toBe(false);
   });
 

--- a/tests/unit/events/event-authority-partition.test.ts
+++ b/tests/unit/events/event-authority-partition.test.ts
@@ -1,6 +1,6 @@
 // ─── The governance/telemetry partition, and the fold it has to survive ──────
 //
-// @oracle-sources: ../../../src/events/partition/witnesses.ts, ../../../src/projections/views/workflow-state-projection.ts
+// @oracle-sources: ../../../src/events/partition/witnesses.ts, ../../../src/events/partition/demotions.ts, ../../../src/projections/views/workflow-state-projection.ts
 //
 // Two claims, and neither is checkable without the other.
 //
@@ -51,8 +51,10 @@ import type { z } from 'zod';
 import {
   deriveEventAuthority,
   type AuthorityWitness,
+  type CharterDemotion,
   type EventAuthority,
 } from '../../../src/events/partition/authority.js';
+import { CHARTER_DEMOTIONS } from '../../../src/events/partition/demotions.js';
 import { GOVERNANCE_WITNESSES } from '../../../src/events/partition/witnesses.js';
 import {
   EVENT_AUTHORITY,
@@ -171,12 +173,36 @@ const A_GOVERNANCE_WITNESS: AuthorityWitness = {
   because: 'A seeded witness, standing in for a real promotion.',
 };
 
+const A_CHARTER_DEMOTION: CharterDemotion = {
+  evidence: [
+    'lvlup-sw/exarchos#1599 seeded charter act',
+    'lvlup-sw/exarchos#1876 ratified event-authority decision record',
+  ],
+  because: 'A seeded demotion, standing in for a real charter act.',
+};
+
+/**
+ * The bucket the ratified charter names as telemetry EXAMPLES — the per-tool
+ * and turn records, the team family, and four named types. A demotion outside
+ * this bucket would be a new decision wearing a flip's clothes, and a member of
+ * it still classified governance is the backlog the charter schedules.
+ */
+const NAMED_BY_CHARTER = (type: string): boolean =>
+  type.startsWith('tool.') ||
+  type.startsWith('team.') ||
+  type === 'turn.completed' ||
+  type === 'subagent.tokens_used' ||
+  type === 'launch.executing_started' ||
+  type === 'shepherd.iteration' ||
+  type === 'stack.submitted';
+
 describe('EventAuthority — the partition is derived, and telemetry means droppable', () => {
-  it('EventAuthority_LiveMap_IsTheDerivationOfEveryAnnotationAndWitness', () => {
+  it('EventAuthority_LiveMap_IsTheDerivationOfEveryAnnotationWitnessAndDemotion', () => {
     const rebuilt = deriveEventAuthority(
       EventTypes,
       tierEmissionSourceOf,
       GOVERNANCE_WITNESSES,
+      CHARTER_DEMOTIONS,
     );
 
     // The denominator first: an empty rebuild would make every comparison below
@@ -216,6 +242,103 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
         'already.governance': A_GOVERNANCE_WITNESS,
       }),
     ).toThrow(/already\.governance/);
+  });
+
+  it('EventAuthority_DemotionOfAnAutoTierType_ClassifiesItTelemetryAndOnlyIt', () => {
+    // The one way an `auto` type leaves governance. The sibling with no row
+    // stays where the tier put it, so the row is doing the work and not the
+    // tier.
+    const derived = deriveEventAuthority(
+      ['flipped.record', 'kept.record'],
+      () => 'auto',
+      {},
+      { 'flipped.record': A_CHARTER_DEMOTION },
+    );
+    expect(derived).toEqual({ 'flipped.record': 'telemetry', 'kept.record': 'governance' });
+  });
+
+  it('EventAuthority_DemotionForAnUnknownEventType_IsNamedInTheThrow', () => {
+    expect(() =>
+      deriveEventAuthority(['live.record'], () => 'auto', {}, {
+        'renamed.away': A_CHARTER_DEMOTION,
+      }),
+    ).toThrow(/charter demotion\(s\) name an event type that is not in the population: renamed\.away/);
+  });
+
+  it('EventAuthority_DemotionOnATypeAlreadyTelemetryByTier_IsNamedAsDeadCover', () => {
+    expect(() =>
+      deriveEventAuthority(['already.telemetry'], () => 'model', {}, {
+        'already.telemetry': A_CHARTER_DEMOTION,
+      }),
+    ).toThrow(/whose tier already derives telemetry: already\.telemetry/);
+  });
+
+  it('EventAuthority_WitnessAndDemotionOnOneType_IsNamedAsAContradictionNotResolved', () => {
+    // This is the shape a flip takes when a new reader overtakes it: someone
+    // adds a raw-reader witness for a type the demotion table already holds.
+    // Neither table may win silently, and the message must say which type —
+    // on BOTH tiers, because the dead-cover arms would otherwise claim it.
+    for (const tier of ['auto', 'model'] as const) {
+      expect(() =>
+        deriveEventAuthority(
+          ['contested.record'],
+          () => tier,
+          { 'contested.record': A_GOVERNANCE_WITNESS },
+          { 'contested.record': A_CHARTER_DEMOTION },
+        ),
+      ).toThrow(/BOTH a governance witness and a charter demotion: contested\.record/);
+    }
+  });
+
+  it('CharterDemotions_EveryLiveRow_IsACharterNamedTypeNowClassifiedTelemetryWithBothCitations', () => {
+    const demoted = Object.keys(CHARTER_DEMOTIONS).sort();
+    // The denominator: an empty table makes every filter below vacuous, and
+    // this slice is the one that put the first rows in.
+    expect(demoted.length).toBeGreaterThan(0);
+
+    const outsideTheCharter = demoted.filter((type) => !NAMED_BY_CHARTER(type));
+    expect(
+      outsideTheCharter,
+      'A demotion of a type the ratified charter never called telemetry is a new decision, not ' +
+        'a flip. Take it to the roadmap first, then widen NAMED_BY_CHARTER with the citation.',
+    ).toEqual([]);
+
+    const notTelemetry = demoted.filter((type) => classifyEventAuthority(type) !== 'telemetry');
+    expect(notTelemetry).toEqual([]);
+
+    // The act on the roadmap made the flip land; the decision record is what
+    // it executes. A row missing either is a judgment with no paper trail.
+    const uncited = demoted.filter((type) => {
+      const evidence = CHARTER_DEMOTIONS[type]?.evidence ?? [];
+      return (
+        !evidence.some((citation) => citation.includes('lvlup-sw/exarchos#1599')) ||
+        !evidence.some((citation) => citation.includes('lvlup-sw/exarchos#1876'))
+      );
+    });
+    expect(uncited).toEqual([]);
+  });
+
+  it('CharterDemotions_SeededDemotionOfAFoldDiscriminatingType_IsCaughtByTheDifferentialFold', () => {
+    // A wrong demotion — a row for a type the canonical fold consumes — must
+    // reach an oracle, or the demotion table is a way to drop governance
+    // events with every check green. Take a discriminating type whose tier is
+    // `auto` and that carries no witness (so the row is admissible at load),
+    // derive with it demoted, and show the governance-filtered fold diverges.
+    const candidate = DISCRIMINATING.find(
+      (type) => tierEmissionSourceOf(type) === 'auto' && GOVERNANCE_WITNESSES[type] === undefined,
+    );
+    expect(candidate).toBeDefined();
+    if (candidate === undefined) return;
+
+    const seeded = deriveEventAuthority(EventTypes, tierEmissionSourceOf, GOVERNANCE_WITNESSES, {
+      ...CHARTER_DEMOTIONS,
+      [candidate]: A_CHARTER_DEMOTION,
+    });
+    expect(seeded[candidate]).toBe('telemetry');
+
+    const seededTelemetry = new Set(EventTypes.filter((type) => seeded[type] === 'telemetry'));
+    expect(seededTelemetry.has(candidate)).toBe(true);
+    expect(JSON.stringify(foldExcluding(seededTelemetry))).not.toBe(FULL_FOLD);
   });
 
   it('EventAuthority_TelemetrySet_IsNonEmptyAndDerivedFromTheMap', () => {
@@ -387,16 +510,20 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     // gap is a BACKLOG, and a backlog is a thing you count. Pinning the exact
     // set makes every flip a visible shrink and makes a new disagreement
     // impossible to add silently.
-    const namedByCharter = (type: string): boolean =>
-      type.startsWith('tool.') ||
-      type.startsWith('team.') ||
-      type === 'turn.completed' ||
-      type === 'subagent.tokens_used' ||
-      type === 'launch.executing_started' ||
-      type === 'shepherd.iteration' ||
-      type === 'stack.submitted';
-
-    const charterExamples = EventTypes.filter(namedByCharter);
+    //
+    // The first flips landed with the 2026-09-05 charter act: the per-tool and
+    // turn records and the token self-report are demoted by charter row, and
+    // `stack.submitted` left the expectation table that was its only reader.
+    // Nine remain, each for a measured reason — the team family carries the
+    // canonical fold (spawned/disbanded), the stop hook's teammate resolution
+    // (assigned/dispatched), the saga verifier (planned/completed/failed) and
+    // the agent-event validator; `shepherd.iteration` is the escalation bound's
+    // event-sourced count; and `launch.executing_started`, which the decision
+    // record filed beside the hook-tier self-reports, is on the tree the START
+    // claim of the launch liveness pair that `ps` and the phantom-launch heal
+    // pair against. That last one is why a demotion is a judgment made against
+    // the tree and never against the charter's text.
+    const charterExamples = EventTypes.filter(NAMED_BY_CHARTER);
     expect(charterExamples.length).toBeGreaterThan(10);
 
     const stillGovernance = charterExamples
@@ -412,8 +539,6 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     ).toEqual([
       'launch.executing_started',
       'shepherd.iteration',
-      'stack.submitted',
-      'subagent.tokens_used',
       'team.disbanded',
       'team.spawned',
       'team.task.assigned',
@@ -421,11 +546,6 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
       'team.task.failed',
       'team.task.planned',
       'team.teammate.dispatched',
-      'tool.action_errored',
-      'tool.completed',
-      'tool.errored',
-      'tool.invoked',
-      'turn.completed',
     ]);
   });
 

--- a/tests/unit/events/event-authority-partition.test.ts
+++ b/tests/unit/events/event-authority-partition.test.ts
@@ -145,14 +145,16 @@ const CORPUS: readonly WorkflowEvent[] = EventTypes.map((type, index) =>
   }),
 );
 
-function fold(events: readonly WorkflowEvent[]): unknown {
+type FoldedState = ReturnType<typeof workflowStateProjection.init>;
+
+function fold(events: readonly WorkflowEvent[]): FoldedState {
   return events.reduce(
     (state, event) => workflowStateProjection.apply(state, event),
     workflowStateProjection.init(),
   );
 }
 
-function foldExcluding(excluded: ReadonlySet<string>): unknown {
+function foldExcluding(excluded: ReadonlySet<string>): FoldedState {
   return fold(CORPUS.filter((event) => !excluded.has(event.type)));
 }
 
@@ -370,8 +372,15 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     });
     expect(seeded[candidate]).toBe('telemetry');
 
-    const seededTelemetry = new Set(EventTypes.filter((type) => seeded[type] === 'telemetry'));
-    expect(seededTelemetry.has(candidate)).toBe(true);
+    // Control: the LIVE telemetry set folds back to the full state, and the
+    // seeded set is that set plus exactly the candidate — so the divergence
+    // below is the seeded row's, not some already-telemetry type's.
+    const liveTelemetry: ReadonlySet<string> = TELEMETRY_EVENTS;
+    expect(JSON.stringify(foldExcluding(liveTelemetry))).toBe(FULL_FOLD);
+    const seededTelemetry = new Set<string>(
+      EventTypes.filter((type) => seeded[type] === 'telemetry'),
+    );
+    expect([...seededTelemetry].filter((type) => !liveTelemetry.has(type))).toEqual([candidate]);
     expect(JSON.stringify(foldExcluding(seededTelemetry))).not.toBe(FULL_FOLD);
   });
 

--- a/tests/unit/events/event-authority-partition.test.ts
+++ b/tests/unit/events/event-authority-partition.test.ts
@@ -5,8 +5,9 @@
 // Two claims, and neither is checkable without the other.
 //
 // The first is that the partition is DERIVED: rebuild it from the catalog, the
-// annotations and the witness table and you get exactly the shipped map, and a
-// population it cannot partition fails by name rather than defaulting.
+// annotations and the two override tables — witnesses and charter demotions —
+// and you get exactly the shipped map, and a population it cannot partition
+// fails by name rather than defaulting.
 //
 // The second is what the partition MEANS. "Telemetry" is only a real claim if
 // dropping every telemetry event leaves the canonical fold's answer unchanged.
@@ -54,7 +55,10 @@ import {
   type CharterDemotion,
   type EventAuthority,
 } from '../../../src/events/partition/authority.js';
-import { CHARTER_DEMOTIONS } from '../../../src/events/partition/demotions.js';
+import {
+  CHARTER_DEMOTIONS,
+  assertCharterCitations,
+} from '../../../src/events/partition/demotions.js';
 import { GOVERNANCE_WITNESSES } from '../../../src/events/partition/witnesses.js';
 import {
   EVENT_AUTHORITY,
@@ -174,27 +178,41 @@ const A_GOVERNANCE_WITNESS: AuthorityWitness = {
 };
 
 const A_CHARTER_DEMOTION: CharterDemotion = {
-  evidence: [
-    'lvlup-sw/exarchos#1599 seeded charter act',
-    'lvlup-sw/exarchos#1876 ratified event-authority decision record',
-  ],
+  act: 'https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-1',
+  record: 'https://github.com/lvlup-sw/exarchos/issues/1876#issuecomment-1',
   because: 'A seeded demotion, standing in for a real charter act.',
 };
 
 /**
- * The bucket the ratified charter names as telemetry EXAMPLES — the per-tool
- * and turn records, the team family, and four named types. A demotion outside
- * this bucket would be a new decision wearing a flip's clothes, and a member of
- * it still classified governance is the backlog the charter schedules.
+ * The bucket the ratified charter names as telemetry EXAMPLES, enumerated as
+ * the catalog stood when the first act was made — the per-tool and turn
+ * records, the team family's seven members, and four named types. A demotion
+ * outside this bucket would be a new decision wearing a flip's clothes, and a
+ * member of it still classified governance is the backlog the charter
+ * schedules.
+ *
+ * A LITERAL set, not a family predicate: a member added to the tool or team
+ * family later was not named by the record, so its flip is a new decision too,
+ * and a `startsWith` would have admitted it as if the act had covered it.
  */
-const NAMED_BY_CHARTER = (type: string): boolean =>
-  type.startsWith('tool.') ||
-  type.startsWith('team.') ||
-  type === 'turn.completed' ||
-  type === 'subagent.tokens_used' ||
-  type === 'launch.executing_started' ||
-  type === 'shepherd.iteration' ||
-  type === 'stack.submitted';
+const CHARTER_TELEMETRY_EXAMPLES: ReadonlySet<string> = new Set([
+  'tool.invoked',
+  'tool.completed',
+  'tool.errored',
+  'tool.action_errored',
+  'turn.completed',
+  'subagent.tokens_used',
+  'launch.executing_started',
+  'team.spawned',
+  'team.disbanded',
+  'team.task.planned',
+  'team.task.assigned',
+  'team.teammate.dispatched',
+  'team.task.completed',
+  'team.task.failed',
+  'shepherd.iteration',
+  'stack.submitted',
+]);
 
 describe('EventAuthority — the partition is derived, and telemetry means droppable', () => {
   it('EventAuthority_LiveMap_IsTheDerivationOfEveryAnnotationWitnessAndDemotion', () => {
@@ -296,26 +314,42 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     // this slice is the one that put the first rows in.
     expect(demoted.length).toBeGreaterThan(0);
 
-    const outsideTheCharter = demoted.filter((type) => !NAMED_BY_CHARTER(type));
+    const outsideTheCharter = demoted.filter((type) => !CHARTER_TELEMETRY_EXAMPLES.has(type));
     expect(
       outsideTheCharter,
       'A demotion of a type the ratified charter never called telemetry is a new decision, not ' +
-        'a flip. Take it to the roadmap first, then widen NAMED_BY_CHARTER with the citation.',
+        'a flip. Take it to the roadmap first, then add the type to CHARTER_TELEMETRY_EXAMPLES ' +
+        'with the new act as its citation.',
     ).toEqual([]);
 
     const notTelemetry = demoted.filter((type) => classifyEventAuthority(type) !== 'telemetry');
     expect(notTelemetry).toEqual([]);
 
     // The act on the roadmap made the flip land; the decision record is what
-    // it executes. A row missing either is a judgment with no paper trail.
-    const uncited = demoted.filter((type) => {
-      const evidence = CHARTER_DEMOTIONS[type]?.evidence ?? [];
-      return (
-        !evidence.some((citation) => citation.includes('lvlup-sw/exarchos#1599')) ||
-        !evidence.some((citation) => citation.includes('lvlup-sw/exarchos#1876'))
-      );
-    });
-    expect(uncited).toEqual([]);
+    // it executes. Both citations are TYPED, so a literal that is not a comment
+    // on #1599 or #1876 does not compile (the self-tests in demotions.ts pin the
+    // placeholder shape the first draft carried). The load-time check is what a
+    // cast cannot get past; it is exercised here on the live table and, through
+    // the same function, on a seeded row that still carries the placeholder.
+    expect(() => assertCharterCitations(CHARTER_DEMOTIONS)).not.toThrow();
+    expect(() =>
+      assertCharterCitations({
+        'seeded.record': {
+          act: 'https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-CHARTER_ACT_COMMENT_ID',
+          record: 'https://github.com/lvlup-sw/exarchos/issues/1876#issuecomment-5465417502',
+          because: 'A row that never had its placeholder filled in.',
+        },
+      }),
+    ).toThrow(/seeded\.record \(act: .*CHARTER_ACT_COMMENT_ID/);
+    expect(() =>
+      assertCharterCitations({
+        'seeded.record': {
+          act: 'https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-5555387087',
+          record: 'https://github.com/lvlup-sw/exarchos/issues/1876',
+          because: 'A row citing the issue rather than the comment that ratified the record.',
+        },
+      }),
+    ).toThrow(/seeded\.record/);
   });
 
   it('CharterDemotions_SeededDemotionOfAFoldDiscriminatingType_IsCaughtByTheDifferentialFold', () => {
@@ -520,10 +554,19 @@ describe('EventAuthority — the partition is derived, and telemetry means dropp
     // the agent-event validator; `shepherd.iteration` is the escalation bound's
     // event-sourced count; and `launch.executing_started`, which the decision
     // record filed beside the hook-tier self-reports, is on the tree the START
-    // claim of the launch liveness pair that `ps` and the phantom-launch heal
-    // pair against. That last one is why a demotion is a judgment made against
-    // the tree and never against the charter's text.
-    const charterExamples = EventTypes.filter(NAMED_BY_CHARTER);
+    // claim of the launch liveness pair — read raw by the `worktrees@v1`
+    // reducer that `ps` and the phantom-launch heal fold, so the reader census
+    // names it, and paired by the descriptor the declaration conjunct's
+    // liveness arm names. That last one is why a demotion is a judgment made
+    // against the tree and never against the charter's text.
+    const catalog = new Set<string>(EventTypes);
+    const renamedAway = [...CHARTER_TELEMETRY_EXAMPLES].filter((type) => !catalog.has(type));
+    expect(
+      renamedAway,
+      'A charter example is no longer a catalog type — the list outlived a rename or a retirement.',
+    ).toEqual([]);
+    const charterExamples = EventTypes.filter((type) => CHARTER_TELEMETRY_EXAMPLES.has(type));
+    expect(charterExamples.length).toBe(CHARTER_TELEMETRY_EXAMPLES.size);
     expect(charterExamples.length).toBeGreaterThan(10);
 
     const stillGovernance = charterExamples

--- a/tests/unit/verbs/gates/check-event-emissions.test.ts
+++ b/tests/unit/verbs/gates/check-event-emissions.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
 }));
 
 import {
+  EVENT_DESCRIPTIONS,
   PHASE_EXPECTED_EVENTS,
   assertDescriptionsLive,
   assertExpectationsLive,
@@ -99,11 +100,18 @@ describe('PHASE_EXPECTED_EVENTS', () => {
     expect(data.hints.map((h) => h.eventType)).not.toContain('review.routed');
   });
 
-  it('PhaseExpectedEvents_SynthesizePhase_ExpectsStackAndShepherd', () => {
-    const synthesizeEvents = PHASE_EXPECTED_EVENTS['synthesize'];
-    expect(synthesizeEvents).toBeDefined();
-    expect(synthesizeEvents).toContain('stack.submitted');
-    expect(synthesizeEvents).toContain('shepherd.iteration');
+  it('PhaseExpectedEvents_SynthesizePhase_ExpectsShepherdAndNoLongerStackSubmitted', () => {
+    // `stack.submitted` was flipped to telemetry by the first event-authority
+    // charter act (#1599, executing #1876): this row was the only dependency
+    // on it, so the flip IS the deletion of the row and of its hint. The
+    // literal pin is deliberate — re-adding the type here is a re-promotion,
+    // and the partition's declaration conjunct would then demand a witness.
+    expect(PHASE_EXPECTED_EVENTS['synthesize']).toEqual([
+      'team.spawned',
+      'team.disbanded',
+      'shepherd.iteration',
+    ]);
+    expect(Object.keys(EVENT_DESCRIPTIONS)).not.toContain('stack.submitted');
   });
 
   it('CheckEventEmissions_DelegatePhase_IncludesTaskProgressed', () => {

--- a/tests/unit/verbs/gates/check-event-emissions.test.ts
+++ b/tests/unit/verbs/gates/check-event-emissions.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../../../src/projections/fold-at-tail.js', () => ({
 import {
   EVENT_DESCRIPTIONS,
   PHASE_EXPECTED_EVENTS,
+  assertDescriptionsCoverExpectations,
   assertDescriptionsLive,
   assertExpectationsLive,
   handleCheckEventEmissions,
@@ -112,6 +113,42 @@ describe('PHASE_EXPECTED_EVENTS', () => {
       'shepherd.iteration',
     ]);
     expect(Object.keys(EVENT_DESCRIPTIONS)).not.toContain('stack.submitted');
+  });
+
+  it('EventDescriptions_LiveTables_DescribeExactlyTheExpectedPopulation', () => {
+    // The denominator first: a pair of empty tables would agree about nothing.
+    expect(Object.keys(EVENT_DESCRIPTIONS).length).toBeGreaterThan(0);
+    expect(Object.values(PHASE_EXPECTED_EVENTS).flat().length).toBeGreaterThan(0);
+    expect(() =>
+      assertDescriptionsCoverExpectations(PHASE_EXPECTED_EVENTS, EVENT_DESCRIPTIONS),
+    ).not.toThrow();
+  });
+
+  it('EventDescriptions_RowNoPhaseExpects_IsNamedAtLoad', () => {
+    // The stale-prose direction: a description that outlived its expectation
+    // row — what a flip is required to delete in the same commit.
+    const seededType = 'seeded.described-but-unexpected';
+    expect(() =>
+      assertDescriptionsCoverExpectations(PHASE_EXPECTED_EVENTS, {
+        ...EVENT_DESCRIPTIONS,
+        [seededType]: 'Emit seeded.described-but-unexpected via exarchos_event',
+      }),
+    ).toThrow(new RegExp(`no phase expects: ${seededType.replace('.', '\\.')}`));
+  });
+
+  it('EventDescriptions_ExpectationWithoutARow_IsNamedAtLoad', () => {
+    // The generic-hint direction: an expected event nobody described. The
+    // fixture drops a LIVE expected type from the description table, so it
+    // stays valid whatever the rows say tomorrow.
+    const [dropped] = Object.values(PHASE_EXPECTED_EVENTS).flat();
+    expect(dropped).toBeDefined();
+    if (dropped === undefined) return;
+    const withoutOne = Object.fromEntries(
+      Object.entries(EVENT_DESCRIPTIONS).filter(([eventType]) => eventType !== dropped),
+    );
+    expect(() => assertDescriptionsCoverExpectations(PHASE_EXPECTED_EVENTS, withoutOne)).toThrow(
+      new RegExp(`does not describe: ${dropped.replace('.', '\\.')}`),
+    );
   });
 
   it('CheckEventEmissions_DelegatePhase_IncludesTaskProgressed', () => {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -4,10 +4,10 @@
   "identity": "(suite path within the file, test name, runner) — path is metadata, never identity",
   "countingSemantics": "Cases are CALL SITES, not expanded executions. A table-driven `it.each([...])` is one entry here and N tests at runtime, so this total is not comparable to any runner's expanded count and no runner totals are pinned here — a pinned pair went stale the first time the tree grew. The call site is the right unit for reconciliation: it survives a move, whereas an expansion index depends on the table contents and would churn on any data edit. A drop in call sites is the signal this oracle exists to catch.",
   "totals": {
-    "testFiles": 1262,
-    "parsedFiles": 1217,
+    "testFiles": 1264,
+    "parsedFiles": 1219,
     "shellFiles": 45,
-    "cases": 13909,
+    "cases": 13918,
     "dynamicTitles": 150,
     "unparseableFiles": 0
   },
@@ -5797,11 +5797,6 @@
         },
         {
           "suite": "ActionContractConjunct — a declared event is a governance event",
-          "name": "ActionContractConjunct_EveryDescriptionRow_IsReachedByAnExpectationRow",
-          "dynamic": false
-        },
-        {
-          "suite": "ActionContractConjunct — a declared event is a governance event",
           "name": "ActionContractConjunct_EveryDeclaredEventName_IsAKnownEventType",
           "dynamic": false
         },
@@ -5859,6 +5854,22 @@
         {
           "suite": "RawReaderCensus — no fold-external reader depends on a telemetry event",
           "name": "RawReaderCensus_UnscopedFoldsAndUnresolvedDiscriminants_AreReportedNotDropped",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/architecture/event-emissions-gate-consumers.test.ts": {
+      "file": "tests/architecture/event-emissions-gate-consumers.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "EventEmissionsGate — nothing shipped decides on its verdict",
+          "name": "EventEmissionsGate_GateNameLiteral_AppearsOnlyInTheGateModule",
+          "dynamic": false
+        },
+        {
+          "suite": "EventEmissionsGate — nothing shipped decides on its verdict",
+          "name": "EventEmissionsGate_SeededReaderDiscriminatingOnTheName_IsNamedAndAnImportIsNot",
           "dynamic": false
         }
       ]
@@ -6464,6 +6475,27 @@
         {
           "suite": "ArtifactKind",
           "name": "NoRenderedFile_IsHandEdited",
+          "dynamic": false
+        }
+      ]
+    },
+    "tests/architecture/skill-prose-gate-row-agreement.test.ts": {
+      "file": "tests/architecture/skill-prose-gate-row-agreement.test.ts",
+      "runner": "vitest:root",
+      "cases": [
+        {
+          "suite": "SkillProse — the checked-by sentence names the gate row",
+          "name": "SkillProse_EverySite_HasAnExpectationRowAndAContentFile",
+          "dynamic": false
+        },
+        {
+          "suite": "SkillProse — the checked-by sentence names the gate row",
+          "name": "SkillProse_CheckedLine_NamesExactlyTheGateRow",
+          "dynamic": false
+        },
+        {
+          "suite": "SkillProse — the checked-by sentence names the gate row",
+          "name": "SkillProse_SeededDisagreement_IsNamedInBothDirectionsAndOnAMissingLine",
           "dynamic": false
         }
       ]
@@ -11352,6 +11384,16 @@
         {
           "suite": "CI path-filter & guard coverage (DR-22)",
           "name": "LayerCensus_HostScripts_AreRunStepsOnBothPlatforms",
+          "dynamic": false
+        },
+        {
+          "suite": "CI path-filter & guard coverage (DR-22)",
+          "name": "LayerCensus_UnitProjectHostScripts_AreRunStepsOnBothPlatforms",
+          "dynamic": false
+        },
+        {
+          "suite": "CI path-filter & guard coverage (DR-22)",
+          "name": "IsUnitProjectScript_ResolvesOneAliasHopAndNoMore",
           "dynamic": false
         },
         {
@@ -52222,6 +52264,21 @@
         {
           "suite": "PHASE_EXPECTED_EVENTS",
           "name": "PhaseExpectedEvents_SynthesizePhase_ExpectsShepherdAndNoLongerStackSubmitted",
+          "dynamic": false
+        },
+        {
+          "suite": "PHASE_EXPECTED_EVENTS",
+          "name": "EventDescriptions_LiveTables_DescribeExactlyTheExpectedPopulation",
+          "dynamic": false
+        },
+        {
+          "suite": "PHASE_EXPECTED_EVENTS",
+          "name": "EventDescriptions_RowNoPhaseExpects_IsNamedAtLoad",
+          "dynamic": false
+        },
+        {
+          "suite": "PHASE_EXPECTED_EVENTS",
+          "name": "EventDescriptions_ExpectationWithoutARow_IsNamedAtLoad",
           "dynamic": false
         },
         {

--- a/tools/audit/test-inventory-baseline.json
+++ b/tools/audit/test-inventory-baseline.json
@@ -7,7 +7,7 @@
     "testFiles": 1262,
     "parsedFiles": 1217,
     "shellFiles": 45,
-    "cases": 13901,
+    "cases": 13909,
     "dynamicTitles": 150,
     "unparseableFiles": 0
   },
@@ -5797,6 +5797,11 @@
         },
         {
           "suite": "ActionContractConjunct — a declared event is a governance event",
+          "name": "ActionContractConjunct_EveryDescriptionRow_IsReachedByAnExpectationRow",
+          "dynamic": false
+        },
+        {
+          "suite": "ActionContractConjunct — a declared event is a governance event",
           "name": "ActionContractConjunct_EveryDeclaredEventName_IsAKnownEventType",
           "dynamic": false
         },
@@ -5808,6 +5813,11 @@
         {
           "suite": "ActionContractConjunct — a declared event is a governance event",
           "name": "ActionContractConjunct_SeededContractNamingATelemetryType_IsNamedInTheFailure",
+          "dynamic": false
+        },
+        {
+          "suite": "ActionContractConjunct — a declared event is a governance event",
+          "name": "ActionContractConjunct_ADemotedLivenessStart_WouldBeNamedBySite",
           "dynamic": false
         }
       ]
@@ -24007,7 +24017,7 @@
       "cases": [
         {
           "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
-          "name": "EventAuthority_LiveMap_IsTheDerivationOfEveryAnnotationAndWitness",
+          "name": "EventAuthority_LiveMap_IsTheDerivationOfEveryAnnotationWitnessAndDemotion",
           "dynamic": false
         },
         {
@@ -24028,6 +24038,36 @@
         {
           "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
           "name": "EventAuthority_WitnessOnATypeAlreadyGovernanceByTier_IsNamedAsDeadCover",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_DemotionOfAnAutoTierType_ClassifiesItTelemetryAndOnlyIt",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_DemotionForAnUnknownEventType_IsNamedInTheThrow",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_DemotionOnATypeAlreadyTelemetryByTier_IsNamedAsDeadCover",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "EventAuthority_WitnessAndDemotionOnOneType_IsNamedAsAContradictionNotResolved",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "CharterDemotions_EveryLiveRow_IsACharterNamedTypeNowClassifiedTelemetryWithBothCitations",
+          "dynamic": false
+        },
+        {
+          "suite": "EventAuthority — the partition is derived, and telemetry means droppable",
+          "name": "CharterDemotions_SeededDemotionOfAFoldDiscriminatingType_IsCaughtByTheDifferentialFold",
           "dynamic": false
         },
         {
@@ -52181,7 +52221,7 @@
         },
         {
           "suite": "PHASE_EXPECTED_EVENTS",
-          "name": "PhaseExpectedEvents_SynthesizePhase_ExpectsStackAndShepherd",
+          "name": "PhaseExpectedEvents_SynthesizePhase_ExpectsShepherdAndNoLongerStackSubmitted",
           "dynamic": false
         },
         {

--- a/tools/conformance/src/report-coupling-seed.ts
+++ b/tools/conformance/src/report-coupling-seed.ts
@@ -56,6 +56,12 @@
 // Entries are never ADDED to either map — an addition changes the seed key set, and the pinned
 // digest is what makes that a red build rather than a line a reviewer has to notice.
 //
+// One entry is NOT paid down that way. A type the event-authority charter has flipped to
+// telemetry (`src/events/partition/demotions.ts`; `stack.submitted`, by deleting its expectation
+// row) must not be re-tiered to an `auto` tier: the partition would file it governance again
+// with no witness, and its pinned charter backlog names that as a promotion against the charter.
+// The flip is that entry's paydown — nothing has to remember the append, because nothing checks.
+//
 // DR-20 records the Wave-5 exit condition — a floor of 2, `team.spawned` and `team.disbanded`,
 // which cannot be re-coupled until #1473 lands. That floor is an EXIT CONDITION, not this guard's
 // seed; the two were conflated in an earlier revision of the spec. The two entries carry


### PR DESCRIPTION
## Summary

First charter-backed event-authority flips — #1888 item 6, executed for the first time. Seven types leave governance, ordered by the charter act posted on the roadmap first, as the tracker requires: https://github.com/lvlup-sw/exarchos/issues/1599#issuecomment-5555387087 (executing the ratified decision record, #1876).

- **Six `auto`-tier runtime-telemetry types** (`tool.invoked`, `tool.completed`, `tool.errored`, `tool.action_errored`, `turn.completed`, `subagent.tokens_used`) are demoted by a new **charter-demotion arm** in the partition derivation. Item 6's stated mechanism (row deletion) has no rows to delete for these — they were governance by tier, with no expectation or description row anywhere — so the act records that amendment: an `auto`-tier type leaves governance only by a row in `src/events/partition/demotions.ts` citing the act and the record. Promotion stays witness-based; neither direction is derived from a measurement.
- **`stack.submitted`** flips by item 6's own mechanism: its `PHASE_EXPECTED_EVENTS['synthesize']` row, its `EVENT_DESCRIPTIONS` row and its `gate-expectation` witness are deleted, and the synthesize skill prose says so. This is the one **shipped behavior change**: `check_event_emissions` no longer demands `stack.submitted` in the synthesize phase, on the explicit gate call and on the per-call `_eventHints` surface.
- **`launch.executing_started` does NOT flip**, although the record lists it. On the tree it is the START claim of the launch liveness pair, read raw by the `worktrees@v1` reducer and paired by `ps` and the phantom-launch heal. The reader census names the reducer; a new `liveness-pair` arm in the declaration conjunct names the descriptor. The act records this premise correction (and that the record's `hook`-tier label is wrong for both types it names: the only `hook`-deriving tier has zero members).
- The pinned charter-tension backlog shrinks **16 → 9**.

Second commit is the `/verify-code` disposition over the first: a 23-obligation ledger evaluated by three fresh-context lenses — **9 refuted with evidence, 14 confirmed**, every confirmed class converted to a guard or named as open.

Refs #1888 (item 6), #1856, #1875, #1599.

## Changes

**Partition (`src/events/partition/`)**
- `authority.ts`: `deriveEventAuthority(eventTypes, tierSourceOf, witnesses, demotions = {})` — governance iff witness OR (`auto` AND no demotion); seven fail-closed refusals (empty population, unannotated, stale witness, stale demotion, witness∧demotion contradiction, dead-cover witness, dead-cover demotion), each naming its offenders. `CharterActUrl` / `DecisionRecordCitation` template-literal types pin citations to comments on #1599 / #1876; `CharterDemotion { act, record, because }`.
- `demotions.ts` (new): six rows; `CHARTER_ACT` is one literal so the compiler checks it; three `ExpectTrue<NotAssignableTo>` self-tests reject the placeholder shape, a wrong-issue URL and an anchor-less record (sited in `src/` because `tests/tsconfig.json` excludes `tests/unit/**`); `assertCharterCitations` re-checks the values at load — the one thing a single `as` cannot get past.
- `witnesses.ts`: `stack.submitted` gate-expectation row deleted; both tables keyed by `EventType` at the literal (`satisfies` inside the freeze — a plain annotated freeze skips the excess-key check once one key overlaps; measured).
- `event-authority.ts`: passes `CHARTER_DEMOTIONS`; RESERVED marker now records two facts for the first consumer — telemetry is a fold fact, not a stream placement (`subagent.tokens_used` and `stack.submitted` ride feature streams), and the dormant auto-correction path in the telemetry middleware is the one in-tree reader that would become correctness-bearing without a partition change.

**Gate (`src/verbs/gates/check-event-emissions.ts`)**
- `synthesize` row: `['team.spawned', 'team.disbanded', 'shepherd.iteration']`; `stack.submitted` description deleted; `EVENT_DESCRIPTIONS` exported.
- `assertDescriptionsCoverExpectations` at load, both directions. The reverse direction was **red on the live tree**: `task.assigned` (derived delegate row) had no description and fell through to a generic hint. Row added; the `??` fallback replaced by a fail-closed lookup.

**Oracles**
- `tests/unit/events/event-authority-partition.test.ts`: six new derivation cases (demotion classifies, unknown type, dead cover, contradiction on both tiers), a seeded-demotion differential-fold probe (a wrong demotion of a fold-discriminating type is caught), the citation check on the live table and on seeded placeholder / anchor-less rows, `CHARTER_TELEMETRY_EXAMPLES` as a literal 16-member set (a `startsWith` predicate would have admitted future family members with no act), backlog pin 16 → 9.
- `tests/architecture/event-authority-contracts.test.ts`: `liveness-pair` arm; pure `staleGateExpectationWitnesses` with a seeded row (the arm has zero live rows, so the seeded row is what keeps the auditor non-vacuous); liveness population pinned to the derived sum over `LIVENESS_DESCRIPTORS` instead of a literal floor; launch-start probe.
- **New** `tests/architecture/skill-prose-gate-row-agreement.test.ts`: the synthesize skill's "Checked by `check-event-emissions` in this phase:" line is compared as a set against the gate row, both directions, with seeded over-claim / under-claim / missing-line fixtures.
- **New** `tests/architecture/event-emissions-gate-consumers.test.ts`: the quoted gate name `'event-emissions'` appears only in the gate module — a `gate.executed` reader that starts deciding on it is named.
- `tests/scripts/ci-topology.test.ts`: the `unit` vitest lane (the architecture oracles' only host) pinned to `ci-gate` on both platforms, resolving the `test:run → test:unit` alias; the core lane already had this pin.
- `tests/unit/verbs/gates/check-event-emissions.test.ts`: literal synthesize pin; three seeded tests for the load-time pairing.

**Prose / baselines**: synthesize `SKILL.md` (content + rendered), migration baseline + snapshot, `report-coupling-seed.ts` header (a charter-flipped type is not paid down by re-tiering — that re-promotes it and the backlog pin names it), test-inventory baseline spliced (+2 files, +9 cases).

## Test Plan

Local, at `27c01db6c` (worktree; `node_modules` symlinked from the main checkout):
- `npm run typecheck` (root + `tools/conformance` + `tests`): clean. `eslint` on changed sources: clean. `npx tsx tools/audit/knip-diff.ts`: OK. `node tools/audit/gates/check-module-intent.mjs`: exit 0. `npm run render:guard`: clean post-commit.
- `npx vitest run tests/architecture tests/unit/events tests/unit/verbs/gates tests/unit/projections tests/core/integration/suite-invariants.test.ts`: 3258 passed; the 2 failures are the known local-environment ones (`published-contract` needs a full binary build; `worktree-inventory` is a worktree artifact). `npm run test:conformance`: 323 passed. `tests/migration`: 56 passed. Grep-gates vitest files (cast ratchet, guard inventory, measured premises, effect ledger, audit-delivery closure, ci-topology): all passed.
- **Kill-probes** (edit → run → restore): re-adding `stack.submitted` to the synthesize row → conjunct names `check-event-emissions.PHASE_EXPECTED_EVENTS.synthesize`; mutating fold arm for `tool.invoked` → `DifferentialFold_EveryTelemetryType_FoldsToIdentity` names it; raw-reader witness for `tool.invoked` → load-time contradiction throw; appending `stack.submitted` to the skill's checked line → named by the prose test; a quoted `'event-emissions'` in `convergence-view.ts` → named by the consumer scan; placeholder anchor in `CHARTER_ACT` → `TS2322` at compile AND a load-time throw naming all six rows.
- **Refutation-lens probes** (recorded in the verification workspace): old-vs-new derivation over 20,000 random populations, 0 mismatches for the 3-arg and explicit-`{}` calls; real reader census over `src/` minus `src/projections/`: `launch.executing_started → [worktrees.ts]`, merge/mutation starts and all seven flipped types → `[]`.

**Residue (stated, not silently passed)**
- "Telemetry" here means the canonical fold and every fold-external correctness-bearing reader are independent of the type. Secondary views still fold these types into hints and affordances; whether an advisory affordance counts as "deciding" is #1888 item 9's question. The act states the bound as not discharged.
- The delegate skill's "checked by `check-event-emissions`" table **disagrees with its derived row today** (omits `team.disbanded`, `task.progressed`) — pre-existing, measured, not fixed here; the new prose comparator covers synthesize only until delegate's table takes the machine-shaped line.
- A rung-1 prose generator is blocked by the layer rule (`src/install` may not import `src/verbs`); needs a generated intermediate.
- Pre-existing and unproven, named by the review: the expectation table's keys are not joined to the HSM `states`; a new `AuthorityArm` member no oracle iterates would be silent (per-arm filters, no runtime enumeration); the `@oracle-sources` ratchet has no `tests/architecture` root (recorded exemption in `corpus.ts`).
- `published-contract.test.ts` was not run locally (needs the binary build); CI measures it. Test-inventory case records have no CI reader for changed files (file-level only).
- Plugin deployment lag: the rendered skill and the server ship independently, so an installed plugin can carry the old prose against a new server for one release (both skews reduce to "the gate no longer demands it", which is the intended change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
